### PR TITLE
Correct typos in 3.2 Interfaces section; remove trailing whitespace

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -795,7 +795,7 @@ public interface B extends A {
             from any non-callback interfaces, and non-callback interfaces <span class='rfc2119'>MUST NOT</span>
             inherit from any callback interfaces.
             Callback interfaces <span class='rfc2119'>MUST NOT</span> have any
-            have any <a class='dfnref' href='#dfn-consequential-interfaces'>consequential interfaces</a>.
+            <a class='dfnref' href='#dfn-consequential-interfaces'>consequential interfaces</a>.
           </p>
           <p>
             <a class='dfnref' href='#dfn-static-attribute'>Static attributes</a> and
@@ -808,7 +808,7 @@ public interface B extends A {
               <a class='dfnref' href='#dfn-callback-interface'>callback interfaces</a>
               that have only a single <a class='dfnref' href='#dfn-operation'>operation</a>,
               unless required to describe the requirements of existing APIs.
-              Instead, a <a class='dfnref' href='#dfn-callback-function'>callback function</a> <span class='rfc2119'>SHOULD</span> used.
+              Instead, a <a class='dfnref' href='#dfn-callback-function'>callback function</a> <span class='rfc2119'>SHOULD</span> be used.
             </p>
             <p>
               The definition of <span class='idltype'>EventListener</span> as a

--- a/v1.xml
+++ b/v1.xml
@@ -816,7 +816,7 @@ public interface B extends A {
             from any non-callback interfaces, and non-callback interfaces <span class='rfc2119'>MUST NOT</span>
             inherit from any callback interfaces.
             Callback interfaces <span class='rfc2119'>MUST NOT</span> have any
-            have any <a class='dfnref' href='#dfn-consequential-interfaces'>consequential interfaces</a>.
+            <a class='dfnref' href='#dfn-consequential-interfaces'>consequential interfaces</a>.
           </p>
           <p>
             <a class='dfnref' href='#dfn-static-attribute'>Static attributes</a> <span class='rfc2119'>MUST NOT</span>
@@ -828,7 +828,7 @@ public interface B extends A {
               <a class='dfnref' href='#dfn-callback-interface'>callback interfaces</a>
               that have only a single <a class='dfnref' href='#dfn-operation'>operation</a>,
               unless required to describe the requirements of existing APIs.
-              Instead, a <a class='dfnref' href='#dfn-callback-function'>callback function</a> <span class='rfc2119'>SHOULD</span> used.
+              Instead, a <a class='dfnref' href='#dfn-callback-function'>callback function</a> <span class='rfc2119'>SHOULD</span> be used.
             </p>
             <p>
               The definition of <span class='idltype'>EventListener</span> as a


### PR DESCRIPTION
Addressed your comments!
