### PR TITLE
Add "initializing objects from iterables" section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <link rel="stylesheet" href="http://www.w3.org/StyleSheets/TR/W3C-ED" type="text/css" /></head>
 
   <body>
-    <div class="head"><div><a href="http://www.w3.org/"><img src="http://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL (Second Edition)</h1><h2>W3C Editor’s Draft <em>16 June 2014</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/">http://heycam.github.io/webidl/</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
+    <div class="head"><div><a href="http://www.w3.org/"><img src="http://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL (Second Edition)</h1><h2>W3C Editor’s Draft <em>8 July 2014</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/">http://heycam.github.io/webidl/</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
               Send feedback to <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a> or <a href="https://www.w3.org/Bugs/Public/enter_bug.cgi?product=WebAppsWG&amp;component=WebIDL">file a bug</a> (<a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=WebIDL&amp;resolution=---">open bugs</a>)
             </dd><dt>Editor:</dt><dd><a href="http://mcc.id.au/">Cameron McCormack</a>, Mozilla Corporation &lt;cam@mcc.id.au&gt;</dd></dl><p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &copy; 2014 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>&reg;</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p></div><hr /><script async="" src="file-bug.js"></script>
 
@@ -72,7 +72,7 @@
         report can be found in the <a href="http://www.w3.org/TR/">W3C technical
           reports index</a> at http://www.w3.org/TR/.
       </em></p><p>
-        This document is the 16 June 2014 <b>Editor’s Draft</b> of the
+        This document is the 8 July 2014 <b>Editor’s Draft</b> of the
         <cite>Web IDL (Second Edition)</cite> specification.
       
       Please send comments about this document to
@@ -124,7 +124,7 @@
 
     <div id="toc">
       <h2>Table of Contents</h2>
-      <div class="toc"><ul><li><a href="#introduction">1. Introduction</a><ul><li><a href="#conventions">1.1. Typographic conventions</a></li></ul></li><li><a href="#conformance">2. Conformance</a></li><li><a href="#idl">3. Interface definition language</a><ul><li><a href="#idl-names">3.1. Names</a></li><li><a href="#idl-interfaces">3.2. Interfaces</a><ul><li><a href="#idl-constants">3.2.1. Constants</a></li><li><a href="#idl-attributes">3.2.2. Attributes</a></li><li><a href="#idl-operations">3.2.3. Operations</a></li><li><a href="#idl-special-operations">3.2.4. Special operations</a><ul><li><a href="#idl-legacy-callers">3.2.4.1. Legacy callers</a></li><li><a href="#idl-stringifiers">3.2.4.2. Stringifiers</a></li><li><a href="#idl-serializers">3.2.4.3. Serializers</a></li><li><a href="#idl-indexed-properties">3.2.4.4. Indexed properties</a></li><li><a href="#idl-named-properties">3.2.4.5. Named properties</a></li></ul></li><li><a href="#idl-static-attributes-and-operations">3.2.5. Static attributes and operations</a></li><li><a href="#idl-overloading">3.2.6. Overloading</a></li><li><a href="#idl-iterators">3.2.7. Iterators</a></li></ul></li><li><a href="#idl-dictionaries">3.3. Dictionaries</a></li><li><a href="#idl-exceptions">3.4. Exceptions</a></li><li><a href="#idl-enums">3.5. Enumerations</a></li><li><a href="#idl-callback-functions">3.6. Callback functions</a></li><li><a href="#idl-typedefs">3.7. Typedefs</a></li><li><a href="#idl-implements-statements">3.8. Implements statements</a></li><li><a href="#idl-objects">3.9. Objects implementing interfaces</a></li><li><a href="#idl-types">3.10. Types</a><ul><li><a href="#idl-any">3.10.1. any</a></li><li><a href="#idl-boolean">3.10.2. boolean</a></li><li><a href="#idl-byte">3.10.3. byte</a></li><li><a href="#idl-octet">3.10.4. octet</a></li><li><a href="#idl-short">3.10.5. short</a></li><li><a href="#idl-unsigned-short">3.10.6. unsigned short</a></li><li><a href="#idl-long">3.10.7. long</a></li><li><a href="#idl-unsigned-long">3.10.8. unsigned long</a></li><li><a href="#idl-long-long">3.10.9. long long</a></li><li><a href="#idl-unsigned-long-long">3.10.10. unsigned long long</a></li><li><a href="#idl-float">3.10.11. float</a></li><li><a href="#idl-unrestricted-float">3.10.12. unrestricted float</a></li><li><a href="#idl-double">3.10.13. double</a></li><li><a href="#idl-unrestricted-double">3.10.14. unrestricted double</a></li><li><a href="#idl-DOMString">3.10.15. DOMString</a></li><li><a href="#idl-ByteString">3.10.16. ByteString</a></li><li><a href="#idl-object">3.10.17. object</a></li><li><a href="#idl-interface">3.10.18. Interface types</a></li><li><a href="#idl-dictionary">3.10.19. Dictionary types</a></li><li><a href="#idl-enumeration">3.10.20. Enumeration types</a></li><li><a href="#idl-callback-function">3.10.21. Callback function types</a></li><li><a href="#idl-nullable-type">3.10.22. Nullable types — <var>T</var>?</a></li><li><a href="#idl-sequence">3.10.23. Sequences — sequence&lt;<var>T</var>&gt;</a></li><li><a href="#idl-array">3.10.24. Arrays — <var>T</var>[]</a></li><li><a href="#idl-promise">3.10.25. Promise types — Promise&lt;<var>T</var>&gt;</a></li><li><a href="#idl-union">3.10.26. Union types</a></li><li><a href="#idl-Date">3.10.27. Date</a></li><li><a href="#idl-RegExp">3.10.28. RegExp</a></li></ul></li><li><a href="#idl-extended-attributes">3.11. Extended attributes</a></li></ul></li><li><a href="#ecmascript-binding">4. ECMAScript binding</a><ul><li><a href="#es-environment">4.1. ECMAScript environment</a></li><li><a href="#es-type-mapping">4.2. ECMAScript type mapping</a><ul><li><a href="#es-any">4.2.1. any</a></li><li><a href="#es-void">4.2.2. void</a></li><li><a href="#es-boolean">4.2.3. boolean</a></li><li><a href="#es-byte">4.2.4. byte</a></li><li><a href="#es-octet">4.2.5. octet</a></li><li><a href="#es-short">4.2.6. short</a></li><li><a href="#es-unsigned-short">4.2.7. unsigned short</a></li><li><a href="#es-long">4.2.8. long</a></li><li><a href="#es-unsigned-long">4.2.9. unsigned long</a></li><li><a href="#es-long-long">4.2.10. long long</a></li><li><a href="#es-unsigned-long-long">4.2.11. unsigned long long</a></li><li><a href="#es-float">4.2.12. float</a></li><li><a href="#es-unrestricted-float">4.2.13. unrestricted float</a></li><li><a href="#es-double">4.2.14. double</a></li><li><a href="#es-unrestricted-double">4.2.15. unrestricted double</a></li><li><a href="#es-DOMString">4.2.16. DOMString</a></li><li><a href="#es-ByteString">4.2.17. ByteString</a></li><li><a href="#es-object">4.2.18. object</a></li><li><a href="#es-interface">4.2.19. Interface types</a></li><li><a href="#es-dictionary">4.2.20. Dictionary types</a></li><li><a href="#es-enumeration">4.2.21. Enumeration types</a></li><li><a href="#es-callback-function">4.2.22. Callback function types</a></li><li><a href="#es-nullable-type">4.2.23. Nullable types — <var>T</var>?</a></li><li><a href="#es-sequence">4.2.24. Sequences — sequence&lt;<var>T</var>&gt;</a></li><li><a href="#es-array">4.2.25. Arrays — <var>T</var>[]</a><ul><li><a href="#platform-array-object-getownproperty">4.2.25.1. Platform array object [[GetOwnProperty]] method</a></li><li><a href="#platform-array-object-defineownproperty">4.2.25.2. Platform array object [[DefineOwnProperty]] method</a></li><li><a href="#platform-array-object-delete">4.2.25.3. Platform array object [[Delete]] method</a></li></ul></li><li><a href="#es-promise">4.2.26. Promise types — Promise&lt;<var>T</var>&gt;</a></li><li><a href="#es-union">4.2.27. Union types</a></li><li><a href="#es-Date">4.2.28. Date</a></li><li><a href="#es-RegExp">4.2.29. RegExp</a></li></ul></li><li><a href="#es-extended-attributes">4.3. ECMAScript-specific extended attributes</a><ul><li><a href="#ArrayClass">4.3.1. [ArrayClass]</a></li><li><a href="#Clamp">4.3.2. [Clamp]</a></li><li><a href="#Constructor">4.3.3. [Constructor]</a></li><li><a href="#EnforceRange">4.3.4. [EnforceRange]</a></li><li><a href="#EnsureUTF16">4.3.5. [EnsureUTF16]</a></li><li><a href="#Exposed">4.3.6. [Exposed]</a></li><li><a href="#ImplicitThis">4.3.7. [ImplicitThis]</a></li><li><a href="#Global">4.3.8. [Global] and [PrimaryGlobal]</a></li><li><a href="#LenientThis">4.3.9. [LenientThis]</a></li><li><a href="#MapClass">4.3.10. [MapClass]</a></li><li><a href="#NamedConstructor">4.3.11. [NamedConstructor]</a></li><li><a href="#NewObject">4.3.12. [NewObject]</a></li><li><a href="#NoInterfaceObject">4.3.13. [NoInterfaceObject]</a></li><li><a href="#OverrideBuiltins">4.3.14. [OverrideBuiltins]</a></li><li><a href="#PutForwards">4.3.15. [PutForwards]</a></li><li><a href="#Replaceable">4.3.16. [Replaceable]</a></li><li><a href="#SameObject">4.3.17. [SameObject]</a></li><li><a href="#TreatNonObjectAsNull">4.3.18. [TreatNonObjectAsNull]</a></li><li><a href="#TreatNullAs">4.3.19. [TreatNullAs]</a></li><li><a href="#Unforgeable">4.3.20. [Unforgeable]</a></li></ul></li><li><a href="#es-security">4.4. Security</a></li><li><a href="#es-interfaces">4.5. Interfaces</a><ul><li><a href="#interface-object">4.5.1. Interface object</a><ul><li><a href="#es-interface-call">4.5.1.1. Interface object [[Call]] method</a></li><li><a href="#es-interface-hasinstance">4.5.1.2. Interface object [[HasInstance]] method</a></li></ul></li><li><a href="#named-constructors">4.5.2. Named constructors</a></li><li><a href="#es-dictionary-constructors">4.5.3. Dictionary constructors</a></li><li><a href="#interface-prototype-object">4.5.4. Interface prototype object</a></li><li><a href="#named-properties-object">4.5.5. Named properties object</a><ul><li><a href="#named-properties-object-getownproperty">4.5.5.1. Named properties object [[GetOwnProperty]] method</a></li><li><a href="#named-properties-object-defineownproperty">4.5.5.2. Named properties object [[DefineOwnProperty]] method</a></li><li><a href="#named-properties-object-delete">4.5.5.3. Named properties object [[Delete]] method</a></li></ul></li><li><a href="#es-constants">4.5.6. Constants</a></li><li><a href="#es-attributes">4.5.7. Attributes</a></li><li><a href="#es-operations">4.5.8. Operations</a><ul><li><a href="#es-stringifier">4.5.8.1. Stringifiers</a></li><li><a href="#es-serializer">4.5.8.2. Serializers</a></li></ul></li><li><a href="#es-iterators">4.5.9. Iterators</a><ul><li><a href="#es-default-iterator-object">4.5.9.1. Default iterator objects</a></li><li><a href="#es-iterator-prototype-object">4.5.9.2. Iterator prototype object</a></li><li><a href="#es-iterator-object-interfaces">4.5.9.3. Iterator object interfaces</a></li></ul></li><li><a href="#es-map-members">4.5.10. Map members</a><ul><li><a href="#es-map-size">4.5.10.1. size</a></li><li><a href="#es-map-entries">4.5.10.2. entries</a></li><li><a href="#es-map-keys">4.5.10.3. keys</a></li><li><a href="#es-map-values">4.5.10.4. values</a></li><li><a href="#es-map-clear">4.5.10.5. clear</a></li><li><a href="#es-map-delete">4.5.10.6. delete</a></li><li><a href="#es-map-forEach">4.5.10.7. forEach</a></li><li><a href="#es-map-get">4.5.10.8. get</a></li><li><a href="#es-map-has">4.5.10.9. has</a></li><li><a href="#es-map-set">4.5.10.10. set</a></li></ul></li></ul></li><li><a href="#es-implements-statements">4.6. Implements statements</a></li><li><a href="#es-platform-objects">4.7. Platform objects implementing interfaces</a><ul><li><a href="#indexed-and-named-properties">4.7.1. Indexed and named properties</a></li><li><a href="#getownproperty">4.7.2. Platform object [[GetOwnProperty]] method</a></li><li><a href="#defineownproperty">4.7.3. Platform object [[DefineOwnProperty]] method</a></li><li><a href="#delete">4.7.4. Platform object [[Delete]] method</a></li><li><a href="#call">4.7.5. Platform object [[Call]] method</a></li><li><a href="#property-enumeration">4.7.6. Property enumeration</a></li></ul></li><li><a href="#es-user-objects">4.8. User objects implementing callback interfaces</a></li><li><a href="#es-invoking-callback-functions">4.9. Invoking callback functions</a></li><li><a href="#es-exceptions">4.10. Exceptions</a><ul><li><a href="#es-exception-interface-object">4.10.1. Exception interface object</a><ul><li><a href="#es-exception-call">4.10.1.1. Exception interface object [[Call]] method</a></li></ul></li><li><a href="#es-exception-interface-prototype-object">4.10.2. Exception interface prototype object</a></li><li><a href="#es-exception-constants">4.10.3. Constants</a></li><li><a href="#es-exception-fields">4.10.4. Exception fields</a></li></ul></li><li><a href="#es-exception-objects">4.11. Exception objects</a></li><li><a href="#es-throwing-exceptions">4.12. Throwing exceptions</a></li><li><a href="#es-handling-exceptions">4.13. Handling exceptions</a></li></ul></li><li><a href="#common">5. Common definitions</a><ul><li><a href="#common-DOMTimeStamp">5.1. DOMTimeStamp</a></li><li><a href="#common-Function">5.2. Function</a></li><li><a href="#common-VoidFunction">5.3. VoidFunction</a></li></ul></li><li><a href="#extensibility">6. Extensibility</a></li><li><a href="#referencing">7. Referencing this specification</a></li><li><a href="#acknowledgements">8. Acknowledgements</a></li></ul><ul><li><a href="#idl-grammar">A. IDL grammar</a></li><li><a href="#references">B. References</a><ul><li><a href="#normative-references">B.1. Normative references</a></li><li><a href="#informative-references">B.2. Informative references</a></li></ul></li><li><a href="#changes">C. Changes</a></li></ul></div>
+      <div class="toc"><ul><li><a href="#introduction">1. Introduction</a><ul><li><a href="#conventions">1.1. Typographic conventions</a></li></ul></li><li><a href="#conformance">2. Conformance</a></li><li><a href="#idl">3. Interface definition language</a><ul><li><a href="#idl-names">3.1. Names</a></li><li><a href="#idl-interfaces">3.2. Interfaces</a><ul><li><a href="#idl-constants">3.2.1. Constants</a></li><li><a href="#idl-attributes">3.2.2. Attributes</a></li><li><a href="#idl-operations">3.2.3. Operations</a></li><li><a href="#idl-special-operations">3.2.4. Special operations</a><ul><li><a href="#idl-legacy-callers">3.2.4.1. Legacy callers</a></li><li><a href="#idl-stringifiers">3.2.4.2. Stringifiers</a></li><li><a href="#idl-serializers">3.2.4.3. Serializers</a></li><li><a href="#idl-indexed-properties">3.2.4.4. Indexed properties</a></li><li><a href="#idl-named-properties">3.2.4.5. Named properties</a></li></ul></li><li><a href="#idl-static-attributes-and-operations">3.2.5. Static attributes and operations</a></li><li><a href="#idl-overloading">3.2.6. Overloading</a></li><li><a href="#idl-iterators">3.2.7. Iterators</a></li></ul></li><li><a href="#idl-dictionaries">3.3. Dictionaries</a></li><li><a href="#idl-exceptions">3.4. Exceptions</a></li><li><a href="#idl-enums">3.5. Enumerations</a></li><li><a href="#idl-callback-functions">3.6. Callback functions</a></li><li><a href="#idl-typedefs">3.7. Typedefs</a></li><li><a href="#idl-implements-statements">3.8. Implements statements</a></li><li><a href="#idl-objects">3.9. Objects implementing interfaces</a></li><li><a href="#idl-types">3.10. Types</a><ul><li><a href="#idl-any">3.10.1. any</a></li><li><a href="#idl-boolean">3.10.2. boolean</a></li><li><a href="#idl-byte">3.10.3. byte</a></li><li><a href="#idl-octet">3.10.4. octet</a></li><li><a href="#idl-short">3.10.5. short</a></li><li><a href="#idl-unsigned-short">3.10.6. unsigned short</a></li><li><a href="#idl-long">3.10.7. long</a></li><li><a href="#idl-unsigned-long">3.10.8. unsigned long</a></li><li><a href="#idl-long-long">3.10.9. long long</a></li><li><a href="#idl-unsigned-long-long">3.10.10. unsigned long long</a></li><li><a href="#idl-float">3.10.11. float</a></li><li><a href="#idl-unrestricted-float">3.10.12. unrestricted float</a></li><li><a href="#idl-double">3.10.13. double</a></li><li><a href="#idl-unrestricted-double">3.10.14. unrestricted double</a></li><li><a href="#idl-DOMString">3.10.15. DOMString</a></li><li><a href="#idl-ByteString">3.10.16. ByteString</a></li><li><a href="#idl-object">3.10.17. object</a></li><li><a href="#idl-interface">3.10.18. Interface types</a></li><li><a href="#idl-dictionary">3.10.19. Dictionary types</a></li><li><a href="#idl-enumeration">3.10.20. Enumeration types</a></li><li><a href="#idl-callback-function">3.10.21. Callback function types</a></li><li><a href="#idl-nullable-type">3.10.22. Nullable types — <var>T</var>?</a></li><li><a href="#idl-sequence">3.10.23. Sequences — sequence&lt;<var>T</var>&gt;</a></li><li><a href="#idl-array">3.10.24. Arrays — <var>T</var>[]</a></li><li><a href="#idl-promise">3.10.25. Promise types — Promise&lt;<var>T</var>&gt;</a></li><li><a href="#idl-union">3.10.26. Union types</a></li><li><a href="#idl-Date">3.10.27. Date</a></li><li><a href="#idl-RegExp">3.10.28. RegExp</a></li></ul></li><li><a href="#idl-extended-attributes">3.11. Extended attributes</a></li></ul></li><li><a href="#ecmascript-binding">4. ECMAScript binding</a><ul><li><a href="#es-environment">4.1. ECMAScript environment</a></li><li><a href="#es-type-mapping">4.2. ECMAScript type mapping</a><ul><li><a href="#es-any">4.2.1. any</a></li><li><a href="#es-void">4.2.2. void</a></li><li><a href="#es-boolean">4.2.3. boolean</a></li><li><a href="#es-byte">4.2.4. byte</a></li><li><a href="#es-octet">4.2.5. octet</a></li><li><a href="#es-short">4.2.6. short</a></li><li><a href="#es-unsigned-short">4.2.7. unsigned short</a></li><li><a href="#es-long">4.2.8. long</a></li><li><a href="#es-unsigned-long">4.2.9. unsigned long</a></li><li><a href="#es-long-long">4.2.10. long long</a></li><li><a href="#es-unsigned-long-long">4.2.11. unsigned long long</a></li><li><a href="#es-float">4.2.12. float</a></li><li><a href="#es-unrestricted-float">4.2.13. unrestricted float</a></li><li><a href="#es-double">4.2.14. double</a></li><li><a href="#es-unrestricted-double">4.2.15. unrestricted double</a></li><li><a href="#es-DOMString">4.2.16. DOMString</a></li><li><a href="#es-ByteString">4.2.17. ByteString</a></li><li><a href="#es-object">4.2.18. object</a></li><li><a href="#es-interface">4.2.19. Interface types</a></li><li><a href="#es-dictionary">4.2.20. Dictionary types</a></li><li><a href="#es-enumeration">4.2.21. Enumeration types</a></li><li><a href="#es-callback-function">4.2.22. Callback function types</a></li><li><a href="#es-nullable-type">4.2.23. Nullable types — <var>T</var>?</a></li><li><a href="#es-sequence">4.2.24. Sequences — sequence&lt;<var>T</var>&gt;</a></li><li><a href="#es-array">4.2.25. Arrays — <var>T</var>[]</a><ul><li><a href="#platform-array-object-getownproperty">4.2.25.1. Platform array object [[GetOwnProperty]] method</a></li><li><a href="#platform-array-object-defineownproperty">4.2.25.2. Platform array object [[DefineOwnProperty]] method</a></li><li><a href="#platform-array-object-delete">4.2.25.3. Platform array object [[Delete]] method</a></li></ul></li><li><a href="#es-promise">4.2.26. Promise types — Promise&lt;<var>T</var>&gt;</a></li><li><a href="#es-union">4.2.27. Union types</a></li><li><a href="#es-Date">4.2.28. Date</a></li><li><a href="#es-RegExp">4.2.29. RegExp</a></li></ul></li><li><a href="#es-extended-attributes">4.3. ECMAScript-specific extended attributes</a><ul><li><a href="#ArrayClass">4.3.1. [ArrayClass]</a></li><li><a href="#Clamp">4.3.2. [Clamp]</a></li><li><a href="#Constructor">4.3.3. [Constructor]</a></li><li><a href="#EnforceRange">4.3.4. [EnforceRange]</a></li><li><a href="#EnsureUTF16">4.3.5. [EnsureUTF16]</a></li><li><a href="#Exposed">4.3.6. [Exposed]</a></li><li><a href="#ImplicitThis">4.3.7. [ImplicitThis]</a></li><li><a href="#Global">4.3.8. [Global] and [PrimaryGlobal]</a></li><li><a href="#LenientThis">4.3.9. [LenientThis]</a></li><li><a href="#MapClass">4.3.10. [MapClass]</a></li><li><a href="#NamedConstructor">4.3.11. [NamedConstructor]</a></li><li><a href="#NewObject">4.3.12. [NewObject]</a></li><li><a href="#NoInterfaceObject">4.3.13. [NoInterfaceObject]</a></li><li><a href="#OverrideBuiltins">4.3.14. [OverrideBuiltins]</a></li><li><a href="#PutForwards">4.3.15. [PutForwards]</a></li><li><a href="#Replaceable">4.3.16. [Replaceable]</a></li><li><a href="#SameObject">4.3.17. [SameObject]</a></li><li><a href="#TreatNonObjectAsNull">4.3.18. [TreatNonObjectAsNull]</a></li><li><a href="#TreatNullAs">4.3.19. [TreatNullAs]</a></li><li><a href="#Unforgeable">4.3.20. [Unforgeable]</a></li></ul></li><li><a href="#es-security">4.4. Security</a></li><li><a href="#es-interfaces">4.5. Interfaces</a><ul><li><a href="#interface-object">4.5.1. Interface object</a><ul><li><a href="#es-interface-call">4.5.1.1. Interface object [[Call]] method</a></li><li><a href="#es-interface-hasinstance">4.5.1.2. Interface object [[HasInstance]] method</a></li></ul></li><li><a href="#named-constructors">4.5.2. Named constructors</a></li><li><a href="#es-dictionary-constructors">4.5.3. Dictionary constructors</a></li><li><a href="#interface-prototype-object">4.5.4. Interface prototype object</a></li><li><a href="#named-properties-object">4.5.5. Named properties object</a><ul><li><a href="#named-properties-object-getownproperty">4.5.5.1. Named properties object [[GetOwnProperty]] method</a></li><li><a href="#named-properties-object-defineownproperty">4.5.5.2. Named properties object [[DefineOwnProperty]] method</a></li><li><a href="#named-properties-object-delete">4.5.5.3. Named properties object [[Delete]] method</a></li></ul></li><li><a href="#es-constants">4.5.6. Constants</a></li><li><a href="#es-attributes">4.5.7. Attributes</a></li><li><a href="#es-operations">4.5.8. Operations</a><ul><li><a href="#es-stringifier">4.5.8.1. Stringifiers</a></li><li><a href="#es-serializer">4.5.8.2. Serializers</a></li></ul></li><li><a href="#es-iterators">4.5.9. Iterators</a><ul><li><a href="#es-default-iterator-object">4.5.9.1. Default iterator objects</a></li><li><a href="#es-iterator-prototype-object">4.5.9.2. Iterator prototype object</a></li><li><a href="#es-iterator-object-interfaces">4.5.9.3. Iterator object interfaces</a></li></ul></li><li><a href="#initializing-objects-from-iterables">4.5.10. Initializing objects from iterables</a></li><li><a href="#es-map-members">4.5.11. Map members</a><ul><li><a href="#es-map-size">4.5.11.1. size</a></li><li><a href="#es-map-entries">4.5.11.2. entries</a></li><li><a href="#es-map-keys">4.5.11.3. keys</a></li><li><a href="#es-map-values">4.5.11.4. values</a></li><li><a href="#es-map-clear">4.5.11.5. clear</a></li><li><a href="#es-map-delete">4.5.11.6. delete</a></li><li><a href="#es-map-forEach">4.5.11.7. forEach</a></li><li><a href="#es-map-get">4.5.11.8. get</a></li><li><a href="#es-map-has">4.5.11.9. has</a></li><li><a href="#es-map-set">4.5.11.10. set</a></li></ul></li></ul></li><li><a href="#es-implements-statements">4.6. Implements statements</a></li><li><a href="#es-platform-objects">4.7. Platform objects implementing interfaces</a><ul><li><a href="#indexed-and-named-properties">4.7.1. Indexed and named properties</a></li><li><a href="#getownproperty">4.7.2. Platform object [[GetOwnProperty]] method</a></li><li><a href="#defineownproperty">4.7.3. Platform object [[DefineOwnProperty]] method</a></li><li><a href="#delete">4.7.4. Platform object [[Delete]] method</a></li><li><a href="#call">4.7.5. Platform object [[Call]] method</a></li><li><a href="#property-enumeration">4.7.6. Property enumeration</a></li></ul></li><li><a href="#es-user-objects">4.8. User objects implementing callback interfaces</a></li><li><a href="#es-invoking-callback-functions">4.9. Invoking callback functions</a></li><li><a href="#es-exceptions">4.10. Exceptions</a><ul><li><a href="#es-exception-interface-object">4.10.1. Exception interface object</a><ul><li><a href="#es-exception-call">4.10.1.1. Exception interface object [[Call]] method</a></li></ul></li><li><a href="#es-exception-interface-prototype-object">4.10.2. Exception interface prototype object</a></li><li><a href="#es-exception-constants">4.10.3. Constants</a></li><li><a href="#es-exception-fields">4.10.4. Exception fields</a></li></ul></li><li><a href="#es-exception-objects">4.11. Exception objects</a></li><li><a href="#es-throwing-exceptions">4.12. Throwing exceptions</a></li><li><a href="#es-handling-exceptions">4.13. Handling exceptions</a></li></ul></li><li><a href="#common">5. Common definitions</a><ul><li><a href="#common-DOMTimeStamp">5.1. DOMTimeStamp</a></li><li><a href="#common-Function">5.2. Function</a></li><li><a href="#common-VoidFunction">5.3. VoidFunction</a></li></ul></li><li><a href="#extensibility">6. Extensibility</a></li><li><a href="#referencing">7. Referencing this specification</a></li><li><a href="#acknowledgements">8. Acknowledgements</a></li></ul><ul><li><a href="#idl-grammar">A. IDL grammar</a></li><li><a href="#references">B. References</a><ul><li><a href="#normative-references">B.1. Normative references</a></li><li><a href="#informative-references">B.2. Informative references</a></li></ul></li><li><a href="#changes">C. Changes</a></li></ul></div>
     </div>
 
     <div id="sections">
@@ -8891,11 +8891,11 @@ show(StringSanitizer.sanitizer(s));  <span class="comment">// Evaluates to [0xff
               is <dfn id="dfn-exposed">exposed</dfn> in a given ECMAScript global environment if:
             </p>
             <ul>
-              <li>the interface or dictionary was declared with an <a class="xattr" href="#Exposed">[Exposed]</a> 
+              <li>the interface or dictionary was declared with an <a class="xattr" href="#Exposed">[Exposed]</a>
               extended attribute, and the ECMAScript global object implements an interface
               that has a <a class="dfnref" href="#dfn-global-name">global name</a> that is in the
               extended attribute's identifier list; or</li>
-              <li>the interface or dictionary was not declared with an <a class="xattr" href="#Exposed">[Exposed]</a> 
+              <li>the interface or dictionary was not declared with an <a class="xattr" href="#Exposed">[Exposed]</a>
               extended attribute, and the ECMAScript global object implements
               the <a class="dfnref" href="#dfn-primary-global-interface">primary global interface</a>.</li>
             </ul>
@@ -8906,12 +8906,12 @@ show(StringSanitizer.sanitizer(s));  <span class="comment">// Evaluates to [0xff
             </p>
             <ul>
               <li>the interface member – or a partial interface definition the interface member
-              was declared on – was declared with an <a class="xattr" href="#Exposed">[Exposed]</a> 
+              was declared on – was declared with an <a class="xattr" href="#Exposed">[Exposed]</a>
               extended attribute, and the ECMAScript global object implements an interface
               that has a <a class="dfnref" href="#dfn-global-name">global name</a> that is in the
               extended attribute's identifier list; or</li>
               <li>the interface member – or a partial interface definition the interface member
-              was declared on – was not declared with an <a class="xattr" href="#Exposed">[Exposed]</a> 
+              was declared on – was not declared with an <a class="xattr" href="#Exposed">[Exposed]</a>
               extended attribute, and the ECMAScript global object implements
               the <a class="dfnref" href="#dfn-primary-global-interface">primary global interface</a>.</li>
             </ul>
@@ -9148,7 +9148,7 @@ var requestAnimationFrame = window.requestAnimationFrame ||
             </p>
             <p>
               If the <a class="xattr" href="#Global">[Global]</a> or
-              <a class="xattr" href="#PrimaryGlobal">[PrimaryGlobal]</a> 
+              <a class="xattr" href="#PrimaryGlobal">[PrimaryGlobal]</a>
               <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>
               is declared with an identifier list argument, then those identifiers are the interface’s
               <dfn id="dfn-global-name">global names</dfn>; otherwise, the interface has
@@ -9415,7 +9415,7 @@ boolean has(<var>KeyType</var> key);
             </div>
             <p>
               See <a href="#interface-prototype-object">section 4.5.4</a>
-              and <a href="#es-map-members">section 4.5.10</a> for the
+              and <a href="#es-map-members">section 4.5.11</a> for the
               specific requirements that the use of <a class="xattr" href="#MapClass">[MapClass]</a>
               entails.
             </p>
@@ -11877,7 +11877,7 @@ interface
 
             <p>
               If the <a class="dfnref" href="#dfn-interface">interface</a>
-              has an <a class="dfnref" href="#dfn-exposed">exposed</a> 
+              has an <a class="dfnref" href="#dfn-exposed">exposed</a>
               <a class="dfnref" href="#dfn-iterator">iterator</a> or
               if the interface defines an <a class="dfnref" href="#dfn-indexed-property-getter">indexed property getter</a>, then
               a property <span class="rfc2119">MUST</span> exist
@@ -12093,8 +12093,56 @@ interface
             </div>
           </div>
 
+          <div id="initializing-objects-from-iterables" class="section">
+            <h4>4.5.10. Initializing objects from iterables</h4>
+
+            <p>
+              Some objects, which are attempting to emulate map- and set-like interfaces, will want to accept iterables
+              as constructor parameters and initialize themselves in this way. Here we provide some algorithms that can
+              be invoked in order to do so in the same way as in the ECMAScript spec, so that those objects behave
+              the same as the built-in <span class="estype">Map</span> and <span class="estype">Set</span> objects.
+            </p>
+
+            <p>
+              To <dfn id="add-map-elements-from-iterable">add map elements from an iterable</dfn> <var>iterable</var> to
+              an object <var>destination</var> with adder method name <var>adder</var>, perform the following steps:
+            </p>
+            <ol class="algorithm">
+              <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type</a>(<var>destination</var>) is not Object, then, <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span> exception</a>.</li>
+              <li>If <var>iterable</var> is not present, let <var>iterable</var> be <span class="esvalue">undefined</span>.</li>
+              <li>If <var>iterable</var> is either <span class="esvalue">undefined</span> or <span class="esvalue">null</span>, then let <var>iter</var> be <span class="esvalue">undefined</span>.</li>
+              <li>Else,
+                <ol>
+                  <li>Let <var>adder</var> be the result of <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-o-p">Get</a>(<var>destination</var>, <var>adder</var>).</li>
+                  <li><a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>adder</var>).</li>
+                  <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">IsCallable</a>(<var>adder</var>) is <span class="esvalue">false</span>, <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span> exception</a>.</li>
+                  <li>Let <var>iter</var> be the result of <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-getiterator">GetIterator</a>(<var>iterable</var>).</li>
+                  <li><a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>iter</var>).</li>
+                </ol>
+              </li>
+              <li>If <var>iter</var> is <span class="esvalue">undefined</span>, then return.</li>
+              <li>Repeat
+                <ol>
+                  <li>Let <var>next</var> be the result of <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iteratorstep">IteratorStep</a>(<var>iter</var>).</li>
+                  <li><a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>next</var>).</li>
+                  <li>If <var>next</var> is <span class="esvalue">false</span>, then return <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-normalcompletion">NormalCompletion</a>(<var>destination</var>).</li>
+                  <li>Let <var>nextItem</var> be <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iteratorvalue">IteratorValue</a>(<var>next</var>).</li>
+                  <li><a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>nextItem</var>).</li>
+                  <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type</a>(<var>nextItem</var>) is not Object, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span> exception</a>.</li>
+                  <li>Let <var>k</var> be the result of <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-o-p">Get</a>(<var>nextItem</var>, <code>'0'</code>).</li>
+                  <li><a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>k</var>).</li>
+                  <li>Let <var>v</var> be the result of <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-o-p">Get</a>(<var>nextItem</var>, <code>'1'</code>).</li>
+                  <li><a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>v</var>).</li>
+                  <li>Let <var>status</var> be the result of calling the [[Call]] internal method of <var>adder</var> with <var>destination</var> as
+                      <var>thisArgument</var> and (<var>k</var>, <var>v</var>) as <var>argumentsList</var>.</li>
+                  <li><a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>status</var>).</li>
+                </ol>
+              </li>
+            </ol>
+          </div>
+
           <div id="es-map-members" class="section">
