### PR TITLE
Correct typos in 3.2 Interfaces section

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <script src="section-links.js" type="application/ecmascript"></script>
     <script src="dfn.js" type="application/ecmascript"></script>
 
-    
+
   <link rel="stylesheet" href="http://www.w3.org/StyleSheets/TR/W3C-ED" type="text/css" /></head>
 
   <body>
@@ -57,7 +57,7 @@
           * Parameterized interface types, for BlahLists
             http://www.w3.org/mid/op.vr2r6waf64w2qv@anne-van-kesterens-macbook-pro.local
         -->
-<!--          
+<!--
       <?revision-note http://www.w3.org/Bugs/Public/buglist.cgi?query_format=advanced&amp;short_desc_type=allwordssubstr&amp;short_desc=&amp;product=WebAppsWG&amp;component=WebIDL&amp;longdesc_type=allwordssubstr&amp;longdesc=&amp;bug_file_loc_type=allwordssubstr&amp;bug_file_loc=&amp;status_whiteboard_type=allwordssubstr&amp;status_whiteboard=&amp;keywords_type=allwords&amp;keywords=&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;emailtype1=substring&amp;email1=&amp;emailtype2=substring&amp;email2=&amp;bug_id_type=anyexact&amp;bug_id=&amp;votes=&amp;chfieldfrom=&amp;chfieldto=Now&amp;chfieldvalue=&amp;cmdtype=doit&amp;order=Importance&amp;field0-0-0=noop&amp;type0-0-0=noop&amp;value0-0-0=?>
 -->
 
@@ -74,7 +74,7 @@
       </em></p><p>
         This document is the 6 November 2013 <b>Editor’s Draft</b> of the
         <cite>Web IDL (Second Edition)</cite> specification.
-      
+
       Please send comments about this document to
       <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
       (<a href="http://lists.w3.org/Archives/Public/public-script-coord/">archived</a>).
