### PR TITLE
Fix https://www.w3.org/Bugs/Public/show_bug.cgi?id=23133

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED" type="text/css" /></head>
 
   <body>
-    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL (Second Edition)</h1><h2>W3C Editor’s Draft <em>3 January 2015</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/">http://heycam.github.io/webidl/</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
+    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL (Second Edition)</h1><h2>W3C Editor’s Draft <em>12 January 2015</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/">http://heycam.github.io/webidl/</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
               Send feedback to <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a> or <a href="https://www.w3.org/Bugs/Public/enter_bug.cgi?product=WebAppsWG&amp;component=WebIDL">file a bug</a> (<a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=WebIDL&amp;resolution=---">open bugs</a>)
             </dd><dt>Editors:</dt><dd><a href="http://mcc.id.au/">Cameron McCormack</a>, Mozilla Corporation &lt;cam@mcc.id.au&gt;</dd><dd>Boris Zbarsky, Mozilla Corporation &lt;bzbarsky@mit.edu&gt;</dd></dl><p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &copy; 2015 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>&reg;</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p></div><hr /><script async="" src="file-bug.js"></script>
 
@@ -72,7 +72,7 @@
         report can be found in the <a href="http://www.w3.org/TR/">W3C technical
           reports index</a> at http://www.w3.org/TR/.
       </em></p><p>
-        This document is the 3 January 2015 <b>Editor’s Draft</b> of the
+        This document is the 12 January 2015 <b>Editor’s Draft</b> of the
         <cite>Web IDL (Second Edition)</cite> specification.
       
       Please send comments about this document to
@@ -6430,7 +6430,8 @@ interface Person {
           it has characteristics as follows:
         </p>
         <ul>
-          <li>Its <span class="prop">[[Prototype]]</span> internal property is <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%FunctionPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).</li>
+          <li>Its <span class="prop">[[Prototype]]</span> internal property is
+          <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%FunctionPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4) unless otherwise specified.</li>
           <li>Its <span class="prop">[[Get]]</span> internal property is set as described in <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver">ECMA-262 section 9.1.8</a>.</li>
           <li>Its <span class="prop">[[Construct]]</span> internal property is set as described in <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-@@create">ECMA-262 section 19.2.2.3</a>.</li>
           <li>Its <span class="prop">@@hasInstance</span> property is set as described in <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-function.prototype-@@hasinstance">ECMA-262 section 19.2.3.8</a>, unless otherwise specified.</li>