-            <h4>4.5.10. Map members</h4>
+            <h4>4.5.11. Map members</h4>
 
             <p>
               If an <a class="dfnref" href="#dfn-interface">interface</a> <var>A</var> is declared with
@@ -12106,7 +12154,7 @@ interface
             </p>
 
             <div id="es-map-size" class="section">
-              <h5>4.5.10.1. size</h5>
+              <h5>4.5.11.1. size</h5>
 
               <p>
                 There <span class="rfc2119">MUST</span> exist a property named “size” on
@@ -12135,7 +12183,7 @@ interface
             </div>
 
             <div id="es-map-entries" class="section">
-              <h5>4.5.10.2. entries</h5>
+              <h5>4.5.11.2. entries</h5>
 
               <p>
                 There <span class="rfc2119">MUST</span> exist a property named “entries” on
@@ -12162,7 +12210,7 @@ interface
             </div>
 
             <div id="es-map-keys" class="section">
-              <h5>4.5.10.3. keys</h5>
+              <h5>4.5.11.3. keys</h5>
 
               <p>
                 There <span class="rfc2119">MUST</span> exist a property named “keys” on
@@ -12189,7 +12237,7 @@ interface
             </div>
 
             <div id="es-map-values" class="section">
-              <h5>4.5.10.4. values</h5>
+              <h5>4.5.11.4. values</h5>
 
               <p>
                 There <span class="rfc2119">MUST</span> exist a property named “values” on
