### PR TITLE
Fix a typo in editorial note for @@toStringTag

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -6249,8 +6249,8 @@ interface Person {
         </p>
         <div class='ednote'>
           <p>Should define whether <a>@@toStringTag</a> is writable, enumerable and configurable.
-            All <a>@@toStringTag</a> properties in he ES6 spec are non-writable and non-enumerable,
-            but some are configurable.  Not sure if that is deliberate.</p>
+            All <a>@@toStringTag</a> properties in the ES6 spec are non-writable and non-enumerable,
+            and configurable.</p>
         </div>
         <p>
           If an object is defined to be a <dfn id='dfn-function-object'>function object</dfn>, then


### PR DESCRIPTION
All `@@toStringTag` instances, short of `Symbol.toStringTag` (where it's exposed as a public API), are configurable in ES6 --- although not everyone is happy about that. It's likely to stay that way