@@ -10674,6 +10675,23 @@ with (thing) {
               <a href="#es-constants">4.5.6</a> and
               <a href="#es-operations">4.5.8</a>
               below.
+            </p>
+            <p>
+              The <span class="prop">[[Prototype]]</span> internal property of
+              an interface object for a non-callback interface is determined as
+              follows:
+              <ol>
+                <li>
+                  If the interface inherits from some other interface, the value
+                  of <span class="prop">[[Prototype]]</span> is the interface
+                  object for that other interface.
+                </li>
+                <li>
+                  If the interface doesn't inherit from any other interface,
+                  the value of <span class="prop">[[Prototype]]</span> is
+                  <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%FunctionPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
+                </li>
+              </ol>
             </p>
             <p>
               An interface object for a non-callback interface <span class="rfc2119">MUST</span> have a property named “prototype”
@@ -15432,6 +15450,12 @@ d.type = et;
                 </p>
               </li>
               <!-- below are changes in v1 too -->
+              <li>
+                <p>
+                  Made the prototype of an interface object of a non-root
+                  interface be the interface object of its ancestor interface.
+                </p>
+              </li>
               <li>
                 <p>
                   Clarified the property attributes of the "prototype" property

--- a/index.xml
+++ b/index.xml
@@ -6257,7 +6257,8 @@ interface Person {
           it has characteristics as follows:
         </p>
         <ul>
-          <li>Its <span class='prop'>[[Prototype]]</span> internal property is <a>%FunctionPrototype%</a>.</li>
+          <li>Its <span class='prop'>[[Prototype]]</span> internal property is
+          <a>%FunctionPrototype%</a> unless otherwise specified.</li>
           <li>Its <span class='prop'>[[Get]]</span> internal property is set as described in <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver">ECMA-262 section 9.1.8</a>.</li>
           <li>Its <span class='prop'>[[Construct]]</span> internal property is set as described in <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-@@create">ECMA-262 section 19.2.2.3</a>.</li>
           <li>Its <span class='prop'>@@hasInstance</span> property is set as described in <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-function.prototype-@@hasinstance">ECMA-262 section 19.2.3.8</a>, unless otherwise specified.</li>
@@ -10507,6 +10508,23 @@ with (thing) {
               <a href='#es-constants'><?sref es-constants?></a> and
               <a href='#es-operations'><?sref es-operations?></a>
               <?sdir es-constants?>.
+            </p>
+            <p>
+              The <span class='prop'>[[Prototype]]</span> internal property of
+              an interface object for a non-callback interface is determined as
+              follows:
+              <ol>
+                <li>
+                  If the interface inherits from some other interface, the value
+                  of <span class='prop'>[[Prototype]]</span> is the interface
+                  object for that other interface.
+                </li>
+                <li>
+                  If the interface doesn't inherit from any other interface,
+                  the value of <span class='prop'>[[Prototype]]</span> is
+                  <a>%FunctionPrototype%</a>.
+                </li>
+              </ol>
             </p>
             <p>
               An interface object for a non-callback interface <span
@@ -15250,6 +15268,12 @@ d.type = et;
                 </p>
               </li>
               <!-- below are changes in v1 too -->
+              <li>
+                <p>
+                  Made the prototype of an interface object of a non-root
+                  interface be the interface object of its ancestor interface.
+                </p>
+              </li>
               <li>
                 <p>
                   Clarified the property attributes of the "prototype" property

--- a/v1.html
+++ b/v1.html
@@ -19,9 +19,9 @@
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED" type="text/css" /></head>
 
   <body>
-    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL</h1><h2>W3C Editor’s Draft <em>9 November 2014</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/v1.html">http://heycam.github.io/webidl/v1.html</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
+    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL</h1><h2>W3C Editor’s Draft <em>12 January 2015</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/v1.html">http://heycam.github.io/webidl/v1.html</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
               Send feedback to <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a> or <a href="https://www.w3.org/Bugs/Public/enter_bug.cgi?product=WebAppsWG&amp;component=WebIDL">file a bug</a> (<a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=WebIDL&amp;resolution=---">open bugs</a>)
-            </dd><dt>Editors:</dt><dd><a href="http://mcc.id.au/">Cameron McCormack</a>, Mozilla Corporation &lt;cam@mcc.id.au&gt;</dd><dd>Boris Zbarsky, Mozilla Corporation &lt;bzbarsky@mit.edu&gt;</dd></dl><p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &copy; 2014 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>&reg;</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p></div><hr /><script async="" src="file-bug.js"></script>
+            </dd><dt>Editors:</dt><dd><a href="http://mcc.id.au/">Cameron McCormack</a>, Mozilla Corporation &lt;cam@mcc.id.au&gt;</dd><dd>Boris Zbarsky, Mozilla Corporation &lt;bzbarsky@mit.edu&gt;</dd></dl><p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &copy; 2015 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>&reg;</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p></div><hr /><script async="" src="file-bug.js"></script>
 
     <!--
     <div id='publication-warning'>
@@ -72,7 +72,7 @@
         report can be found in the <a href="http://www.w3.org/TR/">W3C technical
           reports index</a> at http://www.w3.org/TR/.
       </em></p><p>
-        This document is the 9 November 2014 <b>Editor’s Draft</b> of the
+        This document is the 12 January 2015 <b>Editor’s Draft</b> of the
         <cite>Web IDL</cite> specification.
       
       Please send comments about this document to
@@ -5326,7 +5326,9 @@ interface Person {
           it has characteristics as follows:
         </p>
         <ul>
-          <li>Its <span class="prop">[[Prototype]]</span> internal property is the <span class="esvalue">Function</span> prototype object.</li>
+          <li>Its <span class="prop">[[Prototype]]</span> internal property is
+          the <span class="esvalue">Function</span> prototype object unless
+          otherwise specified.</li>
           <li>Its <span class="prop">[[Get]]</span> internal property is set as described in <a class="external" href="http://es5.github.com/#x15.3.5.4">ECMA-262 section 15.3.5.4</a>.</li>
           <li>Its <span class="prop">[[Construct]]</span> internal property is set as described in <a class="external" href="http://es5.github.com/#x13.2.2">ECMA-262 section 13.2.2</a>.</li>
           <li>Its <span class="prop">[[HasInstance]]</span> internal property is set as described in <a class="external" href="http://es5.github.com/#x15.3.5.3">ECMA-262 section 15.3.5.3</a>, unless otherwise specified.</li>
@@ -8990,6 +8992,23 @@ system.loginTime;  <span class="comment">// So this now evaluates to forgedLogin
               below.
             </p>
             <p>
+              The <span class="prop">[[Prototype]]</span> internal property of
+              an interface object for a non-callback interface is determined as
+              follows:
+              <ol>
+                <li>
+                  If the interface inherits from some other interface, the value
+                  of <span class="prop">[[Prototype]]</span> is the interface
+                  object for that other interface.
+                </li>
+                <li>
+                  If the interface doesn't inherit from any other interface,
+                  the value of <span class="prop">[[Prototype]]</span> is the
+                  <span class="esvalue">Function</span> prototype object.
+                </li>
+              </ol>
+            </p>
+            <p>
               An interface object for a non-callback interface <span class="rfc2119">MUST</span> have a property named “prototype”
               with attributes
               <span class="descriptor">{ [[Writable]]: <span class="esvalue">false</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">false</span> }</span>
@@ -12239,6 +12258,12 @@ d.type = et;
           <dt>Current editor’s draft</dt>
           <dd>
             <ul>
+              <li>
+                <p>
+                  Made the prototype of an interface object of a non-root
+                  interface be the interface object of its ancestor interface.
+                </p>
+              </li>
               <li>
                 <p>
                   Clarified the property attributes of the "prototype" property

--- a/v1.xml
+++ b/v1.xml
@@ -5154,7 +5154,9 @@ interface Person {
           it has characteristics as follows:
         </p>
         <ul>
-          <li>Its <span class='prop'>[[Prototype]]</span> internal property is the <span class='esvalue'>Function</span> prototype object.</li>
+          <li>Its <span class='prop'>[[Prototype]]</span> internal property is
+          the <span class='esvalue'>Function</span> prototype object unless
+          otherwise specified.</li>
           <li>Its <span class='prop'>[[Get]]</span> internal property is set as described in <a class="external" href="http://es5.github.com/#x15.3.5.4">ECMA-262 section 15.3.5.4</a>.</li>
           <li>Its <span class='prop'>[[Construct]]</span> internal property is set as described in <a class="external" href="http://es5.github.com/#x13.2.2">ECMA-262 section 13.2.2</a>.</li>
           <li>Its <span class='prop'>[[HasInstance]]</span> internal property is set as described in <a class="external" href="http://es5.github.com/#x15.3.5.3">ECMA-262 section 15.3.5.3</a>, unless otherwise specified.</li>
@@ -8821,6 +8823,23 @@ system.loginTime;  <span class='comment'>// So this now evaluates to forgedLogin
               <?sdir es-constants?>.
             </p>
             <p>
+              The <span class='prop'>[[Prototype]]</span> internal property of
+              an interface object for a non-callback interface is determined as
+              follows:
+              <ol>
+                <li>
+                  If the interface inherits from some other interface, the value
+                  of <span class='prop'>[[Prototype]]</span> is the interface
+                  object for that other interface.
+                </li>
+                <li>
+                  If the interface doesn't inherit from any other interface,
+                  the value of <span class='prop'>[[Prototype]]</span> is the
+                  <span class='esvalue'>Function</span> prototype object.
+                </li>
+              </ol>
+            </p>
+            <p>
               An interface object for a non-callback interface <span
               class='rfc2119'>MUST</span> have a property named “prototype”
               with attributes
@@ -12088,6 +12107,12 @@ d.type = et;
           <dt>Current editor’s draft</dt>
           <dd>
             <ul>
+              <li>
+                <p>
+                  Made the prototype of an interface object of a non-root
+                  interface be the interface object of its ancestor interface.
+                </p>
+              </li>
               <li>
                 <p>
                   Clarified the property attributes of the "prototype" property


### PR DESCRIPTION
By hooking up interface object prototype chains to follow the interface inheritance chain, which is how ES6 classes that extend each other work.