@@ -12216,7 +12264,7 @@ interface
             </div>
 
             <div id="es-map-clear" class="section">
-              <h5>4.5.10.5. clear</h5>
+              <h5>4.5.11.5. clear</h5>
 
               <p>
                 If <var>A</var> and <var>A</var>’s
@@ -12249,7 +12297,7 @@ interface
             </div>
 
             <div id="es-map-delete" class="section">
-              <h5>4.5.10.6. delete</h5>
+              <h5>4.5.11.6. delete</h5>
 
               <p>
                 If <var>A</var> and <var>A</var>’s
@@ -12284,7 +12332,7 @@ interface
             </div>
 
             <div id="es-map-forEach" class="section">
-              <h5>4.5.10.7. forEach</h5>
+              <h5>4.5.11.7. forEach</h5>
 
               <p>
                 If <var>A</var> and <var>A</var>’s
@@ -12317,7 +12365,7 @@ interface
             </div>
 
             <div id="es-map-get" class="section">
-              <h5>4.5.10.8. get</h5>
+              <h5>4.5.11.8. get</h5>
 
               <p>
                 If <var>A</var> and <var>A</var>’s
@@ -12363,7 +12411,7 @@ interface
             </div>
 
             <div id="es-map-has" class="section">
-              <h5>4.5.10.9. has</h5>
+              <h5>4.5.11.9. has</h5>
 
               <p>
                 If <var>A</var> and <var>A</var>’s
