### PR TITLE
Add a platform object [[Set]] internal method so we can have prototype setters show through even if an object has a named property of the same name and can have named creators work correctly on [OverrideBuiltins] objects even if thre is a property with the same name on the prototype.

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED" type="text/css" /></head>
 
   <body>
-    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL (Second Edition)</h1><h2>W3C Editor’s Draft <em>27 February 2015</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/">http://heycam.github.io/webidl/</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
+    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL (Second Edition)</h1><h2>W3C Editor’s Draft <em>12 March 2015</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/">http://heycam.github.io/webidl/</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
               Send feedback to <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a> or <a href="https://www.w3.org/Bugs/Public/enter_bug.cgi?product=WebAppsWG&amp;component=WebIDL">file a bug</a> (<a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=WebIDL&amp;resolution=---">open bugs</a>)
             </dd><dt>Editors:</dt><dd><a href="http://mcc.id.au/">Cameron McCormack</a>, Mozilla Corporation &lt;cam@mcc.id.au&gt;</dd><dd>Boris Zbarsky, Mozilla Corporation &lt;bzbarsky@mit.edu&gt;</dd></dl><p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &copy; 2015 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>&reg;</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p></div><hr /><script async="" src="file-bug.js"></script>
 
@@ -72,7 +72,7 @@
         report can be found in the <a href="http://www.w3.org/TR/">W3C technical
           reports index</a> at http://www.w3.org/TR/.
       </em></p><p>
-        This document is the 27 February 2015 <b>Editor’s Draft</b> of the
+        This document is the 12 March 2015 <b>Editor’s Draft</b> of the
         <cite>Web IDL (Second Edition)</cite> specification.
       
       Please send comments about this document to
@@ -124,7 +124,7 @@
 
     <div id="toc">
       <h2>Table of Contents</h2>
-      <div class="toc"><ul><li><a href="#introduction">1. Introduction</a><ul><li><a href="#conventions">1.1. Typographic conventions</a></li></ul></li><li><a href="#conformance">2. Conformance</a></li><li><a href="#idl">3. Interface definition language</a><ul><li><a href="#idl-names">3.1. Names</a></li><li><a href="#idl-interfaces">3.2. Interfaces</a><ul><li><a href="#idl-constants">3.2.1. Constants</a></li><li><a href="#idl-attributes">3.2.2. Attributes</a></li><li><a href="#idl-operations">3.2.3. Operations</a></li><li><a href="#idl-special-operations">3.2.4. Special operations</a><ul><li><a href="#idl-legacy-callers">3.2.4.1. Legacy callers</a></li><li><a href="#idl-stringifiers">3.2.4.2. Stringifiers</a></li><li><a href="#idl-serializers">3.2.4.3. Serializers</a></li><li><a href="#idl-indexed-properties">3.2.4.4. Indexed properties</a></li><li><a href="#idl-named-properties">3.2.4.5. Named properties</a></li></ul></li><li><a href="#idl-static-attributes-and-operations">3.2.5. Static attributes and operations</a></li><li><a href="#idl-overloading">3.2.6. Overloading</a></li><li><a href="#idl-iterable">3.2.7. Iterable declarations</a></li><li><a href="#idl-maplike">3.2.8. Maplike declarations</a></li><li><a href="#idl-setlike">3.2.9. Setlike declarations</a></li></ul></li><li><a href="#idl-dictionaries">3.3. Dictionaries</a></li><li><a href="#idl-exceptions">3.4. Exceptions</a><ul><li><a href="#idl-DOMException-error-names">3.4.1. Error names</a></li></ul></li><li><a href="#idl-enums">3.5. Enumerations</a></li><li><a href="#idl-callback-functions">3.6. Callback functions</a></li><li><a href="#idl-typedefs">3.7. Typedefs</a></li><li><a href="#idl-implements-statements">3.8. Implements statements</a></li><li><a href="#idl-objects">3.9. Objects implementing interfaces</a></li><li><a href="#idl-types">3.10. Types</a><ul><li><a href="#idl-any">3.10.1. any</a></li><li><a href="#idl-boolean">3.10.2. boolean</a></li><li><a href="#idl-byte">3.10.3. byte</a></li><li><a href="#idl-octet">3.10.4. octet</a></li><li><a href="#idl-short">3.10.5. short</a></li><li><a href="#idl-unsigned-short">3.10.6. unsigned short</a></li><li><a href="#idl-long">3.10.7. long</a></li><li><a href="#idl-unsigned-long">3.10.8. unsigned long</a></li><li><a href="#idl-long-long">3.10.9. long long</a></li><li><a href="#idl-unsigned-long-long">3.10.10. unsigned long long</a></li><li><a href="#idl-float">3.10.11. float</a></li><li><a href="#idl-unrestricted-float">3.10.12. unrestricted float</a></li><li><a href="#idl-double">3.10.13. double</a></li><li><a href="#idl-unrestricted-double">3.10.14. unrestricted double</a></li><li><a href="#idl-DOMString">3.10.15. DOMString</a></li><li><a href="#idl-ByteString">3.10.16. ByteString</a></li><li><a href="#idl-USVString">3.10.17. USVString</a></li><li><a href="#idl-object">3.10.18. object</a></li><li><a href="#idl-interface">3.10.19. Interface types</a></li><li><a href="#idl-dictionary">3.10.20. Dictionary types</a></li><li><a href="#idl-enumeration">3.10.21. Enumeration types</a></li><li><a href="#idl-callback-function">3.10.22. Callback function types</a></li><li><a href="#idl-nullable-type">3.10.23. Nullable types — <var>T</var>?</a></li><li><a href="#idl-sequence">3.10.24. Sequences — sequence&lt;<var>T</var>&gt;</a></li><li><a href="#idl-array">3.10.25. Arrays — <var>T</var>[]</a></li><li><a href="#idl-promise">3.10.26. Promise types — Promise&lt;<var>T</var>&gt;</a></li><li><a href="#idl-union">3.10.27. Union types</a></li><li><a href="#idl-Date">3.10.28. Date</a></li><li><a href="#idl-RegExp">3.10.29. RegExp</a></li><li><a href="#idl-Error">3.10.30. Error</a></li><li><a href="#idl-DOMException">3.10.31. DOMException</a></li><li><a href="#idl-buffer-source-types">3.10.32. Buffer source types</a></li></ul></li><li><a href="#idl-extended-attributes">3.11. Extended attributes</a></li></ul></li><li><a href="#ecmascript-binding">4. ECMAScript binding</a><ul><li><a href="#es-environment">4.1. ECMAScript environment</a></li><li><a href="#es-type-mapping">4.2. ECMAScript type mapping</a><ul><li><a href="#es-any">4.2.1. any</a></li><li><a href="#es-void">4.2.2. void</a></li><li><a href="#es-boolean">4.2.3. boolean</a></li><li><a href="#es-byte">4.2.4. byte</a></li><li><a href="#es-octet">4.2.5. octet</a></li><li><a href="#es-short">4.2.6. short</a></li><li><a href="#es-unsigned-short">4.2.7. unsigned short</a></li><li><a href="#es-long">4.2.8. long</a></li><li><a href="#es-unsigned-long">4.2.9. unsigned long</a></li><li><a href="#es-long-long">4.2.10. long long</a></li><li><a href="#es-unsigned-long-long">4.2.11. unsigned long long</a></li><li><a href="#es-float">4.2.12. float</a></li><li><a href="#es-unrestricted-float">4.2.13. unrestricted float</a></li><li><a href="#es-double">4.2.14. double</a></li><li><a href="#es-unrestricted-double">4.2.15. unrestricted double</a></li><li><a href="#es-DOMString">4.2.16. DOMString</a></li><li><a href="#es-ByteString">4.2.17. ByteString</a></li><li><a href="#es-USVString">4.2.18. USVString</a></li><li><a href="#es-object">4.2.19. object</a></li><li><a href="#es-interface">4.2.20. Interface types</a></li><li><a href="#es-dictionary">4.2.21. Dictionary types</a></li><li><a href="#es-enumeration">4.2.22. Enumeration types</a></li><li><a href="#es-callback-function">4.2.23. Callback function types</a></li><li><a href="#es-nullable-type">4.2.24. Nullable types — <var>T</var>?</a></li><li><a href="#es-sequence">4.2.25. Sequences — sequence&lt;<var>T</var>&gt;</a><ul><li><a href="#create-sequence-from-iterable">4.2.25.1. Creating a sequence from an iterable</a></li></ul></li><li><a href="#es-array">4.2.26. Arrays — <var>T</var>[]</a><ul><li><a href="#platform-array-object-getownproperty">4.2.26.1. Platform array object [[GetOwnProperty]] method</a></li><li><a href="#platform-array-object-defineownproperty">4.2.26.2. Platform array object [[DefineOwnProperty]] method</a></li><li><a href="#platform-array-object-delete">4.2.26.3. Platform array object [[Delete]] method</a></li></ul></li><li><a href="#es-promise">4.2.27. Promise types — Promise&lt;<var>T</var>&gt;</a></li><li><a href="#es-union">4.2.28. Union types</a></li><li><a href="#es-Date">4.2.29. Date</a></li><li><a href="#es-RegExp">4.2.30. RegExp</a></li><li><a href="#es-Error">4.2.31. Error</a></li><li><a href="#es-DOMException">4.2.32. DOMException</a></li><li><a href="#es-buffer-source-types">4.2.33. Buffer source types</a></li></ul></li><li><a href="#es-extended-attributes">4.3. ECMAScript-specific extended attributes</a><ul><li><a href="#ArrayClass">4.3.1. [ArrayClass]</a></li><li><a href="#Clamp">4.3.2. [Clamp]</a></li><li><a href="#Constructor">4.3.3. [Constructor]</a></li><li><a href="#EnforceRange">4.3.4. [EnforceRange]</a></li><li><a href="#Exposed">4.3.5. [Exposed]</a></li><li><a href="#ImplicitThis">4.3.6. [ImplicitThis]</a></li><li><a href="#Global">4.3.7. [Global] and [PrimaryGlobal]</a></li><li><a href="#LenientThis">4.3.8. [LenientThis]</a></li><li><a href="#NamedConstructor">4.3.9. [NamedConstructor]</a></li><li><a href="#NewObject">4.3.10. [NewObject]</a></li><li><a href="#NoInterfaceObject">4.3.11. [NoInterfaceObject]</a></li><li><a href="#OverrideBuiltins">4.3.12. [OverrideBuiltins]</a></li><li><a href="#PutForwards">4.3.13. [PutForwards]</a></li><li><a href="#Replaceable">4.3.14. [Replaceable]</a></li><li><a href="#SameObject">4.3.15. [SameObject]</a></li><li><a href="#TreatNonObjectAsNull">4.3.16. [TreatNonObjectAsNull]</a></li><li><a href="#TreatNullAs">4.3.17. [TreatNullAs]</a></li><li><a href="#Unforgeable">4.3.18. [Unforgeable]</a></li><li><a href="#Unscopeable">4.3.19. [Unscopeable]</a></li></ul></li><li><a href="#es-security">4.4. Security</a></li><li><a href="#es-interfaces">4.5. Interfaces</a><ul><li><a href="#interface-object">4.5.1. Interface object</a><ul><li><a href="#es-interface-call">4.5.1.1. Interface object [[Call]] method</a></li><li><a href="#es-interface-hasinstance">4.5.1.2. Interface object [[HasInstance]] method</a></li></ul></li><li><a href="#named-constructors">4.5.2. Named constructors</a></li><li><a href="#es-dictionary-constructors">4.5.3. Dictionary constructors</a></li><li><a href="#interface-prototype-object">4.5.4. Interface prototype object</a></li><li><a href="#named-properties-object">4.5.5. Named properties object</a><ul><li><a href="#named-properties-object-getownproperty">4.5.5.1. Named properties object [[GetOwnProperty]] method</a></li><li><a href="#named-properties-object-defineownproperty">4.5.5.2. Named properties object [[DefineOwnProperty]] method</a></li><li><a href="#named-properties-object-delete">4.5.5.3. Named properties object [[Delete]] method</a></li></ul></li><li><a href="#es-constants">4.5.6. Constants</a></li><li><a href="#es-attributes">4.5.7. Attributes</a></li><li><a href="#es-operations">4.5.8. Operations</a><ul><li><a href="#es-stringifier">4.5.8.1. Stringifiers</a></li><li><a href="#es-serializer">4.5.8.2. Serializers</a></li></ul></li><li><a href="#es-iterators">4.5.9. Common iterator behavior</a><ul><li><a href="#es-iterator">4.5.9.1. @@iterator</a></li><li><a href="#es-forEach">4.5.9.2. forEach</a></li></ul></li><li><a href="#es-iterable">4.5.10. Iterable declarations</a><ul><li><a href="#es-iterable-entries">4.5.10.1. entries</a></li><li><a href="#es-iterable-keys">4.5.10.2. keys</a></li><li><a href="#es-iterable-values">4.5.10.3. values</a></li><li><a href="#es-default-iterator-object">4.5.10.4. Default iterator objects</a></li><li><a href="#es-iterator-prototype-object">4.5.10.5. Iterator prototype object</a></li></ul></li><li><a href="#es-maplike">4.5.11. Maplike declarations</a><ul><li><a href="#es-map-size">4.5.11.1. size</a></li><li><a href="#es-map-entries">4.5.11.2. entries</a></li><li><a href="#es-map-keys-values">4.5.11.3. keys and values</a></li><li><a href="#es-map-get-has">4.5.11.4. get and has</a></li><li><a href="#es-map-clear">4.5.11.5. clear</a></li><li><a href="#es-map-delete">4.5.11.6. delete</a></li><li><a href="#es-map-set">4.5.11.7. set</a></li></ul></li><li><a href="#es-setlike">4.5.12. Setlike declarations</a><ul><li><a href="#es-set-size">4.5.12.1. size</a></li><li><a href="#es-set-values">4.5.12.2. values</a></li><li><a href="#es-set-entries-keys">4.5.12.3. entries and keys</a></li><li><a href="#es-set-has">4.5.12.4. has</a></li><li><a href="#es-add-delete">4.5.12.5. add and delete</a></li><li><a href="#es-set-clear">4.5.12.6. clear</a></li></ul></li><li><a href="#initializing-objects-from-iterables">4.5.13. Initializing objects from iterables</a></li></ul></li><li><a href="#es-implements-statements">4.6. Implements statements</a></li><li><a href="#es-platform-objects">4.7. Platform objects implementing interfaces</a><ul><li><a href="#indexed-and-named-properties">4.7.1. Indexed and named properties</a></li><li><a href="#getownproperty">4.7.2. Platform object [[GetOwnProperty]] method</a></li><li><a href="#defineownproperty">4.7.3. Platform object [[DefineOwnProperty]] method</a></li><li><a href="#delete">4.7.4. Platform object [[Delete]] method</a></li><li><a href="#call">4.7.5. Platform object [[Call]] method</a></li><li><a href="#property-enumeration">4.7.6. Property enumeration</a></li></ul></li><li><a href="#es-user-objects">4.8. User objects implementing callback interfaces</a></li><li><a href="#es-invoking-callback-functions">4.9. Invoking callback functions</a></li><li><a href="#es-exceptions">4.10. Exceptions</a><ul><li><a href="#es-DOMException-constructor-object">4.10.1. DOMException constructor object</a><ul><li><a href="#es-DOMException-call">4.10.1.1. DOMException constructor object [[Call]] method</a></li></ul></li><li><a href="#es-DOMException-prototype-object">4.10.2. DOMException prototype object</a></li></ul></li><li><a href="#es-exception-objects">4.11. Exception objects</a></li><li><a href="#es-creating-throwing-exceptions">4.12. Creating and throwing exceptions</a></li><li><a href="#es-handling-exceptions">4.13. Handling exceptions</a></li></ul></li><li><a href="#common">5. Common definitions</a><ul><li><a href="#common-ArrayBufferView">5.1. ArrayBufferView</a></li><li><a href="#common-BufferSource">5.2. BufferSource</a></li><li><a href="#common-DOMTimeStamp">5.3. DOMTimeStamp</a></li><li><a href="#common-Function">5.4. Function</a></li><li><a href="#common-VoidFunction">5.5. VoidFunction</a></li></ul></li><li><a href="#extensibility">6. Extensibility</a></li><li><a href="#referencing">7. Referencing this specification</a></li><li><a href="#acknowledgements">8. Acknowledgements</a></li></ul><ul><li><a href="#idl-grammar">A. IDL grammar</a></li><li><a href="#references">B. References</a><ul><li><a href="#normative-references">B.1. Normative references</a></li><li><a href="#informative-references">B.2. Informative references</a></li></ul></li><li><a href="#changes">C. Changes</a></li></ul></div>
+      <div class="toc"><ul><li><a href="#introduction">1. Introduction</a><ul><li><a href="#conventions">1.1. Typographic conventions</a></li></ul></li><li><a href="#conformance">2. Conformance</a></li><li><a href="#idl">3. Interface definition language</a><ul><li><a href="#idl-names">3.1. Names</a></li><li><a href="#idl-interfaces">3.2. Interfaces</a><ul><li><a href="#idl-constants">3.2.1. Constants</a></li><li><a href="#idl-attributes">3.2.2. Attributes</a></li><li><a href="#idl-operations">3.2.3. Operations</a></li><li><a href="#idl-special-operations">3.2.4. Special operations</a><ul><li><a href="#idl-legacy-callers">3.2.4.1. Legacy callers</a></li><li><a href="#idl-stringifiers">3.2.4.2. Stringifiers</a></li><li><a href="#idl-serializers">3.2.4.3. Serializers</a></li><li><a href="#idl-indexed-properties">3.2.4.4. Indexed properties</a></li><li><a href="#idl-named-properties">3.2.4.5. Named properties</a></li></ul></li><li><a href="#idl-static-attributes-and-operations">3.2.5. Static attributes and operations</a></li><li><a href="#idl-overloading">3.2.6. Overloading</a></li><li><a href="#idl-iterable">3.2.7. Iterable declarations</a></li><li><a href="#idl-maplike">3.2.8. Maplike declarations</a></li><li><a href="#idl-setlike">3.2.9. Setlike declarations</a></li></ul></li><li><a href="#idl-dictionaries">3.3. Dictionaries</a></li><li><a href="#idl-exceptions">3.4. Exceptions</a><ul><li><a href="#idl-DOMException-error-names">3.4.1. Error names</a></li></ul></li><li><a href="#idl-enums">3.5. Enumerations</a></li><li><a href="#idl-callback-functions">3.6. Callback functions</a></li><li><a href="#idl-typedefs">3.7. Typedefs</a></li><li><a href="#idl-implements-statements">3.8. Implements statements</a></li><li><a href="#idl-objects">3.9. Objects implementing interfaces</a></li><li><a href="#idl-types">3.10. Types</a><ul><li><a href="#idl-any">3.10.1. any</a></li><li><a href="#idl-boolean">3.10.2. boolean</a></li><li><a href="#idl-byte">3.10.3. byte</a></li><li><a href="#idl-octet">3.10.4. octet</a></li><li><a href="#idl-short">3.10.5. short</a></li><li><a href="#idl-unsigned-short">3.10.6. unsigned short</a></li><li><a href="#idl-long">3.10.7. long</a></li><li><a href="#idl-unsigned-long">3.10.8. unsigned long</a></li><li><a href="#idl-long-long">3.10.9. long long</a></li><li><a href="#idl-unsigned-long-long">3.10.10. unsigned long long</a></li><li><a href="#idl-float">3.10.11. float</a></li><li><a href="#idl-unrestricted-float">3.10.12. unrestricted float</a></li><li><a href="#idl-double">3.10.13. double</a></li><li><a href="#idl-unrestricted-double">3.10.14. unrestricted double</a></li><li><a href="#idl-DOMString">3.10.15. DOMString</a></li><li><a href="#idl-ByteString">3.10.16. ByteString</a></li><li><a href="#idl-USVString">3.10.17. USVString</a></li><li><a href="#idl-object">3.10.18. object</a></li><li><a href="#idl-interface">3.10.19. Interface types</a></li><li><a href="#idl-dictionary">3.10.20. Dictionary types</a></li><li><a href="#idl-enumeration">3.10.21. Enumeration types</a></li><li><a href="#idl-callback-function">3.10.22. Callback function types</a></li><li><a href="#idl-nullable-type">3.10.23. Nullable types — <var>T</var>?</a></li><li><a href="#idl-sequence">3.10.24. Sequences — sequence&lt;<var>T</var>&gt;</a></li><li><a href="#idl-array">3.10.25. Arrays — <var>T</var>[]</a></li><li><a href="#idl-promise">3.10.26. Promise types — Promise&lt;<var>T</var>&gt;</a></li><li><a href="#idl-union">3.10.27. Union types</a></li><li><a href="#idl-Date">3.10.28. Date</a></li><li><a href="#idl-RegExp">3.10.29. RegExp</a></li><li><a href="#idl-Error">3.10.30. Error</a></li><li><a href="#idl-DOMException">3.10.31. DOMException</a></li><li><a href="#idl-buffer-source-types">3.10.32. Buffer source types</a></li></ul></li><li><a href="#idl-extended-attributes">3.11. Extended attributes</a></li></ul></li><li><a href="#ecmascript-binding">4. ECMAScript binding</a><ul><li><a href="#es-environment">4.1. ECMAScript environment</a></li><li><a href="#es-type-mapping">4.2. ECMAScript type mapping</a><ul><li><a href="#es-any">4.2.1. any</a></li><li><a href="#es-void">4.2.2. void</a></li><li><a href="#es-boolean">4.2.3. boolean</a></li><li><a href="#es-byte">4.2.4. byte</a></li><li><a href="#es-octet">4.2.5. octet</a></li><li><a href="#es-short">4.2.6. short</a></li><li><a href="#es-unsigned-short">4.2.7. unsigned short</a></li><li><a href="#es-long">4.2.8. long</a></li><li><a href="#es-unsigned-long">4.2.9. unsigned long</a></li><li><a href="#es-long-long">4.2.10. long long</a></li><li><a href="#es-unsigned-long-long">4.2.11. unsigned long long</a></li><li><a href="#es-float">4.2.12. float</a></li><li><a href="#es-unrestricted-float">4.2.13. unrestricted float</a></li><li><a href="#es-double">4.2.14. double</a></li><li><a href="#es-unrestricted-double">4.2.15. unrestricted double</a></li><li><a href="#es-DOMString">4.2.16. DOMString</a></li><li><a href="#es-ByteString">4.2.17. ByteString</a></li><li><a href="#es-USVString">4.2.18. USVString</a></li><li><a href="#es-object">4.2.19. object</a></li><li><a href="#es-interface">4.2.20. Interface types</a></li><li><a href="#es-dictionary">4.2.21. Dictionary types</a></li><li><a href="#es-enumeration">4.2.22. Enumeration types</a></li><li><a href="#es-callback-function">4.2.23. Callback function types</a></li><li><a href="#es-nullable-type">4.2.24. Nullable types — <var>T</var>?</a></li><li><a href="#es-sequence">4.2.25. Sequences — sequence&lt;<var>T</var>&gt;</a><ul><li><a href="#create-sequence-from-iterable">4.2.25.1. Creating a sequence from an iterable</a></li></ul></li><li><a href="#es-array">4.2.26. Arrays — <var>T</var>[]</a><ul><li><a href="#platform-array-object-getownproperty">4.2.26.1. Platform array object [[GetOwnProperty]] method</a></li><li><a href="#platform-array-object-defineownproperty">4.2.26.2. Platform array object [[DefineOwnProperty]] method</a></li><li><a href="#platform-array-object-delete">4.2.26.3. Platform array object [[Delete]] method</a></li></ul></li><li><a href="#es-promise">4.2.27. Promise types — Promise&lt;<var>T</var>&gt;</a></li><li><a href="#es-union">4.2.28. Union types</a></li><li><a href="#es-Date">4.2.29. Date</a></li><li><a href="#es-RegExp">4.2.30. RegExp</a></li><li><a href="#es-Error">4.2.31. Error</a></li><li><a href="#es-DOMException">4.2.32. DOMException</a></li><li><a href="#es-buffer-source-types">4.2.33. Buffer source types</a></li></ul></li><li><a href="#es-extended-attributes">4.3. ECMAScript-specific extended attributes</a><ul><li><a href="#ArrayClass">4.3.1. [ArrayClass]</a></li><li><a href="#Clamp">4.3.2. [Clamp]</a></li><li><a href="#Constructor">4.3.3. [Constructor]</a></li><li><a href="#EnforceRange">4.3.4. [EnforceRange]</a></li><li><a href="#Exposed">4.3.5. [Exposed]</a></li><li><a href="#ImplicitThis">4.3.6. [ImplicitThis]</a></li><li><a href="#Global">4.3.7. [Global] and [PrimaryGlobal]</a></li><li><a href="#LenientThis">4.3.8. [LenientThis]</a></li><li><a href="#NamedConstructor">4.3.9. [NamedConstructor]</a></li><li><a href="#NewObject">4.3.10. [NewObject]</a></li><li><a href="#NoInterfaceObject">4.3.11. [NoInterfaceObject]</a></li><li><a href="#OverrideBuiltins">4.3.12. [OverrideBuiltins]</a></li><li><a href="#PutForwards">4.3.13. [PutForwards]</a></li><li><a href="#Replaceable">4.3.14. [Replaceable]</a></li><li><a href="#SameObject">4.3.15. [SameObject]</a></li><li><a href="#TreatNonObjectAsNull">4.3.16. [TreatNonObjectAsNull]</a></li><li><a href="#TreatNullAs">4.3.17. [TreatNullAs]</a></li><li><a href="#Unforgeable">4.3.18. [Unforgeable]</a></li><li><a href="#Unscopeable">4.3.19. [Unscopeable]</a></li></ul></li><li><a href="#es-security">4.4. Security</a></li><li><a href="#es-interfaces">4.5. Interfaces</a><ul><li><a href="#interface-object">4.5.1. Interface object</a><ul><li><a href="#es-interface-call">4.5.1.1. Interface object [[Call]] method</a></li><li><a href="#es-interface-hasinstance">4.5.1.2. Interface object [[HasInstance]] method</a></li></ul></li><li><a href="#named-constructors">4.5.2. Named constructors</a></li><li><a href="#es-dictionary-constructors">4.5.3. Dictionary constructors</a></li><li><a href="#interface-prototype-object">4.5.4. Interface prototype object</a></li><li><a href="#named-properties-object">4.5.5. Named properties object</a><ul><li><a href="#named-properties-object-getownproperty">4.5.5.1. Named properties object [[GetOwnProperty]] method</a></li><li><a href="#named-properties-object-defineownproperty">4.5.5.2. Named properties object [[DefineOwnProperty]] method</a></li><li><a href="#named-properties-object-delete">4.5.5.3. Named properties object [[Delete]] method</a></li></ul></li><li><a href="#es-constants">4.5.6. Constants</a></li><li><a href="#es-attributes">4.5.7. Attributes</a></li><li><a href="#es-operations">4.5.8. Operations</a><ul><li><a href="#es-stringifier">4.5.8.1. Stringifiers</a></li><li><a href="#es-serializer">4.5.8.2. Serializers</a></li></ul></li><li><a href="#es-iterators">4.5.9. Common iterator behavior</a><ul><li><a href="#es-iterator">4.5.9.1. @@iterator</a></li><li><a href="#es-forEach">4.5.9.2. forEach</a></li></ul></li><li><a href="#es-iterable">4.5.10. Iterable declarations</a><ul><li><a href="#es-iterable-entries">4.5.10.1. entries</a></li><li><a href="#es-iterable-keys">4.5.10.2. keys</a></li><li><a href="#es-iterable-values">4.5.10.3. values</a></li><li><a href="#es-default-iterator-object">4.5.10.4. Default iterator objects</a></li><li><a href="#es-iterator-prototype-object">4.5.10.5. Iterator prototype object</a></li></ul></li><li><a href="#es-maplike">4.5.11. Maplike declarations</a><ul><li><a href="#es-map-size">4.5.11.1. size</a></li><li><a href="#es-map-entries">4.5.11.2. entries</a></li><li><a href="#es-map-keys-values">4.5.11.3. keys and values</a></li><li><a href="#es-map-get-has">4.5.11.4. get and has</a></li><li><a href="#es-map-clear">4.5.11.5. clear</a></li><li><a href="#es-map-delete">4.5.11.6. delete</a></li><li><a href="#es-map-set">4.5.11.7. set</a></li></ul></li><li><a href="#es-setlike">4.5.12. Setlike declarations</a><ul><li><a href="#es-set-size">4.5.12.1. size</a></li><li><a href="#es-set-values">4.5.12.2. values</a></li><li><a href="#es-set-entries-keys">4.5.12.3. entries and keys</a></li><li><a href="#es-set-has">4.5.12.4. has</a></li><li><a href="#es-add-delete">4.5.12.5. add and delete</a></li><li><a href="#es-set-clear">4.5.12.6. clear</a></li></ul></li><li><a href="#initializing-objects-from-iterables">4.5.13. Initializing objects from iterables</a></li></ul></li><li><a href="#es-implements-statements">4.6. Implements statements</a></li><li><a href="#es-platform-objects">4.7. Platform objects implementing interfaces</a><ul><li><a href="#indexed-and-named-properties">4.7.1. Indexed and named properties</a></li><li><a href="#getownproperty-guts">4.7.2. The PlatformObjectGetOwnProperty abstract operation</a></li><li><a href="#getownproperty">4.7.3. Platform object [[GetOwnProperty]] method</a></li><li><a href="#invoking-indexed-setter">4.7.4. Invoking a platform object indexed property setter</a></li><li><a href="#invoking-named-setter">4.7.5. Invoking a platform object named property setter</a></li><li><a href="#platformobjectset">4.7.6. Platform object [[Set]] method</a></li><li><a href="#defineownproperty">4.7.7. Platform object [[DefineOwnProperty]] method</a></li><li><a href="#delete">4.7.8. Platform object [[Delete]] method</a></li><li><a href="#call">4.7.9. Platform object [[Call]] method</a></li><li><a href="#property-enumeration">4.7.10. Property enumeration</a></li></ul></li><li><a href="#es-user-objects">4.8. User objects implementing callback interfaces</a></li><li><a href="#es-invoking-callback-functions">4.9. Invoking callback functions</a></li><li><a href="#es-exceptions">4.10. Exceptions</a><ul><li><a href="#es-DOMException-constructor-object">4.10.1. DOMException constructor object</a><ul><li><a href="#es-DOMException-call">4.10.1.1. DOMException constructor object [[Call]] method</a></li></ul></li><li><a href="#es-DOMException-prototype-object">4.10.2. DOMException prototype object</a></li></ul></li><li><a href="#es-exception-objects">4.11. Exception objects</a></li><li><a href="#es-creating-throwing-exceptions">4.12. Creating and throwing exceptions</a></li><li><a href="#es-handling-exceptions">4.13. Handling exceptions</a></li></ul></li><li><a href="#common">5. Common definitions</a><ul><li><a href="#common-ArrayBufferView">5.1. ArrayBufferView</a></li><li><a href="#common-BufferSource">5.2. BufferSource</a></li><li><a href="#common-DOMTimeStamp">5.3. DOMTimeStamp</a></li><li><a href="#common-Function">5.4. Function</a></li><li><a href="#common-VoidFunction">5.5. VoidFunction</a></li></ul></li><li><a href="#extensibility">6. Extensibility</a></li><li><a href="#referencing">7. Referencing this specification</a></li><li><a href="#acknowledgements">8. Acknowledgements</a></li></ul><ul><li><a href="#idl-grammar">A. IDL grammar</a></li><li><a href="#references">B. References</a><ul><li><a href="#normative-references">B.1. Normative references</a></li><li><a href="#informative-references">B.2. Informative references</a></li></ul></li><li><a href="#changes">C. Changes</a></li></ul></div>
     </div>
 
     <div id="sections">
@@ -6367,8 +6367,9 @@ interface Person {
           <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-built-in-function-objects-call-thisargument-argumentslist">9.3.1</a> unless otherwise specified, in which case one or
           more of the following are redefined in accordance with the rules for exotic objects:
           <span class="prop">[[Call]]</span>,
+          <span class="prop">[[Set]]</span>,
           <span class="prop">[[DefineOwnProperty]]</span>,
-          <span class="prop">[[GetOwnProperty]]</span> and
+          <span class="prop">[[GetOwnProperty]]</span>,
           <span class="prop">[[Delete]]</span> and
           <span class="prop">[[HasInstance]]</span>.
         </p>
@@ -9461,8 +9462,8 @@ var requestAnimationFrame = window.requestAnimationFrame ||
             </p>
             <p>
               See <a href="#named-properties-object">section 4.5.5</a>,
-              <a href="#getownproperty">section 4.7.2</a> and
-              <a href="#defineownproperty">section 4.7.3</a>
+              <a href="#getownproperty">section 4.7.3</a> and
+              <a href="#defineownproperty">section 4.7.7</a>
               for the specific requirements that the use of
               <a class="xattr" href="#Global">[Global]</a> and <a class="xattr" href="#Global">[PrimaryGlobal]</a>
               entails for named properties,
@@ -9825,7 +9826,7 @@ var fn = Query.prototype.lookupEntry;  <span class="comment">// exception, Query
             </p>
             <p>
               See <a href="#indexed-and-named-properties">section 4.7.1</a>
-              and <a href="#defineownproperty">section 4.7.3</a>
+              and <a href="#defineownproperty">section 4.7.7</a>
               for the specific requirements that the use of
               <a class="xattr" href="#OverrideBuiltins">[OverrideBuiltins]</a> entails.
             </p>
@@ -10478,7 +10479,7 @@ interface B5 : A3 {
               <a href="#es-operations">section 4.5.8</a>,
               <a href="#es-platform-objects">section 4.7</a>,
               <a href="#indexed-and-named-properties">section 4.7.1</a> and
-              <a href="#defineownproperty">section 4.7.3</a>
+              <a href="#defineownproperty">section 4.7.7</a>
               for the specific requirements that the use of
               <a class="xattr" href="#Unforgeable">[Unforgeable]</a> entails.
             </p>
@@ -13493,7 +13494,8 @@ C implements A;</code></pre></div></div>
             <p>
               The name of each property that appears to exist due to an object supporting indexed properties
               is an <dfn id="dfn-array-index-property-name">array index property name</dfn>, which is a property
-              name <var>P</var> for which the following algorithm returns <span class="esvalue">true</span>:
+              name <var>P</var> such that <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#ecmascript-data-types-and-values">Type</a>(<var>P</var>) is String
+              and for which the following algorithm returns <span class="esvalue">true</span>:
             </p>
             <ol class="algorithm">
               <li>Let <var>i</var> be <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-touint32">ToUint32</a>(<var>P</var>).</li>
@@ -13587,27 +13589,25 @@ C implements A;</code></pre></div></div>
             <p>
               Support for <a class="dfnref" href="#dfn-getter">getters</a> is
               handled by the <a href="#defineownproperty">platform object [[GetOwnProperty]] method</a>
-              defined in section 4.7.2, and
+              defined in section 4.7.3, and
               for <a class="dfnref" href="#dfn-setter">setters</a>
               by the <a href="#defineownproperty">platform object [[DefineOwnProperty]] method</a>
-              defined in section 4.7.3.
+              defined in section 4.7.7 and the <a href="#platformobjectset">platform object [[Set]] method</a>
+              defined in section 4.7.6.
             </p>
           </div>
 
-          <div id="getownproperty" class="section">
-            <h4>4.7.2. Platform object [[GetOwnProperty]] method</h4>
+          <div id="getownproperty-guts" class="section">
+            <h4>4.7.2. The PlatformObjectGetOwnProperty abstract operation</h4>
 
             <p>
-              The internal <span class="prop">[[GetOwnProperty]]</span> method of every
-              <a class="dfnref" href="#dfn-platform-object">platform object</a> <var>O</var> that implements an <a class="dfnref" href="#dfn-interface">interface</a>
-              which <a class="dfnref" href="#dfn-support-indexed-properties">supports indexed</a> or
-              <a class="dfnref" href="#dfn-support-named-properties">named properties</a>
-              <span class="rfc2119">MUST</span> behave as follows when called with property name <var>P</var>:
+              The <span class="prop">PlatformObjectGetOwnProperty</span>
+              abstract operation performs the following steps when called with an
+              object <var>O</var>, a property name <var>P</var>, and a boolean
+              <var>ignoreNamedProps</var> value:
             </p>
 
             <ol class="algorithm">
-              <li>Let <var>ignore</var> be false.</li>
-
               <li>
                 If <var>O</var> <a class="dfnref" href="#dfn-support-indexed-properties">supports indexed properties</a>
                 and <var>P</var> is an <a class="dfnref" href="#dfn-array-index-property-name">array index property name</a>, then:
@@ -13635,14 +13635,14 @@ C implements A;</code></pre></div></div>
                       <li>Return <var>desc</var>.</li>
                     </ol>
                   </li>
-                  <li>Set <var>ignore</var> to true.</li>
+                  <li>Set <var>ignoreNamedProps</var> to true.</li>
                 </ol>
               </li>
 
               <li>If <var>O</var> <a class="dfnref" href="#dfn-support-named-properties">supports named properties</a>, <var>O</var> does not
                 implement an <a class="dfnref" href="#dfn-interface">interface</a> with the <a class="xattr" href="#Global">[Global]</a> or <a class="xattr" href="#PrimaryGlobal">[PrimaryGlobal]</a>
                 <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>, the result of running the <a class="dfnref" href="#dfn-named-property-visibility">named property visibility algorithm</a> with
-                property name <var>P</var> and object <var>O</var> is true, and <var>ignore</var> is false, then:
+                property name <var>P</var> and object <var>O</var> is true, and <var>ignoreNamedProps</var> is false, then:
                 <ol>
                   <li>Let <var>operation</var> be the operation used to declare the named property getter.</li>
 
@@ -13674,8 +13674,143 @@ C implements A;</code></pre></div></div>
             </ol>
           </div>
 
+          <div id="getownproperty" class="section">
+            <h4>4.7.3. Platform object [[GetOwnProperty]] method</h4>
+
+            <p>
+              The internal <span class="prop">[[GetOwnProperty]]</span> method of every
+              <a class="dfnref" href="#dfn-platform-object">platform object</a> <var>O</var> that implements an <a class="dfnref" href="#dfn-interface">interface</a>
+              which <a class="dfnref" href="#dfn-support-indexed-properties">supports indexed</a> or
+              <a class="dfnref" href="#dfn-support-named-properties">named properties</a>
+              <span class="rfc2119">MUST</span> behave as follows when called with property name <var>P</var>:
+            </p>
+
+            <ol class="algorithm">
+              <li>
+                Return the result of invoking the <a class="dfnref" href="#getownproperty-guts">PlatformObjectGetOwnProperty</a>
+                abstract operation with
+                <var>O</var>, <var>P</var>, and <span class="esvalue">false</span> as
+                arguments.
+              </li>
+            </ol>
+          </div>
+
+          <div id="invoking-indexed-setter" class="section">
+            <h4>4.7.4. Invoking a platform object indexed property setter</h4>
+            <p>
+              To <dfn id="invoke-indexed-setter">invoke an indexed property
+              setter</dfn> with property name <var>P</var> and ECMAScript value
+              <var>V</var>, the following steps <span class="rfc2119">MUST</span> be performed:
+            </p>
+            <ol class="algorithm">
+              <li>Let <var>index</var> be the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-touint32">ToUint32</a>(<var>P</var>).</li>
+              <li>Let <var>creating</var> be true if <var>index</var> is not a <a class="dfnref" href="#dfn-supported-property-indices">supported property index</a>, and false otherwise.</li>
+              <li>Let <var>operation</var> be the operation used to declare the indexed property setter.</li>
+              <li>Let <var>T</var> be the type of the second argument of <var>operation</var>.</li>
+              <li>Let <var>value</var> be the result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a> <var>V</var> to an IDL value of type <var>T</var>.</li>
+              <li>If <var>operation</var> was defined without an <a class="dfnref" href="#dfn-identifier">identifier</a>, then:
+              <ol>
+                <li>If <var>creating</var> is true, then perform the steps listed in the interface description to
+                <a class="dfnref" href="#dfn-set-the-value-of-a-new-indexed-property">set the value of a new indexed property</a>
+                with <var>index</var> as the index and <var>value</var> as the value.</li>
+                <li>Otherwise, <var>creating</var> is false.  Perform the steps listed in the interface description to
+                <a class="dfnref" href="#dfn-set-the-value-of-an-existing-indexed-property">set the value of an existing indexed property</a>
+                with <var>index</var> as the index and <var>value</var> as the value.</li>
+              </ol>
+              </li>
+              <li>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of
+              <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</li>
+            </ol>
+          </div>
+
+          <div id="invoking-named-setter" class="section">
+            <h4>4.7.5. Invoking a platform object named property setter</h4>
+            <p>
+              To <dfn id="invoke-named-setter">invoke a named property
+              setter</dfn> with property name <var>P</var> and ECMAScript value
+              <var>V</var>, the following steps <span class="rfc2119">MUST</span> be performed:
+            </p>
+            <ol class="algorithm">
+              <li>Let <var>creating</var> be true if <var>P</var> is not a <a class="dfnref" href="#dfn-supported-property-names">supported property name</a>, and false otherwise.</li>
+              <li>Let <var>operation</var> be the operation used to declare the named property setter.</li>
+              <li>Let <var>T</var> be the type of the second argument of <var>operation</var>.</li>
+              <li>Let <var>value</var> be the result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a> <var>V</var> to an IDL value of type <var>T</var>.</li>
+              <li>If <var>operation</var> was defined without an <a class="dfnref" href="#dfn-identifier">identifier</a>, then:
+              <ol>
+                <li>If <var>creating</var> is true, then perform the steps listed in the interface description to
+                <a class="dfnref" href="#dfn-set-the-value-of-a-new-named-property">set the value of a new named property</a>
+                with <var>P</var> as the name and <var>value</var> as the value.</li>
+                <li>Otherwise, <var>creating</var> is false.  Perform the steps listed in the interface description to
+                <a class="dfnref" href="#dfn-set-the-value-of-an-existing-named-property">set the value of an existing named property</a>
+                with <var>P</var> as the name and <var>value</var> as the value.</li>
+              </ol>
+              </li>
+              <li>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of
+              <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</li>
+            </ol>
+          </div>
+
+          <div id="platformobjectset" class="section">
+            <h4>4.7.6. Platform object [[Set]] method</h4>
+
+            <p>
+              The internal <span class="prop">[[Set]]</span> method of every
+              <a class="dfnref" href="#dfn-platform-object">platform object</a> <var>O</var> that implements an <a class="dfnref" href="#dfn-interface">interface</a>
+              which <a class="dfnref" href="#dfn-support-indexed-properties">supports indexed</a> or
+              <a class="dfnref" href="#dfn-support-named-properties">named properties</a>
+              <span class="rfc2119">MUST</span> behave as follows when called
+              with property name <var>P</var>, value <var>V</var>, and
+              ECMAScript language value <var>Receiver</var>:
+            </p>
+
+            <ol class="algorithm">
+              <li>If <var>O</var> and <var>Receiver</var> are the same object,
+              then:
+              <ol>
+                <li>
+                  If <var>O</var> <a class="dfnref" href="#dfn-support-indexed-properties">supports indexed
+                  properties</a>, <var>P</var> is an <a class="dfnref" href="#dfn-array-index-property-name">array index property
+                  name</a>, and <var>O</var> implements an interface with an <a class="dfnref" href="#dfn-indexed-property-setter">indexed
+                  property setter</a>, then:
+                  <ol>
+                    <li>
+                      <a href="#invoking-indexed-setter">Invoke the indexed
+                      property setter</a> with <var>P</var> and <var>V</var>.
+                    </li>
+                    <li>Return <span class="esvalue">true</span>.</li>
+                  </ol>
+                </li>
+
+                <li>
+                  If <var>O</var> <a class="dfnref" href="#dfn-support-named-properties">supports named
+                  properties</a>, <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#ecmascript-data-types-and-values">Type</a>(<var>P</var>) is String,
+                  <var>P</var> is not an <a class="dfnref" href="#dfn-array-index-property-name">array index property
+                  name</a>, and <var>O</var> implements an interface with a <a class="dfnref" href="#dfn-named-property-setter">named
+                  property setter</a>, then:
+                  <ol>
+                    <li>
+                      <a href="#invoking-named-setter">Invoke the named
+                      property setter</a> with <var>P</var> and <var>V</var>.
+                    </li>
+                    <li>Return <span class="esvalue">true</span>.</li>
+                  </ol>
+                </li>
+              </ol>
+              </li>
+              <li>
+                Let <var>ownDesc</var> be the result of invoking the <a class="dfnref" href="#getownproperty-guts">PlatformObjectGetOwnProperty</a>
+                abstract operation with
+                <var>O</var>, <var>P</var>, and <span class="esvalue">true</span> as
+                arguments.
+              </li>
+              <li>
+                Perform steps 3-11 of the <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver">default [[Set]] internal method</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 9.1.9).
+              </li>
+            </ol>
+          </div>
+
           <div id="defineownproperty" class="section">
-            <h4>4.7.3. Platform object [[DefineOwnProperty]] method</h4>
+            <h4>4.7.7. Platform object [[DefineOwnProperty]] method</h4>
 
             <p>
               The internal <span class="prop">[[DefineOwnProperty]]</span> method of every
@@ -13694,24 +13829,9 @@ C implements A;</code></pre></div></div>
                 <var>P</var> is an <a class="dfnref" href="#dfn-array-index-property-name">array index property name</a>, then:
                 <ol>
                   <li>If the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-isdatadescriptor">IsDataDescriptor</a>(<var>Desc</var>) is <span class="esvalue">false</span>, then Reject.</li>
-                  <li>Let <var>index</var> be the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-touint32">ToUint32</a>(<var>P</var>).</li>
-                  <li>Let <var>creating</var> be true if <var>index</var> is not a <a class="dfnref" href="#dfn-supported-property-indices">supported property index</a>, and false otherwise.</li>
                   <li>If <var>O</var> does not implement an interface with an <a class="dfnref" href="#dfn-indexed-property-setter">indexed property setter</a>, then Reject.</li>
-                  <li>Let <var>operation</var> be the operation used to declare the indexed property setter.</li>
-                  <li>Let <var>T</var> be the type of the second argument of <var>operation</var>.</li>
-                  <li>Let <var>value</var> be the result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a> <var>Desc</var>.<span class="prop">[[Value]]</span> to an IDL value of type <var>T</var>.</li>
-                  <li>If <var>operation</var> was defined without an <a class="dfnref" href="#dfn-identifier">identifier</a>, then:
-                    <ol>
-                      <li>If <var>creating</var> is true, then perform the steps listed in the interface description to
-                        <a class="dfnref" href="#dfn-set-the-value-of-a-new-indexed-property">set the value of a new indexed property</a>
-                        with <var>index</var> as the index and <var>value</var> as the value.</li>
-                      <li>Otherwise, <var>creating</var> is false.  Perform the steps listed in the interface description to
-                        <a class="dfnref" href="#dfn-set-the-value-of-an-existing-indexed-property">set the value of an existing indexed property</a>
-                        with <var>index</var> as the index and <var>value</var> as the value.</li>
-                    </ol>
-                  </li>
-                  <li>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of
-                    <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</li>
+                  <li><a href="#invoking-indexed-setter">Invoke the indexed
+                  property setter</a> with <var>P</var> and <var>Desc</var>.<span class="prop">[[Value]]</span>.</li>
                   <li>Return <span class="esvalue">true</span>.</li>
                 </ol>
               </li>
@@ -13756,21 +13876,11 @@ C implements A;</code></pre></div></div>
                       <li>If <var>O</var> implements an interface with a <a class="dfnref" href="#dfn-named-property-setter">named property setter</a>, then:
                         <ol>
                           <li>If the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-isdatadescriptor">IsDataDescriptor</a>(<var>Desc</var>) is <span class="esvalue">false</span>, then Reject.</li>
-                          <li>Let <var>operation</var> be the operation used to declare the named property setter.</li>
-                          <li>Let <var>T</var> be the type of the second argument of <var>operation</var>.</li>
-                          <li>Let <var>value</var> be the result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a> <var>Desc</var>.<span class="prop">[[Value]]</span> to an IDL value of type <var>T</var>.</li>
-                          <li>If <var>operation</var> was defined without an <a class="dfnref" href="#dfn-identifier">identifier</a>, then:
-                            <ol>
-                              <li>If <var>creating</var> is true, then perform the steps listed in the interface description to
-                                <a class="dfnref" href="#dfn-set-the-value-of-a-new-named-property">set the value of a new named property</a>
-                                with <var>P</var> as the name and <var>value</var> as the value.</li>
-                              <li>Otherwise, <var>creating</var> is false.  Perform the steps listed in the interface description to
-                                <a class="dfnref" href="#dfn-set-the-value-of-an-existing-named-property">set the value of an existing named property</a>
-                                with <var>P</var> as the name and <var>value</var> as the value.</li>
-                            </ol>
+                          <li>
+                            <a href="#invoking-named-setter">Invoke the named
+                          property setter</a> with <var>P</var> and
+                          <var>Desc</var>.<span class="prop">[[Value]]</span>.
                           </li>
-                          <li>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of
-                            <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</li>
                           <li>Return <span class="esvalue">true</span>.</li>
                         </ol>
                       </li>
@@ -13787,7 +13897,7 @@ C implements A;</code></pre></div></div>
           </div>
 
           <div id="delete" class="section">
-            <h4>4.7.4. Platform object [[Delete]] method</h4>
+            <h4>4.7.8. Platform object [[Delete]] method</h4>
 
             <p>
               The internal <span class="prop">[[Delete]]</span> method of every
@@ -13847,7 +13957,7 @@ C implements A;</code></pre></div></div>
           </div>
 
           <div id="call" class="section">
-            <h4>4.7.5. Platform object [[Call]] method</h4>
+            <h4>4.7.9. Platform object [[Call]] method</h4>
 
             <p>
               The internal <span class="prop">[[Call]]</span> method of every
@@ -13875,7 +13985,7 @@ C implements A;</code></pre></div></div>
           </div>
 
           <div id="property-enumeration" class="section">
-            <h4>4.7.6. Property enumeration</h4>
+            <h4>4.7.10. Property enumeration</h4>
 
             <p>
               This document does not define a complete property enumeration order
@@ -15401,6 +15511,12 @@ d.type = et;
                 </p>
               </li>
               <!-- below are changes in v1 too -->
+              <li>
+                <p>
+                  Added a platform object [[Set]] internal method to handle
+                  named and indexed setters better.
+                </p>
+              </li>
               <li>
                 <p>
                   Removed the concept of creators; setters are always also

--- a/index.xml
+++ b/index.xml
@@ -88,6 +88,7 @@
         <term name='array index' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-array-exotic-objects' ref='ECMA-262' section='9.4.2'/>
         <term name='default [[GetOwnProperty]] internal method' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p' ref='ECMA-262' section='9.1.5'/>
         <term name='default [[DefineOwnProperty]] internal method' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc' ref='ECMA-262' section='9.1.6'/>
+        <term name='default [[Set]] internal method' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver' ref='ECMA-262' section='9.1.9'/>
         <term name='equally close values' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-language-types-number-type' ref='ECMA-262' section='6.1.6'/>
         <term name='internal slot' class='external' href='https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots'/>
         <term name="ReturnIfAbrupt" class='external'
@@ -6197,8 +6198,9 @@ interface Person {
           <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-built-in-function-objects-call-thisargument-argumentslist">9.3.1</a> unless otherwise specified, in which case one or
           more of the following are redefined in accordance with the rules for exotic objects:
           <span class="prop">[[Call]]</span>,
+          <span class="prop">[[Set]]</span>,
           <span class="prop">[[DefineOwnProperty]]</span>,
-          <span class="prop">[[GetOwnProperty]]</span> and
+          <span class="prop">[[GetOwnProperty]]</span>,
           <span class="prop">[[Delete]]</span> and
           <span class="prop">[[HasInstance]]</span>.
         </p>
@@ -13336,7 +13338,8 @@ C implements A;</x:codeblock>
             <p>
               The name of each property that appears to exist due to an object supporting indexed properties
               is an <dfn id='dfn-array-index-property-name'>array index property name</dfn>, which is a property
-              name <var>P</var> for which the following algorithm returns <span class='esvalue'>true</span>:
+              name <var>P</var> such that <a>Type</a>(<var>P</var>) is String
+              and for which the following algorithm returns <span class='esvalue'>true</span>:
             </p>
             <ol class='algorithm'>
               <li>Let <var>i</var> be <a>ToUint32</a>(<var>P</var>).</li>
@@ -13433,24 +13436,23 @@ C implements A;</x:codeblock>
               defined in section <?sref getownproperty?>, and
               for <a class='dfnref' href='#dfn-setter'>setters</a>
               by the <a href='#defineownproperty'>platform object [[DefineOwnProperty]] method</a>
-              defined in section <?sref defineownproperty?>.
+              defined in section <?sref defineownproperty?> and the <a
+              href='#platformobjectset'>platform object [[Set]] method</a>
+              defined in section <?sref platformobjectset?>.
             </p>
           </div>
 
-          <div id='getownproperty' class='section'>
-            <h4>Platform object [[GetOwnProperty]] method</h4>
+          <div id='getownproperty-guts' class='section'>
+            <h4>The PlatformObjectGetOwnProperty abstract operation</h4>
 
             <p>
-              The internal <span class='prop'>[[GetOwnProperty]]</span> method of every
-              <a class='dfnref' href='#dfn-platform-object'>platform object</a> <var>O</var> that implements an <a class='dfnref' href='#dfn-interface'>interface</a>
-              which <a class='dfnref' href='#dfn-support-indexed-properties'>supports indexed</a> or
-              <a class='dfnref' href='#dfn-support-named-properties'>named properties</a>
-              <span class='rfc2119'>MUST</span> behave as follows when called with property name <var>P</var>:
+              The <span class='prop'>PlatformObjectGetOwnProperty</span>
+              abstract operation performs the following steps when called with an
+              object <var>O</var>, a property name <var>P</var>, and a boolean
+              <var>ignoreNamedProps</var> value:
             </p>
 
             <ol class='algorithm'>
-              <li>Let <var>ignore</var> be false.</li>
-
               <li>
                 If <var>O</var> <a class='dfnref' href='#dfn-support-indexed-properties'>supports indexed properties</a>
                 and <var>P</var> is an <a class='dfnref' href='#dfn-array-index-property-name'>array index property name</a>, then:
@@ -13478,14 +13480,14 @@ C implements A;</x:codeblock>
                       <li>Return <var>desc</var>.</li>
                     </ol>
                   </li>
-                  <li>Set <var>ignore</var> to true.</li>
+                  <li>Set <var>ignoreNamedProps</var> to true.</li>
                 </ol>
               </li>
 
               <li>If <var>O</var> <a class='dfnref' href='#dfn-support-named-properties'>supports named properties</a>, <var>O</var> does not
                 implement an <a class='dfnref' href='#dfn-interface'>interface</a> with the <a class='xattr' href='#Global'>[Global]</a> or <a class='xattr' href='#PrimaryGlobal'>[PrimaryGlobal]</a>
                 <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a>, the result of running the <a class='dfnref' href='#dfn-named-property-visibility'>named property visibility algorithm</a> with
-                property name <var>P</var> and object <var>O</var> is true, and <var>ignore</var> is false, then:
+                property name <var>P</var> and object <var>O</var> is true, and <var>ignoreNamedProps</var> is false, then:
                 <ol>
                   <li>Let <var>operation</var> be the operation used to declare the named property getter.</li>
 
@@ -13517,6 +13519,151 @@ C implements A;</x:codeblock>
             </ol>
           </div>
 
+          <div id='getownproperty' class='section'>
+            <h4>Platform object [[GetOwnProperty]] method</h4>
+
+            <p>
+              The internal <span class='prop'>[[GetOwnProperty]]</span> method of every
+              <a class='dfnref' href='#dfn-platform-object'>platform object</a> <var>O</var> that implements an <a class='dfnref' href='#dfn-interface'>interface</a>
+              which <a class='dfnref' href='#dfn-support-indexed-properties'>supports indexed</a> or
+              <a class='dfnref' href='#dfn-support-named-properties'>named properties</a>
+              <span class='rfc2119'>MUST</span> behave as follows when called with property name <var>P</var>:
+            </p>
+
+            <ol class='algorithm'>
+              <li>
+                Return the result of invoking the <a class='dfnref'
+                href='#getownproperty-guts'>PlatformObjectGetOwnProperty</a>
+                abstract operation with
+                <var>O</var>, <var>P</var>, and <span class='esvalue'>false</span> as
+                arguments.
+              </li>
+            </ol>
+          </div>
+
+          <div id='invoking-indexed-setter' class='section'>
+            <h4>Invoking a platform object indexed property setter</h4>
+            <p>
+              To <dfn id='invoke-indexed-setter'>invoke an indexed property
+              setter</dfn> with property name <var>P</var> and ECMAScript value
+              <var>V</var>, the following steps <span
+              class='rfc2119'>MUST</span> be performed:
+            </p>
+            <ol class='algorithm'>
+              <li>Let <var>index</var> be the result of calling <a>ToUint32</a>(<var>P</var>).</li>
+              <li>Let <var>creating</var> be true if <var>index</var> is not a <a class='dfnref' href='#dfn-supported-property-indices'>supported property index</a>, and false otherwise.</li>
+              <li>Let <var>operation</var> be the operation used to declare the indexed property setter.</li>
+              <li>Let <var>T</var> be the type of the second argument of <var>operation</var>.</li>
+              <li>Let <var>value</var> be the result of <a class='dfnref' href='#dfn-convert-ecmascript-to-idl-value'>converting</a> <var>V</var> to an IDL value of type <var>T</var>.</li>
+              <li>If <var>operation</var> was defined without an <a class='dfnref' href='#dfn-identifier'>identifier</a>, then:
+              <ol>
+                <li>If <var>creating</var> is true, then perform the steps listed in the interface description to
+                <a class='dfnref' href='#dfn-set-the-value-of-a-new-indexed-property'>set the value of a new indexed property</a>
+                with <var>index</var> as the index and <var>value</var> as the value.</li>
+                <li>Otherwise, <var>creating</var> is false.  Perform the steps listed in the interface description to
+                <a class='dfnref' href='#dfn-set-the-value-of-an-existing-indexed-property'>set the value of an existing indexed property</a>
+                with <var>index</var> as the index and <var>value</var> as the value.</li>
+              </ol>
+              </li>
+              <li>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of
+              <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</li>
+            </ol>
+          </div>
+
+          <div id='invoking-named-setter' class='section'>
+            <h4>Invoking a platform object named property setter</h4>
+            <p>
+              To <dfn id='invoke-named-setter'>invoke a named property
+              setter</dfn> with property name <var>P</var> and ECMAScript value
+              <var>V</var>, the following steps <span
+              class='rfc2119'>MUST</span> be performed:
+            </p>
+            <ol class='algorithm'>
+              <li>Let <var>creating</var> be true if <var>P</var> is not a <a class='dfnref' href='#dfn-supported-property-names'>supported property name</a>, and false otherwise.</li>
+              <li>Let <var>operation</var> be the operation used to declare the named property setter.</li>
+              <li>Let <var>T</var> be the type of the second argument of <var>operation</var>.</li>
+              <li>Let <var>value</var> be the result of <a class='dfnref' href='#dfn-convert-ecmascript-to-idl-value'>converting</a> <var>V</var> to an IDL value of type <var>T</var>.</li>
+              <li>If <var>operation</var> was defined without an <a class='dfnref' href='#dfn-identifier'>identifier</a>, then:
+              <ol>
+                <li>If <var>creating</var> is true, then perform the steps listed in the interface description to
+                <a class='dfnref' href='#dfn-set-the-value-of-a-new-named-property'>set the value of a new named property</a>
+                with <var>P</var> as the name and <var>value</var> as the value.</li>
+                <li>Otherwise, <var>creating</var> is false.  Perform the steps listed in the interface description to
+                <a class='dfnref' href='#dfn-set-the-value-of-an-existing-named-property'>set the value of an existing named property</a>
+                with <var>P</var> as the name and <var>value</var> as the value.</li>
+              </ol>
+              </li>
+              <li>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of
+              <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</li>
+            </ol>
+          </div>
+
+          <div id='platformobjectset' class='section'>
+            <h4>Platform object [[Set]] method</h4>
+
+            <p>
+              The internal <span class='prop'>[[Set]]</span> method of every
+              <a class='dfnref' href='#dfn-platform-object'>platform object</a> <var>O</var> that implements an <a class='dfnref' href='#dfn-interface'>interface</a>
+              which <a class='dfnref' href='#dfn-support-indexed-properties'>supports indexed</a> or
+              <a class='dfnref' href='#dfn-support-named-properties'>named properties</a>
+              <span class='rfc2119'>MUST</span> behave as follows when called
+              with property name <var>P</var>, value <var>V</var>, and
+              ECMAScript language value <var>Receiver</var>:
+            </p>
+
+            <ol class='algorithm'>
+              <li>If <var>O</var> and <var>Receiver</var> are the same object,
+              then:
+              <ol>
+                <li>
+                  If <var>O</var> <a class='dfnref'
+                  href='#dfn-support-indexed-properties'>supports indexed
+                  properties</a>, <var>P</var> is an <a class='dfnref'
+                  href='#dfn-array-index-property-name'>array index property
+                  name</a>, and <var>O</var> implements an interface with an <a
+                  class='dfnref' href='#dfn-indexed-property-setter'>indexed
+                  property setter</a>, then:
+                  <ol>
+                    <li>
+                      <a href='#invoking-indexed-setter'>Invoke the indexed
+                      property setter</a> with <var>P</var> and <var>V</var>.
+                    </li>
+                    <li>Return <span class='esvalue'>true</span>.</li>
+                  </ol>
+                </li>
+
+                <li>
+                  If <var>O</var> <a class='dfnref'
+                  href='#dfn-support-named-properties'>supports named
+                  properties</a>, <a>Type</a>(<var>P</var>) is String,
+                  <var>P</var> is not an <a class='dfnref'
+                  href='#dfn-array-index-property-name'>array index property
+                  name</a>, and <var>O</var> implements an interface with a <a
+                  class='dfnref' href='#dfn-named-property-setter'>named
+                  property setter</a>, then:
+                  <ol>
+                    <li>
+                      <a href='#invoking-named-setter'>Invoke the named
+                      property setter</a> with <var>P</var> and <var>V</var>.
+                    </li>
+                    <li>Return <span class='esvalue'>true</span>.</li>
+                  </ol>
+                </li>
+              </ol>
+              </li>
+              <li>
+                Let <var>ownDesc</var> be the result of invoking the <a class='dfnref'
+                href='#getownproperty-guts'>PlatformObjectGetOwnProperty</a>
+                abstract operation with
+                <var>O</var>, <var>P</var>, and <span class='esvalue'>true</span> as
+                arguments.
+              </li>
+              <li>
+                Perform steps 3-11 of the <a>default [[Set]] internal method</a>.
+              </li>
+            </ol>
+          </div>
+
           <div id='defineownproperty' class='section'>
             <h4>Platform object [[DefineOwnProperty]] method</h4>
 
@@ -13537,24 +13684,9 @@ C implements A;</x:codeblock>
                 <var>P</var> is an <a class='dfnref' href='#dfn-array-index-property-name'>array index property name</a>, then:
                 <ol>
                   <li>If the result of calling <a>IsDataDescriptor</a>(<var>Desc</var>) is <span class='esvalue'>false</span>, then Reject.</li>
-                  <li>Let <var>index</var> be the result of calling <a>ToUint32</a>(<var>P</var>).</li>
-                  <li>Let <var>creating</var> be true if <var>index</var> is not a <a class='dfnref' href='#dfn-supported-property-indices'>supported property index</a>, and false otherwise.</li>
                   <li>If <var>O</var> does not implement an interface with an <a class='dfnref' href='#dfn-indexed-property-setter'>indexed property setter</a>, then Reject.</li>
-                  <li>Let <var>operation</var> be the operation used to declare the indexed property setter.</li>
-                  <li>Let <var>T</var> be the type of the second argument of <var>operation</var>.</li>
-                  <li>Let <var>value</var> be the result of <a class='dfnref' href='#dfn-convert-ecmascript-to-idl-value'>converting</a> <var>Desc</var>.<span class='prop'>[[Value]]</span> to an IDL value of type <var>T</var>.</li>
-                  <li>If <var>operation</var> was defined without an <a class='dfnref' href='#dfn-identifier'>identifier</a>, then:
-                    <ol>
-                      <li>If <var>creating</var> is true, then perform the steps listed in the interface description to
-                        <a class='dfnref' href='#dfn-set-the-value-of-a-new-indexed-property'>set the value of a new indexed property</a>
-                        with <var>index</var> as the index and <var>value</var> as the value.</li>
-                      <li>Otherwise, <var>creating</var> is false.  Perform the steps listed in the interface description to
-                        <a class='dfnref' href='#dfn-set-the-value-of-an-existing-indexed-property'>set the value of an existing indexed property</a>
-                        with <var>index</var> as the index and <var>value</var> as the value.</li>
-                    </ol>
-                  </li>
-                  <li>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of
-                    <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</li>
+                  <li><a href='#invoking-indexed-setter'>Invoke the indexed
+                  property setter</a> with <var>P</var> and <var>Desc</var>.<span class='prop'>[[Value]]</span>.</li>
                   <li>Return <span class='esvalue'>true</span>.</li>
                 </ol>
               </li>
@@ -13599,21 +13731,11 @@ C implements A;</x:codeblock>
                       <li>If <var>O</var> implements an interface with a <a class='dfnref' href='#dfn-named-property-setter'>named property setter</a>, then:
                         <ol>
                           <li>If the result of calling <a>IsDataDescriptor</a>(<var>Desc</var>) is <span class='esvalue'>false</span>, then Reject.</li>
-                          <li>Let <var>operation</var> be the operation used to declare the named property setter.</li>
-                          <li>Let <var>T</var> be the type of the second argument of <var>operation</var>.</li>
-                          <li>Let <var>value</var> be the result of <a class='dfnref' href='#dfn-convert-ecmascript-to-idl-value'>converting</a> <var>Desc</var>.<span class='prop'>[[Value]]</span> to an IDL value of type <var>T</var>.</li>
-                          <li>If <var>operation</var> was defined without an <a class='dfnref' href='#dfn-identifier'>identifier</a>, then:
-                            <ol>
-                              <li>If <var>creating</var> is true, then perform the steps listed in the interface description to
-                                <a class='dfnref' href='#dfn-set-the-value-of-a-new-named-property'>set the value of a new named property</a>
-                                with <var>P</var> as the name and <var>value</var> as the value.</li>
-                              <li>Otherwise, <var>creating</var> is false.  Perform the steps listed in the interface description to
-                                <a class='dfnref' href='#dfn-set-the-value-of-an-existing-named-property'>set the value of an existing named property</a>
-                                with <var>P</var> as the name and <var>value</var> as the value.</li>
-                            </ol>
+                          <li>
+                            <a href='#invoking-named-setter'>Invoke the named
+                          property setter</a> with <var>P</var> and
+                          <var>Desc</var>.<span class='prop'>[[Value]]</span>.
                           </li>
-                          <li>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of
-                            <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</li>
                           <li>Return <span class='esvalue'>true</span>.</li>
                         </ol>
                       </li>
@@ -15226,6 +15348,12 @@ d.type = et;
                 </p>
               </li>
               <!-- below are changes in v1 too -->
+              <li>
+                <p>
+                  Added a platform object [[Set]] internal method to handle
+                  named and indexed setters better.
+                </p>
+              </li>
               <li>
                 <p>
                   Removed the concept of creators; setters are always also

--- a/v1.html
+++ b/v1.html
@@ -19,7 +19,7 @@
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED" type="text/css" /></head>
 
   <body>
-    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL</h1><h2>W3C Editor’s Draft <em>27 February 2015</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/v1.html">http://heycam.github.io/webidl/v1.html</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
+    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL</h1><h2>W3C Editor’s Draft <em>12 March 2015</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/v1.html">http://heycam.github.io/webidl/v1.html</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
               Send feedback to <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a> or <a href="https://www.w3.org/Bugs/Public/enter_bug.cgi?product=WebAppsWG&amp;component=WebIDL">file a bug</a> (<a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=WebIDL&amp;resolution=---">open bugs</a>)
             </dd><dt>Editors:</dt><dd><a href="http://mcc.id.au/">Cameron McCormack</a>, Mozilla Corporation &lt;cam@mcc.id.au&gt;</dd><dd>Boris Zbarsky, Mozilla Corporation &lt;bzbarsky@mit.edu&gt;</dd></dl><p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &copy; 2015 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>&reg;</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p></div><hr /><script async="" src="file-bug.js"></script>
 
@@ -72,7 +72,7 @@
         report can be found in the <a href="http://www.w3.org/TR/">W3C technical
           reports index</a> at http://www.w3.org/TR/.
       </em></p><p>
-        This document is the 27 February 2015 <b>Editor’s Draft</b> of the
+        This document is the 12 March 2015 <b>Editor’s Draft</b> of the
         <cite>Web IDL</cite> specification.
       
       Please send comments about this document to
@@ -146,7 +146,7 @@
 
     <div id="toc">
       <h2>Table of Contents</h2>
-      <div class="toc"><ul><li><a href="#introduction">1. Introduction</a><ul><li><a href="#conventions">1.1. Typographic conventions</a></li></ul></li><li><a href="#conformance">2. Conformance</a></li><li><a href="#idl">3. Interface definition language</a><ul><li><a href="#idl-names">3.1. Names</a></li><li><a href="#idl-interfaces">3.2. Interfaces</a><ul><li><a href="#idl-constants">3.2.1. Constants</a></li><li><a href="#idl-attributes">3.2.2. Attributes</a></li><li><a href="#idl-operations">3.2.3. Operations</a></li><li><a href="#idl-special-operations">3.2.4. Special operations</a><ul><li><a href="#idl-legacy-callers">3.2.4.1. Legacy callers</a></li><li><a href="#idl-stringifiers">3.2.4.2. Stringifiers</a></li><li><a href="#idl-indexed-properties">3.2.4.3. Indexed properties</a></li><li><a href="#idl-named-properties">3.2.4.4. Named properties</a></li></ul></li><li><a href="#idl-static-operations">3.2.5. Static operations</a></li><li><a href="#idl-overloading">3.2.6. Overloading</a></li></ul></li><li><a href="#idl-dictionaries">3.3. Dictionaries</a></li><li><a href="#idl-exceptions">3.4. Exceptions</a></li><li><a href="#idl-enums">3.5. Enumerations</a></li><li><a href="#idl-callback-functions">3.6. Callback functions</a></li><li><a href="#idl-typedefs">3.7. Typedefs</a></li><li><a href="#idl-implements-statements">3.8. Implements statements</a></li><li><a href="#idl-objects">3.9. Objects implementing interfaces</a></li><li><a href="#idl-types">3.10. Types</a><ul><li><a href="#idl-any">3.10.1. any</a></li><li><a href="#idl-boolean">3.10.2. boolean</a></li><li><a href="#idl-byte">3.10.3. byte</a></li><li><a href="#idl-octet">3.10.4. octet</a></li><li><a href="#idl-short">3.10.5. short</a></li><li><a href="#idl-unsigned-short">3.10.6. unsigned short</a></li><li><a href="#idl-long">3.10.7. long</a></li><li><a href="#idl-unsigned-long">3.10.8. unsigned long</a></li><li><a href="#idl-long-long">3.10.9. long long</a></li><li><a href="#idl-unsigned-long-long">3.10.10. unsigned long long</a></li><li><a href="#idl-float">3.10.11. float</a></li><li><a href="#idl-unrestricted-float">3.10.12. unrestricted float</a></li><li><a href="#idl-double">3.10.13. double</a></li><li><a href="#idl-unrestricted-double">3.10.14. unrestricted double</a></li><li><a href="#idl-DOMString">3.10.15. DOMString</a></li><li><a href="#idl-object">3.10.16. object</a></li><li><a href="#idl-interface">3.10.17. Interface types</a></li><li><a href="#idl-dictionary">3.10.18. Dictionary types</a></li><li><a href="#idl-enumeration">3.10.19. Enumeration types</a></li><li><a href="#idl-callback-function">3.10.20. Callback function types</a></li><li><a href="#idl-nullable-type">3.10.21. Nullable types — <var>T</var>?</a></li><li><a href="#idl-sequence">3.10.22. Sequences — sequence&lt;<var>T</var>&gt;</a></li><li><a href="#idl-array">3.10.23. Arrays — <var>T</var>[]</a></li><li><a href="#idl-union">3.10.24. Union types</a></li><li><a href="#idl-Date">3.10.25. Date</a></li></ul></li><li><a href="#idl-extended-attributes">3.11. Extended attributes</a></li></ul></li><li><a href="#ecmascript-binding">4. ECMAScript binding</a><ul><li><a href="#es-environment">4.1. ECMAScript environment</a></li><li><a href="#es-type-mapping">4.2. ECMAScript type mapping</a><ul><li><a href="#es-any">4.2.1. any</a></li><li><a href="#es-void">4.2.2. void</a></li><li><a href="#es-boolean">4.2.3. boolean</a></li><li><a href="#es-byte">4.2.4. byte</a></li><li><a href="#es-octet">4.2.5. octet</a></li><li><a href="#es-short">4.2.6. short</a></li><li><a href="#es-unsigned-short">4.2.7. unsigned short</a></li><li><a href="#es-long">4.2.8. long</a></li><li><a href="#es-unsigned-long">4.2.9. unsigned long</a></li><li><a href="#es-long-long">4.2.10. long long</a></li><li><a href="#es-unsigned-long-long">4.2.11. unsigned long long</a></li><li><a href="#es-float">4.2.12. float</a></li><li><a href="#es-unrestricted-float">4.2.13. unrestricted float</a></li><li><a href="#es-double">4.2.14. double</a></li><li><a href="#es-unrestricted-double">4.2.15. unrestricted double</a></li><li><a href="#es-DOMString">4.2.16. DOMString</a></li><li><a href="#es-object">4.2.17. object</a></li><li><a href="#es-interface">4.2.18. Interface types</a></li><li><a href="#es-dictionary">4.2.19. Dictionary types</a></li><li><a href="#es-enumeration">4.2.20. Enumeration types</a></li><li><a href="#es-callback-function">4.2.21. Callback function types</a></li><li><a href="#es-nullable-type">4.2.22. Nullable types — <var>T</var>?</a></li><li><a href="#es-sequence">4.2.23. Sequences — sequence&lt;<var>T</var>&gt;</a></li><li><a href="#es-array">4.2.24. Arrays — <var>T</var>[]</a><ul><li><a href="#platform-array-object-getownproperty">4.2.24.1. Platform array object [[GetOwnProperty]] method</a></li><li><a href="#platform-array-object-defineownproperty">4.2.24.2. Platform array object [[DefineOwnProperty]] method</a></li><li><a href="#platform-array-object-delete">4.2.24.3. Platform array object [[Delete]] method</a></li></ul></li><li><a href="#es-union">4.2.25. Union types</a></li><li><a href="#es-Date">4.2.26. Date</a></li></ul></li><li><a href="#es-extended-attributes">4.3. ECMAScript-specific extended attributes</a><ul><li><a href="#ArrayClass">4.3.1. [ArrayClass]</a></li><li><a href="#Clamp">4.3.2. [Clamp]</a></li><li><a href="#Constructor">4.3.3. [Constructor]</a></li><li><a href="#EnforceRange">4.3.4. [EnforceRange]</a></li><li><a href="#Global">4.3.5. [Global] and [PrimaryGlobal]</a></li><li><a href="#Exposed">4.3.6. [Exposed]</a></li><li><a href="#ImplicitThis">4.3.7. [ImplicitThis]</a></li><li><a href="#LenientThis">4.3.8. [LenientThis]</a></li><li><a href="#NamedConstructor">4.3.9. [NamedConstructor]</a></li><li><a href="#NoInterfaceObject">4.3.10. [NoInterfaceObject]</a></li><li><a href="#OverrideBuiltins">4.3.11. [OverrideBuiltins]</a></li><li><a href="#PutForwards">4.3.12. [PutForwards]</a></li><li><a href="#Replaceable">4.3.13. [Replaceable]</a></li><li><a href="#TreatNonObjectAsNull">4.3.14. [TreatNonObjectAsNull]</a></li><li><a href="#TreatNullAs">4.3.15. [TreatNullAs]</a></li><li><a href="#Unforgeable">4.3.16. [Unforgeable]</a></li></ul></li><li><a href="#es-security">4.4. Security</a></li><li><a href="#es-interfaces">4.5. Interfaces</a><ul><li><a href="#interface-object">4.5.1. Interface object</a><ul><li><a href="#es-interface-call">4.5.1.1. Interface object [[Call]] method</a></li><li><a href="#es-interface-hasinstance">4.5.1.2. Interface object [[HasInstance]] method</a></li></ul></li><li><a href="#named-constructors">4.5.2. Named constructors</a></li><li><a href="#interface-prototype-object">4.5.3. Interface prototype object</a></li><li><a href="#named-properties-object">4.5.4. Named properties object</a><ul><li><a href="#named-properties-object-getownproperty">4.5.4.1. Named properties object [[GetOwnProperty]] method</a></li><li><a href="#named-properties-object-defineownproperty">4.5.4.2. Named properties object [[DefineOwnProperty]] method</a></li><li><a href="#named-properties-object-delete">4.5.4.3. Named properties object [[Delete]] method</a></li></ul></li><li><a href="#es-constants">4.5.5. Constants</a></li><li><a href="#es-attributes">4.5.6. Attributes</a></li><li><a href="#es-operations">4.5.7. Operations</a></li></ul></li><li><a href="#es-implements-statements">4.6. Implements statements</a></li><li><a href="#es-platform-objects">4.7. Platform objects implementing interfaces</a><ul><li><a href="#indexed-and-named-properties">4.7.1. Indexed and named properties</a></li><li><a href="#getownproperty">4.7.2. Platform object [[GetOwnProperty]] method</a></li><li><a href="#defineownproperty">4.7.3. Platform object [[DefineOwnProperty]] method</a></li><li><a href="#delete">4.7.4. Platform object [[Delete]] method</a></li><li><a href="#call">4.7.5. Platform object [[Call]] method</a></li><li><a href="#property-enumeration">4.7.6. Property enumeration</a></li></ul></li><li><a href="#es-user-objects">4.8. User objects implementing callback interfaces</a></li><li><a href="#es-invoking-callback-functions">4.9. Invoking callback functions</a></li><li><a href="#es-exceptions">4.10. Exceptions</a><ul><li><a href="#es-exception-interface-object">4.10.1. Exception interface object</a><ul><li><a href="#es-exception-call">4.10.1.1. Exception interface object [[Call]] method</a></li></ul></li><li><a href="#es-exception-interface-prototype-object">4.10.2. Exception interface prototype object</a></li><li><a href="#es-exception-constants">4.10.3. Constants</a></li><li><a href="#es-exception-fields">4.10.4. Exception fields</a></li></ul></li><li><a href="#es-exception-objects">4.11. Exception objects</a></li><li><a href="#es-throwing-exceptions">4.12. Throwing exceptions</a></li><li><a href="#es-handling-exceptions">4.13. Handling exceptions</a></li></ul></li><li><a href="#common">5. Common definitions</a><ul><li><a href="#common-DOMTimeStamp">5.1. DOMTimeStamp</a></li><li><a href="#common-Function">5.2. Function</a></li><li><a href="#common-VoidFunction">5.3. VoidFunction</a></li></ul></li><li><a href="#extensibility">6. Extensibility</a></li><li><a href="#referencing">7. Referencing this specification</a></li><li><a href="#acknowledgements">8. Acknowledgements</a></li></ul><ul><li><a href="#idl-grammar">A. IDL grammar</a></li><li><a href="#references">B. References</a><ul><li><a href="#normative-references">B.1. Normative references</a></li><li><a href="#informative-references">B.2. Informative references</a></li></ul></li><li><a href="#cr-exit">C. Candidate Recommendation exit criteria</a></li><li><a href="#changes">D. Changes</a></li></ul></div>
+      <div class="toc"><ul><li><a href="#introduction">1. Introduction</a><ul><li><a href="#conventions">1.1. Typographic conventions</a></li></ul></li><li><a href="#conformance">2. Conformance</a></li><li><a href="#idl">3. Interface definition language</a><ul><li><a href="#idl-names">3.1. Names</a></li><li><a href="#idl-interfaces">3.2. Interfaces</a><ul><li><a href="#idl-constants">3.2.1. Constants</a></li><li><a href="#idl-attributes">3.2.2. Attributes</a></li><li><a href="#idl-operations">3.2.3. Operations</a></li><li><a href="#idl-special-operations">3.2.4. Special operations</a><ul><li><a href="#idl-legacy-callers">3.2.4.1. Legacy callers</a></li><li><a href="#idl-stringifiers">3.2.4.2. Stringifiers</a></li><li><a href="#idl-indexed-properties">3.2.4.3. Indexed properties</a></li><li><a href="#idl-named-properties">3.2.4.4. Named properties</a></li></ul></li><li><a href="#idl-static-operations">3.2.5. Static operations</a></li><li><a href="#idl-overloading">3.2.6. Overloading</a></li></ul></li><li><a href="#idl-dictionaries">3.3. Dictionaries</a></li><li><a href="#idl-exceptions">3.4. Exceptions</a></li><li><a href="#idl-enums">3.5. Enumerations</a></li><li><a href="#idl-callback-functions">3.6. Callback functions</a></li><li><a href="#idl-typedefs">3.7. Typedefs</a></li><li><a href="#idl-implements-statements">3.8. Implements statements</a></li><li><a href="#idl-objects">3.9. Objects implementing interfaces</a></li><li><a href="#idl-types">3.10. Types</a><ul><li><a href="#idl-any">3.10.1. any</a></li><li><a href="#idl-boolean">3.10.2. boolean</a></li><li><a href="#idl-byte">3.10.3. byte</a></li><li><a href="#idl-octet">3.10.4. octet</a></li><li><a href="#idl-short">3.10.5. short</a></li><li><a href="#idl-unsigned-short">3.10.6. unsigned short</a></li><li><a href="#idl-long">3.10.7. long</a></li><li><a href="#idl-unsigned-long">3.10.8. unsigned long</a></li><li><a href="#idl-long-long">3.10.9. long long</a></li><li><a href="#idl-unsigned-long-long">3.10.10. unsigned long long</a></li><li><a href="#idl-float">3.10.11. float</a></li><li><a href="#idl-unrestricted-float">3.10.12. unrestricted float</a></li><li><a href="#idl-double">3.10.13. double</a></li><li><a href="#idl-unrestricted-double">3.10.14. unrestricted double</a></li><li><a href="#idl-DOMString">3.10.15. DOMString</a></li><li><a href="#idl-object">3.10.16. object</a></li><li><a href="#idl-interface">3.10.17. Interface types</a></li><li><a href="#idl-dictionary">3.10.18. Dictionary types</a></li><li><a href="#idl-enumeration">3.10.19. Enumeration types</a></li><li><a href="#idl-callback-function">3.10.20. Callback function types</a></li><li><a href="#idl-nullable-type">3.10.21. Nullable types — <var>T</var>?</a></li><li><a href="#idl-sequence">3.10.22. Sequences — sequence&lt;<var>T</var>&gt;</a></li><li><a href="#idl-array">3.10.23. Arrays — <var>T</var>[]</a></li><li><a href="#idl-union">3.10.24. Union types</a></li><li><a href="#idl-Date">3.10.25. Date</a></li></ul></li><li><a href="#idl-extended-attributes">3.11. Extended attributes</a></li></ul></li><li><a href="#ecmascript-binding">4. ECMAScript binding</a><ul><li><a href="#es-environment">4.1. ECMAScript environment</a></li><li><a href="#es-type-mapping">4.2. ECMAScript type mapping</a><ul><li><a href="#es-any">4.2.1. any</a></li><li><a href="#es-void">4.2.2. void</a></li><li><a href="#es-boolean">4.2.3. boolean</a></li><li><a href="#es-byte">4.2.4. byte</a></li><li><a href="#es-octet">4.2.5. octet</a></li><li><a href="#es-short">4.2.6. short</a></li><li><a href="#es-unsigned-short">4.2.7. unsigned short</a></li><li><a href="#es-long">4.2.8. long</a></li><li><a href="#es-unsigned-long">4.2.9. unsigned long</a></li><li><a href="#es-long-long">4.2.10. long long</a></li><li><a href="#es-unsigned-long-long">4.2.11. unsigned long long</a></li><li><a href="#es-float">4.2.12. float</a></li><li><a href="#es-unrestricted-float">4.2.13. unrestricted float</a></li><li><a href="#es-double">4.2.14. double</a></li><li><a href="#es-unrestricted-double">4.2.15. unrestricted double</a></li><li><a href="#es-DOMString">4.2.16. DOMString</a></li><li><a href="#es-object">4.2.17. object</a></li><li><a href="#es-interface">4.2.18. Interface types</a></li><li><a href="#es-dictionary">4.2.19. Dictionary types</a></li><li><a href="#es-enumeration">4.2.20. Enumeration types</a></li><li><a href="#es-callback-function">4.2.21. Callback function types</a></li><li><a href="#es-nullable-type">4.2.22. Nullable types — <var>T</var>?</a></li><li><a href="#es-sequence">4.2.23. Sequences — sequence&lt;<var>T</var>&gt;</a></li><li><a href="#es-array">4.2.24. Arrays — <var>T</var>[]</a><ul><li><a href="#platform-array-object-getownproperty">4.2.24.1. Platform array object [[GetOwnProperty]] method</a></li><li><a href="#platform-array-object-defineownproperty">4.2.24.2. Platform array object [[DefineOwnProperty]] method</a></li><li><a href="#platform-array-object-delete">4.2.24.3. Platform array object [[Delete]] method</a></li></ul></li><li><a href="#es-union">4.2.25. Union types</a></li><li><a href="#es-Date">4.2.26. Date</a></li></ul></li><li><a href="#es-extended-attributes">4.3. ECMAScript-specific extended attributes</a><ul><li><a href="#ArrayClass">4.3.1. [ArrayClass]</a></li><li><a href="#Clamp">4.3.2. [Clamp]</a></li><li><a href="#Constructor">4.3.3. [Constructor]</a></li><li><a href="#EnforceRange">4.3.4. [EnforceRange]</a></li><li><a href="#Global">4.3.5. [Global] and [PrimaryGlobal]</a></li><li><a href="#Exposed">4.3.6. [Exposed]</a></li><li><a href="#ImplicitThis">4.3.7. [ImplicitThis]</a></li><li><a href="#LenientThis">4.3.8. [LenientThis]</a></li><li><a href="#NamedConstructor">4.3.9. [NamedConstructor]</a></li><li><a href="#NoInterfaceObject">4.3.10. [NoInterfaceObject]</a></li><li><a href="#OverrideBuiltins">4.3.11. [OverrideBuiltins]</a></li><li><a href="#PutForwards">4.3.12. [PutForwards]</a></li><li><a href="#Replaceable">4.3.13. [Replaceable]</a></li><li><a href="#TreatNonObjectAsNull">4.3.14. [TreatNonObjectAsNull]</a></li><li><a href="#TreatNullAs">4.3.15. [TreatNullAs]</a></li><li><a href="#Unforgeable">4.3.16. [Unforgeable]</a></li></ul></li><li><a href="#es-security">4.4. Security</a></li><li><a href="#es-interfaces">4.5. Interfaces</a><ul><li><a href="#interface-object">4.5.1. Interface object</a><ul><li><a href="#es-interface-call">4.5.1.1. Interface object [[Call]] method</a></li><li><a href="#es-interface-hasinstance">4.5.1.2. Interface object [[HasInstance]] method</a></li></ul></li><li><a href="#named-constructors">4.5.2. Named constructors</a></li><li><a href="#interface-prototype-object">4.5.3. Interface prototype object</a></li><li><a href="#named-properties-object">4.5.4. Named properties object</a><ul><li><a href="#named-properties-object-getownproperty">4.5.4.1. Named properties object [[GetOwnProperty]] method</a></li><li><a href="#named-properties-object-defineownproperty">4.5.4.2. Named properties object [[DefineOwnProperty]] method</a></li><li><a href="#named-properties-object-delete">4.5.4.3. Named properties object [[Delete]] method</a></li></ul></li><li><a href="#es-constants">4.5.5. Constants</a></li><li><a href="#es-attributes">4.5.6. Attributes</a></li><li><a href="#es-operations">4.5.7. Operations</a></li></ul></li><li><a href="#es-implements-statements">4.6. Implements statements</a></li><li><a href="#es-platform-objects">4.7. Platform objects implementing interfaces</a><ul><li><a href="#indexed-and-named-properties">4.7.1. Indexed and named properties</a></li><li><a href="#getownproperty-guts">4.7.2. The PlatformObjectGetOwnProperty abstract operation</a></li><li><a href="#getownproperty">4.7.3. Platform object [[GetOwnProperty]] method</a></li><li><a href="#invoking-indexed-setter">4.7.4. Invoking a platform object indexed property setter</a></li><li><a href="#invoking-named-setter">4.7.5. Invoking a platform object named property setter</a></li><li><a href="#platformobjectset">4.7.6. Platform object [[Set]] method</a></li><li><a href="#defineownproperty">4.7.7. Platform object [[DefineOwnProperty]] method</a></li><li><a href="#delete">4.7.8. Platform object [[Delete]] method</a></li><li><a href="#call">4.7.9. Platform object [[Call]] method</a></li><li><a href="#property-enumeration">4.7.10. Property enumeration</a></li></ul></li><li><a href="#es-user-objects">4.8. User objects implementing callback interfaces</a></li><li><a href="#es-invoking-callback-functions">4.9. Invoking callback functions</a></li><li><a href="#es-exceptions">4.10. Exceptions</a><ul><li><a href="#es-exception-interface-object">4.10.1. Exception interface object</a><ul><li><a href="#es-exception-call">4.10.1.1. Exception interface object [[Call]] method</a></li></ul></li><li><a href="#es-exception-interface-prototype-object">4.10.2. Exception interface prototype object</a></li><li><a href="#es-exception-constants">4.10.3. Constants</a></li><li><a href="#es-exception-fields">4.10.4. Exception fields</a></li></ul></li><li><a href="#es-exception-objects">4.11. Exception objects</a></li><li><a href="#es-throwing-exceptions">4.12. Throwing exceptions</a></li><li><a href="#es-handling-exceptions">4.13. Handling exceptions</a></li></ul></li><li><a href="#common">5. Common definitions</a><ul><li><a href="#common-DOMTimeStamp">5.1. DOMTimeStamp</a></li><li><a href="#common-Function">5.2. Function</a></li><li><a href="#common-VoidFunction">5.3. VoidFunction</a></li></ul></li><li><a href="#extensibility">6. Extensibility</a></li><li><a href="#referencing">7. Referencing this specification</a></li><li><a href="#acknowledgements">8. Acknowledgements</a></li></ul><ul><li><a href="#idl-grammar">A. IDL grammar</a></li><li><a href="#references">B. References</a><ul><li><a href="#normative-references">B.1. Normative references</a></li><li><a href="#informative-references">B.2. Informative references</a></li></ul></li><li><a href="#cr-exit">C. Candidate Recommendation exit criteria</a></li><li><a href="#changes">D. Changes</a></li></ul></div>
     </div>
 
     <div id="sections">
@@ -5227,8 +5227,9 @@ interface Person {
           <a class="external" href="http://es5.github.com/#x13.2">13.2</a> unless otherwise specified, in which case one or
           more of the following are redefined in accordance with the rules for host objects:
           <span class="prop">[[Call]]</span>,
+          <span class="prop">[[Set]]</span>,
           <span class="prop">[[DefineOwnProperty]]</span>,
-          <span class="prop">[[GetOwnProperty]]</span> and
+          <span class="prop">[[GetOwnProperty]]</span>,
           <span class="prop">[[Delete]]</span> and
           <span class="prop">[[HasInstance]]</span>.
         </p>
@@ -7685,8 +7686,8 @@ var requestAnimationFrame = window.requestAnimationFrame ||
             </p>
             <p>
               See <a href="#named-properties-object">section 4.5.4</a>,
-              <a href="#getownproperty">section 4.7.2</a> and
-              <a href="#defineownproperty">section 4.7.3</a>
+              <a href="#getownproperty">section 4.7.3</a> and
+              <a href="#defineownproperty">section 4.7.7</a>
               for the specific requirements that the use of
               <a class="xattr" href="#Global">[Global]</a> and <a class="xattr" href="#Global">[PrimaryGlobal]</a>
               entails for named properties,
@@ -8210,7 +8211,7 @@ var fn = Query.prototype.lookupEntry;  <span class="comment">// exception, Query
             </p>
             <p>
               See <a href="#indexed-and-named-properties">section 4.7.1</a>
-              and <a href="#defineownproperty">section 4.7.3</a>
+              and <a href="#defineownproperty">section 4.7.7</a>
               for the specific requirements that the use of
               <a class="xattr" href="#OverrideBuiltins">[OverrideBuiltins]</a> entails.
             </p>
@@ -8808,7 +8809,7 @@ interface B5 : A3 {
               <a href="#es-operations">section 4.5.7</a>,
               <a href="#es-platform-objects">section 4.7</a>,
               <a href="#indexed-and-named-properties">section 4.7.1</a> and
-              <a href="#defineownproperty">section 4.7.3</a>
+              <a href="#defineownproperty">section 4.7.7</a>
               for the specific requirements that the use of
               <a class="xattr" href="#Unforgeable">[Unforgeable]</a> entails.
             </p>
@@ -10434,7 +10435,8 @@ C implements A;</code></pre></div></div>
             <p>
               The name of each property that appears to exist due to an object supporting indexed properties
               is an <dfn id="dfn-array-index-property-name">array index property name</dfn>, which is a property
-              name <var>P</var> for which the following algorithm returns <span class="esvalue">true</span>:
+              name <var>P</var> such that <a class="external" href="http://es5.github.com/#Type">Type</a>(<var>P</var>) is String
+              and for which the following algorithm returns <span class="esvalue">true</span>:
             </p>
             <ol class="algorithm">
               <li>Let <var>i</var> be <a class="external" href="http://es5.github.com/#x9.6">ToUint32</a>(<var>P</var>).</li>
@@ -10525,27 +10527,25 @@ C implements A;</code></pre></div></div>
             <p>
               Support for <a class="dfnref" href="#dfn-getter">getters</a> is
               handled by the <a href="#defineownproperty">platform object [[GetOwnProperty]] method</a>
-              defined in section 4.7.2, and
+              defined in section 4.7.3, and
               for <a class="dfnref" href="#dfn-setter">setters</a>
               by the <a href="#defineownproperty">platform object [[DefineOwnProperty]] method</a>
-              defined in section 4.7.3.
+              defined in section 4.7.7 and the <a href="#platformobjectset">platform object [[Set]] method</a>
+              defined in section 4.7.6.
             </p>
           </div>
 
-          <div id="getownproperty" class="section">
-            <h4>4.7.2. Platform object [[GetOwnProperty]] method</h4>
+          <div id="getownproperty-guts" class="section">
+            <h4>4.7.2. The PlatformObjectGetOwnProperty abstract operation</h4>
 
             <p>
-              The internal <span class="prop">[[GetOwnProperty]]</span> method of every
-              <a class="dfnref" href="#dfn-platform-object">platform object</a> <var>O</var> that implements an <a class="dfnref" href="#dfn-interface">interface</a>
-              which <a class="dfnref" href="#dfn-support-indexed-properties">supports indexed</a> or
-              <a class="dfnref" href="#dfn-support-named-properties">named properties</a>
-              <span class="rfc2119">MUST</span> behave as follows when called with property name <var>P</var>:
+              The <span class="prop">PlatformObjectGetOwnProperty</span>
+              abstract operation performs the following steps when called with an
+              object <var>O</var>, a property name <var>P</var>, and a boolean
+              <var>ignoreNamedProps</var> value:
             </p>
 
             <ol class="algorithm">
-              <li>Let <var>ignore</var> be false.</li>
-
               <li>
                 If <var>O</var> <a class="dfnref" href="#dfn-support-indexed-properties">supports indexed properties</a>
                 and <var>P</var> is an <a class="dfnref" href="#dfn-array-index-property-name">array index property name</a>, then:
@@ -10573,14 +10573,14 @@ C implements A;</code></pre></div></div>
                       <li>Return <var>desc</var>.</li>
                     </ol>
                   </li>
-                  <li>Set <var>ignore</var> to true.</li>
+                  <li>Set <var>ignoreNamedProps</var> to true.</li>
                 </ol>
               </li>
 
               <li>If <var>O</var> <a class="dfnref" href="#dfn-support-named-properties">supports named properties</a>, <var>O</var> does not
                 implement an <a class="dfnref" href="#dfn-interface">interface</a> with the <a class="xattr" href="#Global">[Global]</a> or <a class="xattr" href="#PrimaryGlobal">[PrimaryGlobal]</a>
                 <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>, the result of running the <a class="dfnref" href="#dfn-named-property-visibility">named property visibility algorithm</a> with
-                property name <var>P</var> and object <var>O</var> is true, and <var>ignore</var> is false, then:
+                property name <var>P</var> and object <var>O</var> is true, and <var>ignoreNamedProps</var> is false, then:
                 <ol>
                   <li>Let <var>operation</var> be the operation used to declare the named property getter.</li>
 
@@ -10612,8 +10612,143 @@ C implements A;</code></pre></div></div>
             </ol>
           </div>
 
+          <div id="getownproperty" class="section">
+            <h4>4.7.3. Platform object [[GetOwnProperty]] method</h4>
+
+            <p>
+              The internal <span class="prop">[[GetOwnProperty]]</span> method of every
+              <a class="dfnref" href="#dfn-platform-object">platform object</a> <var>O</var> that implements an <a class="dfnref" href="#dfn-interface">interface</a>
+              which <a class="dfnref" href="#dfn-support-indexed-properties">supports indexed</a> or
+              <a class="dfnref" href="#dfn-support-named-properties">named properties</a>
+              <span class="rfc2119">MUST</span> behave as follows when called with property name <var>P</var>:
+            </p>
+
+            <ol class="algorithm">
+              <li>
+                Return the result of invoking the <a class="dfnref" href="#getownproperty-guts">PlatformObjectGetOwnProperty</a>
+                abstract operation with
+                <var>O</var>, <var>P</var>, and <span class="esvalue">false</span> as
+                arguments.
+              </li>
+            </ol>
+          </div>
+
+          <div id="invoking-indexed-setter" class="section">
+            <h4>4.7.4. Invoking a platform object indexed property setter</h4>
+            <p>
+              To <dfn id="invoke-indexed-setter">invoke an indexed property
+              setter</dfn> with property name <var>P</var> and ECMAScript value
+              <var>V</var>, the following steps <span class="rfc2119">MUST</span> be performed:
+            </p>
+            <ol class="algorithm">
+              <li>Let <var>index</var> be the result of calling <a class="external" href="http://es5.github.com/#x9.6">ToUint32</a>(<var>P</var>).</li>
+              <li>Let <var>creating</var> be true if <var>index</var> is not a <a class="dfnref" href="#dfn-supported-property-indices">supported property index</a>, and false otherwise.</li>
+              <li>Let <var>operation</var> be the operation used to declare the indexed property setter.</li>
+              <li>Let <var>T</var> be the type of the second argument of <var>operation</var>.</li>
+              <li>Let <var>value</var> be the result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a> <var>V</var> to an IDL value of type <var>T</var>.</li>
+              <li>If <var>operation</var> was defined without an <a class="dfnref" href="#dfn-identifier">identifier</a>, then:
+              <ol>
+                <li>If <var>creating</var> is true, then perform the steps listed in the interface description to
+                <a class="dfnref" href="#dfn-set-the-value-of-a-new-indexed-property">set the value of a new indexed property</a>
+                with <var>index</var> as the index and <var>value</var> as the value.</li>
+                <li>Otherwise, <var>creating</var> is false.  Perform the steps listed in the interface description to
+                <a class="dfnref" href="#dfn-set-the-value-of-an-existing-indexed-property">set the value of an existing indexed property</a>
+                with <var>index</var> as the index and <var>value</var> as the value.</li>
+              </ol>
+              </li>
+              <li>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of
+              <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</li>
+            </ol>
+          </div>
+
+          <div id="invoking-named-setter" class="section">
+            <h4>4.7.5. Invoking a platform object named property setter</h4>
+            <p>
+              To <dfn id="invoke-named-setter">invoke a named property
+              setter</dfn> with property name <var>P</var> and ECMAScript value
+              <var>V</var>, the following steps <span class="rfc2119">MUST</span> be performed:
+            </p>
+            <ol class="algorithm">
+              <li>Let <var>creating</var> be true if <var>P</var> is not a <a class="dfnref" href="#dfn-supported-property-names">supported property name</a>, and false otherwise.</li>
+              <li>Let <var>operation</var> be the operation used to declare the named property setter.</li>
+              <li>Let <var>T</var> be the type of the second argument of <var>operation</var>.</li>
+              <li>Let <var>value</var> be the result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a> <var>V</var> to an IDL value of type <var>T</var>.</li>
+              <li>If <var>operation</var> was defined without an <a class="dfnref" href="#dfn-identifier">identifier</a>, then:
+              <ol>
+                <li>If <var>creating</var> is true, then perform the steps listed in the interface description to
+                <a class="dfnref" href="#dfn-set-the-value-of-a-new-named-property">set the value of a new named property</a>
+                with <var>P</var> as the name and <var>value</var> as the value.</li>
+                <li>Otherwise, <var>creating</var> is false.  Perform the steps listed in the interface description to
+                <a class="dfnref" href="#dfn-set-the-value-of-an-existing-named-property">set the value of an existing named property</a>
+                with <var>P</var> as the name and <var>value</var> as the value.</li>
+              </ol>
+              </li>
+              <li>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of
+              <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</li>
+            </ol>
+          </div>
+
+          <div id="platformobjectset" class="section">
+            <h4>4.7.6. Platform object [[Set]] method</h4>
+
+            <p>
+              The internal <span class="prop">[[Set]]</span> method of every
+              <a class="dfnref" href="#dfn-platform-object">platform object</a> <var>O</var> that implements an <a class="dfnref" href="#dfn-interface">interface</a>
+              which <a class="dfnref" href="#dfn-support-indexed-properties">supports indexed</a> or
+              <a class="dfnref" href="#dfn-support-named-properties">named properties</a>
+              <span class="rfc2119">MUST</span> behave as follows when called
+              with property name <var>P</var>, value <var>V</var>, and
+              ECMAScript language value <var>Receiver</var>:
+            </p>
+
+            <ol class="algorithm">
+              <li>If <var>O</var> and <var>Receiver</var> are the same object,
+              then:
+              <ol>
+                <li>
+                  If <var>O</var> <a class="dfnref" href="#dfn-support-indexed-properties">supports indexed
+                  properties</a>, <var>P</var> is an <a class="dfnref" href="#dfn-array-index-property-name">array index property
+                  name</a>, and <var>O</var> implements an interface with an <a class="dfnref" href="#dfn-indexed-property-setter">indexed
+                  property setter</a>, then:
+                  <ol>
+                    <li>
+                      <a href="#invoking-indexed-setter">Invoke the indexed
+                      property setter</a> with <var>P</var> and <var>V</var>.
+                    </li>
+                    <li>Return <span class="esvalue">true</span>.</li>
+                  </ol>
+                </li>
+
+                <li>
+                  If <var>O</var> <a class="dfnref" href="#dfn-support-named-properties">supports named
+                  properties</a>, <a class="external" href="http://es5.github.com/#Type">Type</a>(<var>P</var>) is String,
+                  <var>P</var> is not an <a class="dfnref" href="#dfn-array-index-property-name">array index property
+                  name</a>, and <var>O</var> implements an interface with a <a class="dfnref" href="#dfn-named-property-setter">named
+                  property setter</a>, then:
+                  <ol>
+                    <li>
+                      <a href="#invoking-named-setter">Invoke the named
+                      property setter</a> with <var>P</var> and <var>V</var>.
+                    </li>
+                    <li>Return <span class="esvalue">true</span>.</li>
+                  </ol>
+                </li>
+              </ol>
+              </li>
+              <li>
+                Let <var>ownDesc</var> be the result of invoking the <a class="dfnref" href="#getownproperty-guts">PlatformObjectGetOwnProperty</a>
+                abstract operation with
+                <var>O</var>, <var>P</var>, and <span class="esvalue">true</span> as
+                arguments.
+              </li>
+              <li>
+                Perform steps 3-11 of the <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver">default [[Set]] internal method</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 9.1.9).
+              </li>
+            </ol>
+          </div>
+
           <div id="defineownproperty" class="section">
-            <h4>4.7.3. Platform object [[DefineOwnProperty]] method</h4>
+            <h4>4.7.7. Platform object [[DefineOwnProperty]] method</h4>
 
             <p>
               The internal <span class="prop">[[DefineOwnProperty]]</span> method of every
@@ -10632,24 +10767,9 @@ C implements A;</code></pre></div></div>
                 <var>P</var> is an <a class="dfnref" href="#dfn-array-index-property-name">array index property name</a>, then:
                 <ol>
                   <li>If the result of calling <a class="external" href="http://es5.github.com/#x8.10.2">IsDataDescriptor</a>(<var>Desc</var>) is <span class="esvalue">false</span>, then Reject.</li>
-                  <li>Let <var>index</var> be the result of calling <a class="external" href="http://es5.github.com/#x9.6">ToUint32</a>(<var>P</var>).</li>
-                  <li>Let <var>creating</var> be true if <var>index</var> is not a <a class="dfnref" href="#dfn-supported-property-indices">supported property index</a>, and false otherwise.</li>
                   <li>If <var>O</var> does not implement an interface with an <a class="dfnref" href="#dfn-indexed-property-setter">indexed property setter</a>, then Reject.</li>
-                  <li>Let <var>operation</var> be the operation used to declare the indexed property setter.</li>
-                  <li>Let <var>T</var> be the type of the second argument of <var>operation</var>.</li>
-                  <li>Let <var>value</var> be the result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a> <var>Desc</var>.<span class="prop">[[Value]]</span> to an IDL value of type <var>T</var>.</li>
-                  <li>If <var>operation</var> was defined without an <a class="dfnref" href="#dfn-identifier">identifier</a>, then:
-                    <ol>
-                      <li>If <var>creating</var> is true, then perform the steps listed in the interface description to
-                        <a class="dfnref" href="#dfn-set-the-value-of-a-new-indexed-property">set the value of a new indexed property</a>
-                        with <var>index</var> as the index and <var>value</var> as the value.</li>
-                      <li>Otherwise, <var>creating</var> is false.  Perform the steps listed in the interface description to
-                        <a class="dfnref" href="#dfn-set-the-value-of-an-existing-indexed-property">set the value of an existing indexed property</a>
-                        with <var>index</var> as the index and <var>value</var> as the value.</li>
-                    </ol>
-                  </li>
-                  <li>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of
-                    <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</li>
+                  <li><a href="#invoking-indexed-setter">Invoke the indexed
+                  property setter</a> with <var>P</var> and <var>Desc</var>.<span class="prop">[[Value]]</span>.</li>
                   <li>Return <span class="esvalue">true</span>.</li>
                 </ol>
               </li>
@@ -10694,21 +10814,11 @@ C implements A;</code></pre></div></div>
                       <li>If <var>O</var> implements an interface with a <a class="dfnref" href="#dfn-named-property-setter">named property setter</a>, then:
                         <ol>
                           <li>If the result of calling <a class="external" href="http://es5.github.com/#x8.10.2">IsDataDescriptor</a>(<var>Desc</var>) is <span class="esvalue">false</span>, then Reject.</li>
-                          <li>Let <var>operation</var> be the operation used to declare the named property setter.</li>
-                          <li>Let <var>T</var> be the type of the second argument of <var>operation</var>.</li>
-                          <li>Let <var>value</var> be the result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a> <var>Desc</var>.<span class="prop">[[Value]]</span> to an IDL value of type <var>T</var>.</li>
-                          <li>If <var>operation</var> was defined without an <a class="dfnref" href="#dfn-identifier">identifier</a>, then:
-                            <ol>
-                              <li>If <var>creating</var> is true, then perform the steps listed in the interface description to
-                                <a class="dfnref" href="#dfn-set-the-value-of-a-new-named-property">set the value of a new named property</a>
-                                with <var>P</var> as the name and <var>value</var> as the value.</li>
-                              <li>Otherwise, <var>creating</var> is false.  Perform the steps listed in the interface description to
-                                <a class="dfnref" href="#dfn-set-the-value-of-an-existing-named-property">set the value of an existing named property</a>
-                                with <var>P</var> as the name and <var>value</var> as the value.</li>
-                            </ol>
+                          <li>
+                            <a href="#invoking-named-setter">Invoke the named
+                          property setter</a> with <var>P</var> and
+                          <var>Desc</var>.<span class="prop">[[Value]]</span>.
                           </li>
-                          <li>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of
-                            <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</li>
                           <li>Return <span class="esvalue">true</span>.</li>
                         </ol>
                       </li>
@@ -10725,7 +10835,7 @@ C implements A;</code></pre></div></div>
           </div>
 
           <div id="delete" class="section">
-            <h4>4.7.4. Platform object [[Delete]] method</h4>
+            <h4>4.7.8. Platform object [[Delete]] method</h4>
 
             <p>
               The internal <span class="prop">[[Delete]]</span> method of every
@@ -10787,7 +10897,7 @@ C implements A;</code></pre></div></div>
           </div>
 
           <div id="call" class="section">
-            <h4>4.7.5. Platform object [[Call]] method</h4>
+            <h4>4.7.9. Platform object [[Call]] method</h4>
 
             <p>
               The internal <span class="prop">[[Call]]</span> method of every
@@ -10815,7 +10925,7 @@ C implements A;</code></pre></div></div>
           </div>
 
           <div id="property-enumeration" class="section">
-            <h4>4.7.6. Property enumeration</h4>
+            <h4>4.7.10. Property enumeration</h4>
 
             <p>
               This document does not define a complete property enumeration order
@@ -12166,6 +12276,12 @@ d.type = et;
           <dt>Current editor’s draft</dt>
           <dd>
             <ul>
+              <li>
+                <p>
+                  Added a platform object [[Set]] internal method to handle
+                  named and indexed setters better.
+                </p>
+              </li>
               <li>
                 <p>
                   Removed the concept of creators; setters are always also

--- a/v1.xml
+++ b/v1.xml
@@ -75,6 +75,7 @@
         <term name='array index' class='external' href='http://es5.github.com/#x15.4' ref='ECMA-262' section='15.4'/>
         <term name='default [[GetOwnProperty]] internal method' class='external' href='http://es5.github.com/#x8.12.1' ref='ECMA-262' section='8.12.1'/>
         <term name='default [[DefineOwnProperty]] internal method' class='external' href='http://es5.github.com/#x8.12.9' ref='ECMA-262' section='8.12.9'/>
+        <term name='default [[Set]] internal method' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver' ref='ECMA-262' section='9.1.9'/>
         <term name='equally close values' class='external' href='http://es5.github.com/#x8.5' ref='ECMA-262' section='8.5'/>
         <term name='Array prototype object' class='external' href='http://es5.github.com/#x15.4.4' ref='ECMA-262' section='15.4.4'/>
         <term name='Object prototype object' class='external' href='http://es5.github.com/#x15.2.4' ref='ECMA-262' section='15.2.4'/>
@@ -5058,8 +5059,9 @@ interface Person {
           <a class="external" href="http://es5.github.com/#x13.2">13.2</a> unless otherwise specified, in which case one or
           more of the following are redefined in accordance with the rules for host objects:
           <span class="prop">[[Call]]</span>,
+          <span class="prop">[[Set]]</span>,
           <span class="prop">[[DefineOwnProperty]]</span>,
-          <span class="prop">[[GetOwnProperty]]</span> and
+          <span class="prop">[[GetOwnProperty]]</span>,
           <span class="prop">[[Delete]]</span> and
           <span class="prop">[[HasInstance]]</span>.
         </p>
@@ -10272,7 +10274,8 @@ C implements A;</x:codeblock>
             <p>
               The name of each property that appears to exist due to an object supporting indexed properties
               is an <dfn id='dfn-array-index-property-name'>array index property name</dfn>, which is a property
-              name <var>P</var> for which the following algorithm returns <span class='esvalue'>true</span>:
+              name <var>P</var> such that <a>Type</a>(<var>P</var>) is String
+              and for which the following algorithm returns <span class='esvalue'>true</span>:
             </p>
             <ol class='algorithm'>
               <li>Let <var>i</var> be <a>ToUint32</a>(<var>P</var>).</li>
@@ -10366,24 +10369,23 @@ C implements A;</x:codeblock>
               defined in section <?sref getownproperty?>, and
               for <a class='dfnref' href='#dfn-setter'>setters</a>
               by the <a href='#defineownproperty'>platform object [[DefineOwnProperty]] method</a>
-              defined in section <?sref defineownproperty?>.
+              defined in section <?sref defineownproperty?> and the <a
+              href='#platformobjectset'>platform object [[Set]] method</a>
+              defined in section <?sref platformobjectset?>.
             </p>
           </div>
 
-          <div id='getownproperty' class='section'>
-            <h4>Platform object [[GetOwnProperty]] method</h4>
+          <div id='getownproperty-guts' class='section'>
+            <h4>The PlatformObjectGetOwnProperty abstract operation</h4>
 
             <p>
-              The internal <span class='prop'>[[GetOwnProperty]]</span> method of every
-              <a class='dfnref' href='#dfn-platform-object'>platform object</a> <var>O</var> that implements an <a class='dfnref' href='#dfn-interface'>interface</a>
-              which <a class='dfnref' href='#dfn-support-indexed-properties'>supports indexed</a> or
-              <a class='dfnref' href='#dfn-support-named-properties'>named properties</a>
-              <span class='rfc2119'>MUST</span> behave as follows when called with property name <var>P</var>:
+              The <span class='prop'>PlatformObjectGetOwnProperty</span>
+              abstract operation performs the following steps when called with an
+              object <var>O</var>, a property name <var>P</var>, and a boolean
+              <var>ignoreNamedProps</var> value:
             </p>
 
             <ol class='algorithm'>
-              <li>Let <var>ignore</var> be false.</li>
-
               <li>
                 If <var>O</var> <a class='dfnref' href='#dfn-support-indexed-properties'>supports indexed properties</a>
                 and <var>P</var> is an <a class='dfnref' href='#dfn-array-index-property-name'>array index property name</a>, then:
@@ -10411,14 +10413,14 @@ C implements A;</x:codeblock>
                       <li>Return <var>desc</var>.</li>
                     </ol>
                   </li>
-                  <li>Set <var>ignore</var> to true.</li>
+                  <li>Set <var>ignoreNamedProps</var> to true.</li>
                 </ol>
               </li>
 
               <li>If <var>O</var> <a class='dfnref' href='#dfn-support-named-properties'>supports named properties</a>, <var>O</var> does not
                 implement an <a class='dfnref' href='#dfn-interface'>interface</a> with the <a class='xattr' href='#Global'>[Global]</a> or <a class='xattr' href='#PrimaryGlobal'>[PrimaryGlobal]</a>
                 <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a>, the result of running the <a class='dfnref' href='#dfn-named-property-visibility'>named property visibility algorithm</a> with
-                property name <var>P</var> and object <var>O</var> is true, and <var>ignore</var> is false, then:
+                property name <var>P</var> and object <var>O</var> is true, and <var>ignoreNamedProps</var> is false, then:
                 <ol>
                   <li>Let <var>operation</var> be the operation used to declare the named property getter.</li>
 
@@ -10450,6 +10452,151 @@ C implements A;</x:codeblock>
             </ol>
           </div>
 
+          <div id='getownproperty' class='section'>
+            <h4>Platform object [[GetOwnProperty]] method</h4>
+
+            <p>
+              The internal <span class='prop'>[[GetOwnProperty]]</span> method of every
+              <a class='dfnref' href='#dfn-platform-object'>platform object</a> <var>O</var> that implements an <a class='dfnref' href='#dfn-interface'>interface</a>
+              which <a class='dfnref' href='#dfn-support-indexed-properties'>supports indexed</a> or
+              <a class='dfnref' href='#dfn-support-named-properties'>named properties</a>
+              <span class='rfc2119'>MUST</span> behave as follows when called with property name <var>P</var>:
+            </p>
+
+            <ol class='algorithm'>
+              <li>
+                Return the result of invoking the <a class='dfnref'
+                href='#getownproperty-guts'>PlatformObjectGetOwnProperty</a>
+                abstract operation with
+                <var>O</var>, <var>P</var>, and <span class='esvalue'>false</span> as
+                arguments.
+              </li>
+            </ol>
+          </div>
+
+          <div id='invoking-indexed-setter' class='section'>
+            <h4>Invoking a platform object indexed property setter</h4>
+            <p>
+              To <dfn id='invoke-indexed-setter'>invoke an indexed property
+              setter</dfn> with property name <var>P</var> and ECMAScript value
+              <var>V</var>, the following steps <span
+              class='rfc2119'>MUST</span> be performed:
+            </p>
+            <ol class='algorithm'>
+              <li>Let <var>index</var> be the result of calling <a>ToUint32</a>(<var>P</var>).</li>
+              <li>Let <var>creating</var> be true if <var>index</var> is not a <a class='dfnref' href='#dfn-supported-property-indices'>supported property index</a>, and false otherwise.</li>
+              <li>Let <var>operation</var> be the operation used to declare the indexed property setter.</li>
+              <li>Let <var>T</var> be the type of the second argument of <var>operation</var>.</li>
+              <li>Let <var>value</var> be the result of <a class='dfnref' href='#dfn-convert-ecmascript-to-idl-value'>converting</a> <var>V</var> to an IDL value of type <var>T</var>.</li>
+              <li>If <var>operation</var> was defined without an <a class='dfnref' href='#dfn-identifier'>identifier</a>, then:
+              <ol>
+                <li>If <var>creating</var> is true, then perform the steps listed in the interface description to
+                <a class='dfnref' href='#dfn-set-the-value-of-a-new-indexed-property'>set the value of a new indexed property</a>
+                with <var>index</var> as the index and <var>value</var> as the value.</li>
+                <li>Otherwise, <var>creating</var> is false.  Perform the steps listed in the interface description to
+                <a class='dfnref' href='#dfn-set-the-value-of-an-existing-indexed-property'>set the value of an existing indexed property</a>
+                with <var>index</var> as the index and <var>value</var> as the value.</li>
+              </ol>
+              </li>
+              <li>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of
+              <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</li>
+            </ol>
+          </div>
+
+          <div id='invoking-named-setter' class='section'>
+            <h4>Invoking a platform object named property setter</h4>
+            <p>
+              To <dfn id='invoke-named-setter'>invoke a named property
+              setter</dfn> with property name <var>P</var> and ECMAScript value
+              <var>V</var>, the following steps <span
+              class='rfc2119'>MUST</span> be performed:
+            </p>
+            <ol class='algorithm'>
+              <li>Let <var>creating</var> be true if <var>P</var> is not a <a class='dfnref' href='#dfn-supported-property-names'>supported property name</a>, and false otherwise.</li>
+              <li>Let <var>operation</var> be the operation used to declare the named property setter.</li>
+              <li>Let <var>T</var> be the type of the second argument of <var>operation</var>.</li>
+              <li>Let <var>value</var> be the result of <a class='dfnref' href='#dfn-convert-ecmascript-to-idl-value'>converting</a> <var>V</var> to an IDL value of type <var>T</var>.</li>
+              <li>If <var>operation</var> was defined without an <a class='dfnref' href='#dfn-identifier'>identifier</a>, then:
+              <ol>
+                <li>If <var>creating</var> is true, then perform the steps listed in the interface description to
+                <a class='dfnref' href='#dfn-set-the-value-of-a-new-named-property'>set the value of a new named property</a>
+                with <var>P</var> as the name and <var>value</var> as the value.</li>
+                <li>Otherwise, <var>creating</var> is false.  Perform the steps listed in the interface description to
+                <a class='dfnref' href='#dfn-set-the-value-of-an-existing-named-property'>set the value of an existing named property</a>
+                with <var>P</var> as the name and <var>value</var> as the value.</li>
+              </ol>
+              </li>
+              <li>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of
+              <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</li>
+            </ol>
+          </div>
+
+          <div id='platformobjectset' class='section'>
+            <h4>Platform object [[Set]] method</h4>
+
+            <p>
+              The internal <span class='prop'>[[Set]]</span> method of every
+              <a class='dfnref' href='#dfn-platform-object'>platform object</a> <var>O</var> that implements an <a class='dfnref' href='#dfn-interface'>interface</a>
+              which <a class='dfnref' href='#dfn-support-indexed-properties'>supports indexed</a> or
+              <a class='dfnref' href='#dfn-support-named-properties'>named properties</a>
+              <span class='rfc2119'>MUST</span> behave as follows when called
+              with property name <var>P</var>, value <var>V</var>, and
+              ECMAScript language value <var>Receiver</var>:
+            </p>
+
+            <ol class='algorithm'>
+              <li>If <var>O</var> and <var>Receiver</var> are the same object,
+              then:
+              <ol>
+                <li>
+                  If <var>O</var> <a class='dfnref'
+                  href='#dfn-support-indexed-properties'>supports indexed
+                  properties</a>, <var>P</var> is an <a class='dfnref'
+                  href='#dfn-array-index-property-name'>array index property
+                  name</a>, and <var>O</var> implements an interface with an <a
+                  class='dfnref' href='#dfn-indexed-property-setter'>indexed
+                  property setter</a>, then:
+                  <ol>
+                    <li>
+                      <a href='#invoking-indexed-setter'>Invoke the indexed
+                      property setter</a> with <var>P</var> and <var>V</var>.
+                    </li>
+                    <li>Return <span class='esvalue'>true</span>.</li>
+                  </ol>
+                </li>
+
+                <li>
+                  If <var>O</var> <a class='dfnref'
+                  href='#dfn-support-named-properties'>supports named
+                  properties</a>, <a>Type</a>(<var>P</var>) is String,
+                  <var>P</var> is not an <a class='dfnref'
+                  href='#dfn-array-index-property-name'>array index property
+                  name</a>, and <var>O</var> implements an interface with a <a
+                  class='dfnref' href='#dfn-named-property-setter'>named
+                  property setter</a>, then:
+                  <ol>
+                    <li>
+                      <a href='#invoking-named-setter'>Invoke the named
+                      property setter</a> with <var>P</var> and <var>V</var>.
+                    </li>
+                    <li>Return <span class='esvalue'>true</span>.</li>
+                  </ol>
+                </li>
+              </ol>
+              </li>
+              <li>
+                Let <var>ownDesc</var> be the result of invoking the <a class='dfnref'
+                href='#getownproperty-guts'>PlatformObjectGetOwnProperty</a>
+                abstract operation with
+                <var>O</var>, <var>P</var>, and <span class='esvalue'>true</span> as
+                arguments.
+              </li>
+              <li>
+                Perform steps 3-11 of the <a>default [[Set]] internal method</a>.
+              </li>
+            </ol>
+          </div>
+
           <div id='defineownproperty' class='section'>
             <h4>Platform object [[DefineOwnProperty]] method</h4>
 
@@ -10470,24 +10617,9 @@ C implements A;</x:codeblock>
                 <var>P</var> is an <a class='dfnref' href='#dfn-array-index-property-name'>array index property name</a>, then:
                 <ol>
                   <li>If the result of calling <a>IsDataDescriptor</a>(<var>Desc</var>) is <span class='esvalue'>false</span>, then Reject.</li>
-                  <li>Let <var>index</var> be the result of calling <a>ToUint32</a>(<var>P</var>).</li>
-                  <li>Let <var>creating</var> be true if <var>index</var> is not a <a class='dfnref' href='#dfn-supported-property-indices'>supported property index</a>, and false otherwise.</li>
                   <li>If <var>O</var> does not implement an interface with an <a class='dfnref' href='#dfn-indexed-property-setter'>indexed property setter</a>, then Reject.</li>
-                  <li>Let <var>operation</var> be the operation used to declare the indexed property setter.</li>
-                  <li>Let <var>T</var> be the type of the second argument of <var>operation</var>.</li>
-                  <li>Let <var>value</var> be the result of <a class='dfnref' href='#dfn-convert-ecmascript-to-idl-value'>converting</a> <var>Desc</var>.<span class='prop'>[[Value]]</span> to an IDL value of type <var>T</var>.</li>
-                  <li>If <var>operation</var> was defined without an <a class='dfnref' href='#dfn-identifier'>identifier</a>, then:
-                    <ol>
-                      <li>If <var>creating</var> is true, then perform the steps listed in the interface description to
-                        <a class='dfnref' href='#dfn-set-the-value-of-a-new-indexed-property'>set the value of a new indexed property</a>
-                        with <var>index</var> as the index and <var>value</var> as the value.</li>
-                      <li>Otherwise, <var>creating</var> is false.  Perform the steps listed in the interface description to
-                        <a class='dfnref' href='#dfn-set-the-value-of-an-existing-indexed-property'>set the value of an existing indexed property</a>
-                        with <var>index</var> as the index and <var>value</var> as the value.</li>
-                    </ol>
-                  </li>
-                  <li>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of
-                    <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</li>
+                  <li><a href='#invoking-indexed-setter'>Invoke the indexed
+                  property setter</a> with <var>P</var> and <var>Desc</var>.<span class='prop'>[[Value]]</span>.</li>
                   <li>Return <span class='esvalue'>true</span>.</li>
                 </ol>
               </li>
@@ -10532,21 +10664,11 @@ C implements A;</x:codeblock>
                       <li>If <var>O</var> implements an interface with a <a class='dfnref' href='#dfn-named-property-setter'>named property setter</a>, then:
                         <ol>
                           <li>If the result of calling <a>IsDataDescriptor</a>(<var>Desc</var>) is <span class='esvalue'>false</span>, then Reject.</li>
-                          <li>Let <var>operation</var> be the operation used to declare the named property setter.</li>
-                          <li>Let <var>T</var> be the type of the second argument of <var>operation</var>.</li>
-                          <li>Let <var>value</var> be the result of <a class='dfnref' href='#dfn-convert-ecmascript-to-idl-value'>converting</a> <var>Desc</var>.<span class='prop'>[[Value]]</span> to an IDL value of type <var>T</var>.</li>
-                          <li>If <var>operation</var> was defined without an <a class='dfnref' href='#dfn-identifier'>identifier</a>, then:
-                            <ol>
-                              <li>If <var>creating</var> is true, then perform the steps listed in the interface description to
-                                <a class='dfnref' href='#dfn-set-the-value-of-a-new-named-property'>set the value of a new named property</a>
-                                with <var>P</var> as the name and <var>value</var> as the value.</li>
-                              <li>Otherwise, <var>creating</var> is false.  Perform the steps listed in the interface description to
-                                <a class='dfnref' href='#dfn-set-the-value-of-an-existing-named-property'>set the value of an existing named property</a>
-                                with <var>P</var> as the name and <var>value</var> as the value.</li>
-                            </ol>
+                          <li>
+                            <a href='#invoking-named-setter'>Invoke the named
+                          property setter</a> with <var>P</var> and
+                          <var>Desc</var>.<span class='prop'>[[Value]]</span>.
                           </li>
-                          <li>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of
-                            <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</li>
                           <li>Return <span class='esvalue'>true</span>.</li>
                         </ol>
                       </li>
@@ -12022,6 +12144,12 @@ d.type = et;
           <dt>Current editor’s draft</dt>
           <dd>
             <ul>
+              <li>
+                <p>
+                  Added a platform object [[Set]] internal method to handle
+                  named and indexed setters better.
+                </p>
+              </li>
               <li>
                 <p>
                   Removed the concept of creators; setters are always also


### PR DESCRIPTION
This fixes <https://www.w3.org/Bugs/Public/show_bug.cgi?id=25025> and
<https://www.w3.org/Bugs/Public/show_bug.cgi?id=26521>.