### PR TITLE
Rename [TreatNonCallableAsNull] to [TreatNonObjectAsNull] and change its semantics to allow setting non-callable objects but no-op the call to them.

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
           * Parameterized interface types, for BlahLists
             http://www.w3.org/mid/op.vr2r6waf64w2qv@anne-van-kesterens-macbook-pro.local
         -->
-<!--          
+<!--
       <?revision-note http://www.w3.org/Bugs/Public/buglist.cgi?query_format=advanced&amp;short_desc_type=allwordssubstr&amp;short_desc=&amp;product=WebAppsWG&amp;component=WebIDL&amp;longdesc_type=allwordssubstr&amp;longdesc=&amp;bug_file_loc_type=allwordssubstr&amp;bug_file_loc=&amp;status_whiteboard_type=allwordssubstr&amp;status_whiteboard=&amp;keywords_type=allwords&amp;keywords=&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;emailtype1=substring&amp;email1=&amp;emailtype2=substring&amp;email2=&amp;bug_id_type=anyexact&amp;bug_id=&amp;votes=&amp;chfieldfrom=&amp;chfieldto=Now&amp;chfieldvalue=&amp;cmdtype=doit&amp;order=Importance&amp;field0-0-0=noop&amp;type0-0-0=noop&amp;value0-0-0=?>
 -->
 
@@ -124,7 +124,7 @@
 
     <div id="toc">
       <h2>Table of Contents</h2>
-      <div class="toc"><ul><li><a href="#introduction">1. Introduction</a><ul><li><a href="#conventions">1.1. Typographic conventions</a></li></ul></li><li><a href="#conformance">2. Conformance</a></li><li><a href="#idl">3. Interface definition language</a><ul><li><a href="#idl-names">3.1. Names</a></li><li><a href="#idl-interfaces">3.2. Interfaces</a><ul><li><a href="#idl-constants">3.2.1. Constants</a></li><li><a href="#idl-attributes">3.2.2. Attributes</a></li><li><a href="#idl-operations">3.2.3. Operations</a></li><li><a href="#idl-special-operations">3.2.4. Special operations</a><ul><li><a href="#idl-legacy-callers">3.2.4.1. Legacy callers</a></li><li><a href="#idl-stringifiers">3.2.4.2. Stringifiers</a></li><li><a href="#idl-serializers">3.2.4.3. Serializers</a></li><li><a href="#idl-indexed-properties">3.2.4.4. Indexed properties</a></li><li><a href="#idl-named-properties">3.2.4.5. Named properties</a></li></ul></li><li><a href="#idl-static-attributes-and-operations">3.2.5. Static attributes and operations</a></li><li><a href="#idl-overloading">3.2.6. Overloading</a></li><li><a href="#idl-iterators">3.2.7. Iterators</a></li></ul></li><li><a href="#idl-dictionaries">3.3. Dictionaries</a></li><li><a href="#idl-exceptions">3.4. Exceptions</a></li><li><a href="#idl-enums">3.5. Enumerations</a></li><li><a href="#idl-callback-functions">3.6. Callback functions</a></li><li><a href="#idl-typedefs">3.7. Typedefs</a></li><li><a href="#idl-implements-statements">3.8. Implements statements</a></li><li><a href="#idl-objects">3.9. Objects implementing interfaces</a></li><li><a href="#idl-types">3.10. Types</a><ul><li><a href="#idl-any">3.10.1. any</a></li><li><a href="#idl-boolean">3.10.2. boolean</a></li><li><a href="#idl-byte">3.10.3. byte</a></li><li><a href="#idl-octet">3.10.4. octet</a></li><li><a href="#idl-short">3.10.5. short</a></li><li><a href="#idl-unsigned-short">3.10.6. unsigned short</a></li><li><a href="#idl-long">3.10.7. long</a></li><li><a href="#idl-unsigned-long">3.10.8. unsigned long</a></li><li><a href="#idl-long-long">3.10.9. long long</a></li><li><a href="#idl-unsigned-long-long">3.10.10. unsigned long long</a></li><li><a href="#idl-float">3.10.11. float</a></li><li><a href="#idl-unrestricted-float">3.10.12. unrestricted float</a></li><li><a href="#idl-double">3.10.13. double</a></li><li><a href="#idl-unrestricted-double">3.10.14. unrestricted double</a></li><li><a href="#idl-DOMString">3.10.15. DOMString</a></li><li><a href="#idl-ByteString">3.10.16. ByteString</a></li><li><a href="#idl-object">3.10.17. object</a></li><li><a href="#idl-interface">3.10.18. Interface types</a></li><li><a href="#idl-dictionary">3.10.19. Dictionary types</a></li><li><a href="#idl-enumeration">3.10.20. Enumeration types</a></li><li><a href="#idl-callback-function">3.10.21. Callback function types</a></li><li><a href="#idl-nullable-type">3.10.22. Nullable types — <var>T</var>?</a></li><li><a href="#idl-sequence">3.10.23. Sequences — sequence&lt;<var>T</var>&gt;</a></li><li><a href="#idl-array">3.10.24. Arrays — <var>T</var>[]</a></li><li><a href="#idl-union">3.10.25. Union types</a></li><li><a href="#idl-Date">3.10.26. Date</a></li><li><a href="#idl-RegExp">3.10.27. RegExp</a></li></ul></li><li><a href="#idl-extended-attributes">3.11. Extended attributes</a></li></ul></li><li><a href="#ecmascript-binding">4. ECMAScript binding</a><ul><li><a href="#es-environment">4.1. ECMAScript environment</a></li><li><a href="#es-type-mapping">4.2. ECMAScript type mapping</a><ul><li><a href="#es-any">4.2.1. any</a></li><li><a href="#es-void">4.2.2. void</a></li><li><a href="#es-boolean">4.2.3. boolean</a></li><li><a href="#es-byte">4.2.4. byte</a></li><li><a href="#es-octet">4.2.5. octet</a></li><li><a href="#es-short">4.2.6. short</a></li><li><a href="#es-unsigned-short">4.2.7. unsigned short</a></li><li><a href="#es-long">4.2.8. long</a></li><li><a href="#es-unsigned-long">4.2.9. unsigned long</a></li><li><a href="#es-long-long">4.2.10. long long</a></li><li><a href="#es-unsigned-long-long">4.2.11. unsigned long long</a></li><li><a href="#es-float">4.2.12. float</a></li><li><a href="#es-unrestricted-float">4.2.13. unrestricted float</a></li><li><a href="#es-double">4.2.14. double</a></li><li><a href="#es-unrestricted-double">4.2.15. unrestricted double</a></li><li><a href="#es-DOMString">4.2.16. DOMString</a></li><li><a href="#es-ByteString">4.2.17. ByteString</a></li><li><a href="#es-object">4.2.18. object</a></li><li><a href="#es-interface">4.2.19. Interface types</a></li><li><a href="#es-dictionary">4.2.20. Dictionary types</a></li><li><a href="#es-enumeration">4.2.21. Enumeration types</a></li><li><a href="#es-callback-function">4.2.22. Callback function types</a></li><li><a href="#es-nullable-type">4.2.23. Nullable types — <var>T</var>?</a></li><li><a href="#es-sequence">4.2.24. Sequences — sequence&lt;<var>T</var>&gt;</a></li><li><a href="#es-array">4.2.25. Arrays — <var>T</var>[]</a><ul><li><a href="#platform-array-object-getownproperty">4.2.25.1. Platform array object [[GetOwnProperty]] method</a></li><li><a href="#platform-array-object-defineownproperty">4.2.25.2. Platform array object [[DefineOwnProperty]] method</a></li><li><a href="#platform-array-object-delete">4.2.25.3. Platform array object [[Delete]] method</a></li></ul></li><li><a href="#es-union">4.2.26. Union types</a></li><li><a href="#es-Date">4.2.27. Date</a></li><li><a href="#es-RegExp">4.2.28. RegExp</a></li></ul></li><li><a href="#es-extended-attributes">4.3. ECMAScript-specific extended attributes</a><ul><li><a href="#ArrayClass">4.3.1. [ArrayClass]</a></li><li><a href="#Clamp">4.3.2. [Clamp]</a></li><li><a href="#Constructor">4.3.3. [Constructor]</a></li><li><a href="#EnforceRange">4.3.4. [EnforceRange]</a></li><li><a href="#EnsureUTF16">4.3.5. [EnsureUTF16]</a></li><li><a href="#ImplicitThis">4.3.6. [ImplicitThis]</a></li><li><a href="#Global">4.3.7. [Global]</a></li><li><a href="#LenientThis">4.3.8. [LenientThis]</a></li><li><a href="#MapClass">4.3.9. [MapClass]</a></li><li><a href="#NamedConstructor">4.3.10. [NamedConstructor]</a></li><li><a href="#NewObject">4.3.11. [NewObject]</a></li><li><a href="#NoInterfaceObject">4.3.12. [NoInterfaceObject]</a></li><li><a href="#OverrideBuiltins">4.3.13. [OverrideBuiltins]</a></li><li><a href="#PutForwards">4.3.14. [PutForwards]</a></li><li><a href="#Replaceable">4.3.15. [Replaceable]</a></li><li><a href="#SameObject">4.3.16. [SameObject]</a></li><li><a href="#TreatNonCallableAsNull">4.3.17. [TreatNonCallableAsNull]</a></li><li><a href="#TreatNullAs">4.3.18. [TreatNullAs]</a></li><li><a href="#TreatUndefinedAs">4.3.19. [TreatUndefinedAs]</a></li><li><a href="#Unforgeable">4.3.20. [Unforgeable]</a></li></ul></li><li><a href="#es-security">4.4. Security</a></li><li><a href="#es-interfaces">4.5. Interfaces</a><ul><li><a href="#interface-object">4.5.1. Interface object</a><ul><li><a href="#es-interface-call">4.5.1.1. Interface object [[Call]] method</a></li><li><a href="#es-interface-hasinstance">4.5.1.2. Interface object [[HasInstance]] method</a></li></ul></li><li><a href="#named-constructors">4.5.2. Named constructors</a></li><li><a href="#es-dictionary-constructors">4.5.3. Dictionary constructors</a></li><li><a href="#interface-prototype-object">4.5.4. Interface prototype object</a></li><li><a href="#named-properties-object">4.5.5. Named properties object</a><ul><li><a href="#named-properties-object-getownproperty">4.5.5.1. Named properties object [[GetOwnProperty]] method</a></li><li><a href="#named-properties-object-defineownproperty">4.5.5.2. Named properties object [[DefineOwnProperty]] method</a></li><li><a href="#named-properties-object-delete">4.5.5.3. Named properties object [[Delete]] method</a></li></ul></li><li><a href="#es-constants">4.5.6. Constants</a></li><li><a href="#es-attributes">4.5.7. Attributes</a></li><li><a href="#es-operations">4.5.8. Operations</a><ul><li><a href="#es-stringifier">4.5.8.1. Stringifiers</a></li><li><a href="#es-serializer">4.5.8.2. Serializers</a></li></ul></li><li><a href="#es-iterators">4.5.9. Iterators</a><ul><li><a href="#es-default-iterator-object">4.5.9.1. Default iterator objects</a></li><li><a href="#es-iterator-prototype-object">4.5.9.2. Iterator prototype object</a></li><li><a href="#es-iterator-object-interfaces">4.5.9.3. Iterator object interfaces</a></li></ul></li><li><a href="#es-map-members">4.5.10. Map members</a><ul><li><a href="#es-map-size">4.5.10.1. size</a></li><li><a href="#es-map-entries">4.5.10.2. entries</a></li><li><a href="#es-map-keys">4.5.10.3. keys</a></li><li><a href="#es-map-values">4.5.10.4. values</a></li><li><a href="#es-map-clear">4.5.10.5. clear</a></li><li><a href="#es-map-delete">4.5.10.6. delete</a></li><li><a href="#es-map-forEach">4.5.10.7. forEach</a></li><li><a href="#es-map-get">4.5.10.8. get</a></li><li><a href="#es-map-has">4.5.10.9. has</a></li><li><a href="#es-map-set">4.5.10.10. set</a></li></ul></li></ul></li><li><a href="#es-implements-statements">4.6. Implements statements</a></li><li><a href="#es-platform-objects">4.7. Platform objects implementing interfaces</a><ul><li><a href="#indexed-and-named-properties">4.7.1. Indexed and named properties</a></li><li><a href="#getownproperty">4.7.2. Platform object [[GetOwnProperty]] method</a></li><li><a href="#defineownproperty">4.7.3. Platform object [[DefineOwnProperty]] method</a></li><li><a href="#delete">4.7.4. Platform object [[Delete]] method</a></li><li><a href="#call">4.7.5. Platform object [[Call]] method</a></li><li><a href="#property-enumeration">4.7.6. Property enumeration</a></li></ul></li><li><a href="#es-user-objects">4.8. User objects implementing callback interfaces</a></li><li><a href="#es-invoking-callback-functions">4.9. Invoking callback functions</a></li><li><a href="#es-exceptions">4.10. Exceptions</a><ul><li><a href="#es-exception-interface-object">4.10.1. Exception interface object</a><ul><li><a href="#es-exception-call">4.10.1.1. Exception interface object [[Call]] method</a></li></ul></li><li><a href="#es-exception-interface-prototype-object">4.10.2. Exception interface prototype object</a></li><li><a href="#es-exception-constants">4.10.3. Constants</a></li><li><a href="#es-exception-fields">4.10.4. Exception fields</a></li></ul></li><li><a href="#es-exception-objects">4.11. Exception objects</a></li><li><a href="#es-throwing-exceptions">4.12. Throwing exceptions</a></li><li><a href="#es-handling-exceptions">4.13. Handling exceptions</a></li></ul></li><li><a href="#common">5. Common definitions</a><ul><li><a href="#common-DOMTimeStamp">5.1. DOMTimeStamp</a></li><li><a href="#common-Function">5.2. Function</a></li><li><a href="#common-VoidFunction">5.3. VoidFunction</a></li></ul></li><li><a href="#extensibility">6. Extensibility</a></li><li><a href="#referencing">7. Referencing this specification</a></li><li><a href="#acknowledgements">8. Acknowledgements</a></li></ul><ul><li><a href="#idl-grammar">A. IDL grammar</a></li><li><a href="#references">B. References</a><ul><li><a href="#normative-references">B.1. Normative references</a></li><li><a href="#informative-references">B.2. Informative references</a></li></ul></li><li><a href="#changes">C. Changes</a></li></ul></div>
+      <div class="toc"><ul><li><a href="#introduction">1. Introduction</a><ul><li><a href="#conventions">1.1. Typographic conventions</a></li></ul></li><li><a href="#conformance">2. Conformance</a></li><li><a href="#idl">3. Interface definition language</a><ul><li><a href="#idl-names">3.1. Names</a></li><li><a href="#idl-interfaces">3.2. Interfaces</a><ul><li><a href="#idl-constants">3.2.1. Constants</a></li><li><a href="#idl-attributes">3.2.2. Attributes</a></li><li><a href="#idl-operations">3.2.3. Operations</a></li><li><a href="#idl-special-operations">3.2.4. Special operations</a><ul><li><a href="#idl-legacy-callers">3.2.4.1. Legacy callers</a></li><li><a href="#idl-stringifiers">3.2.4.2. Stringifiers</a></li><li><a href="#idl-serializers">3.2.4.3. Serializers</a></li><li><a href="#idl-indexed-properties">3.2.4.4. Indexed properties</a></li><li><a href="#idl-named-properties">3.2.4.5. Named properties</a></li></ul></li><li><a href="#idl-static-attributes-and-operations">3.2.5. Static attributes and operations</a></li><li><a href="#idl-overloading">3.2.6. Overloading</a></li><li><a href="#idl-iterators">3.2.7. Iterators</a></li></ul></li><li><a href="#idl-dictionaries">3.3. Dictionaries</a></li><li><a href="#idl-exceptions">3.4. Exceptions</a></li><li><a href="#idl-enums">3.5. Enumerations</a></li><li><a href="#idl-callback-functions">3.6. Callback functions</a></li><li><a href="#idl-typedefs">3.7. Typedefs</a></li><li><a href="#idl-implements-statements">3.8. Implements statements</a></li><li><a href="#idl-objects">3.9. Objects implementing interfaces</a></li><li><a href="#idl-types">3.10. Types</a><ul><li><a href="#idl-any">3.10.1. any</a></li><li><a href="#idl-boolean">3.10.2. boolean</a></li><li><a href="#idl-byte">3.10.3. byte</a></li><li><a href="#idl-octet">3.10.4. octet</a></li><li><a href="#idl-short">3.10.5. short</a></li><li><a href="#idl-unsigned-short">3.10.6. unsigned short</a></li><li><a href="#idl-long">3.10.7. long</a></li><li><a href="#idl-unsigned-long">3.10.8. unsigned long</a></li><li><a href="#idl-long-long">3.10.9. long long</a></li><li><a href="#idl-unsigned-long-long">3.10.10. unsigned long long</a></li><li><a href="#idl-float">3.10.11. float</a></li><li><a href="#idl-unrestricted-float">3.10.12. unrestricted float</a></li><li><a href="#idl-double">3.10.13. double</a></li><li><a href="#idl-unrestricted-double">3.10.14. unrestricted double</a></li><li><a href="#idl-DOMString">3.10.15. DOMString</a></li><li><a href="#idl-ByteString">3.10.16. ByteString</a></li><li><a href="#idl-object">3.10.17. object</a></li><li><a href="#idl-interface">3.10.18. Interface types</a></li><li><a href="#idl-dictionary">3.10.19. Dictionary types</a></li><li><a href="#idl-enumeration">3.10.20. Enumeration types</a></li><li><a href="#idl-callback-function">3.10.21. Callback function types</a></li><li><a href="#idl-nullable-type">3.10.22. Nullable types — <var>T</var>?</a></li><li><a href="#idl-sequence">3.10.23. Sequences — sequence&lt;<var>T</var>&gt;</a></li><li><a href="#idl-array">3.10.24. Arrays — <var>T</var>[]</a></li><li><a href="#idl-union">3.10.25. Union types</a></li><li><a href="#idl-Date">3.10.26. Date</a></li><li><a href="#idl-RegExp">3.10.27. RegExp</a></li></ul></li><li><a href="#idl-extended-attributes">3.11. Extended attributes</a></li></ul></li><li><a href="#ecmascript-binding">4. ECMAScript binding</a><ul><li><a href="#es-environment">4.1. ECMAScript environment</a></li><li><a href="#es-type-mapping">4.2. ECMAScript type mapping</a><ul><li><a href="#es-any">4.2.1. any</a></li><li><a href="#es-void">4.2.2. void</a></li><li><a href="#es-boolean">4.2.3. boolean</a></li><li><a href="#es-byte">4.2.4. byte</a></li><li><a href="#es-octet">4.2.5. octet</a></li><li><a href="#es-short">4.2.6. short</a></li><li><a href="#es-unsigned-short">4.2.7. unsigned short</a></li><li><a href="#es-long">4.2.8. long</a></li><li><a href="#es-unsigned-long">4.2.9. unsigned long</a></li><li><a href="#es-long-long">4.2.10. long long</a></li><li><a href="#es-unsigned-long-long">4.2.11. unsigned long long</a></li><li><a href="#es-float">4.2.12. float</a></li><li><a href="#es-unrestricted-float">4.2.13. unrestricted float</a></li><li><a href="#es-double">4.2.14. double</a></li><li><a href="#es-unrestricted-double">4.2.15. unrestricted double</a></li><li><a href="#es-DOMString">4.2.16. DOMString</a></li><li><a href="#es-ByteString">4.2.17. ByteString</a></li><li><a href="#es-object">4.2.18. object</a></li><li><a href="#es-interface">4.2.19. Interface types</a></li><li><a href="#es-dictionary">4.2.20. Dictionary types</a></li><li><a href="#es-enumeration">4.2.21. Enumeration types</a></li><li><a href="#es-callback-function">4.2.22. Callback function types</a></li><li><a href="#es-nullable-type">4.2.23. Nullable types — <var>T</var>?</a></li><li><a href="#es-sequence">4.2.24. Sequences — sequence&lt;<var>T</var>&gt;</a></li><li><a href="#es-array">4.2.25. Arrays — <var>T</var>[]</a><ul><li><a href="#platform-array-object-getownproperty">4.2.25.1. Platform array object [[GetOwnProperty]] method</a></li><li><a href="#platform-array-object-defineownproperty">4.2.25.2. Platform array object [[DefineOwnProperty]] method</a></li><li><a href="#platform-array-object-delete">4.2.25.3. Platform array object [[Delete]] method</a></li></ul></li><li><a href="#es-union">4.2.26. Union types</a></li><li><a href="#es-Date">4.2.27. Date</a></li><li><a href="#es-RegExp">4.2.28. RegExp</a></li></ul></li><li><a href="#es-extended-attributes">4.3. ECMAScript-specific extended attributes</a><ul><li><a href="#ArrayClass">4.3.1. [ArrayClass]</a></li><li><a href="#Clamp">4.3.2. [Clamp]</a></li><li><a href="#Constructor">4.3.3. [Constructor]</a></li><li><a href="#EnforceRange">4.3.4. [EnforceRange]</a></li><li><a href="#EnsureUTF16">4.3.5. [EnsureUTF16]</a></li><li><a href="#ImplicitThis">4.3.6. [ImplicitThis]</a></li><li><a href="#Global">4.3.7. [Global]</a></li><li><a href="#LenientThis">4.3.8. [LenientThis]</a></li><li><a href="#MapClass">4.3.9. [MapClass]</a></li><li><a href="#NamedConstructor">4.3.10. [NamedConstructor]</a></li><li><a href="#NewObject">4.3.11. [NewObject]</a></li><li><a href="#NoInterfaceObject">4.3.12. [NoInterfaceObject]</a></li><li><a href="#OverrideBuiltins">4.3.13. [OverrideBuiltins]</a></li><li><a href="#PutForwards">4.3.14. [PutForwards]</a></li><li><a href="#Replaceable">4.3.15. [Replaceable]</a></li><li><a href="#SameObject">4.3.16. [SameObject]</a></li><li><a href="#TreatNonObjectAsNull">4.3.17. [TreatNonObjectAsNull]</a></li><li><a href="#TreatNullAs">4.3.18. [TreatNullAs]</a></li><li><a href="#TreatUndefinedAs">4.3.19. [TreatUndefinedAs]</a></li><li><a href="#Unforgeable">4.3.20. [Unforgeable]</a></li></ul></li><li><a href="#es-security">4.4. Security</a></li><li><a href="#es-interfaces">4.5. Interfaces</a><ul><li><a href="#interface-object">4.5.1. Interface object</a><ul><li><a href="#es-interface-call">4.5.1.1. Interface object [[Call]] method</a></li><li><a href="#es-interface-hasinstance">4.5.1.2. Interface object [[HasInstance]] method</a></li></ul></li><li><a href="#named-constructors">4.5.2. Named constructors</a></li><li><a href="#es-dictionary-constructors">4.5.3. Dictionary constructors</a></li><li><a href="#interface-prototype-object">4.5.4. Interface prototype object</a></li><li><a href="#named-properties-object">4.5.5. Named properties object</a><ul><li><a href="#named-properties-object-getownproperty">4.5.5.1. Named properties object [[GetOwnProperty]] method</a></li><li><a href="#named-properties-object-defineownproperty">4.5.5.2. Named properties object [[DefineOwnProperty]] method</a></li><li><a href="#named-properties-object-delete">4.5.5.3. Named properties object [[Delete]] method</a></li></ul></li><li><a href="#es-constants">4.5.6. Constants</a></li><li><a href="#es-attributes">4.5.7. Attributes</a></li><li><a href="#es-operations">4.5.8. Operations</a><ul><li><a href="#es-stringifier">4.5.8.1. Stringifiers</a></li><li><a href="#es-serializer">4.5.8.2. Serializers</a></li></ul></li><li><a href="#es-iterators">4.5.9. Iterators</a><ul><li><a href="#es-default-iterator-object">4.5.9.1. Default iterator objects</a></li><li><a href="#es-iterator-prototype-object">4.5.9.2. Iterator prototype object</a></li><li><a href="#es-iterator-object-interfaces">4.5.9.3. Iterator object interfaces</a></li></ul></li><li><a href="#es-map-members">4.5.10. Map members</a><ul><li><a href="#es-map-size">4.5.10.1. size</a></li><li><a href="#es-map-entries">4.5.10.2. entries</a></li><li><a href="#es-map-keys">4.5.10.3. keys</a></li><li><a href="#es-map-values">4.5.10.4. values</a></li><li><a href="#es-map-clear">4.5.10.5. clear</a></li><li><a href="#es-map-delete">4.5.10.6. delete</a></li><li><a href="#es-map-forEach">4.5.10.7. forEach</a></li><li><a href="#es-map-get">4.5.10.8. get</a></li><li><a href="#es-map-has">4.5.10.9. has</a></li><li><a href="#es-map-set">4.5.10.10. set</a></li></ul></li></ul></li><li><a href="#es-implements-statements">4.6. Implements statements</a></li><li><a href="#es-platform-objects">4.7. Platform objects implementing interfaces</a><ul><li><a href="#indexed-and-named-properties">4.7.1. Indexed and named properties</a></li><li><a href="#getownproperty">4.7.2. Platform object [[GetOwnProperty]] method</a></li><li><a href="#defineownproperty">4.7.3. Platform object [[DefineOwnProperty]] method</a></li><li><a href="#delete">4.7.4. Platform object [[Delete]] method</a></li><li><a href="#call">4.7.5. Platform object [[Call]] method</a></li><li><a href="#property-enumeration">4.7.6. Property enumeration</a></li></ul></li><li><a href="#es-user-objects">4.8. User objects implementing callback interfaces</a></li><li><a href="#es-invoking-callback-functions">4.9. Invoking callback functions</a></li><li><a href="#es-exceptions">4.10. Exceptions</a><ul><li><a href="#es-exception-interface-object">4.10.1. Exception interface object</a><ul><li><a href="#es-exception-call">4.10.1.1. Exception interface object [[Call]] method</a></li></ul></li><li><a href="#es-exception-interface-prototype-object">4.10.2. Exception interface prototype object</a></li><li><a href="#es-exception-constants">4.10.3. Constants</a></li><li><a href="#es-exception-fields">4.10.4. Exception fields</a></li></ul></li><li><a href="#es-exception-objects">4.11. Exception objects</a></li><li><a href="#es-throwing-exceptions">4.12. Throwing exceptions</a></li><li><a href="#es-handling-exceptions">4.13. Handling exceptions</a></li></ul></li><li><a href="#common">5. Common definitions</a><ul><li><a href="#common-DOMTimeStamp">5.1. DOMTimeStamp</a></li><li><a href="#common-Function">5.2. Function</a></li><li><a href="#common-VoidFunction">5.3. VoidFunction</a></li></ul></li><li><a href="#extensibility">6. Extensibility</a></li><li><a href="#referencing">7. Referencing this specification</a></li><li><a href="#acknowledgements">8. Acknowledgements</a></li></ul><ul><li><a href="#idl-grammar">A. IDL grammar</a></li><li><a href="#references">B. References</a><ul><li><a href="#normative-references">B.1. Normative references</a></li><li><a href="#informative-references">B.2. Informative references</a></li></ul></li><li><a href="#changes">C. Changes</a></li></ul></div>
     </div>
 
     <div id="sections">