@@ -12397,7 +12445,7 @@ interface
             </div>
 
             <div id="es-map-set" class="section">
-              <h5>4.5.10.10. set</h5>
+              <h5>4.5.11.10. set</h5>
 
               <p>
                 If <var>A</var> and <var>A</var>’s

--- a/index.xml
+++ b/index.xml
@@ -8704,11 +8704,11 @@ show(StringSanitizer.sanitizer(s));  <span class='comment'>// Evaluates to [0xff
               is <dfn id='dfn-exposed'>exposed</dfn> in a given ECMAScript global environment if:
             </p>
             <ul>
-              <li>the interface or dictionary was declared with an <a class='xattr' href='#Exposed'>[Exposed]</a> 
+              <li>the interface or dictionary was declared with an <a class='xattr' href='#Exposed'>[Exposed]</a>
               extended attribute, and the ECMAScript global object implements an interface
               that has a <a class='dfnref' href='#dfn-global-name'>global name</a> that is in the
               extended attribute's identifier list; or</li>
-              <li>the interface or dictionary was not declared with an <a class='xattr' href='#Exposed'>[Exposed]</a> 
+              <li>the interface or dictionary was not declared with an <a class='xattr' href='#Exposed'>[Exposed]</a>
               extended attribute, and the ECMAScript global object implements
               the <a class='dfnref' href='#dfn-primary-global-interface'>primary global interface</a>.</li>
             </ul>
