### PR TITLE
Fix <https://www.w3.org/Bugs/Public/show_bug.cgi?id=27170>

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED" type="text/css" /></head>
 
   <body>
-    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL (Second Edition)</h1><h2>W3C Editor’s Draft <em>7 October 2014</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/">http://heycam.github.io/webidl/</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
+    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL (Second Edition)</h1><h2>W3C Editor’s Draft <em>25 October 2014</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/">http://heycam.github.io/webidl/</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
               Send feedback to <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a> or <a href="https://www.w3.org/Bugs/Public/enter_bug.cgi?product=WebAppsWG&amp;component=WebIDL">file a bug</a> (<a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=WebIDL&amp;resolution=---">open bugs</a>)
             </dd><dt>Editors:</dt><dd><a href="http://mcc.id.au/">Cameron McCormack</a>, Mozilla Corporation &lt;cam@mcc.id.au&gt;</dd><dd>Boris Zbarsky, Mozilla Corporation &lt;bzbarsky@mit.edu&gt;</dd></dl><p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &copy; 2014 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>&reg;</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p></div><hr /><script async="" src="file-bug.js"></script>
 
@@ -72,7 +72,7 @@
         report can be found in the <a href="http://www.w3.org/TR/">W3C technical
           reports index</a> at http://www.w3.org/TR/.
       </em></p><p>
-        This document is the 7 October 2014 <b>Editor’s Draft</b> of the
+        This document is the 25 October 2014 <b>Editor’s Draft</b> of the
         <cite>Web IDL (Second Edition)</cite> specification.
       
       Please send comments about this document to
@@ -11207,7 +11207,7 @@ with (thing) {
               </p>
               <p>
                 Interface objects for non-callback interfaces <span class="rfc2119">MUST</span> have a property named “length”
-                with attributes <span class="descriptor">{ [[Writable]]: <span class="esvalue">false</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">false</span> }</span>
+                with attributes <span class="descriptor">{ [[Writable]]: <span class="esvalue">false</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">true</span> }</span>
                 whose value is a <span class="estype">Number</span>.
                 If the <a class="xattr" href="#Constructor">[Constructor]</a>
                 <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>,
@@ -11230,6 +11230,11 @@ with (thing) {
                   Return the length of the shortest argument list of the entries in <var>S</var>.
                 </li>
               </ol>
+              <p>
+                All interface objects <span class="rfc2119">MUST</span> have a
+                property named “name” with attributes <span class="descriptor">{ [[Writable]]: <span class="esvalue">false</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">true</span> }</span>
+                whose value is the identifier of the corresponding interface.
+              </p>
             </div>
 
             <div id="es-interface-hasinstance" class="section">
@@ -11319,7 +11324,7 @@ with (thing) {
             </p>
             <p>
               A named constructor <span class="rfc2119">MUST</span> have a property named “length”
-              with attributes <span class="descriptor">{ [[Writable]]: <span class="esvalue">false</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">false</span> }</span>
+              with attributes <span class="descriptor">{ [[Writable]]: <span class="esvalue">false</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">true</span> }</span>
               whose value is a <span class="estype">Number</span> determined as follows:
             </p>
             <ol class="algorithm">
@@ -11335,6 +11340,11 @@ with (thing) {
                 Return the length of the shortest argument list of the entries in <var>S</var>.
               </li>
             </ol>
+            <p>
+              A named constructor <span class="rfc2119">MUST</span> have a property named “name”
+              with attributes <span class="descriptor">{ [[Writable]]: <span class="esvalue">false</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">true</span> }</span>
+              whose value is the identifier used for the named constructor.
+            </p>
             <p>
               A named constructor <span class="rfc2119">MUST</span> also have a property named
               “prototype” with attributes
@@ -11406,7 +11416,7 @@ with (thing) {
             </p>
             <p>
               A dictionary constructor object <span class="rfc2119">MUST</span> have a property named “length”
-              with attributes <span class="descriptor">{ [[Writable]]: <span class="esvalue">false</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">false</span> }</span>
+              with attributes <span class="descriptor">{ [[Writable]]: <span class="esvalue">false</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">true</span> }</span>
               whose value is a <span class="estype">Number</span> determined as follows:
             </p>
             <ol class="algorithm">
@@ -11424,6 +11434,11 @@ with (thing) {
                 Return the length of the shortest argument list of the entries in <var>S</var>.
               </li>
             </ol>
+            <p>
+              A dictionary constructor object <span class="rfc2119">MUST</span> have a property named “name”
+              with attributes <span class="descriptor">{ [[Writable]]: <span class="esvalue">false</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">true</span> }</span>
+              whose value is the identifier of the dictionary.
+            </p>
           </div>
 
           <div id="interface-prototype-object" class="section">
@@ -15279,6 +15294,18 @@ d.type = et;
             <ul>
               <li>
                 <p>
+                  Gave interface objects, named constructors, and dictionary
+                  constructors a "name" property to match ES6.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Made the "length" property on dictionary constructors
+                  configurable.
+                </p>
+              </li>
+              <li>
+                <p>
                   Added types for <a class="idltype" href="#idl-ArrayBuffer">ArrayBuffer</a>, <a class="idltype" href="#idl-DataView">DataView</a>
                   and typed array objects.
                 </p>
@@ -15288,6 +15315,12 @@ d.type = et;
                   Added <a class="idltype" href="#idl-USVString">USVString</a> and allowed string literals in IDL to
                   be used to give values for all string-typed optional argument and dictionary
                   member default values.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Made sequences distinguishable from dictionaries, callback
+                  functions, and all interface types.
                 </p>
               </li>
               <li>
@@ -15398,8 +15431,8 @@ d.type = et;
               <!-- below are changes in v1 too -->
               <li>
                 <p>
-                  Made sequences distinguishable from dictionaries, callback
-                  functions, and all interface types.
+                  Made the "length" property on interface objects and named
+                  constructors configurable.
                 </p>
               </li>
               <li>

--- a/index.xml
+++ b/index.xml
@@ -11043,7 +11043,7 @@ with (thing) {
               </p>
               <p>
                 Interface objects for non-callback interfaces <span class='rfc2119'>MUST</span> have a property named “length”
-                with attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>false</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>false</span> }</span>
+                with attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>false</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>true</span> }</span>
                 whose value is a <span class='estype'>Number</span>.
                 If the <a class='xattr' href='#Constructor'>[Constructor]</a>
                 <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a>,
@@ -11066,6 +11066,11 @@ with (thing) {
                   Return the length of the shortest argument list of the entries in <var>S</var>.
                 </li>
               </ol>
+              <p>
+                All interface objects <span class='rfc2119'>MUST</span> have a
+                property named “name” with attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>false</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>true</span> }</span>
+                whose value is the identifier of the corresponding interface.
+              </p>
             </div>
 
             <div id='es-interface-hasinstance' class='section'>
@@ -11155,7 +11160,7 @@ with (thing) {
             </p>
             <p>
               A named constructor <span class='rfc2119'>MUST</span> have a property named “length”
-              with attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>false</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>false</span> }</span>
+              with attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>false</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>true</span> }</span>
               whose value is a <span class='estype'>Number</span> determined as follows:
             </p>
             <ol class='algorithm'>
@@ -11171,6 +11176,11 @@ with (thing) {
                 Return the length of the shortest argument list of the entries in <var>S</var>.
               </li>
             </ol>
+            <p>
+              A named constructor <span class='rfc2119'>MUST</span> have a property named “name”
+              with attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>false</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>true</span> }</span>
+              whose value is the identifier used for the named constructor.
+            </p>
             <p>
               A named constructor <span class='rfc2119'>MUST</span> also have a property named
               “prototype” with attributes
@@ -11242,7 +11252,7 @@ with (thing) {
             </p>
             <p>
               A dictionary constructor object <span class='rfc2119'>MUST</span> have a property named “length”
-              with attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>false</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>false</span> }</span>
+              with attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>false</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>true</span> }</span>
               whose value is a <span class='estype'>Number</span> determined as follows:
             </p>
             <ol class='algorithm'>
@@ -11260,6 +11270,11 @@ with (thing) {
                 Return the length of the shortest argument list of the entries in <var>S</var>.
               </li>
             </ol>
+            <p>
+              A dictionary constructor object <span class='rfc2119'>MUST</span> have a property named “name”
+              with attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>false</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>true</span> }</span>
+              whose value is the identifier of the dictionary.
+            </p>
           </div>
 
           <div id='interface-prototype-object' class='section'>
@@ -15095,6 +15110,18 @@ d.type = et;
             <ul>
               <li>
                 <p>
+                  Gave interface objects, named constructors, and dictionary
+                  constructors a "name" property to match ES6.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Made the "length" property on dictionary constructors
+                  configurable.
+                </p>
+              </li>
+              <li>
+                <p>
                   Added types for <span class='idltype'>ArrayBuffer</span>, <span class='idltype'>DataView</span>
                   and typed array objects.
                 </p>
@@ -15104,6 +15131,12 @@ d.type = et;
                   Added <span class='idltype'>USVString</span> and allowed string literals in IDL to
                   be used to give values for all string-typed optional argument and dictionary
                   member default values.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Made sequences distinguishable from dictionaries, callback
+                  functions, and all interface types.
                 </p>
               </li>
               <li>
@@ -15214,8 +15247,8 @@ d.type = et;
               <!-- below are changes in v1 too -->
               <li>
                 <p>
-                  Made sequences distinguishable from dictionaries, callback
-                  functions, and all interface types.
+                  Made the "length" property on interface objects and named
+                  constructors configurable.
                 </p>
               </li>
               <li>

--- a/v1.html
+++ b/v1.html
@@ -19,7 +19,7 @@
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED" type="text/css" /></head>
 
   <body>
-    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL</h1><h2>W3C Editor’s Draft <em>4 October 2014</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/v1.html">http://heycam.github.io/webidl/v1.html</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
+    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL</h1><h2>W3C Editor’s Draft <em>25 October 2014</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/v1.html">http://heycam.github.io/webidl/v1.html</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
               Send feedback to <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a> or <a href="https://www.w3.org/Bugs/Public/enter_bug.cgi?product=WebAppsWG&amp;component=WebIDL">file a bug</a> (<a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=WebIDL&amp;resolution=---">open bugs</a>)
             </dd><dt>Editors:</dt><dd><a href="http://mcc.id.au/">Cameron McCormack</a>, Mozilla Corporation &lt;cam@mcc.id.au&gt;</dd><dd>Boris Zbarsky, Mozilla Corporation &lt;bzbarsky@mit.edu&gt;</dd></dl><p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &copy; 2014 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>&reg;</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p></div><hr /><script async="" src="file-bug.js"></script>
 
@@ -72,7 +72,7 @@
         report can be found in the <a href="http://www.w3.org/TR/">W3C technical
           reports index</a> at http://www.w3.org/TR/.
       </em></p><p>
-        This document is the 4 October 2014 <b>Editor’s Draft</b> of the
+        This document is the 25 October 2014 <b>Editor’s Draft</b> of the
         <cite>Web IDL</cite> specification.
       
       Please send comments about this document to
@@ -9371,7 +9371,7 @@ system.loginTime;  <span class="comment">// So this now evaluates to forgedLogin
               <p>
                 Interface objects for non-callback interfaces declared with a <a class="xattr" href="#Constructor">[Constructor]</a>
                 extended attribute <span class="rfc2119">MUST</span> have a property named “length”
-                with attributes <span class="descriptor">{ [[Writable]]: <span class="esvalue">false</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">false</span> }</span>
+                with attributes <span class="descriptor">{ [[Writable]]: <span class="esvalue">false</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">true</span> }</span>
                 whose value is a <span class="estype">Number</span>.
                 If the <a class="xattr" href="#Constructor">[Constructor]</a>
                 <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>,
@@ -9483,7 +9483,7 @@ system.loginTime;  <span class="comment">// So this now evaluates to forgedLogin
             </p>
             <p>
               A named constructor <span class="rfc2119">MUST</span> have a property named “length”
-              with attributes <span class="descriptor">{ [[Writable]]: <span class="esvalue">false</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">false</span> }</span>
+              with attributes <span class="descriptor">{ [[Writable]]: <span class="esvalue">false</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">true</span> }</span>
               whose value is a <span class="estype">Number</span> determined as follows:
             </p>
             <ol class="algorithm">
@@ -12241,6 +12241,12 @@ d.type = et;
           <dt>Current editor’s draft</dt>
           <dd>
             <ul>
+              <li>
+                <p>
+                  Made the "length" property on interface objects and named
+                  constructors configurable.
+                </p>
+              </li>
               <li>
                 <p>
                   Added a way to mark dictionary members as required.

--- a/v1.xml
+++ b/v1.xml
@@ -9202,7 +9202,7 @@ system.loginTime;  <span class='comment'>// So this now evaluates to forgedLogin
               <p>
                 Interface objects for non-callback interfaces declared with a <a class='xattr' href='#Constructor'>[Constructor]</a>
                 extended attribute <span class='rfc2119'>MUST</span> have a property named “length”
-                with attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>false</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>false</span> }</span>
+                with attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>false</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>true</span> }</span>
                 whose value is a <span class='estype'>Number</span>.
                 If the <a class='xattr' href='#Constructor'>[Constructor]</a>
                 <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a>,
@@ -9314,7 +9314,7 @@ system.loginTime;  <span class='comment'>// So this now evaluates to forgedLogin
             </p>
             <p>
               A named constructor <span class='rfc2119'>MUST</span> have a property named “length”
-              with attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>false</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>false</span> }</span>
+              with attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>false</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>true</span> }</span>
               whose value is a <span class='estype'>Number</span> determined as follows:
             </p>
             <ol class='algorithm'>
@@ -12088,6 +12088,12 @@ d.type = et;
           <dt>Current editor’s draft</dt>
           <dd>
             <ul>
+              <li>
+                <p>
+                  Made the "length" property on interface objects and named
+                  constructors configurable.
+                </p>
+              </li>
               <li>
                 <p>
                   Added a way to mark dictionary members as required.


### PR DESCRIPTION
Define a "name" property on interface objects, named constructors, and dictionary constructors, and match the ES spec in terms of whether the "length" and "name" are configurable.