@@ -521,11 +521,11 @@ dictionary <i>identifier</i> {
           </span></td></tr></table>
           <p>
             If an <a class="sym" href="#prod-identifier">identifier</a> token is used, then the
-            <a class="dfnref" href="#dfn-identifier">identifier</a> of the operation argument 
-            is the value of that token with any leading 
+            <a class="dfnref" href="#dfn-identifier">identifier</a> of the operation argument
+            is the value of that token with any leading
             <span class="char">U+005F LOW LINE ("_")</span> character (underscore) removed.
             If instead one of the <a class="sym" href="#prod-ArgumentNameKeyword">ArgumentNameKeyword</a>
-            keyword token is used, then the <a class="dfnref" href="#dfn-identifier">identifier</a> of the operation argument 
+            keyword token is used, then the <a class="dfnref" href="#dfn-identifier">identifier</a> of the operation argument
             is simply that token.
           </p>
           <p>
@@ -822,7 +822,7 @@ public interface B extends A {
             from any non-callback interfaces, and non-callback interfaces <span class="rfc2119">MUST NOT</span>
             inherit from any callback interfaces.
             Callback interfaces <span class="rfc2119">MUST NOT</span> have any
-            have any <a class="dfnref" href="#dfn-consequential-interfaces">consequential interfaces</a>.
+            <a class="dfnref" href="#dfn-consequential-interfaces">consequential interfaces</a>.
           </p>
           <p>
             <a class="dfnref" href="#dfn-static-attribute">Static attributes</a> and
@@ -835,7 +835,7 @@ public interface B extends A {
               <a class="dfnref" href="#dfn-callback-interface">callback interfaces</a>
               that have only a single <a class="dfnref" href="#dfn-operation">operation</a>,
               unless required to describe the requirements of existing APIs.
-              Instead, a <a class="dfnref" href="#dfn-callback-function">callback function</a> <span class="rfc2119">SHOULD</span> used.
+              Instead, a <a class="dfnref" href="#dfn-callback-function">callback function</a> <span class="rfc2119">SHOULD</span> be used.
             </p>
             <p>
               The definition of <span class="idltype">EventListener</span> as a
@@ -1252,7 +1252,7 @@ node.appendChild(newNode);  <span class="comment">// This will throw a TypeError
               If <var>VT</var> is the type of the value assigned to a constant, and <var>DT</var>
               is the type of the constant, dictionary member or optional argument itself, then these types <span class="rfc2119">MUST</span>
               be compatible, which is the case if <var>DT</var> and <var>VT</var> are identical,
-              or <var>DT</var> is a <a class="dfnref" href="#dfn-nullable-type">nullable type</a> 
+              or <var>DT</var> is a <a class="dfnref" href="#dfn-nullable-type">nullable type</a>
               whose <a class="dfnref" href="#dfn-inner-type">inner type</a> is <var>VT</var>.
             </p>
             <p>
@@ -1409,7 +1409,7 @@ interface <i>Derived</i> : <i>Ancestor</i> {
               <a class='sym' href='#prod-SetRaises'>SetRaises</a> clauses are used
               to declare the possible exceptions that can be thrown when retrieving
               the value of and assigning a value to the attribute, respectively.
-              Each scoped name in the 
+              Each scoped name in the
               <a class='sym' href='#prod-GetRaises'>GetRaises</a> and
               <a class='sym' href='#prod-SetRaises'>SetRaises</a> clauses
               <span class='rfc2119'>MUST</span> resolve to an <a class='dfnref' href='#dfn-exception'>exception</a>.
@@ -1518,7 +1518,7 @@ interface Person : Animal {
             <ol>
               <li><a class="dfnref" href="#dfn-regular-operation">regular operations</a>, which
               are those used to declare that objects implementing the
-              <a class="dfnref" href="#dfn-interface">interface</a> will have a method with 
+              <a class="dfnref" href="#dfn-interface">interface</a> will have a method with
               the given <a class="dfnref" href="#dfn-identifier">identifier</a>
               <pre class="syntax"><i>return-type</i> <i>identifier</i>(<i>arguments…</i>);</pre></li>
               <li><a class="dfnref" href="#dfn-special-operation">special operations</a>,
@@ -2148,7 +2148,7 @@ f(3);                           <span class="comment">// This also evaluates to 
 stringifier DOMString ();<!--
 omittable stringifier DOMString <i>identifier</i>();--></pre>
               <p>
-                If an operation used to declare a stringifier does not have an 
+                If an operation used to declare a stringifier does not have an
                 <a class="dfnref" href="#dfn-identifier">identifier</a>, then prose
                 accompanying the interface <span class="rfc2119">MUST</span> define
                 the <dfn id="dfn-stringification-behavior">stringification behavior</dfn>
@@ -2163,7 +2163,7 @@ omittable stringifier DOMString <i>identifier</i>();--></pre>
               <p>
                 As a shorthand, if the <code>stringifier</code> keyword
                 is declared using an operation with no identifier, then the
-                operation’s <a class="dfnref" href="#dfn-return-type">return type</a> and 
+                operation’s <a class="dfnref" href="#dfn-return-type">return type</a> and
                 argument list can be omitted.
               </p>
               <pre class="syntax">stringifier;</pre>
@@ -2940,7 +2940,7 @@ omittable deleter <i>type</i> <i>identifier</i>(DOMString <i>identifier</i>);-->
               to an instance of the interface.
             </p>
             <p>
-              Static attributes and operations <span class="rfc2119">MUST NOT</span> be 
+              Static attributes and operations <span class="rfc2119">MUST NOT</span> be
               declared on <a class="dfnref" href="#dfn-callback-interface">callback interfaces</a>.
             </p>
 
@@ -3054,7 +3054,7 @@ partial interface A {
               <a class="dfnref" href="#dfn-operation">operation</a>,
               constructor (specified with <a class="xattr" href="#Constructor">[Constructor]</a>
               or <a class="xattr" href="#NamedConstructor">[NamedConstructor]</a>),
-              <a class="dfnref" href="#dfn-legacy-caller">legacy caller</a> or 
+              <a class="dfnref" href="#dfn-legacy-caller">legacy caller</a> or
               <a class="dfnref" href="#dfn-callback-function">callback function</a>.
               The algorithm to compute an <a class="dfnref" href="#dfn-effective-overload-set">effective overload set</a>
               operates on one of the following six types of IDL constructs, and listed with them below are
@@ -3101,7 +3101,7 @@ partial interface A {
               </dd>
             </dl>
             <p>
-              An effective overload set is used, among other things, to determine whether there are ambiguities in the 
+              An effective overload set is used, among other things, to determine whether there are ambiguities in the
               overloaded operations, constructors and callers specified on an interface.
             </p>
             <p>
@@ -3625,7 +3625,7 @@ partial interface A {
             <!--
             <div class='note'>
               <p>
-                These restrictions on argument types reduce 
+                These restrictions on argument types reduce
                 the possibility of resolution ambiguity in
                 <a class='dfnref' href='#dfn-overloaded'>overloaded</a> operations
                 and constructors, but do not completely
@@ -3686,7 +3686,7 @@ interface C {
             </div>
             <pre class="syntax"><i>iterated-type</i> iterator;</pre>
             <p>
-              The type on the left of the <code>iterator</code> keyword is 
+              The type on the left of the <code>iterator</code> keyword is
               the <dfn id="dfn-iterated-type">iterated type</dfn>,
               which is the type of values the <a class="dfnref" href="#dfn-iterator">iterator</a> will return.
             </p>
@@ -3704,7 +3704,7 @@ interface C {
               <li>a current <dfn id="dfn-iterator-state">iterator state</dfn>,
               which at the time the iterator is first invoked is the
               <dfn id="dfn-uninitialized-iterator-state">uninitialized iterator state</dfn>
-              and in subsequent iterations is whatever value the 
+              and in subsequent iterations is whatever value the
               <a class="dfnref" href="#dfn-iterator-behavior">iterator behavior</a> defines
               it to be updated to, and</li>
               <li>the <dfn id="dfn-iterator-target-object">target object</dfn>, which is
@@ -3840,7 +3840,7 @@ for (let session of sm) {
             <p>
               Prose accompanying an <a class="dfnref" href="#dfn-iterator-object-interface">iterator object interface</a>
               <span class="rfc2119">MUST</span> define the <dfn id="dfn-iterator-object-behavior">iterator object behavior</dfn>,
-              which describes how to determine the next value to be iterated over using the 
+              which describes how to determine the next value to be iterated over using the
               <a class="dfnref" href="#dfn-iterator-object">iterator object</a> itself as the iterator’s state.
               As with <a class="dfnref" href="#dfn-iterator-behavior">iterator behavior</a>, the
               <a class="dfnref" href="#dfn-iterator-object-behavior">iterator object behavior</a> <span class="rfc2119">MUST</span>
@@ -4061,7 +4061,7 @@ for (let session of sm) {
           <p>
             Dictionaries are always passed by value.  In language bindings where a dictionary is represented by an object of some kind, passing a
             dictionary to a <a class="dfnref" href="#dfn-platform-object">platform object</a> will not result in a reference to the dictionary being kept by that object.
-            Similarly, any dictionary returned from a platform object will be a copy and modifications made to it will not be visible to the platform object. 
+            Similarly, any dictionary returned from a platform object will be a copy and modifications made to it will not be visible to the platform object.
           </p>
           <p>
             A dictionary can be defined to <dfn id="dfn-inherit-dictionary">inherit</dfn> from another dictionary.
@@ -4117,7 +4117,7 @@ dictionary <i>Derived</i> : <em>Base</em> {
             interface, <a class="dfnref" href="#dfn-enumeration">enumeration</a>,
             <a class="dfnref" href="#dfn-callback-function">callback function</a> or <a class="dfnref" href="#dfn-typedef">typedef</a>.
             If the dictionary member type is an identifier
-            not followed by <code>?</code>, then the identifier <span class="rfc2119">MUST</span>   
+            not followed by <code>?</code>, then the identifier <span class="rfc2119">MUST</span>
             identify any one of those definitions or a <a class="dfnref" href="#dfn-dictionary">dictionary</a>.
           </p>
           <pre class="syntax">dictionary <i>identifier</i> {
@@ -4247,7 +4247,7 @@ something.f(dict);</code></pre></div></div>
             <p>
               The order that the dictionary members are fetched in determines
               what values they will be taken to have.  Since the order for
-              <span class="idltype">A</span> is defined to be c then d, 
+              <span class="idltype">A</span> is defined to be c then d,
               the value for c will be 1 and the value for d will be 2.
             </p>
           </div>
@@ -4453,7 +4453,7 @@ exception <i>Derived</i> : <em>Base</em> {
             <a class="dfnref" href="#dfn-exception-field">fields</a>.
             If a name is not specified, it is assumed to be the same as the
             <a class="dfnref" href="#dfn-identifier">identifier</a> of the exception.
-            The resulting behavior from throwing an exception is language binding-specific.  
+            The resulting behavior from throwing an exception is language binding-specific.
           </p>
           <div class="note"><div class="noteHeader">Note</div>
             <p>
@@ -4511,7 +4511,7 @@ exception <i>Derived</i> : <em>Base</em> {
              <a class="sym" href="#prod-ExceptionField">ExceptionField</a></span></td></tr><tr id="proddef-ExceptionField"><td><span class="prod-number">[63]</span></td><td><a class="sym" href="#prod-ExceptionField">ExceptionField</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-Type">Type</a> <a class="sym" href="#prod-identifier">identifier</a> ";"</span></td></tr></table>
           <div class="example"><div class="exampleHeader">Example</div>
             <p>
-              The following example demonstrates how a reduced version of DOM Core’s 
+              The following example demonstrates how a reduced version of DOM Core’s
               <span class="idltype">DOMException</span> might be defined for three
               of the existing types of exception and one new one.  Specific types of DOMExceptions
               have historically been distinguished only by an integer code, but in this
@@ -4688,7 +4688,7 @@ meal.type == "noodles";              <span class="comment">// Evaluates to true.
           </p>
           <p>
             The following extended attribute is applicable to callback functions:
-            <a class="xattr" href="#TreatNonCallableAsNull">[TreatNonCallableAsNull]</a>.
+            <a class="xattr" href="#TreatNonObjectAsNull">[TreatNonObjectAsNull]</a>.
           </p>
 
           <table class="grammar"><tr><td><span class="prod-number">[3]</span></td><td><a class="sym" href="#prod-CallbackOrInterface">CallbackOrInterface</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"callback" <a class="sym" href="#prod-CallbackRestOrInterface">CallbackRestOrInterface</a> <br /> |
@@ -6160,7 +6160,7 @@ interface Person {
              "byte" <br /> |
              "double" <br /> |
              "false" <br /> |
-             "float" 
+             "float"
             <br /> |
              "long" <br /> |
              "null" <br /> |
@@ -6404,7 +6404,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               There is one built-in ECMAScript function that behaves differently for
               platform objects with this custom Object.prototype.toString behavior
               compared to the built-in Object.prototype.toString: Function.prototype.bind
-              will return a new <span class="estype">Function</span> object with a 
+              will return a new <span class="estype">Function</span> object with a
               <span class="prop">length</span> property with a non-zero value if the
               object has a <a class="dfnref" href="#dfn-legacy-caller">legacy caller</a>
               that takes at least one argument.
@@ -7441,7 +7441,8 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
 
             <p>
               IDL <a href="#idl-callback-function">callback function types</a> are represented by ECMAScript <span class="estype">Function</span>
-              objects.
+              objects, except in the <a class="xattr" href="#TreatNonObjectAsNull">[TreatNonObjectAsNull]</a> case,
+              when they can be any object.
             </p>
             <p>
               An ECMAScript value <var>V</var> is
@@ -7450,9 +7451,16 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>If the result of calling IsCallable(<var>V</var>) is <span class="esvalue">false</span>,
+              <li>If the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">IsCallable</a>(<var>V</var>) is <span class="esvalue">false</span> and the conversion to an IDL value
+              is not being performed due
+                to <var>V</var> being assigned to an <a class="dfnref" href="#dfn-attribute">attribute</a>
+                whose type is a <a class="dfnref" href="#dfn-nullable-type">nullable</a>
+                <a class="dfnref" href="#dfn-callback-function">callback function</a>
+                that is annotated with <a class="xattr" href="#TreatNonObjectAsNull">[TreatNonObjectAsNull]</a>,
               then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="esvalue">TypeError</span></a>.</li>
-              <li>Return the IDL <a href="#idl-callback-function">callback function type</a> value that represents a reference to that <span class="estype">Function</span> object,
+              <li>Return the IDL <a href="#idl-callback-function">callback
+              function type</a> value that represents a reference to the same
+              object that <var>V</var> represents,
                 with the <a class="dfnref external" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#incumbent-script">incumbent script</a>
                 as the <a class="dfnref" href="#dfn-callback-context">callback context</a>. <a href="#ref-HTML">[HTML]</a>.</li>
             </ol>
@@ -7517,13 +7525,13 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 </ol>
               </li>
               <li>
-                Otherwise, if the result of calling IsCallable(<var>V</var>) is <span class="esvalue">false</span>, and
+                Otherwise, if <a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-8" class="dfnref external">Type</a>(<var>V</var>) is not Object, and
                 the conversion to an IDL value is being performed due
                 to <var>V</var> being assigned to an <a class="dfnref" href="#dfn-attribute">attribute</a>
                 whose type is a <a class="dfnref" href="#dfn-nullable-type">nullable</a>
                 <a class="dfnref" href="#dfn-callback-function">callback function</a>
-                that is annotated with <a class="xattr" href="#TreatNonCallableAsNull">[TreatNonCallableAsNull]</a>,
-                then return the IDL 
+                that is annotated with <a class="xattr" href="#TreatNonObjectAsNull">[TreatNonObjectAsNull]</a>,
+                then return the IDL
                 <a class="dfnref" href="#dfn-nullable-type">nullable type</a> <span class="idltype"><var>T</var>?</span>
                 value <span class="idlvalue">null</span>.
               </li>
@@ -7533,7 +7541,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 value <span class="idlvalue">null</span>.
               </li>
               <li>
-                Otherwise, return the result of 
+                Otherwise, return the result of
                 <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a> <var>V</var>
                 to the <a class="dfnref" href="#dfn-inner-type">inner IDL type</a> <span class="idltype"><var>T</var></span>.
               </li>
@@ -7992,7 +8000,7 @@ results.numbers;              <span class="comment">// This now evaluates to a p
 results.numbers == a;         <span class="comment">// Evaluates to false.</span>
 
 results.numbers.length;       <span class="comment">// Evaluates to 3.</span>
-                            
+
 results.numbers.push(7);      <span class="comment">// Silently ignored in non-strict mode.</span>
 results.numbers.length;       <span class="comment">// So this still evaluates to 3.</span></code></pre></div></div>
             </div>
@@ -8952,7 +8960,7 @@ var requestAnimationFrame = window.requestAnimationFrame ||
               <div class="block"><div class="blockTitleDiv"><span class="blockTitle">IDL</span></div><div class="blockContent"><pre class="code"><code class="idl-code">[Global]
 interface Window {
   getter any (DOMString name);
-  attribute DOMString name; 
+  attribute DOMString name;
   // ...
 };</code></pre></div></div>
               <p>
@@ -9009,7 +9017,7 @@ interface Window {
               <p>
                 Specifications <span class="rfc2119">SHOULD NOT</span> use <a href="#LenientThis" class="xattr">[LenientThis]</a>
                 unless required for compatibility reasons.  Specification authors who
-                wish to use this feature are strongly advised to discuss this on the 
+                wish to use this feature are strongly advised to discuss this on the
                 <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
                 mailing list before proceeding.
               </p>
@@ -9064,7 +9072,7 @@ Example.prototype.y;</code></pre></div></div>
               modifiable key–value pairs, where keys are unique.
             </p>
             <p>
-              Any object that implements an interface declared with the 
+              Any object that implements an interface declared with the
               <a class="xattr" href="#MapClass">[MapClass]</a> extended attribute
               <span class="rfc2119">MUST</span> define what the list of
               <dfn id="dfn-map-entries">map entries</dfn> for the object are
@@ -9312,7 +9320,7 @@ var a2 = new Audio('a.flac');   <span class="comment">// Creates an HTMLAudioEle
                 <span class="rfc2119">SHOULD NOT</span> be used on interfaces that are not
                 solely used as <a class="dfnref" href="#dfn-supplemental-interface">supplemental</a> interfaces,
                 unless there are clear Web compatibility reasons for doing so.  Specification authors who
-                wish to use this feature are strongly advised to discuss this on the 
+                wish to use this feature are strongly advised to discuss this on the
                 <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
                 mailing list before proceeding.
               </p>
@@ -9441,7 +9449,7 @@ interface StringMap2 {
               </p>
               <div class="block"><div class="blockTitleDiv"><span class="blockTitle">ECMAScript</span></div><div class="blockContent"><pre class="code"><code class="es-code"><span class="comment">// Obtain an instance of StringMap.  Assume that it has "abc", "length" and</span>
 <span class="comment">// "toString" as supported property names.</span>
-var map1 = getStringMap();  
+var map1 = getStringMap();
 
 <span class="comment">// This invokes the named property getter.</span>
 map1.abc;
@@ -9456,7 +9464,7 @@ map1.toString;
 
 <span class="comment">// Obtain an instance of StringMap2.  Assume that it also has "abc", "length"</span>
 <span class="comment">// and "toString" as supported property names.</span>
-var map2 = getStringMap2();  
+var map2 = getStringMap2();
 
 <span class="comment">// This invokes the named property getter.</span>
 map2.abc;
@@ -9787,28 +9795,28 @@ counter.value;                                           <span class="comment">/
             </div>
           </div>
 
-          <div id="TreatNonCallableAsNull" class="section">
-            <h4>4.3.17. [TreatNonCallableAsNull]</h4>
+          <div id="TreatNonObjectAsNull" class="section">
+            <h4>4.3.17. [TreatNonObjectAsNull]</h4>
 
             <p>
-              If the <a class="xattr" href="#TreatNonCallableAsNull">[TreatNonCallableAsNull]</a>
+              If the <a class="xattr" href="#TreatNonObjectAsNull">[TreatNonObjectAsNull]</a>
               <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>
               appears on a <a class="dfnref" href="#dfn-callback-function">callback function</a>,
               then it indicates that any value assigned to an <a class="dfnref" href="#dfn-attribute">attribute</a>
               whose type is a <a class="dfnref" href="#dfn-nullable-type">nullable</a>
               <a class="dfnref" href="#dfn-callback-function">callback function</a>
-              that is not a <a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-9.2.2" class="dfnref external">callable</a> object will be converted to
+              that is not an object will be converted to
               the <span class="idlvalue">null</span> value.
             </p>
             <div class="warning"><div class="warningHeader">Warning</div>
               <p>
-                Specifications <span class="rfc2119">SHOULD NOT</span> use <a href="#TreatNonCallableAsNull" class="xattr">[TreatNonCallableAsNull]</a>
+                Specifications <span class="rfc2119">SHOULD NOT</span> use <a href="#TreatNonObjectAsNull" class="xattr">[TreatNonObjectAsNull]</a>
                 unless required to specify the behavior of legacy APIs or for consistency with these
                 APIs.  Specification authors who
-                wish to use this feature are strongly advised to discuss this on the 
+                wish to use this feature are strongly advised to discuss this on the
                 <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
                 mailing list before proceeding.  At the time of writing, the only known
-                valid use of <a href="#TreatNonCallableAsNull" class="xattr">[TreatNonCallableAsNull]</a>
+                valid use of <a href="#TreatNonNonObjectAsNull" class="xattr">[TreatNonObjectAsNull]</a>
                 is for the <a class="dfnref" href="#dfn-callback-function">callback functions</a> used as the type
                 of <a href="http://www.w3.org/TR/2011/WD-html5-20110525/webappapis.html#event-handler-attributes">event handler IDL attributes</a>
                 (<a href="#ref-HTML5">[HTML5]</a>, section 6.1.6.1)
@@ -9818,16 +9826,16 @@ counter.value;                                           <span class="comment">/
             <p>
               See <a href="#es-nullable-type">section 4.2.23</a>
               for the specific requirements that the use of
-              <a class="xattr" href="#TreatNonCallableAsNull">[TreatNonCallableAsNull]</a> entails.
+              <a class="xattr" href="#TreatNonObjectAsNull">[TreatNonObjectAsNull]</a> entails.
             </p>
             <div class="example"><div class="exampleHeader">Example</div>
               <p>
                 The following <a class="dfnref" href="#dfn-idl-fragment">IDL fragment</a> defines an interface that has one
-                attribute whose type is a <a class="xattr" href="#TreatNonCallableAsNull">[TreatNonCallableAsNull]</a>-annotated
+                attribute whose type is a <a class="xattr" href="#TreatNonObjectAsNull">[TreatNonObjectAsNull]</a>-annotated
                 <a class="dfnref" href="#dfn-callback-function">callback function</a> and another whose type is a
                 <a class="dfnref" href="#dfn-callback-function">callback function</a> without the <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>:
               </p>
-              <div class="block"><div class="blockTitleDiv"><span class="blockTitle">IDL</span></div><div class="blockContent"><pre class="code"><code class="idl-code">[TreatNonCallableAsNull]
+              <div class="block"><div class="blockTitleDiv"><span class="blockTitle">IDL</span></div><div class="blockContent"><pre class="code"><code class="idl-code">[TreatNonObjectAsNull]
 callback OccurrenceHandler = void (DOMString details);
 
 callback ErrorHandler = void (DOMString details);
@@ -9838,7 +9846,7 @@ interface Manager {
 };</code></pre></div></div>
               <p>
                 In an ECMAScript implementation, assigning a value that is not
-                callable (such as a <span class="estype">Number</span> value)
+                an object (such as a <span class="estype">Number</span> value)
                 to handler1 will have different behavior from that when assigning
                 to handler2:
               </p>
@@ -10169,7 +10177,7 @@ interface B5 : A3 {
               </p>
               <div class="block"><div class="blockTitleDiv"><span class="blockTitle">IDL</span></div><div class="blockContent"><pre class="code"><code class="idl-code">interface System {
   [Unforgeable] readonly attribute DOMString username;
-  readonly attribute Date loginTime; 
+  readonly attribute Date loginTime;
 };</code></pre></div></div>
               <p>
                 In an ECMAScript implementation of the interface, the username attribute will be exposed as a non-configurable property on the
@@ -10244,7 +10252,7 @@ system.loginTime;  <span class="comment">// So this now evaluates to forgedLogin
             The characteristics of an interface object are described in <a href="#interface-object">section 4.5.1</a>
             below.
           </p>
-          
+
           <p>
             In addition, for every <a class="xattr" href="#NamedConstructor">[NamedConstructor]</a>
             extended attribute on an interface, a corresponding property <span class="rfc2119">MUST</span>
@@ -10534,7 +10542,7 @@ system.loginTime;  <span class="comment">// So this now evaluates to forgedLogin
                     </li>
 
                     <li>
-                      Otherwise: 
+                      Otherwise:
                       <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.
                     </li>
                   </ol>
@@ -11163,7 +11171,7 @@ interface LivingHuman {
   unsigned short age;
 };
 
-interface 
+interface
             </div>
           </div>
           -->
@@ -11812,7 +11820,7 @@ interface
                 The state of a <a class="dfnref" href="#dfn-default-iterator-object">default iterator object</a>
                 can be <a class="dfnref" href="#dfn-uninitialized-iterator-state">uninitialized</a>,
                 or it can be any value that the <a class="dfnref" href="#dfn-iterator-behavior">iterator behavior</a>
-                of the <a class="dfnref" href="#dfn-interface">interface</a> specifies, 
+                of the <a class="dfnref" href="#dfn-interface">interface</a> specifies,
                 or it can be the special value <strong>finished</strong>.  When a
                 <a class="dfnref" href="#dfn-default-iterator-object">default iterator object</a> is first created,
                 its state begins <a class="dfnref" href="#dfn-uninitialized-iterator-state">uninitialized</a>.
@@ -12334,7 +12342,7 @@ C implements A;</code></pre></div></div>
           </p>
           <p>
             The global environment that a given <a class="dfnref" href="#dfn-platform-object">platform object</a>
-            is associated with can <dfn id="dfn-change-global-environment">change</dfn> after it has been created.  When 
+            is associated with can <dfn id="dfn-change-global-environment">change</dfn> after it has been created.  When
             the global environment associated with a platform object is changed, its internal
             <span class="prop">[[Prototype]]</span> property <span class="rfc2119">MUST</span> be immediately
             updated to be the <a class="dfnref" href="#dfn-interface-prototype-object">interface prototype object</a>
@@ -12503,7 +12511,7 @@ C implements A;</code></pre></div></div>
           </ul>
 
           <p>
-            The <a class="dfnref" href="#dfn-class-string">class string</a> of 
+            The <a class="dfnref" href="#dfn-class-string">class string</a> of
             a platform object that implements one or more interfaces
             <span class="rfc2119">MUST</span> be the <a class="dfnref" href="#dfn-identifier">identifier</a> of
             the <a class="dfnref" href="#dfn-primary-interface">primary interface</a>
@@ -12588,7 +12596,7 @@ C implements A;</code></pre></div></div>
             -->
             <p>
               A property name is an <dfn id="dfn-unforgeable-property-name">unforgeable property name</dfn> on a
-              given platform object if the object implements an <a class="dfnref" href="#dfn-interface">interface</a> that 
+              given platform object if the object implements an <a class="dfnref" href="#dfn-interface">interface</a> that
               has an <a class="dfnref" href="#dfn-interface-member">interface member</a> with that identifier
               and that interface member is <a class="dfnref" href="#dfn-unforgeable-on-an-interface">unforgeable</a> on any of
               the interfaces that <var>O</var> implements.  If the object implements an
@@ -13173,7 +13181,11 @@ C implements A;</code></pre></div></div>
           </p>
           <ol class="algorithm">
             <li>Let <var>V</var> be the IDL <a class="dfnref" href="#idl-callback-function">callback function type</a> value.</li>
-            <li>Let <var>F</var> be the ECMAScript <a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-9.2.2" class="dfnref external">callable</a> object corresponding to <var>V</var>.</li>
+            <li>Let <var>F</var> be the ECMAScript object corresponding to <var>V</var>.</li>
+            <li>Let <var>R</var> be an uninitialized variable.</li>
+            <li>If <a class="dfnref external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">IsCallable</a>(<var>F</var>) is false, then set <var>R</var> to the value <span class="estype">undefined</span>.</li>
+            <li>Otherwise,
+            <ol>
             <li>Initialize <var>values</var> to be an empty list of ECMAScript values.</li>
             <li>Initialize <var>count</var> to 0.</li>
             <li>Initialize <var>i</var> to 0.</li>
@@ -13189,7 +13201,6 @@ C implements A;</code></pre></div></div>
             <li>Truncate <var>values</var> to have length <var>count</var>.</li>
             <li>Let <var>script</var> be the <a class="dfnref" href="#dfn-callback-context">callback context</a> associated with <var>V</var>.</li>
             <li>Push <var>script</var> on to the <a class="dfnref external" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html">stack of incumbent scripts</a>. <a href="#ref-HTML">[HTML]</a></li>
-            <li>Let <var>R</var> be an uninitialized variable.</li>
             <li>Try running the following step:
               <ol>
                 <li>Set <var>R</var> to the result of invoking the <span class="prop">[[Call]]</span> method of <var>F</var>, providing the <a class="dfnref" href="#dfn-callback-this-value">callback this value</a> as the <span class="esvalue">this</span> value and <var>values</var> as the argument values.</li>
@@ -13199,6 +13210,8 @@ C implements A;</code></pre></div></div>
                 <li>Pop <var>script</var> off the <a class="dfnref external" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html">stack of incumbent scripts</a>.</li>
                 <li>If an exception was thrown, end these steps, and allow it to propagate.</li>
               </ol>
+            </li>
+            </ol>
             </li>
             <li>If the callback function’s return type is <a class="idltype" href="#idl-void">void</a>, return.</li>
             <li>
@@ -13215,7 +13228,7 @@ C implements A;</code></pre></div></div>
             For every <a class="dfnref" href="#dfn-exception">exception</a> that is not declared with the
             <a class="xattr" href="#NoInterfaceObject">[NoInterfaceObject]</a>
             <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>,
-            a corresponding property <span class="rfc2119">MUST</span> exist on the 
+            a corresponding property <span class="rfc2119">MUST</span> exist on the
             ECMAScript global object.
             The name of the property is the <a class="dfnref" href="#dfn-identifier">identifier</a> of the exception,
             and its value is an object called the
@@ -13297,7 +13310,7 @@ C implements A;</code></pre></div></div>
               properties that correspond to the <a class="dfnref" href="#dfn-constant">constants</a>
               and <a class="dfnref" href="#dfn-exception-field">exception fields</a>
               defined on the exception.  These properties are described in more detail in
-              sections <a href="#es-exception-constants">4.10.3</a> 
+              sections <a href="#es-exception-constants">4.10.3</a>
               and <a href="#es-exception-fields">4.10.4</a>,
               below.
             </p>
@@ -14076,7 +14089,7 @@ d.type = et;
              "byte" <br /> |
              "double" <br /> |
              "false" <br /> |
-             "float" 
+             "float"
             <br /> |
              "long" <br /> |
              "null" <br /> |
@@ -14415,6 +14428,15 @@ d.type = et;
                 </p>
               </li>
               <!-- below are changes in v1 too -->
+              <li>
+                <p>
+                  Renamed [TreatNonCallableAsNull] to [TreatNonObjectAsNull]
+                  and changed its semantics to allow any object.  Changed
+                  callback function invocation to be a no-op when the object is
+                  not callable, which can now happen in the
+                  [TreatNonObjectAsNull] case.
+                </p>
+              </li>
               <li>
                 <p>
                   Changed the default this value for callbacks from null to undefined.

--- a/index.xml
+++ b/index.xml
@@ -4575,7 +4575,7 @@ meal.type == "noodles";              <span class='comment'>// Evaluates to true.
           </p>
           <p>
             The following extended attribute is applicable to callback functions:
-            <a class='xattr' href='#TreatNonCallableAsNull'>[TreatNonCallableAsNull]</a>.
+            <a class='xattr' href='#TreatNonObjectAsNull'>[TreatNonObjectAsNull]</a>.
           </p>
 
           <?productions grammar CallbackOrInterface CallbackRestOrInterface CallbackRest?>
@@ -7223,7 +7223,9 @@ iframe.appendChild instanceof w.Function;  <span class='comment'>// Evaluates to
 
             <p>
               IDL <a href='#idl-callback-function'>callback function types</a> are represented by ECMAScript <span class='estype'>Function</span>
-              objects.
+              objects, except in the <a class='xattr'
+              href='#TreatNonObjectAsNull'>[TreatNonObjectAsNull]</a> case,
+              when they can be any object.
             </p>
             <p>
               An ECMAScript value <var>V</var> is
@@ -7232,9 +7234,17 @@ iframe.appendChild instanceof w.Function;  <span class='comment'>// Evaluates to
               by running the following algorithm:
             </p>
             <ol class='algorithm'>
-              <li>If the result of calling IsCallable(<var>V</var>) is <span class='esvalue'>false</span>,
+              <li>If the result of calling <a class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable'>IsCallable</a>(<var>V</var>) is <span
+              class='esvalue'>false</span> and the conversion to an IDL value
+              is not being performed due
+                to <var>V</var> being assigned to an <a class='dfnref' href='#dfn-attribute'>attribute</a>
+                whose type is a <a class='dfnref' href='#dfn-nullable-type'>nullable</a>
+                <a class='dfnref' href='#dfn-callback-function'>callback function</a>
+                that is annotated with <a class='xattr' href='#TreatNonObjectAsNull'>[TreatNonObjectAsNull]</a>,
               then <a href='#ecmascript-throw' class='dfnref external'>throw a <span class='esvalue'>TypeError</span></a>.</li>
-              <li>Return the IDL <a href='#idl-callback-function'>callback function type</a> value that represents a reference to that <span class='estype'>Function</span> object,
+              <li>Return the IDL <a href='#idl-callback-function'>callback
+              function type</a> value that represents a reference to the same
+              object that <var>V</var> represents,
                 with the <a class='dfnref external' href='http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#incumbent-script'>incumbent script</a>
                 as the <a class='dfnref' href='#dfn-callback-context'>callback context</a>. <a href='#ref-HTML'>[HTML]</a>.</li>
             </ol>
@@ -7299,12 +7309,14 @@ iframe.appendChild instanceof w.Function;  <span class='comment'>// Evaluates to
                 </ol>
               </li>
               <li>
-                Otherwise, if the result of calling IsCallable(<var>V</var>) is <span class='esvalue'>false</span>, and
+                Otherwise, if <a
+                href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-8'
+                class='dfnref external'>Type</a>(<var>V</var>) is not Object, and
                 the conversion to an IDL value is being performed due
                 to <var>V</var> being assigned to an <a class='dfnref' href='#dfn-attribute'>attribute</a>
                 whose type is a <a class='dfnref' href='#dfn-nullable-type'>nullable</a>
                 <a class='dfnref' href='#dfn-callback-function'>callback function</a>
-                that is annotated with <a class='xattr' href='#TreatNonCallableAsNull'>[TreatNonCallableAsNull]</a>,
+                that is annotated with <a class='xattr' href='#TreatNonObjectAsNull'>[TreatNonObjectAsNull]</a>,
                 then return the IDL
                 <a class='dfnref' href='#dfn-nullable-type'>nullable type</a> <span class='idltype'><var>T</var>?</span>
                 value <span class='idlvalue'>null</span>.
@@ -9569,28 +9581,28 @@ counter.value;                                           <span class='comment'>/
             </div>
           </div>
 
-          <div id='TreatNonCallableAsNull' class='section'>
-            <h4>[TreatNonCallableAsNull]</h4>
+          <div id='TreatNonObjectAsNull' class='section'>
+            <h4>[TreatNonObjectAsNull]</h4>
 
             <p>
-              If the <a class='xattr' href='#TreatNonCallableAsNull'>[TreatNonCallableAsNull]</a>
+              If the <a class='xattr' href='#TreatNonObjectAsNull'>[TreatNonObjectAsNull]</a>
               <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a>
               appears on a <a class='dfnref' href='#dfn-callback-function'>callback function</a>,
               then it indicates that any value assigned to an <a class='dfnref' href='#dfn-attribute'>attribute</a>
               whose type is a <a class='dfnref' href='#dfn-nullable-type'>nullable</a>
               <a class='dfnref' href='#dfn-callback-function'>callback function</a>
-              that is not a <a href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-9.2.2' class='dfnref external'>callable</a> object will be converted to
+              that is not an object will be converted to
               the <span class='idlvalue'>null</span> value.
             </p>
             <div class='warning'>
               <p>
-                Specifications <span class='rfc2119'>SHOULD NOT</span> use <a href='#TreatNonCallableAsNull' class='xattr'>[TreatNonCallableAsNull]</a>
+                Specifications <span class='rfc2119'>SHOULD NOT</span> use <a href='#TreatNonObjectAsNull' class='xattr'>[TreatNonObjectAsNull]</a>
                 unless required to specify the behavior of legacy APIs or for consistency with these
                 APIs.  Specification authors who
                 wish to use this feature are strongly advised to discuss this on the
                 <a href='mailto:public-script-coord@w3.org'>public-script-coord@w3.org</a>
                 mailing list before proceeding.  At the time of writing, the only known
-                valid use of <a href='#TreatNonCallableAsNull' class='xattr'>[TreatNonCallableAsNull]</a>
+                valid use of <a href='#TreatNonNonObjectAsNull' class='xattr'>[TreatNonObjectAsNull]</a>
                 is for the <a class='dfnref' href='#dfn-callback-function'>callback functions</a> used as the type
                 of <a href='http://www.w3.org/TR/2011/WD-html5-20110525/webappapis.html#event-handler-attributes'>event handler IDL attributes</a>
                 (<a href='#ref-HTML5'>[HTML5]</a>, section 6.1.6.1)
@@ -9600,16 +9612,16 @@ counter.value;                                           <span class='comment'>/
             <p>
               See <a href='#es-nullable-type'>section <?sref es-nullable-type?></a>
               for the specific requirements that the use of
-              <a class='xattr' href='#TreatNonCallableAsNull'>[TreatNonCallableAsNull]</a> entails.
+              <a class='xattr' href='#TreatNonObjectAsNull'>[TreatNonObjectAsNull]</a> entails.
             </p>
             <div class='example'>
               <p>
                 The following <a class='dfnref' href='#dfn-idl-fragment'>IDL fragment</a> defines an interface that has one
-                attribute whose type is a <a class='xattr' href='#TreatNonCallableAsNull'>[TreatNonCallableAsNull]</a>-annotated
+                attribute whose type is a <a class='xattr' href='#TreatNonObjectAsNull'>[TreatNonObjectAsNull]</a>-annotated
                 <a class='dfnref' href='#dfn-callback-function'>callback function</a> and another whose type is a
                 <a class='dfnref' href='#dfn-callback-function'>callback function</a> without the <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a>:
               </p>
-              <x:codeblock language='idl'>[TreatNonCallableAsNull]
+              <x:codeblock language='idl'>[TreatNonObjectAsNull]
 callback OccurrenceHandler = void (DOMString details);
 
 callback ErrorHandler = void (DOMString details);
@@ -9620,7 +9632,7 @@ interface Manager {
 };</x:codeblock>
               <p>
                 In an ECMAScript implementation, assigning a value that is not
-                callable (such as a <span class='estype'>Number</span> value)
+                an object (such as a <span class='estype'>Number</span> value)
                 to handler1 will have different behavior from that when assigning
                 to handler2:
               </p>
@@ -12955,7 +12967,11 @@ C implements A;</x:codeblock>
           </p>
           <ol class='algorithm'>
             <li>Let <var>V</var> be the IDL <a class='dfnref' href='#idl-callback-function'>callback function type</a> value.</li>
-            <li>Let <var>F</var> be the ECMAScript <a href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-9.2.2' class='dfnref external'>callable</a> object corresponding to <var>V</var>.</li>
+            <li>Let <var>F</var> be the ECMAScript object corresponding to <var>V</var>.</li>
+            <li>Let <var>R</var> be an uninitialized variable.</li>
+            <li>If <a class='dfnref external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable'>IsCallable</a>(<var>F</var>) is false, then set <var>R</var> to the value <span class='estype'>undefined</span>.</li>
+            <li>Otherwise,
+            <ol>
             <li>Initialize <var>values</var> to be an empty list of ECMAScript values.</li>
             <li>Initialize <var>count</var> to 0.</li>
             <li>Initialize <var>i</var> to 0.</li>
@@ -12971,7 +12987,6 @@ C implements A;</x:codeblock>
             <li>Truncate <var>values</var> to have length <var>count</var>.</li>
             <li>Let <var>script</var> be the <a class='dfnref' href='#dfn-callback-context'>callback context</a> associated with <var>V</var>.</li>
             <li>Push <var>script</var> on to the <a class='dfnref external' href='http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html'>stack of incumbent scripts</a>. <a href='#ref-HTML'>[HTML]</a></li>
-            <li>Let <var>R</var> be an uninitialized variable.</li>
             <li>Try running the following step:
               <ol>
                 <li>Set <var>R</var> to the result of invoking the <span class='prop'>[[Call]]</span> method of <var>F</var>, providing the <a class='dfnref' href='#dfn-callback-this-value'>callback this value</a> as the <span class='esvalue'>this</span> value and <var>values</var> as the argument values.</li>
@@ -12981,6 +12996,8 @@ C implements A;</x:codeblock>
                 <li>Pop <var>script</var> off the <a class='dfnref external' href='http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html'>stack of incumbent scripts</a>.</li>
                 <li>If an exception was thrown, end these steps, and allow it to propagate.</li>
               </ol>
+            </li>
+            </ol>
             </li>
             <li>If the callback function’s return type is <span class='idltype'>void</span>, return.</li>
             <li>
@@ -14204,6 +14221,15 @@ d.type = et;
                 </p>
               </li>
               <!-- below are changes in v1 too -->
+              <li>
+                <p>
+                  Renamed [TreatNonCallableAsNull] to [TreatNonObjectAsNull]
+                  and changed its semantics to allow any object.  Changed
+                  callback function invocation to be a no-op when the object is
+                  not callable, which can now happen in the
+                  [TreatNonObjectAsNull] case.
+                </p>
+              </li>
               <li>
                 <p>
                   Changed the default this value for callbacks from null to undefined.

--- a/v1.html
+++ b/v1.html
@@ -57,7 +57,7 @@
           * Parameterized interface types, for BlahLists
             http://www.w3.org/mid/op.vr2r6waf64w2qv@anne-van-kesterens-macbook-pro.local
         -->
-<!--          
+<!--
       <?revision-note http://www.w3.org/Bugs/Public/buglist.cgi?query_format=advanced&amp;short_desc_type=allwordssubstr&amp;short_desc=&amp;product=WebAppsWG&amp;component=WebIDL&amp;longdesc_type=allwordssubstr&amp;longdesc=&amp;bug_file_loc_type=allwordssubstr&amp;bug_file_loc=&amp;status_whiteboard_type=allwordssubstr&amp;status_whiteboard=&amp;keywords_type=allwords&amp;keywords=&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;emailtype1=substring&amp;email1=&amp;emailtype2=substring&amp;email2=&amp;bug_id_type=anyexact&amp;bug_id=&amp;votes=&amp;chfieldfrom=&amp;chfieldto=Now&amp;chfieldvalue=&amp;cmdtype=doit&amp;order=Importance&amp;field0-0-0=noop&amp;type0-0-0=noop&amp;value0-0-0=?>
 -->
 
@@ -112,7 +112,7 @@
       <p>
         <!--In addition to the issues marked by editorial notes in this document,-->
         There is a <a href="https://www.w3.org/Bugs/Public/buglist.cgi?query_format=advanced&amp;short_desc_type=allwordssubstr&amp;short_desc=&amp;product=WebAppsWG&amp;component=WebIDL&amp;longdesc_type=allwordssubstr&amp;longdesc=&amp;bug_file_loc_type=allwordssubstr&amp;bug_file_loc=&amp;status_whiteboard_type=allwordssubstr&amp;status_whiteboard=&amp;keywords_type=allwords&amp;keywords=&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;emailtype1=substring&amp;email1=&amp;emailtype2=substring&amp;email2=&amp;bug_id_type=anyexact&amp;bug_id=&amp;votes=&amp;chfieldfrom=&amp;chfieldto=Now&amp;chfieldvalue=&amp;cmdtype=doit&amp;order=Reuse%20same%20sort%20as%20last%20time&amp;field0-0-0=noop&amp;type0-0-0=noop&amp;value0-0-0=">bug tracker</a>
-        for the specification.  Issues raised during the three Last Call comment periods 
+        for the specification.  Issues raised during the three Last Call comment periods
         are tracked in the following documents:
       </p>
       <dl>
@@ -146,7 +146,7 @@
 
     <div id="toc">
       <h2>Table of Contents</h2>
-      <div class="toc"><ul><li><a href="#introduction">1. Introduction</a><ul><li><a href="#conventions">1.1. Typographic conventions</a></li></ul></li><li><a href="#conformance">2. Conformance</a></li><li><a href="#idl">3. Interface definition language</a><ul><li><a href="#idl-names">3.1. Names</a></li><li><a href="#idl-interfaces">3.2. Interfaces</a><ul><li><a href="#idl-constants">3.2.1. Constants</a></li><li><a href="#idl-attributes">3.2.2. Attributes</a></li><li><a href="#idl-operations">3.2.3. Operations</a></li><li><a href="#idl-special-operations">3.2.4. Special operations</a><ul><li><a href="#idl-legacy-callers">3.2.4.1. Legacy callers</a></li><li><a href="#idl-stringifiers">3.2.4.2. Stringifiers</a></li><li><a href="#idl-indexed-properties">3.2.4.3. Indexed properties</a></li><li><a href="#idl-named-properties">3.2.4.4. Named properties</a></li></ul></li><li><a href="#idl-static-operations">3.2.5. Static operations</a></li><li><a href="#idl-overloading">3.2.6. Overloading</a></li></ul></li><li><a href="#idl-dictionaries">3.3. Dictionaries</a></li><li><a href="#idl-exceptions">3.4. Exceptions</a></li><li><a href="#idl-enums">3.5. Enumerations</a></li><li><a href="#idl-callback-functions">3.6. Callback functions</a></li><li><a href="#idl-typedefs">3.7. Typedefs</a></li><li><a href="#idl-implements-statements">3.8. Implements statements</a></li><li><a href="#idl-objects">3.9. Objects implementing interfaces</a></li><li><a href="#idl-types">3.10. Types</a><ul><li><a href="#idl-any">3.10.1. any</a></li><li><a href="#idl-boolean">3.10.2. boolean</a></li><li><a href="#idl-byte">3.10.3. byte</a></li><li><a href="#idl-octet">3.10.4. octet</a></li><li><a href="#idl-short">3.10.5. short</a></li><li><a href="#idl-unsigned-short">3.10.6. unsigned short</a></li><li><a href="#idl-long">3.10.7. long</a></li><li><a href="#idl-unsigned-long">3.10.8. unsigned long</a></li><li><a href="#idl-long-long">3.10.9. long long</a></li><li><a href="#idl-unsigned-long-long">3.10.10. unsigned long long</a></li><li><a href="#idl-float">3.10.11. float</a></li><li><a href="#idl-unrestricted-float">3.10.12. unrestricted float</a></li><li><a href="#idl-double">3.10.13. double</a></li><li><a href="#idl-unrestricted-double">3.10.14. unrestricted double</a></li><li><a href="#idl-DOMString">3.10.15. DOMString</a></li><li><a href="#idl-object">3.10.16. object</a></li><li><a href="#idl-interface">3.10.17. Interface types</a></li><li><a href="#idl-dictionary">3.10.18. Dictionary types</a></li><li><a href="#idl-enumeration">3.10.19. Enumeration types</a></li><li><a href="#idl-callback-function">3.10.20. Callback function types</a></li><li><a href="#idl-nullable-type">3.10.21. Nullable types — <var>T</var>?</a></li><li><a href="#idl-sequence">3.10.22. Sequences — sequence&lt;<var>T</var>&gt;</a></li><li><a href="#idl-array">3.10.23. Arrays — <var>T</var>[]</a></li><li><a href="#idl-union">3.10.24. Union types</a></li><li><a href="#idl-Date">3.10.25. Date</a></li></ul></li><li><a href="#idl-extended-attributes">3.11. Extended attributes</a></li></ul></li><li><a href="#ecmascript-binding">4. ECMAScript binding</a><ul><li><a href="#es-environment">4.1. ECMAScript environment</a></li><li><a href="#es-type-mapping">4.2. ECMAScript type mapping</a><ul><li><a href="#es-any">4.2.1. any</a></li><li><a href="#es-void">4.2.2. void</a></li><li><a href="#es-boolean">4.2.3. boolean</a></li><li><a href="#es-byte">4.2.4. byte</a></li><li><a href="#es-octet">4.2.5. octet</a></li><li><a href="#es-short">4.2.6. short</a></li><li><a href="#es-unsigned-short">4.2.7. unsigned short</a></li><li><a href="#es-long">4.2.8. long</a></li><li><a href="#es-unsigned-long">4.2.9. unsigned long</a></li><li><a href="#es-long-long">4.2.10. long long</a></li><li><a href="#es-unsigned-long-long">4.2.11. unsigned long long</a></li><li><a href="#es-float">4.2.12. float</a></li><li><a href="#es-unrestricted-float">4.2.13. unrestricted float</a></li><li><a href="#es-double">4.2.14. double</a></li><li><a href="#es-unrestricted-double">4.2.15. unrestricted double</a></li><li><a href="#es-DOMString">4.2.16. DOMString</a></li><li><a href="#es-object">4.2.17. object</a></li><li><a href="#es-interface">4.2.18. Interface types</a></li><li><a href="#es-dictionary">4.2.19. Dictionary types</a></li><li><a href="#es-enumeration">4.2.20. Enumeration types</a></li><li><a href="#es-callback-function">4.2.21. Callback function types</a></li><li><a href="#es-nullable-type">4.2.22. Nullable types — <var>T</var>?</a></li><li><a href="#es-sequence">4.2.23. Sequences — sequence&lt;<var>T</var>&gt;</a></li><li><a href="#es-array">4.2.24. Arrays — <var>T</var>[]</a><ul><li><a href="#platform-array-object-getownproperty">4.2.24.1. Platform array object [[GetOwnProperty]] method</a></li><li><a href="#platform-array-object-defineownproperty">4.2.24.2. Platform array object [[DefineOwnProperty]] method</a></li><li><a href="#platform-array-object-delete">4.2.24.3. Platform array object [[Delete]] method</a></li></ul></li><li><a href="#es-union">4.2.25. Union types</a></li><li><a href="#es-Date">4.2.26. Date</a></li></ul></li><li><a href="#es-extended-attributes">4.3. ECMAScript-specific extended attributes</a><ul><li><a href="#ArrayClass">4.3.1. [ArrayClass]</a></li><li><a href="#Clamp">4.3.2. [Clamp]</a></li><li><a href="#Constructor">4.3.3. [Constructor]</a></li><li><a href="#EnforceRange">4.3.4. [EnforceRange]</a></li><li><a href="#Global">4.3.5. [Global]</a></li><li><a href="#ImplicitThis">4.3.6. [ImplicitThis]</a></li><li><a href="#LenientThis">4.3.7. [LenientThis]</a></li><li><a href="#NamedConstructor">4.3.8. [NamedConstructor]</a></li><li><a href="#NoInterfaceObject">4.3.9. [NoInterfaceObject]</a></li><li><a href="#OverrideBuiltins">4.3.10. [OverrideBuiltins]</a></li><li><a href="#PutForwards">4.3.11. [PutForwards]</a></li><li><a href="#Replaceable">4.3.12. [Replaceable]</a></li><li><a href="#TreatNonCallableAsNull">4.3.13. [TreatNonCallableAsNull]</a></li><li><a href="#TreatNullAs">4.3.14. [TreatNullAs]</a></li><li><a href="#TreatUndefinedAs">4.3.15. [TreatUndefinedAs]</a></li><li><a href="#Unforgeable">4.3.16. [Unforgeable]</a></li></ul></li><li><a href="#es-security">4.4. Security</a></li><li><a href="#es-interfaces">4.5. Interfaces</a><ul><li><a href="#interface-object">4.5.1. Interface object</a><ul><li><a href="#es-interface-call">4.5.1.1. Interface object [[Call]] method</a></li><li><a href="#es-interface-hasinstance">4.5.1.2. Interface object [[HasInstance]] method</a></li></ul></li><li><a href="#named-constructors">4.5.2. Named constructors</a></li><li><a href="#interface-prototype-object">4.5.3. Interface prototype object</a></li><li><a href="#named-properties-object">4.5.4. Named properties object</a><ul><li><a href="#named-properties-object-getownproperty">4.5.4.1. Named properties object [[GetOwnProperty]] method</a></li><li><a href="#named-properties-object-defineownproperty">4.5.4.2. Named properties object [[DefineOwnProperty]] method</a></li><li><a href="#named-properties-object-delete">4.5.4.3. Named properties object [[Delete]] method</a></li></ul></li><li><a href="#es-constants">4.5.5. Constants</a></li><li><a href="#es-attributes">4.5.6. Attributes</a></li><li><a href="#es-operations">4.5.7. Operations</a></li></ul></li><li><a href="#es-implements-statements">4.6. Implements statements</a></li><li><a href="#es-platform-objects">4.7. Platform objects implementing interfaces</a><ul><li><a href="#indexed-and-named-properties">4.7.1. Indexed and named properties</a></li><li><a href="#getownproperty">4.7.2. Platform object [[GetOwnProperty]] method</a></li><li><a href="#defineownproperty">4.7.3. Platform object [[DefineOwnProperty]] method</a></li><li><a href="#delete">4.7.4. Platform object [[Delete]] method</a></li><li><a href="#call">4.7.5. Platform object [[Call]] method</a></li><li><a href="#property-enumeration">4.7.6. Property enumeration</a></li></ul></li><li><a href="#es-user-objects">4.8. User objects implementing callback interfaces</a></li><li><a href="#es-invoking-callback-functions">4.9. Invoking callback functions</a></li><li><a href="#es-exceptions">4.10. Exceptions</a><ul><li><a href="#es-exception-interface-object">4.10.1. Exception interface object</a><ul><li><a href="#es-exception-call">4.10.1.1. Exception interface object [[Call]] method</a></li></ul></li><li><a href="#es-exception-interface-prototype-object">4.10.2. Exception interface prototype object</a></li><li><a href="#es-exception-constants">4.10.3. Constants</a></li><li><a href="#es-exception-fields">4.10.4. Exception fields</a></li></ul></li><li><a href="#es-exception-objects">4.11. Exception objects</a></li><li><a href="#es-throwing-exceptions">4.12. Throwing exceptions</a></li><li><a href="#es-handling-exceptions">4.13. Handling exceptions</a></li></ul></li><li><a href="#common">5. Common definitions</a><ul><li><a href="#common-DOMTimeStamp">5.1. DOMTimeStamp</a></li><li><a href="#common-Function">5.2. Function</a></li><li><a href="#common-VoidFunction">5.3. VoidFunction</a></li></ul></li><li><a href="#extensibility">6. Extensibility</a></li><li><a href="#referencing">7. Referencing this specification</a></li><li><a href="#acknowledgements">8. Acknowledgements</a></li></ul><ul><li><a href="#idl-grammar">A. IDL grammar</a></li><li><a href="#references">B. References</a><ul><li><a href="#normative-references">B.1. Normative references</a></li><li><a href="#informative-references">B.2. Informative references</a></li></ul></li><li><a href="#cr-exit">C. Candidate Recommendation exit criteria</a></li><li><a href="#changes">D. Changes</a></li></ul></div>
+      <div class="toc"><ul><li><a href="#introduction">1. Introduction</a><ul><li><a href="#conventions">1.1. Typographic conventions</a></li></ul></li><li><a href="#conformance">2. Conformance</a></li><li><a href="#idl">3. Interface definition language</a><ul><li><a href="#idl-names">3.1. Names</a></li><li><a href="#idl-interfaces">3.2. Interfaces</a><ul><li><a href="#idl-constants">3.2.1. Constants</a></li><li><a href="#idl-attributes">3.2.2. Attributes</a></li><li><a href="#idl-operations">3.2.3. Operations</a></li><li><a href="#idl-special-operations">3.2.4. Special operations</a><ul><li><a href="#idl-legacy-callers">3.2.4.1. Legacy callers</a></li><li><a href="#idl-stringifiers">3.2.4.2. Stringifiers</a></li><li><a href="#idl-indexed-properties">3.2.4.3. Indexed properties</a></li><li><a href="#idl-named-properties">3.2.4.4. Named properties</a></li></ul></li><li><a href="#idl-static-operations">3.2.5. Static operations</a></li><li><a href="#idl-overloading">3.2.6. Overloading</a></li></ul></li><li><a href="#idl-dictionaries">3.3. Dictionaries</a></li><li><a href="#idl-exceptions">3.4. Exceptions</a></li><li><a href="#idl-enums">3.5. Enumerations</a></li><li><a href="#idl-callback-functions">3.6. Callback functions</a></li><li><a href="#idl-typedefs">3.7. Typedefs</a></li><li><a href="#idl-implements-statements">3.8. Implements statements</a></li><li><a href="#idl-objects">3.9. Objects implementing interfaces</a></li><li><a href="#idl-types">3.10. Types</a><ul><li><a href="#idl-any">3.10.1. any</a></li><li><a href="#idl-boolean">3.10.2. boolean</a></li><li><a href="#idl-byte">3.10.3. byte</a></li><li><a href="#idl-octet">3.10.4. octet</a></li><li><a href="#idl-short">3.10.5. short</a></li><li><a href="#idl-unsigned-short">3.10.6. unsigned short</a></li><li><a href="#idl-long">3.10.7. long</a></li><li><a href="#idl-unsigned-long">3.10.8. unsigned long</a></li><li><a href="#idl-long-long">3.10.9. long long</a></li><li><a href="#idl-unsigned-long-long">3.10.10. unsigned long long</a></li><li><a href="#idl-float">3.10.11. float</a></li><li><a href="#idl-unrestricted-float">3.10.12. unrestricted float</a></li><li><a href="#idl-double">3.10.13. double</a></li><li><a href="#idl-unrestricted-double">3.10.14. unrestricted double</a></li><li><a href="#idl-DOMString">3.10.15. DOMString</a></li><li><a href="#idl-object">3.10.16. object</a></li><li><a href="#idl-interface">3.10.17. Interface types</a></li><li><a href="#idl-dictionary">3.10.18. Dictionary types</a></li><li><a href="#idl-enumeration">3.10.19. Enumeration types</a></li><li><a href="#idl-callback-function">3.10.20. Callback function types</a></li><li><a href="#idl-nullable-type">3.10.21. Nullable types — <var>T</var>?</a></li><li><a href="#idl-sequence">3.10.22. Sequences — sequence&lt;<var>T</var>&gt;</a></li><li><a href="#idl-array">3.10.23. Arrays — <var>T</var>[]</a></li><li><a href="#idl-union">3.10.24. Union types</a></li><li><a href="#idl-Date">3.10.25. Date</a></li></ul></li><li><a href="#idl-extended-attributes">3.11. Extended attributes</a></li></ul></li><li><a href="#ecmascript-binding">4. ECMAScript binding</a><ul><li><a href="#es-environment">4.1. ECMAScript environment</a></li><li><a href="#es-type-mapping">4.2. ECMAScript type mapping</a><ul><li><a href="#es-any">4.2.1. any</a></li><li><a href="#es-void">4.2.2. void</a></li><li><a href="#es-boolean">4.2.3. boolean</a></li><li><a href="#es-byte">4.2.4. byte</a></li><li><a href="#es-octet">4.2.5. octet</a></li><li><a href="#es-short">4.2.6. short</a></li><li><a href="#es-unsigned-short">4.2.7. unsigned short</a></li><li><a href="#es-long">4.2.8. long</a></li><li><a href="#es-unsigned-long">4.2.9. unsigned long</a></li><li><a href="#es-long-long">4.2.10. long long</a></li><li><a href="#es-unsigned-long-long">4.2.11. unsigned long long</a></li><li><a href="#es-float">4.2.12. float</a></li><li><a href="#es-unrestricted-float">4.2.13. unrestricted float</a></li><li><a href="#es-double">4.2.14. double</a></li><li><a href="#es-unrestricted-double">4.2.15. unrestricted double</a></li><li><a href="#es-DOMString">4.2.16. DOMString</a></li><li><a href="#es-object">4.2.17. object</a></li><li><a href="#es-interface">4.2.18. Interface types</a></li><li><a href="#es-dictionary">4.2.19. Dictionary types</a></li><li><a href="#es-enumeration">4.2.20. Enumeration types</a></li><li><a href="#es-callback-function">4.2.21. Callback function types</a></li><li><a href="#es-nullable-type">4.2.22. Nullable types — <var>T</var>?</a></li><li><a href="#es-sequence">4.2.23. Sequences — sequence&lt;<var>T</var>&gt;</a></li><li><a href="#es-array">4.2.24. Arrays — <var>T</var>[]</a><ul><li><a href="#platform-array-object-getownproperty">4.2.24.1. Platform array object [[GetOwnProperty]] method</a></li><li><a href="#platform-array-object-defineownproperty">4.2.24.2. Platform array object [[DefineOwnProperty]] method</a></li><li><a href="#platform-array-object-delete">4.2.24.3. Platform array object [[Delete]] method</a></li></ul></li><li><a href="#es-union">4.2.25. Union types</a></li><li><a href="#es-Date">4.2.26. Date</a></li></ul></li><li><a href="#es-extended-attributes">4.3. ECMAScript-specific extended attributes</a><ul><li><a href="#ArrayClass">4.3.1. [ArrayClass]</a></li><li><a href="#Clamp">4.3.2. [Clamp]</a></li><li><a href="#Constructor">4.3.3. [Constructor]</a></li><li><a href="#EnforceRange">4.3.4. [EnforceRange]</a></li><li><a href="#Global">4.3.5. [Global]</a></li><li><a href="#ImplicitThis">4.3.6. [ImplicitThis]</a></li><li><a href="#LenientThis">4.3.7. [LenientThis]</a></li><li><a href="#NamedConstructor">4.3.8. [NamedConstructor]</a></li><li><a href="#NoInterfaceObject">4.3.9. [NoInterfaceObject]</a></li><li><a href="#OverrideBuiltins">4.3.10. [OverrideBuiltins]</a></li><li><a href="#PutForwards">4.3.11. [PutForwards]</a></li><li><a href="#Replaceable">4.3.12. [Replaceable]</a></li><li><a href="#TreatNonObjectAsNull">4.3.13. [TreatNonObjectAsNull]</a></li><li><a href="#TreatNullAs">4.3.14. [TreatNullAs]</a></li><li><a href="#TreatUndefinedAs">4.3.15. [TreatUndefinedAs]</a></li><li><a href="#Unforgeable">4.3.16. [Unforgeable]</a></li></ul></li><li><a href="#es-security">4.4. Security</a></li><li><a href="#es-interfaces">4.5. Interfaces</a><ul><li><a href="#interface-object">4.5.1. Interface object</a><ul><li><a href="#es-interface-call">4.5.1.1. Interface object [[Call]] method</a></li><li><a href="#es-interface-hasinstance">4.5.1.2. Interface object [[HasInstance]] method</a></li></ul></li><li><a href="#named-constructors">4.5.2. Named constructors</a></li><li><a href="#interface-prototype-object">4.5.3. Interface prototype object</a></li><li><a href="#named-properties-object">4.5.4. Named properties object</a><ul><li><a href="#named-properties-object-getownproperty">4.5.4.1. Named properties object [[GetOwnProperty]] method</a></li><li><a href="#named-properties-object-defineownproperty">4.5.4.2. Named properties object [[DefineOwnProperty]] method</a></li><li><a href="#named-properties-object-delete">4.5.4.3. Named properties object [[Delete]] method</a></li></ul></li><li><a href="#es-constants">4.5.5. Constants</a></li><li><a href="#es-attributes">4.5.6. Attributes</a></li><li><a href="#es-operations">4.5.7. Operations</a></li></ul></li><li><a href="#es-implements-statements">4.6. Implements statements</a></li><li><a href="#es-platform-objects">4.7. Platform objects implementing interfaces</a><ul><li><a href="#indexed-and-named-properties">4.7.1. Indexed and named properties</a></li><li><a href="#getownproperty">4.7.2. Platform object [[GetOwnProperty]] method</a></li><li><a href="#defineownproperty">4.7.3. Platform object [[DefineOwnProperty]] method</a></li><li><a href="#delete">4.7.4. Platform object [[Delete]] method</a></li><li><a href="#call">4.7.5. Platform object [[Call]] method</a></li><li><a href="#property-enumeration">4.7.6. Property enumeration</a></li></ul></li><li><a href="#es-user-objects">4.8. User objects implementing callback interfaces</a></li><li><a href="#es-invoking-callback-functions">4.9. Invoking callback functions</a></li><li><a href="#es-exceptions">4.10. Exceptions</a><ul><li><a href="#es-exception-interface-object">4.10.1. Exception interface object</a><ul><li><a href="#es-exception-call">4.10.1.1. Exception interface object [[Call]] method</a></li></ul></li><li><a href="#es-exception-interface-prototype-object">4.10.2. Exception interface prototype object</a></li><li><a href="#es-exception-constants">4.10.3. Constants</a></li><li><a href="#es-exception-fields">4.10.4. Exception fields</a></li></ul></li><li><a href="#es-exception-objects">4.11. Exception objects</a></li><li><a href="#es-throwing-exceptions">4.12. Throwing exceptions</a></li><li><a href="#es-handling-exceptions">4.13. Handling exceptions</a></li></ul></li><li><a href="#common">5. Common definitions</a><ul><li><a href="#common-DOMTimeStamp">5.1. DOMTimeStamp</a></li><li><a href="#common-Function">5.2. Function</a></li><li><a href="#common-VoidFunction">5.3. VoidFunction</a></li></ul></li><li><a href="#extensibility">6. Extensibility</a></li><li><a href="#referencing">7. Referencing this specification</a></li><li><a href="#acknowledgements">8. Acknowledgements</a></li></ul><ul><li><a href="#idl-grammar">A. IDL grammar</a></li><li><a href="#references">B. References</a><ul><li><a href="#normative-references">B.1. Normative references</a></li><li><a href="#informative-references">B.2. Informative references</a></li></ul></li><li><a href="#cr-exit">C. Candidate Recommendation exit criteria</a></li><li><a href="#changes">D. Changes</a></li></ul></div>
     </div>
 
     <div id="sections">
@@ -542,11 +542,11 @@ dictionary <i>identifier</i> {
           </span></td></tr></table>
           <p>
             If an <a class="sym" href="#prod-identifier">identifier</a> token is used, then the
-            <a class="dfnref" href="#dfn-identifier">identifier</a> of the operation argument 
-            is the value of that token with any leading 
+            <a class="dfnref" href="#dfn-identifier">identifier</a> of the operation argument
+            is the value of that token with any leading
             <span class="char">U+005F LOW LINE ("_")</span> character (underscore) removed.
             If instead one of the <a class="sym" href="#prod-ArgumentNameKeyword">ArgumentNameKeyword</a>
-            keyword token is used, then the <a class="dfnref" href="#dfn-identifier">identifier</a> of the operation argument 
+            keyword token is used, then the <a class="dfnref" href="#dfn-identifier">identifier</a> of the operation argument
             is simply that token.
           </p>
           <p>
@@ -842,7 +842,7 @@ public interface B extends A {
             from any non-callback interfaces, and non-callback interfaces <span class="rfc2119">MUST NOT</span>
             inherit from any callback interfaces.
             Callback interfaces <span class="rfc2119">MUST NOT</span> have any
-            have any <a class="dfnref" href="#dfn-consequential-interfaces">consequential interfaces</a>.
+            <a class="dfnref" href="#dfn-consequential-interfaces">consequential interfaces</a>.
           </p>
           <p>
             <a class="dfnref" href="#dfn-static-attribute">Static attributes</a> <span class="rfc2119">MUST NOT</span>
@@ -854,7 +854,7 @@ public interface B extends A {
               <a class="dfnref" href="#dfn-callback-interface">callback interfaces</a>
               that have only a single <a class="dfnref" href="#dfn-operation">operation</a>,
               unless required to describe the requirements of existing APIs.
-              Instead, a <a class="dfnref" href="#dfn-callback-function">callback function</a> <span class="rfc2119">SHOULD</span> used.
+              Instead, a <a class="dfnref" href="#dfn-callback-function">callback function</a> <span class="rfc2119">SHOULD</span> be used.
             </p>
             <p>
               The definition of <span class="idltype">EventListener</span> as a
@@ -1251,7 +1251,7 @@ node.appendChild(newNode);  <span class="comment">// This will throw a TypeError
               If <var>VT</var> is the type of the value assigned to a constant, and <var>DT</var>
               is the type of the constant, dictionary member or optional argument itself, then these types <span class="rfc2119">MUST</span>
               be compatible, which is the case if <var>DT</var> and <var>VT</var> are identical,
-              or <var>DT</var> is a <a class="dfnref" href="#dfn-nullable-type">nullable type</a> 
+              or <var>DT</var> is a <a class="dfnref" href="#dfn-nullable-type">nullable type</a>
               whose <a class="dfnref" href="#dfn-inner-type">inner type</a> is <var>VT</var>.
             </p>
             <p>
@@ -1389,7 +1389,7 @@ interface <i>Derived</i> : <i>Ancestor</i> {
               <a class='sym' href='#prod-SetRaises'>SetRaises</a> clauses are used
               to declare the possible exceptions that can be thrown when retrieving
               the value of and assigning a value to the attribute, respectively.
-              Each scoped name in the 
+              Each scoped name in the
               <a class='sym' href='#prod-GetRaises'>GetRaises</a> and
               <a class='sym' href='#prod-SetRaises'>SetRaises</a> clauses
               <span class='rfc2119'>MUST</span> resolve to an <a class='dfnref' href='#dfn-exception'>exception</a>.
@@ -1490,7 +1490,7 @@ interface Person : Animal {
             <ol>
               <li><a class="dfnref" href="#dfn-regular-operation">regular operations</a>, which
               are those used to declare that objects implementing the
-              <a class="dfnref" href="#dfn-interface">interface</a> will have a method with 
+              <a class="dfnref" href="#dfn-interface">interface</a> will have a method with
               the given <a class="dfnref" href="#dfn-identifier">identifier</a>
               <pre class="syntax"><i>return-type</i> <i>identifier</i>(<i>arguments…</i>);</pre></li>
               <li><a class="dfnref" href="#dfn-special-operation">special operations</a>,
@@ -2114,7 +2114,7 @@ f(3);                           <span class="comment">// This also evaluates to 
 stringifier DOMString ();<!--
 omittable stringifier DOMString <i>identifier</i>();--></pre>
               <p>
-                If an operation used to declare a stringifier does not have an 
+                If an operation used to declare a stringifier does not have an
                 <a class="dfnref" href="#dfn-identifier">identifier</a>, then prose
                 accompanying the interface <span class="rfc2119">MUST</span> define
                 the <dfn id="dfn-stringification-behavior">stringification behavior</dfn>
@@ -2129,7 +2129,7 @@ omittable stringifier DOMString <i>identifier</i>();--></pre>
               <p>
                 As a shorthand, if the <code>stringifier</code> keyword
                 is declared using an operation with no identifier, then the
-                operation’s <a class="dfnref" href="#dfn-return-type">return type</a> and 
+                operation’s <a class="dfnref" href="#dfn-return-type">return type</a> and
                 argument list can be omitted.
               </p>
               <pre class="syntax">stringifier;</pre>
@@ -2535,7 +2535,7 @@ omittable deleter <i>type</i> <i>identifier</i>(DOMString <i>identifier</i>);-->
               interface.
             </p>
             <p>
-              Static operations <span class="rfc2119">MUST NOT</span> be 
+              Static operations <span class="rfc2119">MUST NOT</span> be
               declared on <a class="dfnref" href="#dfn-callback-interface">callback interfaces</a>.
             </p>
             <div class="example"><div class="exampleHeader">Example</div>
@@ -2637,7 +2637,7 @@ partial interface A {
               <a class="dfnref" href="#dfn-operation">operation</a>,
               constructor (specified with <a class="xattr" href="#Constructor">[Constructor]</a>
               or <a class="xattr" href="#NamedConstructor">[NamedConstructor]</a>),
-              <a class="dfnref" href="#dfn-legacy-caller">legacy caller</a> or 
+              <a class="dfnref" href="#dfn-legacy-caller">legacy caller</a> or
               <a class="dfnref" href="#dfn-callback-function">callback function</a>.
               The algorithm to compute an <a class="dfnref" href="#dfn-effective-overload-set">effective overload set</a>
               operates on one of the following six types of IDL constructs, and listed with them below are
@@ -2684,7 +2684,7 @@ partial interface A {
               </dd>
             </dl>
             <p>
-              An effective overload set is used, among other things, to determine whether there are ambiguities in the 
+              An effective overload set is used, among other things, to determine whether there are ambiguities in the
               overloaded operations, constructors and callers specified on an interface.
             </p>
             <p>
@@ -3152,7 +3152,7 @@ partial interface A {
             <!--
             <div class='note'>
               <p>
-                These restrictions on argument types reduce 
+                These restrictions on argument types reduce
                 the possibility of resolution ambiguity in
                 <a class='dfnref' href='#dfn-overloaded'>overloaded</a> operations
                 and constructors, but do not completely
@@ -3208,7 +3208,7 @@ interface C {
           <p>
             Dictionaries are always passed by value.  In language bindings where a dictionary is represented by an object of some kind, passing a
             dictionary to a <a class="dfnref" href="#dfn-platform-object">platform object</a> will not result in a reference to the dictionary being kept by that object.
-            Similarly, any dictionary returned from a platform object will be a copy and modifications made to it will not be visible to the platform object. 
+            Similarly, any dictionary returned from a platform object will be a copy and modifications made to it will not be visible to the platform object.
           </p>
           <p>
             A dictionary can be defined to <dfn id="dfn-inherit-dictionary">inherit</dfn> from another dictionary.
@@ -3264,7 +3264,7 @@ dictionary <i>Derived</i> : <em>Base</em> {
             interface, <a class="dfnref" href="#dfn-enumeration">enumeration</a>,
             <a class="dfnref" href="#dfn-callback-function">callback function</a> or <a class="dfnref" href="#dfn-typedef">typedef</a>.
             If the dictionary member type is an identifier
-            not followed by <code>?</code>, then the identifier <span class="rfc2119">MUST</span>   
+            not followed by <code>?</code>, then the identifier <span class="rfc2119">MUST</span>
             identify any one of those definitions or a <a class="dfnref" href="#dfn-dictionary">dictionary</a>.
           </p>
           <pre class="syntax">dictionary <i>identifier</i> {
@@ -3394,7 +3394,7 @@ something.f(dict);</code></pre></div></div>
             <p>
               The order that the dictionary members are fetched in determines
               what values they will be taken to have.  Since the order for
-              <span class="idltype">A</span> is defined to be c then d, 
+              <span class="idltype">A</span> is defined to be c then d,
               the value for c will be 1 and the value for d will be 2.
             </p>
           </div>
@@ -3600,7 +3600,7 @@ exception <i>Derived</i> : <em>Base</em> {
             <a class="dfnref" href="#dfn-exception-field">fields</a>.
             If a name is not specified, it is assumed to be the same as the
             <a class="dfnref" href="#dfn-identifier">identifier</a> of the exception.
-            The resulting behavior from throwing an exception is language binding-specific.  
+            The resulting behavior from throwing an exception is language binding-specific.
           </p>
           <div class="note"><div class="noteHeader">Note</div>
             <p>
@@ -3658,7 +3658,7 @@ exception <i>Derived</i> : <em>Base</em> {
              <a class="sym" href="#prod-ExceptionField">ExceptionField</a></span></td></tr><tr id="proddef-ExceptionField"><td><span class="prod-number">[49]</span></td><td><a class="sym" href="#prod-ExceptionField">ExceptionField</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-Type">Type</a> <a class="sym" href="#prod-identifier">identifier</a> ";"</span></td></tr></table>
           <div class="example"><div class="exampleHeader">Example</div>
             <p>
-              The following example demonstrates how a reduced version of DOM Core’s 
+              The following example demonstrates how a reduced version of DOM Core’s
               <span class="idltype">DOMException</span> might be defined for three
               of the existing types of exception and one new one.  Specific types of DOMExceptions
               have historically been distinguished only by an integer code, but in this
@@ -3830,7 +3830,7 @@ meal.type == "noodles";              <span class="comment">// Evaluates to true.
           </p>
           <p>
             The following extended attribute is applicable to callback functions:
-            <a class="xattr" href="#TreatNonCallableAsNull">[TreatNonCallableAsNull]</a>.
+            <a class="xattr" href="#TreatNonObjectAsNull">[TreatNonObjectAsNull]</a>.
           </p>
 
           <table class="grammar"><tr><td><span class="prod-number">[3]</span></td><td><a class="sym" href="#prod-CallbackOrInterface">CallbackOrInterface</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"callback" <a class="sym" href="#prod-CallbackRestOrInterface">CallbackRestOrInterface</a> <br /> |
@@ -5231,7 +5231,7 @@ interface Person {
              "byte" <br /> |
              "double" <br /> |
              "false" <br /> |
-             "float" 
+             "float"
             <br /> |
              "long" <br /> |
              "null" <br /> |
@@ -5466,7 +5466,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               There is one built-in ECMAScript function that behaves differently for
               platform objects with this custom Object.prototype.toString behavior instead
               of custom <span class="prop">[[Class]]</span> values: Function.prototype.bind
-              will return a new <span class="estype">Function</span> object with a 
+              will return a new <span class="estype">Function</span> object with a
               <span class="prop">length</span> property with a non-zero value if the
               object has a <a class="dfnref" href="#dfn-legacy-caller">legacy caller</a>
               that takes at least one argument.  This is because the ES5 definition of
@@ -6459,7 +6459,8 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
 
             <p>
               IDL <a href="#idl-callback-function">callback function types</a> are represented by ECMAScript <span class="estype">Function</span>
-              objects.
+              objects, except in the <a class="xattr" href="#TreatNonObjectAsNull">[TreatNonObjectAsNull]</a> case,
+              when they can be any object.
             </p>
             <p>
               An ECMAScript value <var>V</var> is
@@ -6468,9 +6469,16 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>If the result of calling IsCallable(<var>V</var>) is <span class="esvalue">false</span>,
+              <li>If the result of calling <a class="external" href="http://es5.github.io/#x9.11">IsCallable</a>(<var>V</var>) is <span class="esvalue">false</span> and the conversion to an IDL value
+              is not being performed due
+                to <var>V</var> being assigned to an <a class="dfnref" href="#dfn-attribute">attribute</a>
+                whose type is a <a class="dfnref" href="#dfn-nullable-type">nullable</a>
+                <a class="dfnref" href="#dfn-callback-function">callback function</a>
+                that is annotated with <a class="xattr" href="#TreatNonObjectAsNull">[TreatNonObjectAsNull]</a>,
               then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="esvalue">TypeError</span></a>.</li>
-              <li>Return the IDL <a href="#idl-callback-function">callback function type</a> value that represents a reference to that <span class="estype">Function</span> object,
+              <li>Return the IDL <a href="#idl-callback-function">callback
+              function type</a> value that represents a reference to the same
+              object that <var>V</var> represents,
                 with the <a class="dfnref external" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#incumbent-script">incumbent script</a>
                 as the <a class="dfnref" href="#dfn-callback-context">callback context</a>. <a href="#ref-HTML">[HTML]</a></li>
             </ol>
@@ -6535,13 +6543,13 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 </ol>
               </li>
               <li>
-                Otherwise, if the result of calling IsCallable(<var>V</var>) is <span class="esvalue">false</span>, and
+                Otherwise, if <a href="http://es5.github.io/#Type" class="dfnref external">Type</a>(<var>V</var>) is not Object, and
                 the conversion to an IDL value is being performed due
                 to <var>V</var> being assigned to an <a class="dfnref" href="#dfn-attribute">attribute</a>
                 whose type is a <a class="dfnref" href="#dfn-nullable-type">nullable</a>
                 <a class="dfnref" href="#dfn-callback-function">callback function</a>
-                that is annotated with <a class="xattr" href="#TreatNonCallableAsNull">[TreatNonCallableAsNull]</a>,
-                then return the IDL 
+                that is annotated with <a class="xattr" href="#TreatNonObjectAsNull">[TreatNonObjectAsNull]</a>,
+                then return the IDL
                 <a class="dfnref" href="#dfn-nullable-type">nullable type</a> <span class="idltype"><var>T</var>?</span>
                 value <span class="idlvalue">null</span>.
               </li>
@@ -6551,7 +6559,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 value <span class="idlvalue">null</span>.
               </li>
               <li>
-                Otherwise, return the result of 
+                Otherwise, return the result of
                 <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a> <var>V</var>
                 to the <a class="dfnref" href="#dfn-inner-type">inner IDL type</a> <span class="idltype"><var>T</var></span>.
               </li>
@@ -7009,7 +7017,7 @@ results.numbers;              <span class="comment">// This now evaluates to a p
 results.numbers == a;         <span class="comment">// Evaluates to false.</span>
 
 results.numbers.length;       <span class="comment">// Evaluates to 3.</span>
-                            
+
 results.numbers.push(7);      <span class="comment">// Silently ignored in non-strict mode.</span>
 results.numbers.length;       <span class="comment">// So this still evaluates to 3.</span></code></pre></div></div>
             </div>
@@ -7764,7 +7772,7 @@ var requestAnimationFrame = window.requestAnimationFrame ||
               <div class="block"><div class="blockTitleDiv"><span class="blockTitle">IDL</span></div><div class="blockContent"><pre class="code"><code class="idl-code">[Global]
 interface Window {
   getter any (DOMString name);
-  attribute DOMString name; 
+  attribute DOMString name;
   // ...
 };</code></pre></div></div>
               <p>
@@ -7875,7 +7883,7 @@ Object.getOwnPropertyDescriptor(Window.prototype, "name").get.call(null);</code>
               <p>
                 Specifications <span class="rfc2119">SHOULD NOT</span> use <a href="#LenientThis" class="xattr">[LenientThis]</a>
                 unless required for compatibility reasons.  Specification authors who
-                wish to use this feature are strongly advised to discuss this on the 
+                wish to use this feature are strongly advised to discuss this on the
                 <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
                 mailing list before proceeding.
               </p>
@@ -8010,7 +8018,7 @@ var a2 = new Audio('a.flac');   <span class="comment">// Creates an HTMLAudioEle
                 <span class="rfc2119">SHOULD NOT</span> be used on interfaces that are not
                 solely used as <a class="dfnref" href="#dfn-supplemental-interface">supplemental</a> interfaces,
                 unless there are clear Web compatibility reasons for doing so.  Specification authors who
-                wish to use this feature are strongly advised to discuss this on the 
+                wish to use this feature are strongly advised to discuss this on the
                 <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
                 mailing list before proceeding.
               </p>
@@ -8139,7 +8147,7 @@ interface StringMap2 {
               </p>
               <div class="block"><div class="blockTitleDiv"><span class="blockTitle">ECMAScript</span></div><div class="blockContent"><pre class="code"><code class="es-code"><span class="comment">// Obtain an instance of StringMap.  Assume that it has "abc", "length" and</span>
 <span class="comment">// "toString" as supported property names.</span>
-var map1 = getStringMap();  
+var map1 = getStringMap();
 
 <span class="comment">// This invokes the named property getter.</span>
 map1.abc;
@@ -8154,7 +8162,7 @@ map1.toString;
 
 <span class="comment">// Obtain an instance of StringMap2.  Assume that it also has "abc", "length"</span>
 <span class="comment">// and "toString" as supported property names.</span>
-var map2 = getStringMap2();  
+var map2 = getStringMap2();
 
 <span class="comment">// This invokes the named property getter.</span>
 map2.abc;
@@ -8435,28 +8443,28 @@ counter.value;                                           <span class="comment">/
             </div>
           </div>
 
-          <div id="TreatNonCallableAsNull" class="section">
-            <h4>4.3.13. [TreatNonCallableAsNull]</h4>
+          <div id="TreatNonObjectAsNull" class="section">
+            <h4>4.3.13. [TreatNonObjectAsNull]</h4>
 
             <p>
-              If the <a class="xattr" href="#TreatNonCallableAsNull">[TreatNonCallableAsNull]</a>
+              If the <a class="xattr" href="#TreatNonObjectAsNull">[TreatNonObjectAsNull]</a>
               <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>
               appears on a <a class="dfnref" href="#dfn-callback-function">callback function</a>,
               then it indicates that any value assigned to an <a class="dfnref" href="#dfn-attribute">attribute</a>
               whose type is a <a class="dfnref" href="#dfn-nullable-type">nullable</a>
               <a class="dfnref" href="#dfn-callback-function">callback function</a>
-              that is not a <a href="http://es5.github.com/#x9.11" class="dfnref external">callable</a> object will be converted to
+              that is not an object will be converted to
               the <span class="idlvalue">null</span> value.
             </p>
             <div class="warning"><div class="warningHeader">Warning</div>
               <p>
-                Specifications <span class="rfc2119">SHOULD NOT</span> use <a href="#TreatNonCallableAsNull" class="xattr">[TreatNonCallableAsNull]</a>
+                Specifications <span class="rfc2119">SHOULD NOT</span> use <a href="#TreatNonObjectAsNull" class="xattr">[TreatNonObjectAsNull]</a>
                 unless required to specify the behavior of legacy APIs or for consistency with these
                 APIs.  Specification authors who
-                wish to use this feature are strongly advised to discuss this on the 
+                wish to use this feature are strongly advised to discuss this on the
                 <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
                 mailing list before proceeding.  At the time of writing, the only known
-                valid use of <a href="#TreatNonCallableAsNull" class="xattr">[TreatNonCallableAsNull]</a>
+                valid use of <a href="#TreatNonNonObjectAsNull" class="xattr">[TreatNonObjectAsNull]</a>
                 is for the <a class="dfnref" href="#dfn-callback-function">callback functions</a> used as the type
                 of <a href="http://www.w3.org/TR/2011/WD-html5-20110525/webappapis.html#event-handler-attributes">event handler IDL attributes</a>
                 (<a href="#ref-HTML5">[HTML5]</a>, section 6.1.6.1)
@@ -8466,16 +8474,16 @@ counter.value;                                           <span class="comment">/
             <p>
               See <a href="#es-nullable-type">section 4.2.22</a>
               for the specific requirements that the use of
-              <a class="xattr" href="#TreatNonCallableAsNull">[TreatNonCallableAsNull]</a> entails.
+              <a class="xattr" href="#TreatNonObjectAsNull">[TreatNonObjectAsNull]</a> entails.
             </p>
             <div class="example"><div class="exampleHeader">Example</div>
               <p>
                 The following <a class="dfnref" href="#dfn-idl-fragment">IDL fragment</a> defines an interface that has one
-                attribute whose type is a <a class="xattr" href="#TreatNonCallableAsNull">[TreatNonCallableAsNull]</a>-annotated
+                attribute whose type is a <a class="xattr" href="#TreatNonObjectAsNull">[TreatNonObjectAsNull]</a>-annotated
                 <a class="dfnref" href="#dfn-callback-function">callback function</a> and another whose type is a
                 <a class="dfnref" href="#dfn-callback-function">callback function</a> without the <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>:
               </p>
-              <div class="block"><div class="blockTitleDiv"><span class="blockTitle">IDL</span></div><div class="blockContent"><pre class="code"><code class="idl-code">[TreatNonCallableAsNull]
+              <div class="block"><div class="blockTitleDiv"><span class="blockTitle">IDL</span></div><div class="blockContent"><pre class="code"><code class="idl-code">[TreatNonObjectAsNull]
 callback OccurrenceHandler = void (DOMString details);
 
 callback ErrorHandler = void (DOMString details);
@@ -8486,7 +8494,7 @@ interface Manager {
 };</code></pre></div></div>
               <p>
                 In an ECMAScript implementation, assigning a value that is not
-                <a href="http://es5.github.com/#x9.11" class="dfnref external">callable</a> (such as a <span class="estype">Number</span> value)
+                an object (such as a <span class="estype">Number</span> value)
                 to handler1 will have different behavior from that when assigning
                 to handler2:
               </p>
@@ -8743,7 +8751,7 @@ c.isMemberOfBreed(undefined);  <span class="comment">// This passes the string "
               An <a class='dfnref' href='#dfn-interface-member'>interface member</a>
               is <dfn id='dfn-unforgeable'>unforgeable</dfn> if the
               <a class='xattr' href='#Unforgeable'>[Unforgeable]</a> extended attribute appears
-              on it, or if <a class='xattr' href='#Unforgeable'>[Unforgeable]</a> appears on the 
+              on it, or if <a class='xattr' href='#Unforgeable'>[Unforgeable]</a> appears on the
               <a class='dfnref' href='#dfn-interface'>interface</a> on which the member
               is declared.
             </p>
@@ -8825,7 +8833,7 @@ interface B5 : A3 {
               </p>
               <div class="block"><div class="blockTitleDiv"><span class="blockTitle">IDL</span></div><div class="blockContent"><pre class="code"><code class="idl-code">interface System {
   [Unforgeable] readonly attribute DOMString username;
-  readonly attribute Date loginTime; 
+  readonly attribute Date loginTime;
 };</code></pre></div></div>
               <p>
                 In an ECMAScript implementation of the interface, the username attribute will be exposed as a non-configurable property on the
@@ -8900,7 +8908,7 @@ system.loginTime;  <span class="comment">// So this now evaluates to forgedLogin
             The characteristics of an interface object are described in <a href="#interface-object">section 4.5.1</a>
             below.
           </p>
-          
+
           <p>
             In addition, for every <a class="xattr" href="#NamedConstructor">[NamedConstructor]</a>
             extended attribute on an interface, a corresponding property <span class="rfc2119">MUST</span>
@@ -9171,7 +9179,7 @@ system.loginTime;  <span class="comment">// So this now evaluates to forgedLogin
                     </li>
 
                     <li>
-                      Otherwise: 
+                      Otherwise:
                       <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.
                     </li>
                   </ol>
@@ -9718,7 +9726,7 @@ interface LivingHuman {
   unsigned short age;
 };
 
-interface 
+interface
             </div>
           </div>
           -->
@@ -10198,7 +10206,7 @@ C implements A;</code></pre></div></div>
           </p>
           <p>
             The global environment that a given <a class="dfnref" href="#dfn-platform-object">platform object</a>
-            is associated with can <dfn id="dfn-change-global-environment">change</dfn> after it has been created.  When 
+            is associated with can <dfn id="dfn-change-global-environment">change</dfn> after it has been created.  When
             the global environment associated with a platform object is changed, its internal
             <span class="prop">[[Prototype]]</span> property <span class="rfc2119">MUST</span> be immediately
             updated to be the <a class="dfnref" href="#dfn-interface-prototype-object">interface prototype object</a>
@@ -10354,7 +10362,7 @@ C implements A;</code></pre></div></div>
           </ul>
 
           <p>
-            The <a class="dfnref" href="#dfn-class-string">class string</a> of 
+            The <a class="dfnref" href="#dfn-class-string">class string</a> of
             a platform object that implements one or more interfaces
             <span class="rfc2119">MUST</span> be the <a class="dfnref" href="#dfn-identifier">identifier</a> of
             the <a class="dfnref" href="#dfn-primary-interface">primary interface</a>
@@ -10439,7 +10447,7 @@ C implements A;</code></pre></div></div>
             -->
             <p>
               A property name is an <dfn id="dfn-unforgeable-property-name">unforgeable property name</dfn> on a
-              given platform object if the object implements an <a class="dfnref" href="#dfn-interface">interface</a> that 
+              given platform object if the object implements an <a class="dfnref" href="#dfn-interface">interface</a> that
               has an <a class="dfnref" href="#dfn-interface-member">interface member</a> with that identifier
               and that interface member is <a class="dfnref" href="#dfn-unforgeable-on-an-interface">unforgeable</a> on any of
               the interfaces that <var>O</var> implements.  If the object implements an
@@ -11018,7 +11026,11 @@ C implements A;</code></pre></div></div>
           </p>
           <ol class="algorithm">
             <li>Let <var>V</var> be the IDL <a class="dfnref" href="#idl-callback-function">callback function type</a> value.</li>
-            <li>Let <var>F</var> be the ECMAScript <a href="http://es5.github.com/#x9.11" class="dfnref external">callable</a> object corresponding to <var>V</var>.</li>
+            <li>Let <var>F</var> be the ECMAScript object corresponding to <var>V</var>.</li>
+            <li>Let <var>R</var> be an uninitialized variable.</li>
+            <li>If <a class="dnref external" href="http://es5.github.io/#x9.11">IsCallable</a>(<var>F</var>) is false, then set <var>R</var> to the value <span class="estype">undefined</span>.</li>
+            <li>Otherwise,
+            <ol>
             <li>Initialize <var>values</var> to be an empty list of ECMAScript values.</li>
             <li>Initialize <var>count</var> to 0.</li>
             <li>Initialize <var>i</var> to 0.</li>
@@ -11034,7 +11046,6 @@ C implements A;</code></pre></div></div>
             <li>Truncate <var>values</var> to have length <var>count</var>.</li>
             <li>Let <var>script</var> be the <a class="dfnref" href="#dfn-callback-context">callback context</a> associated with <var>V</var>.</li>
             <li>Push <var>script</var> on to the <a class="dfnref external" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html">stack of incumbent scripts</a>. <a href="#ref-HTML">[HTML]</a></li>
-            <li>Let <var>R</var> be an uninitialized variable.</li>
             <li>Try running the following step:
               <ol>
                 <li>Set <var>R</var> to the result of invoking the <span class="prop">[[Call]]</span> method of <var>F</var>, providing the <a class="dfnref" href="#dfn-callback-this-value">callback this value</a> as the <span class="esvalue">this</span> value and <var>values</var> as the argument values.</li>
@@ -11044,6 +11055,8 @@ C implements A;</code></pre></div></div>
                 <li>Pop <var>script</var> off the <a class="dfnref external" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html">stack of incumbent scripts</a>.</li>
                 <li>If an exception was thrown, end these steps, and allow it to propagate.</li>
               </ol>
+            </li>
+            </ol>
             </li>
             <li>If the callback function’s return type is <a class="idltype" href="#idl-void">void</a>, return.</li>
             <li>
@@ -11060,7 +11073,7 @@ C implements A;</code></pre></div></div>
             For every <a class="dfnref" href="#dfn-exception">exception</a> that is not declared with the
             <a class="xattr" href="#NoInterfaceObject">[NoInterfaceObject]</a>
             <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>,
-            a corresponding property <span class="rfc2119">MUST</span> exist on the 
+            a corresponding property <span class="rfc2119">MUST</span> exist on the
             ECMAScript global object.
             The name of the property is the <a class="dfnref" href="#dfn-identifier">identifier</a> of the exception,
             and its value is an object called the
@@ -11142,7 +11155,7 @@ C implements A;</code></pre></div></div>
               properties that correspond to the <a class="dfnref" href="#dfn-constant">constants</a>
               and <a class="dfnref" href="#dfn-exception-field">exception fields</a>
               defined on the exception.  These properties are described in more detail in
-              sections <a href="#es-exception-constants">4.10.3</a> 
+              sections <a href="#es-exception-constants">4.10.3</a>
               and <a href="#es-exception-fields">4.10.4</a>,
               below.
             </p>
@@ -11900,7 +11913,7 @@ d.type = et;
              "byte" <br /> |
              "double" <br /> |
              "false" <br /> |
-             "float" 
+             "float"
             <br /> |
              "long" <br /> |
              "null" <br /> |
@@ -12159,6 +12172,15 @@ d.type = et;
           <dt>Current editor’s draft</dt>
           <dd>
             <ul>
+              <li>
+                <p>
+                  Renamed [TreatNonCallableAsNull] to [TreatNonObjectAsNull]
+                  and changed its semantics to allow any object.  Changed
+                  callback function invocation to be a no-op when the object is
+                  not callable, which can now happen in the
+                  [TreatNonObjectAsNull] case.
+                </p>
+              </li>
               <li>
                 <p>
                   Changed the default this value for callbacks from null to undefined.

--- a/v1.xml
+++ b/v1.xml
@@ -3733,7 +3733,7 @@ meal.type == "noodles";              <span class='comment'>// Evaluates to true.
           </p>
           <p>
             The following extended attribute is applicable to callback functions:
-            <a class='xattr' href='#TreatNonCallableAsNull'>[TreatNonCallableAsNull]</a>.
+            <a class='xattr' href='#TreatNonObjectAsNull'>[TreatNonObjectAsNull]</a>.
           </p>
 
           <?productions grammar CallbackOrInterface CallbackRestOrInterface CallbackRest?>
@@ -6263,7 +6263,9 @@ iframe.appendChild instanceof w.Function;  <span class='comment'>// Evaluates to
 
             <p>
               IDL <a href='#idl-callback-function'>callback function types</a> are represented by ECMAScript <span class='estype'>Function</span>
-              objects.
+              objects, except in the <a class='xattr'
+              href='#TreatNonObjectAsNull'>[TreatNonObjectAsNull]</a> case,
+              when they can be any object.
             </p>
             <p>
               An ECMAScript value <var>V</var> is
@@ -6272,9 +6274,17 @@ iframe.appendChild instanceof w.Function;  <span class='comment'>// Evaluates to
               by running the following algorithm:
             </p>
             <ol class='algorithm'>
-              <li>If the result of calling IsCallable(<var>V</var>) is <span class='esvalue'>false</span>,
+              <li>If the result of calling <a class="external" href="http://es5.github.io/#x9.11">IsCallable</a>(<var>V</var>) is <span
+              class='esvalue'>false</span> and the conversion to an IDL value
+              is not being performed due
+                to <var>V</var> being assigned to an <a class='dfnref' href='#dfn-attribute'>attribute</a>
+                whose type is a <a class='dfnref' href='#dfn-nullable-type'>nullable</a>
+                <a class='dfnref' href='#dfn-callback-function'>callback function</a>
+                that is annotated with <a class='xattr' href='#TreatNonObjectAsNull'>[TreatNonObjectAsNull]</a>,
               then <a href='#ecmascript-throw' class='dfnref external'>throw a <span class='esvalue'>TypeError</span></a>.</li>
-              <li>Return the IDL <a href='#idl-callback-function'>callback function type</a> value that represents a reference to that <span class='estype'>Function</span> object,
+              <li>Return the IDL <a href='#idl-callback-function'>callback
+              function type</a> value that represents a reference to the same
+              object that <var>V</var> represents,
                 with the <a class='dfnref external' href='http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#incumbent-script'>incumbent script</a>
                 as the <a class='dfnref' href='#dfn-callback-context'>callback context</a>. <a href='#ref-HTML'>[HTML]</a></li>
             </ol>
@@ -6339,12 +6349,14 @@ iframe.appendChild instanceof w.Function;  <span class='comment'>// Evaluates to
                 </ol>
               </li>
               <li>
-                Otherwise, if the result of calling IsCallable(<var>V</var>) is <span class='esvalue'>false</span>, and
+                Otherwise, if <a
+                href='http://es5.github.io/#Type'
+                class='dfnref external'>Type</a>(<var>V</var>) is not Object, and
                 the conversion to an IDL value is being performed due
                 to <var>V</var> being assigned to an <a class='dfnref' href='#dfn-attribute'>attribute</a>
                 whose type is a <a class='dfnref' href='#dfn-nullable-type'>nullable</a>
                 <a class='dfnref' href='#dfn-callback-function'>callback function</a>
-                that is annotated with <a class='xattr' href='#TreatNonCallableAsNull'>[TreatNonCallableAsNull]</a>,
+                that is annotated with <a class='xattr' href='#TreatNonObjectAsNull'>[TreatNonObjectAsNull]</a>,
                 then return the IDL
                 <a class='dfnref' href='#dfn-nullable-type'>nullable type</a> <span class='idltype'><var>T</var>?</span>
                 value <span class='idlvalue'>null</span>.
@@ -8239,28 +8251,28 @@ counter.value;                                           <span class='comment'>/
             </div>
           </div>
 
-          <div id='TreatNonCallableAsNull' class='section'>
-            <h4>[TreatNonCallableAsNull]</h4>
+          <div id='TreatNonObjectAsNull' class='section'>
+            <h4>[TreatNonObjectAsNull]</h4>
 
             <p>
-              If the <a class='xattr' href='#TreatNonCallableAsNull'>[TreatNonCallableAsNull]</a>
+              If the <a class='xattr' href='#TreatNonObjectAsNull'>[TreatNonObjectAsNull]</a>
               <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a>
               appears on a <a class='dfnref' href='#dfn-callback-function'>callback function</a>,
               then it indicates that any value assigned to an <a class='dfnref' href='#dfn-attribute'>attribute</a>
               whose type is a <a class='dfnref' href='#dfn-nullable-type'>nullable</a>
               <a class='dfnref' href='#dfn-callback-function'>callback function</a>
-              that is not a <a href='http://es5.github.com/#x9.11' class='dfnref external'>callable</a> object will be converted to
+              that is not an object will be converted to
               the <span class='idlvalue'>null</span> value.
             </p>
             <div class='warning'>
               <p>
-                Specifications <span class='rfc2119'>SHOULD NOT</span> use <a href='#TreatNonCallableAsNull' class='xattr'>[TreatNonCallableAsNull]</a>
+                Specifications <span class='rfc2119'>SHOULD NOT</span> use <a href='#TreatNonObjectAsNull' class='xattr'>[TreatNonObjectAsNull]</a>
                 unless required to specify the behavior of legacy APIs or for consistency with these
                 APIs.  Specification authors who
                 wish to use this feature are strongly advised to discuss this on the
                 <a href='mailto:public-script-coord@w3.org'>public-script-coord@w3.org</a>
                 mailing list before proceeding.  At the time of writing, the only known
-                valid use of <a href='#TreatNonCallableAsNull' class='xattr'>[TreatNonCallableAsNull]</a>
+                valid use of <a href='#TreatNonNonObjectAsNull' class='xattr'>[TreatNonObjectAsNull]</a>
                 is for the <a class='dfnref' href='#dfn-callback-function'>callback functions</a> used as the type
                 of <a href='http://www.w3.org/TR/2011/WD-html5-20110525/webappapis.html#event-handler-attributes'>event handler IDL attributes</a>
                 (<a href='#ref-HTML5'>[HTML5]</a>, section 6.1.6.1)
@@ -8270,16 +8282,16 @@ counter.value;                                           <span class='comment'>/
             <p>
               See <a href='#es-nullable-type'>section <?sref es-nullable-type?></a>
               for the specific requirements that the use of
-              <a class='xattr' href='#TreatNonCallableAsNull'>[TreatNonCallableAsNull]</a> entails.
+              <a class='xattr' href='#TreatNonObjectAsNull'>[TreatNonObjectAsNull]</a> entails.
             </p>
             <div class='example'>
               <p>
                 The following <a class='dfnref' href='#dfn-idl-fragment'>IDL fragment</a> defines an interface that has one
-                attribute whose type is a <a class='xattr' href='#TreatNonCallableAsNull'>[TreatNonCallableAsNull]</a>-annotated
+                attribute whose type is a <a class='xattr' href='#TreatNonObjectAsNull'>[TreatNonObjectAsNull]</a>-annotated
                 <a class='dfnref' href='#dfn-callback-function'>callback function</a> and another whose type is a
                 <a class='dfnref' href='#dfn-callback-function'>callback function</a> without the <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a>:
               </p>
-              <x:codeblock language='idl'>[TreatNonCallableAsNull]
+              <x:codeblock language='idl'>[TreatNonObjectAsNull]
 callback OccurrenceHandler = void (DOMString details);
 
 callback ErrorHandler = void (DOMString details);
@@ -8290,7 +8302,7 @@ interface Manager {
 };</x:codeblock>
               <p>
                 In an ECMAScript implementation, assigning a value that is not
-                <a href='http://es5.github.com/#x9.11' class='dfnref external'>callable</a> (such as a <span class='estype'>Number</span> value)
+                an object (such as a <span class='estype'>Number</span> value)
                 to handler1 will have different behavior from that when assigning
                 to handler2:
               </p>
@@ -10822,7 +10834,11 @@ C implements A;</x:codeblock>
           </p>
           <ol class='algorithm'>
             <li>Let <var>V</var> be the IDL <a class='dfnref' href='#idl-callback-function'>callback function type</a> value.</li>
-            <li>Let <var>F</var> be the ECMAScript <a href='http://es5.github.com/#x9.11' class='dfnref external'>callable</a> object corresponding to <var>V</var>.</li>
+            <li>Let <var>F</var> be the ECMAScript object corresponding to <var>V</var>.</li>
+            <li>Let <var>R</var> be an uninitialized variable.</li>
+            <li>If <a class='dnref external' href='http://es5.github.io/#x9.11'>IsCallable</a>(<var>F</var>) is false, then set <var>R</var> to the value <span class='estype'>undefined</span>.</li>
+            <li>Otherwise,
+            <ol>
             <li>Initialize <var>values</var> to be an empty list of ECMAScript values.</li>
             <li>Initialize <var>count</var> to 0.</li>
             <li>Initialize <var>i</var> to 0.</li>
@@ -10838,7 +10854,6 @@ C implements A;</x:codeblock>
             <li>Truncate <var>values</var> to have length <var>count</var>.</li>
             <li>Let <var>script</var> be the <a class='dfnref' href='#dfn-callback-context'>callback context</a> associated with <var>V</var>.</li>
             <li>Push <var>script</var> on to the <a class='dfnref external' href='http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html'>stack of incumbent scripts</a>. <a href='#ref-HTML'>[HTML]</a></li>
-            <li>Let <var>R</var> be an uninitialized variable.</li>
             <li>Try running the following step:
               <ol>
                 <li>Set <var>R</var> to the result of invoking the <span class='prop'>[[Call]]</span> method of <var>F</var>, providing the <a class='dfnref' href='#dfn-callback-this-value'>callback this value</a> as the <span class='esvalue'>this</span> value and <var>values</var> as the argument values.</li>
@@ -10848,6 +10863,8 @@ C implements A;</x:codeblock>
                 <li>Pop <var>script</var> off the <a class='dfnref external' href='http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html'>stack of incumbent scripts</a>.</li>
                 <li>If an exception was thrown, end these steps, and allow it to propagate.</li>
               </ol>
+            </li>
+            </ol>
             </li>
             <li>If the callback function’s return type is <span class='idltype'>void</span>, return.</li>
             <li>
@@ -11979,6 +11996,15 @@ d.type = et;
           <dt>Current editor’s draft</dt>
           <dd>
             <ul>
+              <li>
+                <p>
+                  Renamed [TreatNonCallableAsNull] to [TreatNonObjectAsNull]
+                  and changed its semantics to allow any object.  Changed
+                  callback function invocation to be a no-op when the object is
+                  not callable, which can now happen in the
+                  [TreatNonObjectAsNull] case.
+                </p>
+              </li>
               <li>
                 <p>
                   Changed the default this value for callbacks from null to undefined.


### PR DESCRIPTION
See thread starting http://lists.w3.org/Archives/Public/public-script-coord/2013OctDec/0405.html