@@ -8719,12 +8719,12 @@ show(StringSanitizer.sanitizer(s));  <span class='comment'>// Evaluates to [0xff
             </p>
             <ul>
               <li>the interface member – or a partial interface definition the interface member
-              was declared on – was declared with an <a class='xattr' href='#Exposed'>[Exposed]</a> 
+              was declared on – was declared with an <a class='xattr' href='#Exposed'>[Exposed]</a>
               extended attribute, and the ECMAScript global object implements an interface
               that has a <a class='dfnref' href='#dfn-global-name'>global name</a> that is in the
               extended attribute's identifier list; or</li>
               <li>the interface member – or a partial interface definition the interface member
-              was declared on – was not declared with an <a class='xattr' href='#Exposed'>[Exposed]</a> 
+              was declared on – was not declared with an <a class='xattr' href='#Exposed'>[Exposed]</a>
               extended attribute, and the ECMAScript global object implements
               the <a class='dfnref' href='#dfn-primary-global-interface'>primary global interface</a>.</li>
             </ul>
@@ -8961,7 +8961,7 @@ var requestAnimationFrame = window.requestAnimationFrame ||
             </p>
             <p>
               If the <a class='xattr' href='#Global'>[Global]</a> or
-              <a class='xattr' href='#PrimaryGlobal'>[PrimaryGlobal]</a> 
+              <a class='xattr' href='#PrimaryGlobal'>[PrimaryGlobal]</a>
               <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a>
               is declared with an identifier list argument, then those identifiers are the interface’s
               <dfn id='dfn-global-name'>global names</dfn>; otherwise, the interface has