@@ -521,11 +521,11 @@ dictionary <i>identifier</i> {
           </span></td></tr></table>
           <p>
             If an <a class="sym" href="#prod-identifier">identifier</a> token is used, then the
-            <a class="dfnref" href="#dfn-identifier">identifier</a> of the operation argument 
-            is the value of that token with any leading 
+            <a class="dfnref" href="#dfn-identifier">identifier</a> of the operation argument
+            is the value of that token with any leading
             <span class="char">U+005F LOW LINE ("_")</span> character (underscore) removed.
             If instead one of the <a class="sym" href="#prod-ArgumentNameKeyword">ArgumentNameKeyword</a>
-            keyword token is used, then the <a class="dfnref" href="#dfn-identifier">identifier</a> of the operation argument 
+            keyword token is used, then the <a class="dfnref" href="#dfn-identifier">identifier</a> of the operation argument
             is simply that token.
           </p>
           <p>
@@ -822,7 +822,7 @@ public interface B extends A {
             from any non-callback interfaces, and non-callback interfaces <span class="rfc2119">MUST NOT</span>
             inherit from any callback interfaces.
             Callback interfaces <span class="rfc2119">MUST NOT</span> have any
-            have any <a class="dfnref" href="#dfn-consequential-interfaces">consequential interfaces</a>.
+            <a class="dfnref" href="#dfn-consequential-interfaces">consequential interfaces</a>.
           </p>
           <p>
             <a class="dfnref" href="#dfn-static-attribute">Static attributes</a> and
@@ -835,7 +835,7 @@ public interface B extends A {
               <a class="dfnref" href="#dfn-callback-interface">callback interfaces</a>
               that have only a single <a class="dfnref" href="#dfn-operation">operation</a>,
               unless required to describe the requirements of existing APIs.
-              Instead, a <a class="dfnref" href="#dfn-callback-function">callback function</a> <span class="rfc2119">SHOULD</span> used.
+              Instead, a <a class="dfnref" href="#dfn-callback-function">callback function</a> <span class="rfc2119">SHOULD</span> be used.
             </p>
             <p>
               The definition of <span class="idltype">EventListener</span> as a
@@ -1252,7 +1252,7 @@ node.appendChild(newNode);  <span class="comment">// This will throw a TypeError
               If <var>VT</var> is the type of the value assigned to a constant, and <var>DT</var>
               is the type of the constant, dictionary member or optional argument itself, then these types <span class="rfc2119">MUST</span>
               be compatible, which is the case if <var>DT</var> and <var>VT</var> are identical,
-              or <var>DT</var> is a <a class="dfnref" href="#dfn-nullable-type">nullable type</a> 
+              or <var>DT</var> is a <a class="dfnref" href="#dfn-nullable-type">nullable type</a>
               whose <a class="dfnref" href="#dfn-inner-type">inner type</a> is <var>VT</var>.
             </p>
             <p>
@@ -1409,7 +1409,7 @@ interface <i>Derived</i> : <i>Ancestor</i> {
               <a class='sym' href='#prod-SetRaises'>SetRaises</a> clauses are used
               to declare the possible exceptions that can be thrown when retrieving
               the value of and assigning a value to the attribute, respectively.
-              Each scoped name in the 
+              Each scoped name in the
               <a class='sym' href='#prod-GetRaises'>GetRaises</a> and
               <a class='sym' href='#prod-SetRaises'>SetRaises</a> clauses
               <span class='rfc2119'>MUST</span> resolve to an <a class='dfnref' href='#dfn-exception'>exception</a>.
@@ -1518,7 +1518,7 @@ interface Person : Animal {
             <ol>
               <li><a class="dfnref" href="#dfn-regular-operation">regular operations</a>, which
               are those used to declare that objects implementing the
-              <a class="dfnref" href="#dfn-interface">interface</a> will have a method with 
+              <a class="dfnref" href="#dfn-interface">interface</a> will have a method with
               the given <a class="dfnref" href="#dfn-identifier">identifier</a>
               <pre class="syntax"><i>return-type</i> <i>identifier</i>(<i>arguments…</i>);</pre></li>
               <li><a class="dfnref" href="#dfn-special-operation">special operations</a>,
@@ -2148,7 +2148,7 @@ f(3);                           <span class="comment">// This also evaluates to 
 stringifier DOMString ();<!--
 omittable stringifier DOMString <i>identifier</i>();--></pre>
               <p>
-                If an operation used to declare a stringifier does not have an 
+                If an operation used to declare a stringifier does not have an
                 <a class="dfnref" href="#dfn-identifier">identifier</a>, then prose
                 accompanying the interface <span class="rfc2119">MUST</span> define
                 the <dfn id="dfn-stringification-behavior">stringification behavior</dfn>
@@ -2163,7 +2163,7 @@ omittable stringifier DOMString <i>identifier</i>();--></pre>
               <p>
                 As a shorthand, if the <code>stringifier</code> keyword
                 is declared using an operation with no identifier, then the
-                operation’s <a class="dfnref" href="#dfn-return-type">return type</a> and 
+                operation’s <a class="dfnref" href="#dfn-return-type">return type</a> and
                 argument list can be omitted.
               </p>
               <pre class="syntax">stringifier;</pre>
@@ -2940,7 +2940,7 @@ omittable deleter <i>type</i> <i>identifier</i>(DOMString <i>identifier</i>);-->
               to an instance of the interface.
             </p>
             <p>
-              Static attributes and operations <span class="rfc2119">MUST NOT</span> be 
+              Static attributes and operations <span class="rfc2119">MUST NOT</span> be
               declared on <a class="dfnref" href="#dfn-callback-interface">callback interfaces</a>.
             </p>
 
@@ -3054,7 +3054,7 @@ partial interface A {
               <a class="dfnref" href="#dfn-operation">operation</a>,
               constructor (specified with <a class="xattr" href="#Constructor">[Constructor]</a>
               or <a class="xattr" href="#NamedConstructor">[NamedConstructor]</a>),
-              <a class="dfnref" href="#dfn-legacy-caller">legacy caller</a> or 
+              <a class="dfnref" href="#dfn-legacy-caller">legacy caller</a> or
               <a class="dfnref" href="#dfn-callback-function">callback function</a>.
               The algorithm to compute an <a class="dfnref" href="#dfn-effective-overload-set">effective overload set</a>
               operates on one of the following six types of IDL constructs, and listed with them below are
@@ -3101,7 +3101,7 @@ partial interface A {
               </dd>
             </dl>
             <p>
-              An effective overload set is used, among other things, to determine whether there are ambiguities in the 
+              An effective overload set is used, among other things, to determine whether there are ambiguities in the
               overloaded operations, constructors and callers specified on an interface.
             </p>
             <p>
@@ -3625,7 +3625,7 @@ partial interface A {
             <!--
             <div class='note'>
               <p>
-                These restrictions on argument types reduce 
+                These restrictions on argument types reduce
                 the possibility of resolution ambiguity in
                 <a class='dfnref' href='#dfn-overloaded'>overloaded</a> operations
                 and constructors, but do not completely
@@ -3686,7 +3686,7 @@ interface C {
             </div>
             <pre class="syntax"><i>iterated-type</i> iterator;</pre>
             <p>
-              The type on the left of the <code>iterator</code> keyword is 
+              The type on the left of the <code>iterator</code> keyword is
               the <dfn id="dfn-iterated-type">iterated type</dfn>,
               which is the type of values the <a class="dfnref" href="#dfn-iterator">iterator</a> will return.
             </p>
@@ -3704,7 +3704,7 @@ interface C {
               <li>a current <dfn id="dfn-iterator-state">iterator state</dfn>,
               which at the time the iterator is first invoked is the
               <dfn id="dfn-uninitialized-iterator-state">uninitialized iterator state</dfn>
-              and in subsequent iterations is whatever value the 
+              and in subsequent iterations is whatever value the
               <a class="dfnref" href="#dfn-iterator-behavior">iterator behavior</a> defines
               it to be updated to, and</li>
               <li>the <dfn id="dfn-iterator-target-object">target object</dfn>, which is
@@ -3840,7 +3840,7 @@ for (let session of sm) {
             <p>
               Prose accompanying an <a class="dfnref" href="#dfn-iterator-object-interface">iterator object interface</a>
               <span class="rfc2119">MUST</span> define the <dfn id="dfn-iterator-object-behavior">iterator object behavior</dfn>,
-              which describes how to determine the next value to be iterated over using the 
+              which describes how to determine the next value to be iterated over using the
               <a class="dfnref" href="#dfn-iterator-object">iterator object</a> itself as the iterator’s state.
               As with <a class="dfnref" href="#dfn-iterator-behavior">iterator behavior</a>, the
               <a class="dfnref" href="#dfn-iterator-object-behavior">iterator object behavior</a> <span class="rfc2119">MUST</span>
@@ -4061,7 +4061,7 @@ for (let session of sm) {
           <p>
             Dictionaries are always passed by value.  In language bindings where a dictionary is represented by an object of some kind, passing a
             dictionary to a <a class="dfnref" href="#dfn-platform-object">platform object</a> will not result in a reference to the dictionary being kept by that object.
-            Similarly, any dictionary returned from a platform object will be a copy and modifications made to it will not be visible to the platform object. 
+            Similarly, any dictionary returned from a platform object will be a copy and modifications made to it will not be visible to the platform object.
           </p>
           <p>
             A dictionary can be defined to <dfn id="dfn-inherit-dictionary">inherit</dfn> from another dictionary.
@@ -4117,7 +4117,7 @@ dictionary <i>Derived</i> : <em>Base</em> {
             interface, <a class="dfnref" href="#dfn-enumeration">enumeration</a>,
             <a class="dfnref" href="#dfn-callback-function">callback function</a> or <a class="dfnref" href="#dfn-typedef">typedef</a>.
             If the dictionary member type is an identifier
-            not followed by <code>?</code>, then the identifier <span class="rfc2119">MUST</span>   
+            not followed by <code>?</code>, then the identifier <span class="rfc2119">MUST</span>
             identify any one of those definitions or a <a class="dfnref" href="#dfn-dictionary">dictionary</a>.
           </p>
           <pre class="syntax">dictionary <i>identifier</i> {
@@ -4247,7 +4247,7 @@ something.f(dict);</code></pre></div></div>
             <p>
               The order that the dictionary members are fetched in determines
               what values they will be taken to have.  Since the order for
-              <span class="idltype">A</span> is defined to be c then d, 
+              <span class="idltype">A</span> is defined to be c then d,
               the value for c will be 1 and the value for d will be 2.
             </p>
           </div>
@@ -4453,7 +4453,7 @@ exception <i>Derived</i> : <em>Base</em> {
             <a class="dfnref" href="#dfn-exception-field">fields</a>.
             If a name is not specified, it is assumed to be the same as the
             <a class="dfnref" href="#dfn-identifier">identifier</a> of the exception.
-            The resulting behavior from throwing an exception is language binding-specific.  
+            The resulting behavior from throwing an exception is language binding-specific.
           </p>
           <div class="note"><div class="noteHeader">Note</div>
             <p>
@@ -4511,7 +4511,7 @@ exception <i>Derived</i> : <em>Base</em> {
              <a class="sym" href="#prod-ExceptionField">ExceptionField</a></span></td></tr><tr id="proddef-ExceptionField"><td><span class="prod-number">[63]</span></td><td><a class="sym" href="#prod-ExceptionField">ExceptionField</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-Type">Type</a> <a class="sym" href="#prod-identifier">identifier</a> ";"</span></td></tr></table>
           <div class="example"><div class="exampleHeader">Example</div>
             <p>
-              The following example demonstrates how a reduced version of DOM Core’s 
+              The following example demonstrates how a reduced version of DOM Core’s
               <span class="idltype">DOMException</span> might be defined for three
               of the existing types of exception and one new one.  Specific types of DOMExceptions
               have historically been distinguished only by an integer code, but in this
@@ -6160,7 +6160,7 @@ interface Person {
              "byte" <br /> |
              "double" <br /> |
              "false" <br /> |
-             "float" 
+             "float"
             <br /> |
              "long" <br /> |
              "null" <br /> |
@@ -6404,7 +6404,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               There is one built-in ECMAScript function that behaves differently for
               platform objects with this custom Object.prototype.toString behavior
               compared to the built-in Object.prototype.toString: Function.prototype.bind
-              will return a new <span class="estype">Function</span> object with a 
+              will return a new <span class="estype">Function</span> object with a
               <span class="prop">length</span> property with a non-zero value if the
               object has a <a class="dfnref" href="#dfn-legacy-caller">legacy caller</a>
               that takes at least one argument.
@@ -7523,7 +7523,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 whose type is a <a class="dfnref" href="#dfn-nullable-type">nullable</a>
                 <a class="dfnref" href="#dfn-callback-function">callback function</a>
                 that is annotated with <a class="xattr" href="#TreatNonCallableAsNull">[TreatNonCallableAsNull]</a>,
-                then return the IDL 
+                then return the IDL
                 <a class="dfnref" href="#dfn-nullable-type">nullable type</a> <span class="idltype"><var>T</var>?</span>
                 value <span class="idlvalue">null</span>.
               </li>
@@ -7533,7 +7533,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 value <span class="idlvalue">null</span>.
               </li>
               <li>
-                Otherwise, return the result of 
+                Otherwise, return the result of
                 <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a> <var>V</var>
                 to the <a class="dfnref" href="#dfn-inner-type">inner IDL type</a> <span class="idltype"><var>T</var></span>.
               </li>
@@ -7992,7 +7992,7 @@ results.numbers;              <span class="comment">// This now evaluates to a p
 results.numbers == a;         <span class="comment">// Evaluates to false.</span>
 
 results.numbers.length;       <span class="comment">// Evaluates to 3.</span>
-                            
+
 results.numbers.push(7);      <span class="comment">// Silently ignored in non-strict mode.</span>
 results.numbers.length;       <span class="comment">// So this still evaluates to 3.</span></code></pre></div></div>
             </div>
@@ -8952,7 +8952,7 @@ var requestAnimationFrame = window.requestAnimationFrame ||
               <div class="block"><div class="blockTitleDiv"><span class="blockTitle">IDL</span></div><div class="blockContent"><pre class="code"><code class="idl-code">[Global]
 interface Window {
   getter any (DOMString name);
-  attribute DOMString name; 
+  attribute DOMString name;
   // ...
 };</code></pre></div></div>
               <p>
@@ -9009,7 +9009,7 @@ interface Window {
               <p>
                 Specifications <span class="rfc2119">SHOULD NOT</span> use <a href="#LenientThis" class="xattr">[LenientThis]</a>
                 unless required for compatibility reasons.  Specification authors who
-                wish to use this feature are strongly advised to discuss this on the 
+                wish to use this feature are strongly advised to discuss this on the
                 <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
                 mailing list before proceeding.
               </p>
@@ -9064,7 +9064,7 @@ Example.prototype.y;</code></pre></div></div>
               modifiable key–value pairs, where keys are unique.
             </p>
             <p>
-              Any object that implements an interface declared with the 
+              Any object that implements an interface declared with the
               <a class="xattr" href="#MapClass">[MapClass]</a> extended attribute
               <span class="rfc2119">MUST</span> define what the list of
               <dfn id="dfn-map-entries">map entries</dfn> for the object are
@@ -9312,7 +9312,7 @@ var a2 = new Audio('a.flac');   <span class="comment">// Creates an HTMLAudioEle
                 <span class="rfc2119">SHOULD NOT</span> be used on interfaces that are not
                 solely used as <a class="dfnref" href="#dfn-supplemental-interface">supplemental</a> interfaces,
                 unless there are clear Web compatibility reasons for doing so.  Specification authors who
-                wish to use this feature are strongly advised to discuss this on the 
+                wish to use this feature are strongly advised to discuss this on the
                 <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
                 mailing list before proceeding.
               </p>
@@ -9441,7 +9441,7 @@ interface StringMap2 {
               </p>
               <div class="block"><div class="blockTitleDiv"><span class="blockTitle">ECMAScript</span></div><div class="blockContent"><pre class="code"><code class="es-code"><span class="comment">// Obtain an instance of StringMap.  Assume that it has "abc", "length" and</span>
 <span class="comment">// "toString" as supported property names.</span>
-var map1 = getStringMap();  
+var map1 = getStringMap();
 
 <span class="comment">// This invokes the named property getter.</span>
 map1.abc;
@@ -9456,7 +9456,7 @@ map1.toString;
 
 <span class="comment">// Obtain an instance of StringMap2.  Assume that it also has "abc", "length"</span>
 <span class="comment">// and "toString" as supported property names.</span>
-var map2 = getStringMap2();  
+var map2 = getStringMap2();
 
 <span class="comment">// This invokes the named property getter.</span>
 map2.abc;
@@ -9805,7 +9805,7 @@ counter.value;                                           <span class="comment">/
                 Specifications <span class="rfc2119">SHOULD NOT</span> use <a href="#TreatNonCallableAsNull" class="xattr">[TreatNonCallableAsNull]</a>
                 unless required to specify the behavior of legacy APIs or for consistency with these
                 APIs.  Specification authors who
-                wish to use this feature are strongly advised to discuss this on the 
+                wish to use this feature are strongly advised to discuss this on the
                 <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
                 mailing list before proceeding.  At the time of writing, the only known
                 valid use of <a href="#TreatNonCallableAsNull" class="xattr">[TreatNonCallableAsNull]</a>
@@ -10169,7 +10169,7 @@ interface B5 : A3 {
               </p>
               <div class="block"><div class="blockTitleDiv"><span class="blockTitle">IDL</span></div><div class="blockContent"><pre class="code"><code class="idl-code">interface System {
   [Unforgeable] readonly attribute DOMString username;
-  readonly attribute Date loginTime; 
+  readonly attribute Date loginTime;
 };</code></pre></div></div>
               <p>
                 In an ECMAScript implementation of the interface, the username attribute will be exposed as a non-configurable property on the
@@ -10244,7 +10244,7 @@ system.loginTime;  <span class="comment">// So this now evaluates to forgedLogin
             The characteristics of an interface object are described in <a href="#interface-object">section 4.5.1</a>
             below.
           </p>
-          
+
           <p>
             In addition, for every <a class="xattr" href="#NamedConstructor">[NamedConstructor]</a>
             extended attribute on an interface, a corresponding property <span class="rfc2119">MUST</span>
@@ -10534,7 +10534,7 @@ system.loginTime;  <span class="comment">// So this now evaluates to forgedLogin
                     </li>
 
                     <li>
-                      Otherwise: 
+                      Otherwise:
                       <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.
                     </li>
                   </ol>
@@ -11163,7 +11163,7 @@ interface LivingHuman {
   unsigned short age;
 };
 
-interface 
+interface
             </div>
           </div>
           -->
@@ -11812,7 +11812,7 @@ interface
                 The state of a <a class="dfnref" href="#dfn-default-iterator-object">default iterator object</a>
                 can be <a class="dfnref" href="#dfn-uninitialized-iterator-state">uninitialized</a>,
                 or it can be any value that the <a class="dfnref" href="#dfn-iterator-behavior">iterator behavior</a>
-                of the <a class="dfnref" href="#dfn-interface">interface</a> specifies, 
+                of the <a class="dfnref" href="#dfn-interface">interface</a> specifies,
                 or it can be the special value <strong>finished</strong>.  When a
                 <a class="dfnref" href="#dfn-default-iterator-object">default iterator object</a> is first created,
                 its state begins <a class="dfnref" href="#dfn-uninitialized-iterator-state">uninitialized</a>.
@@ -12334,7 +12334,7 @@ C implements A;</code></pre></div></div>
           </p>
           <p>
             The global environment that a given <a class="dfnref" href="#dfn-platform-object">platform object</a>
-            is associated with can <dfn id="dfn-change-global-environment">change</dfn> after it has been created.  When 
+            is associated with can <dfn id="dfn-change-global-environment">change</dfn> after it has been created.  When
             the global environment associated with a platform object is changed, its internal
             <span class="prop">[[Prototype]]</span> property <span class="rfc2119">MUST</span> be immediately
             updated to be the <a class="dfnref" href="#dfn-interface-prototype-object">interface prototype object</a>
@@ -12503,7 +12503,7 @@ C implements A;</code></pre></div></div>
           </ul>
 
           <p>
-            The <a class="dfnref" href="#dfn-class-string">class string</a> of 
+            The <a class="dfnref" href="#dfn-class-string">class string</a> of
             a platform object that implements one or more interfaces
             <span class="rfc2119">MUST</span> be the <a class="dfnref" href="#dfn-identifier">identifier</a> of
             the <a class="dfnref" href="#dfn-primary-interface">primary interface</a>
@@ -12588,7 +12588,7 @@ C implements A;</code></pre></div></div>
             -->
             <p>
               A property name is an <dfn id="dfn-unforgeable-property-name">unforgeable property name</dfn> on a
-              given platform object if the object implements an <a class="dfnref" href="#dfn-interface">interface</a> that 
+              given platform object if the object implements an <a class="dfnref" href="#dfn-interface">interface</a> that
               has an <a class="dfnref" href="#dfn-interface-member">interface member</a> with that identifier
               and that interface member is <a class="dfnref" href="#dfn-unforgeable-on-an-interface">unforgeable</a> on any of
               the interfaces that <var>O</var> implements.  If the object implements an
@@ -13215,7 +13215,7 @@ C implements A;</code></pre></div></div>
             For every <a class="dfnref" href="#dfn-exception">exception</a> that is not declared with the
             <a class="xattr" href="#NoInterfaceObject">[NoInterfaceObject]</a>
             <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>,
-            a corresponding property <span class="rfc2119">MUST</span> exist on the 
+            a corresponding property <span class="rfc2119">MUST</span> exist on the
             ECMAScript global object.
             The name of the property is the <a class="dfnref" href="#dfn-identifier">identifier</a> of the exception,
             and its value is an object called the
@@ -13297,7 +13297,7 @@ C implements A;</code></pre></div></div>
               properties that correspond to the <a class="dfnref" href="#dfn-constant">constants</a>
               and <a class="dfnref" href="#dfn-exception-field">exception fields</a>
               defined on the exception.  These properties are described in more detail in
-              sections <a href="#es-exception-constants">4.10.3</a> 
+              sections <a href="#es-exception-constants">4.10.3</a>
               and <a href="#es-exception-fields">4.10.4</a>,
               below.
             </p>
@@ -14076,7 +14076,7 @@ d.type = et;
              "byte" <br /> |
              "double" <br /> |
              "false" <br /> |
-             "float" 
+             "float"
             <br /> |
              "long" <br /> |
              "null" <br /> |

--- a/index.xml
+++ b/index.xml
@@ -93,7 +93,7 @@
           * Parameterized interface types, for BlahLists
             http://www.w3.org/mid/op.vr2r6waf64w2qv@anne-van-kesterens-macbook-pro.local
         -->
-<!--          
+<!--
       <?revision-note http://www.w3.org/Bugs/Public/buglist.cgi?query_format=advanced&amp;short_desc_type=allwordssubstr&amp;short_desc=&amp;product=WebAppsWG&amp;component=WebIDL&amp;longdesc_type=allwordssubstr&amp;longdesc=&amp;bug_file_loc_type=allwordssubstr&amp;bug_file_loc=&amp;status_whiteboard_type=allwordssubstr&amp;status_whiteboard=&amp;keywords_type=allwords&amp;keywords=&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;emailtype1=substring&amp;email1=&amp;emailtype2=substring&amp;email2=&amp;bug_id_type=anyexact&amp;bug_id=&amp;votes=&amp;chfieldfrom=&amp;chfieldto=Now&amp;chfieldvalue=&amp;cmdtype=doit&amp;order=Importance&amp;field0-0-0=noop&amp;type0-0-0=noop&amp;value0-0-0=?>
 -->
 
@@ -494,11 +494,11 @@ dictionary <i>identifier</i> {
           <?productions grammar ArgumentNameKeyword?>
           <p>
             If an <a class='sym' href='#prod-identifier'>identifier</a> token is used, then the
-            <a class='dfnref' href='#dfn-identifier'>identifier</a> of the operation argument 
-            is the value of that token with any leading 
+            <a class='dfnref' href='#dfn-identifier'>identifier</a> of the operation argument
+            is the value of that token with any leading
             <span class='char'>U+005F LOW LINE ("_")</span> character (underscore) removed.
             If instead one of the <a class='sym' href='#prod-ArgumentNameKeyword'>ArgumentNameKeyword</a>
-            keyword token is used, then the <a class='dfnref' href='#dfn-identifier'>identifier</a> of the operation argument 
+            keyword token is used, then the <a class='dfnref' href='#dfn-identifier'>identifier</a> of the operation argument
             is simply that token.
           </p>
           <p>
@@ -794,8 +794,7 @@ public interface B extends A {
             <span class='rfc2119'>MUST NOT</span> <a class='dfnref' href='#dfn-inherit'>inherit</a>
             from any non-callback interfaces, and non-callback interfaces <span class='rfc2119'>MUST NOT</span>
             inherit from any callback interfaces.
-            Callback interfaces <span class='rfc2119'>MUST NOT</span> have any
-            have any <a class='dfnref' href='#dfn-consequential-interfaces'>consequential interfaces</a>.
+            Callback interfaces <span class='rfc2119'>MUST NOT</span> have any <a class='dfnref' href='#dfn-consequential-interfaces'>consequential interfaces</a>.
           </p>
           <p>
             <a class='dfnref' href='#dfn-static-attribute'>Static attributes</a> and
@@ -808,7 +807,7 @@ public interface B extends A {
               <a class='dfnref' href='#dfn-callback-interface'>callback interfaces</a>
               that have only a single <a class='dfnref' href='#dfn-operation'>operation</a>,
               unless required to describe the requirements of existing APIs.
-              Instead, a <a class='dfnref' href='#dfn-callback-function'>callback function</a> <span class='rfc2119'>SHOULD</span> used.
+              Instead, a <a class='dfnref' href='#dfn-callback-function'>callback function</a> <span class='rfc2119'>SHOULD</span> be used.
             </p>
             <p>
               The definition of <span class='idltype'>EventListener</span> as a
@@ -1219,7 +1218,7 @@ node.appendChild(newNode);  <span class='comment'>// This will throw a TypeError
               If <var>VT</var> is the type of the value assigned to a constant, and <var>DT</var>
               is the type of the constant, dictionary member or optional argument itself, then these types <span class='rfc2119'>MUST</span>
               be compatible, which is the case if <var>DT</var> and <var>VT</var> are identical,
-              or <var>DT</var> is a <a class='dfnref' href='#dfn-nullable-type'>nullable type</a> 
+              or <var>DT</var> is a <a class='dfnref' href='#dfn-nullable-type'>nullable type</a>
               whose <a class='dfnref' href='#dfn-inner-type'>inner type</a> is <var>VT</var>.
             </p>
             <p>
@@ -1368,7 +1367,7 @@ interface <i>Derived</i> : <i>Ancestor</i> {
               <a class='sym' href='#prod-SetRaises'>SetRaises</a> clauses are used
               to declare the possible exceptions that can be thrown when retrieving
               the value of and assigning a value to the attribute, respectively.
-              Each scoped name in the 
+              Each scoped name in the
               <a class='sym' href='#prod-GetRaises'>GetRaises</a> and
               <a class='sym' href='#prod-SetRaises'>SetRaises</a> clauses
               <span class='rfc2119'>MUST</span> resolve to an <a class='dfnref' href='#dfn-exception'>exception</a>.
@@ -1475,7 +1474,7 @@ interface Person : Animal {
             <ol>
               <li><a class='dfnref' href='#dfn-regular-operation'>regular operations</a>, which
               are those used to declare that objects implementing the
-              <a class='dfnref' href='#dfn-interface'>interface</a> will have a method with 
+              <a class='dfnref' href='#dfn-interface'>interface</a> will have a method with
               the given <a class='dfnref' href='#dfn-identifier'>identifier</a>
               <pre class='syntax'><i>return-type</i> <i>identifier</i>(<i>arguments…</i>);</pre></li>
               <li><a class='dfnref' href='#dfn-special-operation'>special operations</a>,
@@ -2062,7 +2061,7 @@ f(3);                           <span class='comment'>// This also evaluates to 
 stringifier DOMString ();<!--
 omittable stringifier DOMString <i>identifier</i>();--></pre>
               <p>
-                If an operation used to declare a stringifier does not have an 
+                If an operation used to declare a stringifier does not have an
                 <a class='dfnref' href='#dfn-identifier'>identifier</a>, then prose
                 accompanying the interface <span class='rfc2119'>MUST</span> define
                 the <dfn id='dfn-stringification-behavior'>stringification behavior</dfn>
@@ -2077,7 +2076,7 @@ omittable stringifier DOMString <i>identifier</i>();--></pre>
               <p>
                 As a shorthand, if the <code>stringifier</code> keyword
                 is declared using an operation with no identifier, then the
-                operation’s <a class='dfnref' href='#dfn-return-type'>return type</a> and 
+                operation’s <a class='dfnref' href='#dfn-return-type'>return type</a> and
                 argument list can be omitted.
               </p>
               <pre class='syntax'>stringifier;</pre>
@@ -2842,7 +2841,7 @@ omittable deleter <i>type</i> <i>identifier</i>(DOMString <i>identifier</i>);-->
               to an instance of the interface.
             </p>
             <p>
-              Static attributes and operations <span class='rfc2119'>MUST NOT</span> be 
+              Static attributes and operations <span class='rfc2119'>MUST NOT</span> be
               declared on <a class='dfnref' href='#dfn-callback-interface'>callback interfaces</a>.
             </p>
 
@@ -2955,7 +2954,7 @@ partial interface A {
               <a class='dfnref' href='#dfn-operation'>operation</a>,
               constructor (specified with <a class='xattr' href='#Constructor'>[Constructor]</a>
               or <a class='xattr' href='#NamedConstructor'>[NamedConstructor]</a>),
-              <a class='dfnref' href='#dfn-legacy-caller'>legacy caller</a> or 
+              <a class='dfnref' href='#dfn-legacy-caller'>legacy caller</a> or
               <a class='dfnref' href='#dfn-callback-function'>callback function</a>.
               The algorithm to compute an <a class='dfnref' href='#dfn-effective-overload-set'>effective overload set</a>
               operates on one of the following six types of IDL constructs, and listed with them below are
@@ -3002,7 +3001,7 @@ partial interface A {
               </dd>
             </dl>
             <p>
-              An effective overload set is used, among other things, to determine whether there are ambiguities in the 
+              An effective overload set is used, among other things, to determine whether there are ambiguities in the
               overloaded operations, constructors and callers specified on an interface.
             </p>
             <p>
@@ -3526,7 +3525,7 @@ partial interface A {
             <!--
             <div class='note'>
               <p>
-                These restrictions on argument types reduce 
+                These restrictions on argument types reduce
                 the possibility of resolution ambiguity in
                 <a class='dfnref' href='#dfn-overloaded'>overloaded</a> operations
                 and constructors, but do not completely
@@ -3587,7 +3586,7 @@ interface C {
             </div>
             <pre class='syntax'><i>iterated-type</i> iterator;</pre>
             <p>
-              The type on the left of the <code>iterator</code> keyword is 
+              The type on the left of the <code>iterator</code> keyword is
               the <dfn id='dfn-iterated-type'>iterated type</dfn>,
               which is the type of values the <a class='dfnref' href='#dfn-iterator'>iterator</a> will return.
             </p>
@@ -3605,7 +3604,7 @@ interface C {
               <li>a current <dfn id='dfn-iterator-state'>iterator state</dfn>,
               which at the time the iterator is first invoked is the
               <dfn id='dfn-uninitialized-iterator-state'>uninitialized iterator state</dfn>
-              and in subsequent iterations is whatever value the 
+              and in subsequent iterations is whatever value the
               <a class='dfnref' href='#dfn-iterator-behavior'>iterator behavior</a> defines
               it to be updated to, and</li>
               <li>the <dfn id='dfn-iterator-target-object'>target object</dfn>, which is
@@ -3741,7 +3740,7 @@ for (let session of sm) {
             <p>
               Prose accompanying an <a class='dfnref' href='#dfn-iterator-object-interface'>iterator object interface</a>
               <span class='rfc2119'>MUST</span> define the <dfn id='dfn-iterator-object-behavior'>iterator object behavior</dfn>,
-              which describes how to determine the next value to be iterated over using the 
+              which describes how to determine the next value to be iterated over using the
               <a class='dfnref' href='#dfn-iterator-object'>iterator object</a> itself as the iterator’s state.
               As with <a class='dfnref' href='#dfn-iterator-behavior'>iterator behavior</a>, the
               <a class='dfnref' href='#dfn-iterator-object-behavior'>iterator object behavior</a> <span class='rfc2119'>MUST</span>
@@ -3958,7 +3957,7 @@ for (let session of sm) {
           <p>
             Dictionaries are always passed by value.  In language bindings where a dictionary is represented by an object of some kind, passing a
             dictionary to a <a class='dfnref' href='#dfn-platform-object'>platform object</a> will not result in a reference to the dictionary being kept by that object.
-            Similarly, any dictionary returned from a platform object will be a copy and modifications made to it will not be visible to the platform object. 
+            Similarly, any dictionary returned from a platform object will be a copy and modifications made to it will not be visible to the platform object.
           </p>
           <p>
             A dictionary can be defined to <dfn id='dfn-inherit-dictionary'>inherit</dfn> from another dictionary.
@@ -4014,7 +4013,7 @@ dictionary <i>Derived</i> : <em>Base</em> {
             interface, <a class='dfnref' href='#dfn-enumeration'>enumeration</a>,
             <a class='dfnref' href='#dfn-callback-function'>callback function</a> or <a class='dfnref' href='#dfn-typedef'>typedef</a>.
             If the dictionary member type is an identifier
-            not followed by <code>?</code>, then the identifier <span class='rfc2119'>MUST</span>   
+            not followed by <code>?</code>, then the identifier <span class='rfc2119'>MUST</span>
             identify any one of those definitions or a <a class='dfnref' href='#dfn-dictionary'>dictionary</a>.
           </p>
           <pre class='syntax'>dictionary <i>identifier</i> {
@@ -4144,7 +4143,7 @@ something.f(dict);</x:codeblock>
             <p>
               The order that the dictionary members are fetched in determines
               what values they will be taken to have.  Since the order for
-              <span class='idltype'>A</span> is defined to be c then d, 
+              <span class='idltype'>A</span> is defined to be c then d,
               the value for c will be 1 and the value for d will be 2.
             </p>
           </div>
@@ -4345,7 +4344,7 @@ exception <i>Derived</i> : <em>Base</em> {
             <a class='dfnref' href='#dfn-exception-field'>fields</a>.
             If a name is not specified, it is assumed to be the same as the
             <a class='dfnref' href='#dfn-identifier'>identifier</a> of the exception.
-            The resulting behavior from throwing an exception is language binding-specific.  
+            The resulting behavior from throwing an exception is language binding-specific.
           </p>
           <div class='note'>
             <p>
@@ -4400,7 +4399,7 @@ exception <i>Derived</i> : <em>Base</em> {
           <?productions grammar Exception Inheritance ExceptionMembers ExceptionMember ExceptionField?>
           <div class='example'>
             <p>
-              The following example demonstrates how a reduced version of DOM Core’s 
+              The following example demonstrates how a reduced version of DOM Core’s
               <span class='idltype'>DOMException</span> might be defined for three
               of the existing types of exception and one new one.  Specific types of DOMExceptions
               have historically been distinguished only by an integer code, but in this
@@ -6186,7 +6185,7 @@ iframe.appendChild instanceof w.Function;  <span class='comment'>// Evaluates to
               There is one built-in ECMAScript function that behaves differently for
               platform objects with this custom Object.prototype.toString behavior
               compared to the built-in Object.prototype.toString: Function.prototype.bind
-              will return a new <span class='estype'>Function</span> object with a 
+              will return a new <span class='estype'>Function</span> object with a
               <span class='prop'>length</span> property with a non-zero value if the
               object has a <a class='dfnref' href='#dfn-legacy-caller'>legacy caller</a>
               that takes at least one argument.
@@ -7305,7 +7304,7 @@ iframe.appendChild instanceof w.Function;  <span class='comment'>// Evaluates to
                 whose type is a <a class='dfnref' href='#dfn-nullable-type'>nullable</a>
                 <a class='dfnref' href='#dfn-callback-function'>callback function</a>
                 that is annotated with <a class='xattr' href='#TreatNonCallableAsNull'>[TreatNonCallableAsNull]</a>,
-                then return the IDL 
+                then return the IDL
                 <a class='dfnref' href='#dfn-nullable-type'>nullable type</a> <span class='idltype'><var>T</var>?</span>
                 value <span class='idlvalue'>null</span>.
               </li>
@@ -7315,7 +7314,7 @@ iframe.appendChild instanceof w.Function;  <span class='comment'>// Evaluates to
                 value <span class='idlvalue'>null</span>.
               </li>
               <li>
-                Otherwise, return the result of 
+                Otherwise, return the result of
                 <a class='dfnref' href='#dfn-convert-ecmascript-to-idl-value'>converting</a> <var>V</var>
                 to the <a class='dfnref' href='#dfn-inner-type'>inner IDL type</a> <span class='idltype'><var>T</var></span>.
               </li>
@@ -7774,7 +7773,7 @@ results.numbers;              <span class='comment'>// This now evaluates to a p
 results.numbers == a;         <span class='comment'>// Evaluates to false.</span>
 
 results.numbers.length;       <span class='comment'>// Evaluates to 3.</span>
-                            
+
 results.numbers.push(7);      <span class='comment'>// Silently ignored in non-strict mode.</span>
 results.numbers.length;       <span class='comment'>// So this still evaluates to 3.</span></x:codeblock>
             </div>
@@ -8734,7 +8733,7 @@ var requestAnimationFrame = window.requestAnimationFrame ||
               <x:codeblock language='idl'>[Global]
 interface Window {
   getter any (DOMString name);
-  attribute DOMString name; 
+  attribute DOMString name;
   // ...
 };</x:codeblock>
               <p>
@@ -8791,7 +8790,7 @@ interface Window {
               <p>
                 Specifications <span class='rfc2119'>SHOULD NOT</span> use <a href='#LenientThis' class='xattr'>[LenientThis]</a>
                 unless required for compatibility reasons.  Specification authors who
-                wish to use this feature are strongly advised to discuss this on the 
+                wish to use this feature are strongly advised to discuss this on the
                 <a href='mailto:public-script-coord@w3.org'>public-script-coord@w3.org</a>
                 mailing list before proceeding.
               </p>
@@ -8846,7 +8845,7 @@ Example.prototype.y;</x:codeblock>
               modifiable key–value pairs, where keys are unique.
             </p>
             <p>
-              Any object that implements an interface declared with the 
+              Any object that implements an interface declared with the
               <a class='xattr' href='#MapClass'>[MapClass]</a> extended attribute
               <span class='rfc2119'>MUST</span> define what the list of
               <dfn id='dfn-map-entries'>map entries</dfn> for the object are
@@ -9094,7 +9093,7 @@ var a2 = new Audio('a.flac');   <span class='comment'>// Creates an HTMLAudioEle
                 <span class='rfc2119'>SHOULD NOT</span> be used on interfaces that are not
                 solely used as <a class='dfnref' href='#dfn-supplemental-interface'>supplemental</a> interfaces,
                 unless there are clear Web compatibility reasons for doing so.  Specification authors who
-                wish to use this feature are strongly advised to discuss this on the 
+                wish to use this feature are strongly advised to discuss this on the
                 <a href='mailto:public-script-coord@w3.org'>public-script-coord@w3.org</a>
                 mailing list before proceeding.
               </p>
@@ -9223,7 +9222,7 @@ interface StringMap2 {
               </p>
               <x:codeblock language='es'><span class='comment'>// Obtain an instance of StringMap.  Assume that it has "abc", "length" and</span>
 <span class='comment'>// "toString" as supported property names.</span>
-var map1 = getStringMap();  
+var map1 = getStringMap();
 
 <span class='comment'>// This invokes the named property getter.</span>
 map1.abc;
@@ -9238,7 +9237,7 @@ map1.toString;
 
 <span class='comment'>// Obtain an instance of StringMap2.  Assume that it also has "abc", "length"</span>
 <span class='comment'>// and "toString" as supported property names.</span>
-var map2 = getStringMap2();  
+var map2 = getStringMap2();
 
 <span class='comment'>// This invokes the named property getter.</span>
 map2.abc;
@@ -9587,7 +9586,7 @@ counter.value;                                           <span class='comment'>/
                 Specifications <span class='rfc2119'>SHOULD NOT</span> use <a href='#TreatNonCallableAsNull' class='xattr'>[TreatNonCallableAsNull]</a>
                 unless required to specify the behavior of legacy APIs or for consistency with these
                 APIs.  Specification authors who
-                wish to use this feature are strongly advised to discuss this on the 
+                wish to use this feature are strongly advised to discuss this on the
                 <a href='mailto:public-script-coord@w3.org'>public-script-coord@w3.org</a>
                 mailing list before proceeding.  At the time of writing, the only known
                 valid use of <a href='#TreatNonCallableAsNull' class='xattr'>[TreatNonCallableAsNull]</a>
@@ -9951,7 +9950,7 @@ interface B5 : A3 {
               </p>
               <x:codeblock language='idl'>interface System {
   [Unforgeable] readonly attribute DOMString username;
-  readonly attribute Date loginTime; 
+  readonly attribute Date loginTime;
 };</x:codeblock>
               <p>
                 In an ECMAScript implementation of the interface, the username attribute will be exposed as a non-configurable property on the
@@ -10026,7 +10025,7 @@ system.loginTime;  <span class='comment'>// So this now evaluates to forgedLogin
             The characteristics of an interface object are described in <a href='#interface-object'>section <?sref interface-object?></a>
             <?sdir interface-object?>.
           </p>
-          
+
           <p>
             In addition, for every <a class='xattr' href='#NamedConstructor'>[NamedConstructor]</a>
             extended attribute on an interface, a corresponding property <span class='rfc2119'>MUST</span>
@@ -10316,7 +10315,7 @@ system.loginTime;  <span class='comment'>// So this now evaluates to forgedLogin
                     </li>
 
                     <li>
-                      Otherwise: 
+                      Otherwise:
                       <a href='#ecmascript-throw' class='dfnref external'>throw a <span class='estype'>TypeError</span></a>.
                     </li>
                   </ol>
@@ -10945,7 +10944,7 @@ interface LivingHuman {
   unsigned short age;
 };
 
-interface 
+interface
             </div>
           </div>
           -->
@@ -11594,7 +11593,7 @@ interface
                 The state of a <a class='dfnref' href='#dfn-default-iterator-object'>default iterator object</a>
                 can be <a class='dfnref' href='#dfn-uninitialized-iterator-state'>uninitialized</a>,
                 or it can be any value that the <a class='dfnref' href='#dfn-iterator-behavior'>iterator behavior</a>
-                of the <a class='dfnref' href='#dfn-interface'>interface</a> specifies, 
+                of the <a class='dfnref' href='#dfn-interface'>interface</a> specifies,
                 or it can be the special value <strong>finished</strong>.  When a
                 <a class='dfnref' href='#dfn-default-iterator-object'>default iterator object</a> is first created,
                 its state begins <a class='dfnref' href='#dfn-uninitialized-iterator-state'>uninitialized</a>.
@@ -12116,7 +12115,7 @@ C implements A;</x:codeblock>
           </p>
           <p>
             The global environment that a given <a class='dfnref' href='#dfn-platform-object'>platform object</a>
-            is associated with can <dfn id="dfn-change-global-environment">change</dfn> after it has been created.  When 
+            is associated with can <dfn id="dfn-change-global-environment">change</dfn> after it has been created.  When
             the global environment associated with a platform object is changed, its internal
             <span class='prop'>[[Prototype]]</span> property <span class='rfc2119'>MUST</span> be immediately
             updated to be the <a class='dfnref' href='#dfn-interface-prototype-object'>interface prototype object</a>
@@ -12285,7 +12284,7 @@ C implements A;</x:codeblock>
           </ul>
 
           <p>
-            The <a class='dfnref' href='#dfn-class-string'>class string</a> of 
+            The <a class='dfnref' href='#dfn-class-string'>class string</a> of
             a platform object that implements one or more interfaces
             <span class='rfc2119'>MUST</span> be the <a class='dfnref' href='#dfn-identifier'>identifier</a> of
             the <a class='dfnref' href='#dfn-primary-interface'>primary interface</a>
@@ -12370,7 +12369,7 @@ C implements A;</x:codeblock>
             -->
             <p>
               A property name is an <dfn id='dfn-unforgeable-property-name'>unforgeable property name</dfn> on a
-              given platform object if the object implements an <a class='dfnref' href='#dfn-interface'>interface</a> that 
+              given platform object if the object implements an <a class='dfnref' href='#dfn-interface'>interface</a> that
               has an <a class='dfnref' href='#dfn-interface-member'>interface member</a> with that identifier
               and that interface member is <a class='dfnref' href='#dfn-unforgeable-on-an-interface'>unforgeable</a> on any of
               the interfaces that <var>O</var> implements.  If the object implements an
@@ -12997,7 +12996,7 @@ C implements A;</x:codeblock>
             For every <a class='dfnref' href='#dfn-exception'>exception</a> that is not declared with the
             <a class='xattr' href='#NoInterfaceObject'>[NoInterfaceObject]</a>
             <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a>,
-            a corresponding property <span class='rfc2119'>MUST</span> exist on the 
+            a corresponding property <span class='rfc2119'>MUST</span> exist on the
             ECMAScript global object.
             The name of the property is the <a class='dfnref' href='#dfn-identifier'>identifier</a> of the exception,
             and its value is an object called the
@@ -13079,7 +13078,7 @@ C implements A;</x:codeblock>
               properties that correspond to the <a class='dfnref' href='#dfn-constant'>constants</a>
               and <a class='dfnref' href='#dfn-exception-field'>exception fields</a>
               defined on the exception.  These properties are described in more detail in
-              sections <a href='#es-exception-constants'><?sref es-exception-constants?></a> 
+              sections <a href='#es-exception-constants'><?sref es-exception-constants?></a>
               and <a href='#es-exception-fields'><?sref es-exception-fields?></a>,
               <?sdir es-exception-fields?>.
             </p>
@@ -13845,7 +13844,7 @@ d.type = et;
           <prod nt='Other'>
               integer | float | identifier | string <!--| whitespace--> | other
             | "-" | "-Infinity" | "." | "..." | ":" | ";" | "&lt;" | "=" | ">" | "?"
-            | "ByteString" | "Date" | "DOMString" | "Infinity" | "NaN" | "RegExp" | "any" | "boolean" | "byte" | "double" | "false" | "float" 
+            | "ByteString" | "Date" | "DOMString" | "Infinity" | "NaN" | "RegExp" | "any" | "boolean" | "byte" | "double" | "false" | "float"
             | "long" | "null" | "object" | "octet" | "or" | "optional" | "sequence"
             | "short" | "true" | "unsigned" | "void"
             | ArgumentNameKeyword


### PR DESCRIPTION
s/have any have any/have any/
s/SHOULD used/SHOULD be used/

As I don't know the details of the editorial tool used here, I directly changed index.html and index.xml. I just wanted you to be informed the parts need the correction.