@@ -11690,7 +11690,7 @@ interface
 
             <p>
               If the <a class='dfnref' href='#dfn-interface'>interface</a>
-              has an <a class='dfnref' href='#dfn-exposed'>exposed</a> 
+              has an <a class='dfnref' href='#dfn-exposed'>exposed</a>
               <a class='dfnref' href='#dfn-iterator'>iterator</a> or
               if the interface defines an <a class='dfnref' href='#dfn-indexed-property-getter'>indexed property getter</a>, then
               a property <span class='rfc2119'>MUST</span> exist
@@ -11904,6 +11904,54 @@ interface
                 property is the <span class='estype'>Number</span> value <span class='esvalue'>0</span>.
               </p>
             </div>
+          </div>
+
+          <div id='initializing-objects-from-iterables' class='section'>
+            <h4>Initializing objects from iterables</h4>
+
+            <p>
+              Some objects, which are attempting to emulate map- and set-like interfaces, will want to accept iterables
+              as constructor parameters and initialize themselves in this way. Here we provide some algorithms that can
+              be invoked in order to do so in the same way as in the ECMAScript spec, so that those objects behave
+              the same as the built-in <span class='estype'>Map</span> and <span class='estype'>Set</span> objects.
+            </p>
+
+            <p>
+              To <dfn id='add-map-elements-from-iterable'>add map elements from an iterable</dfn> <var>iterable</var> to
+              an object <var>destination</var> with adder method name <var>adder</var>, perform the following steps:
+            </p>
+            <ol class='algorithm'>
+              <li>If <a class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values'>Type</a>(<var>destination</var>) is not Object, then, <a href='#ecmascript-throw' class='dfnref external'>throw a <span class='estype'>TypeError</span> exception</a>.</li>
+              <li>If <var>iterable</var> is not present, let <var>iterable</var> be <span class='esvalue'>undefined</span>.</li>
+              <li>If <var>iterable</var> is either <span class='esvalue'>undefined</span> or <span class='esvalue'>null</span>, then let <var>iter</var> be <span class='esvalue'>undefined</span>.</li>
+              <li>Else,
+                <ol>
+                  <li>Let <var>adder</var> be the result of <a class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-o-p'>Get</a>(<var>destination</var>, <var>adder</var>).</li>
+                  <li><a class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt'>ReturnIfAbrupt</a>(<var>adder</var>).</li>
+                  <li>If <a class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable'>IsCallable</a>(<var>adder</var>) is <span class='esvalue'>false</span>, <a href='#ecmascript-throw' class='dfnref external'>throw a <span class='estype'>TypeError</span> exception</a>.</li>
+                  <li>Let <var>iter</var> be the result of <a class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-getiterator'>GetIterator</a>(<var>iterable</var>).</li>
+                  <li><a class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt'>ReturnIfAbrupt</a>(<var>iter</var>).</li>
+                </ol>
+              </li>
+              <li>If <var>iter</var> is <span class='esvalue'>undefined</span>, then return.</li>
+              <li>Repeat
+                <ol>
+                  <li>Let <var>next</var> be the result of <a class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iteratorstep'>IteratorStep</a>(<var>iter</var>).</li>
+                  <li><a class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt'>ReturnIfAbrupt</a>(<var>next</var>).</li>
+                  <li>If <var>next</var> is <span class='esvalue'>false</span>, then return <a class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-normalcompletion'>NormalCompletion</a>(<var>destination</var>).</li>
+                  <li>Let <var>nextItem</var> be <a class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iteratorvalue'>IteratorValue</a>(<var>next</var>).</li>
+                  <li><a class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt'>ReturnIfAbrupt</a>(<var>nextItem</var>).</li>
+                  <li>If <a class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values'>Type</a>(<var>nextItem</var>) is not Object, then <a href='#ecmascript-throw' class='dfnref external'>throw a <span class='estype'>TypeError</span> exception</a>.</li>
+                  <li>Let <var>k</var> be the result of <a class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-o-p'>Get</a>(<var>nextItem</var>, <code>'0'</code>).</li>
+                  <li><a class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt'>ReturnIfAbrupt</a>(<var>k</var>).</li>
+                  <li>Let <var>v</var> be the result of <a class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-o-p'>Get</a>(<var>nextItem</var>, <code>'1'</code>).</li>
+                  <li><a class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt'>ReturnIfAbrupt</a>(<var>v</var>).</li>
+                  <li>Let <var>status</var> be the result of calling the [[Call]] internal method of <var>adder</var> with <var>destination</var> as
+                      <var>thisArgument</var> and (<var>k</var>, <var>v</var>) as <var>argumentsList</var>.</li>
+                  <li><a class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt'>ReturnIfAbrupt</a>(<var>status</var>).</li>
+                </ol>
+              </li>
+            </ol>
           </div>
 
           <div id='es-map-members' class='section'>


### PR DESCRIPTION
Initially allows you to initialize an object from an iterable in the same fashion as a map.

I couldn't get the XSLT toolchain running on Windows after ~2 hours of trying, so I didn't get a chance to compile this to HTML and test it.
