### PR TITLE
Fragments

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -66,7 +66,7 @@
         <term name='ToObject' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toobject'/>
         <term name='IsAccessorDescriptor' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-isaccessordescriptor'/>
         <term name='IsDataDescriptor' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-isdatadescriptor'/>
-        <term name='Type' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#ecmascript-data-types-and-values'/>
+        <term name='Type' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values'/>
         <term name='sign' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions'/>
         <term name='floor' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions'/>
         <term name='abs' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions'/>
@@ -6286,7 +6286,7 @@ interface Person {
           <a>ToObject</a>,
           <a>IsAccessorDescriptor</a> and
           <a>IsDataDescriptor</a> abstract operations and the
-          <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#ecmascript-data-types-and-values">Type(<var>x</var>)</a>
+          <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type(<var>x</var>)</a>
           notation referenced in this section are defined in ECMA-262 sections 6 and 7.
         </p>
         <p id='ecmascript-throw'>

--- a/index.xml
+++ b/index.xml
@@ -2324,7 +2324,7 @@ serializer = { inherit, <i>attribute-identifier</i>, <i>attribute-identifier</i>
                         <li>Remove any entry in <var>map</var> with key name <var>i</var>.</li>
                         <li>Let <var>V</var> be the value of the attribute with identifier <var>i</var>.</li>
                         <li>Add an entry to <var>map</var> whose key name is <var>i</var> and whose
-                        value is result of <a class='dfnref' href='#dfn-convert-to-serializable-value'>converting</a>
+                        value is result of <a class='dfnref' href='#dfn-convert-to-serialized-value'>converting</a>
                         <var>V</var> to a serialized value.</li>
                       </ol>
                     </li>
@@ -2355,7 +2355,7 @@ serializer = { inherit, attribute };</pre>
                         <li>Remove any entry in <var>map</var> with key name <var>i</var>.</li>
                         <li>Let <var>V</var> be the value of the attribute with identifier <var>i</var>.</li>
                         <li>Add an entry to <var>map</var> whose key name is <var>i</var> and whose
-                        value is result of <a class='dfnref' href='#dfn-convert-to-serializable-value'>converting</a>
+                        value is result of <a class='dfnref' href='#dfn-convert-to-serialized-value'>converting</a>
                         <var>V</var> to a serialized value.</li>
                       </ol>
                     </li>
@@ -2376,7 +2376,7 @@ serializer = { inherit, attribute };</pre>
                       <ol>
                         <li>Let <var>V</var> be the value of the named property with name <var>n</var>.</li>
                         <li>Add an entry to <var>map</var> whose key name is <var>i</var> and whose
-                        value is result of <a class='dfnref' href='#dfn-convert-to-serializable-value'>converting</a>
+                        value is result of <a class='dfnref' href='#dfn-convert-to-serialized-value'>converting</a>
                         <var>V</var> to a serialized value.</li>
                       </ol>
                     </li>
@@ -2397,7 +2397,7 @@ serializer = { inherit, attribute };</pre>
                       <ol>
                         <li>Let <var>V</var> be the value of the attribute with identifier <var>i</var>.</li>
                         <li>Append to <var>list</var> the value that is the result of
-                        <a class='dfnref' href='#dfn-convert-to-serializable-value'>converting</a>
+                        <a class='dfnref' href='#dfn-convert-to-serialized-value'>converting</a>
                         <var>V</var> to a serialized value.</li>
                       </ol>
                     </li>
@@ -2420,7 +2420,7 @@ serializer = { inherit, attribute };</pre>
                         <li>Let <var>V</var> be the value of the indexed property with index <var>i</var>
                           if <var>i</var> is a supported property index, or <span class='idlvalue'>null</span> otherwise.</li>
                         <li>Append to <var>list</var> the value that is the result of
-                        <a class='dfnref' href='#dfn-convert-to-serializable-value'>converting</a>
+                        <a class='dfnref' href='#dfn-convert-to-serialized-value'>converting</a>
                         <var>V</var> to a serialized value.</li>
                         <li>Set <var>i</var> to <var>i</var> + 1.</li>
                       </ol>
@@ -2438,7 +2438,7 @@ serializer = { inherit, attribute };</pre>
                   form of serialization pattern is as follows:</p>
                   <ol class='algorithm'>
                     <li>Let <var>V</var> be the value of the attribute with the specified identifier.</li>
-                    <li>Return the result of <a class='dfnref' href='#dfn-convert-to-serializable-value'>converting</a>
+                    <li>Return the result of <a class='dfnref' href='#dfn-convert-to-serialized-value'>converting</a>
                       <var>V</var> to a serialized value.</li>
                   </ol>
                 </li>
@@ -4281,7 +4281,7 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
             of the exception.
             For a <a class='dfnref' href='#dfn-DOMException'>DOMException</a>,
             the <a class='dfnref' href='#dfn-exception-error-name'>error name</a> <span class='rfc2119'>MUST</span>
-            be one of the names listed in the <a class='dfnref' href='#dfn-error-names-table'>error names table</a>
+            be one of the names listed in the <a class='dfnref' href='#idl-error-names-table'>error names table</a>
             below.  The table also indicates the <a class='dfnref' href='#dfn-DOMException'>DOMException</a>'s integer code
             for that error name, if it has one.
           </p>
@@ -11551,7 +11551,7 @@ interface
                     </ul></li>
                   <li>If the attribute is a regular attribute, then perform the actions listed in the description of the attribute that occur when setting,
                     with <var>O</var> as the object and <var>idlValue</var> as the value.</li>
-                  <li>Otherwise, the attribute is a <a class='dfnref' href='#dfn-static-atttribute'>static attribute</a>.
+                  <li>Otherwise, the attribute is a <a class='dfnref' href='#dfn-static-attribute'>static attribute</a>.
                     Perform the actions listed in the description of the attribute that occur when setting with <var>idlValue</var> as the value.</li>
                   <li>Return <span class='esvalue'>undefined</span>.</li>
                 </ol>

--- a/index.xml
+++ b/index.xml
@@ -3727,7 +3727,7 @@ for (let session of sm) {
   window.alert(session.username);
 }</x:codeblock>
               <p>
-                If the <span class='idltype'>SessionManager</span> interface <a class='dfnref' href='#dfn-supports-indexed-properties'>supported indexed properties</a>
+                If the <span class='idltype'>SessionManager</span> interface <a class='dfnref' href='#dfn-support-indexed-properties'>supported indexed properties</a>
                 and had an <a class='dfnref' href='#dfn-attribute'>attribute</a> named “length”
                 that reflected the number of session objects, we could avoid defining the
                 <a class='dfnref' href='#dfn-values-to-iterate-over'>values to iterate over</a>.
@@ -10206,7 +10206,7 @@ with (thing) {
           <div class='note'>
             <p>The expectation is that the HTML specification defines how a
             security check is performed, and that it will either throw an
-            appropriate exception or return normally. <a href='#refs-HTML'>[HTML]</a></p>
+            appropriate exception or return normally. <a href='#ref-HTML'>[HTML]</a></p>
           </div>
         </div>
 

--- a/index.xml
+++ b/index.xml
@@ -1390,7 +1390,7 @@ node.appendChild(newNode);  <span class='comment'>// This will throw a TypeError
               <li>a <a href='#dfn-dictionary'>dictionary</a></li>
               <li>a <a class='dfnref' href='#dfn-union-type'>union type</a>
                 that has a nullable or non-nullable sequence type or dictionary
-                as one of its <a class='dfnref' href='#dfn-flattened-union-member-type'>flattened member types</a></li>
+                as one of its <a class='dfnref' href='#dfn-flattened-union-member-types'>flattened member types</a></li>
             </ul>
             <p>
               The attribute is <dfn id='dfn-read-only'>read only</dfn> if the
@@ -10406,7 +10406,7 @@ with (thing) {
                         <li>a <a href='#idl-dictionary'>dictionary type</a></li>
                         <li>a <a class='dfnref' href='#dfn-union-type'>union type</a> that
                           <a class='dfnref' href='#dfn-includes-a-nullable-type'>includes a nullable type</a> or that
-                          has a <a href='#idl-dictionary'>dictionary type</a> in its <a class='dfnref' href='#dfn-flattened-union-members'>flattened members</a></li>
+                          has a <a href='#idl-dictionary'>dictionary type</a> in its <a class='dfnref' href='#dfn-flattened-union-member-types'>flattened members</a></li>
                       </ul>
                       then remove from <var>S</var> all other entries.
                     </li>

--- a/index.xml
+++ b/index.xml
@@ -2477,7 +2477,7 @@ serializer = { inherit, attribute };</pre>
                 UTF-16</dd>
                 <dt>a <span class='idltype'>ByteString</span></dt>
                 <dd>the equivalent <span class='idltype'>DOMString</span> value where each code unit has the same value as the corresponding byte value</dd>
-                <dt>a <a class='dfnref' href='#dfn-nullable'>nullable</a> serializable type</dt>
+                <dt>a <a class='dfnref' href='#dfn-nullable-type'>nullable</a> serializable type</dt>
                 <dd>converted to <span class='idltype'>null</span> if that is its value,
                   otherwise converted as per its <a class='dfnref' href='#dfn-inner-type'>inner type</a></dd>
                 <dt>a <a class='dfnref' href='#dfn-union-type'>union type</a> where
@@ -4077,7 +4077,7 @@ dictionary <i>Derived</i> : <em>Base</em> {
           <ul>
             <li>the type is <var>D</var></li>
             <li>the type is a dictionary that <a class='dfnref' href='#dfn-dictionary-inherit'>inherits</a> from <var>D</var></li>
-            <li>the type is a <a class='dfnref' href='#dfn-nullable'>nullable type</a>
+            <li>the type is a <a class='dfnref' href='#dfn-nullable-type'>nullable type</a>
             whose <a class='dfnref' href='#dfn-inner-type'>inner type</a> includes <var>D</var></li>
             <li>the type is a <a href='#idl-sequence'>sequence type</a> or <a href='#idl-frozen-array'>frozen array</a> 
             whose element type includes <var>D</var></li> 

--- a/index.xml
+++ b/index.xml
@@ -5058,7 +5058,7 @@ interface Person {
             The <dfn id='dfn-buffer-source-type'>buffer source types</dfn>
             are <span class='idltype'>ArrayBuffer</span>,
             <span class='idltype'>DataView</span>,
-            and the <a class='dfnref' href='#dfn-typed-array-types'>typed array types</a>.
+            and the <a class='dfnref' href='#dfn-typed-array-type'>typed array types</a>.
           </p>
           <p>
             The <a class='idltype' href='#idl-object'>object</a> type,
@@ -5480,7 +5480,7 @@ interface Person {
                 strings <span class='rfc2119'>SHOULD</span> be represented with
                 <span class='idltype'>DOMString</span> values, even if it is expected
                 that values of the string will always be in ASCII or some
-                8 bit character encoding.  <a href='#idl-sequences'>Sequences</a>,
+                8 bit character encoding.  <a href='#idl-sequence'>Sequences</a>,
                 <a href='#idl-frozen-array'>frozen arrays</a> or <a href='http://www.khronos.org/registry/typedarray/specs/latest/'>Typed Arrays</a>
                 with <span class='idltype'>octet</span> or <span class='idltype'>byte</span>
                 elements <span class='rfc2119'>SHOULD</span> be used for holding
@@ -9853,7 +9853,7 @@ counter.value;                                           <span class='comment'>/
                 wish to use this feature are strongly advised to discuss this on the
                 <a href='mailto:public-script-coord@w3.org'>public-script-coord@w3.org</a>
                 mailing list before proceeding.  At the time of writing, the only known
-                valid use of <a href='#TreatNonNonObjectAsNull' class='xattr'>[TreatNonObjectAsNull]</a>
+                valid use of <a href='#TreatNonObjectAsNull' class='xattr'>[TreatNonObjectAsNull]</a>
                 is for the <a class='dfnref' href='#dfn-callback-function'>callback functions</a> used as the type
                 of <a href='http://www.w3.org/TR/2011/WD-html5-20110525/webappapis.html#event-handler-attributes'>event handler IDL attributes</a>
                 (<a href='#ref-HTML5'>[HTML5]</a>, section 6.1.6.1)

--- a/index.xml
+++ b/index.xml
@@ -5670,7 +5670,7 @@ interface Person {
               another nullable type, or a <a class='dfnref' href='#dfn-union-type'>union type</a>
               that itself has <a class='dfnref' href='#dfn-includes-a-nullable-type'>includes a nullable type</a>
               or has a dictionary type as one of its
-              <a class='dfnref' href='#dfn-flattened-member-type'>flattened member types</a>.
+              <a class='dfnref' href='#dfn-flattened-union-member-type'>flattened member types</a>.
             </p>
             <div class="note">
               <p>Although dictionary types can in general be nullable, they cannot when used

--- a/index.xml
+++ b/index.xml
@@ -2484,7 +2484,7 @@ serializer = { inherit, attribute };</pre>
                   all of its <a class='dfnref' href='#dfn-union-member-type'>member types</a>
                   are serializable types</dt>
                 <dd>converted as per its <a class='dfnref' href='#dfn-specific-type'>specific type</a></dd>
-                <dt>a <a class='dfnref' href='#dfn-sequence'>sequence type</a> that
+                <dt>a <a href='#idl-sequence'>sequence type</a> that
                   has a serializable type as its element type</dt>
                 <dd>converted to a list where each element is the result of converting its
                   corresponding sequence element to a serialized value</dd>

--- a/index.xml
+++ b/index.xml
@@ -8643,7 +8643,7 @@ context.setColorEnforcedRange(-1, 255, 256);</x:codeblock>
               <a class='dfnref' href='#dfn-partial-interface'>partial interface</a>,
               an individual <a class='dfnref' href='#dfn-interface-member'>interface member</a>, or
               <a class='dfnref' href='#dfn-dictionary'>dictionary</a> with a <a href='#es-dictionary-constructors'>constructor</a>,
-              it indicates that the interface, interface member or <a href='#es-dictionary-constructor'>dictionary constructor</a> is exposed
+              it indicates that the interface, interface member or <a href='#es-dictionary-constructors'>dictionary constructor</a> is exposed
               on a particular set of global interfaces, rather than the default of
               being exposed only on the <a class='dfnref' href='#dfn-primary-global-interface'>primary global interface</a>.
             </p>
@@ -14616,9 +14616,9 @@ d.type = et;
           <prod nt='SerializationPatternMap'>"getter" | "inherit" Identifiers | identifier Identifiers | ε</prod>
           <prod nt='SerializationPatternList'>"getter" | identifier Identifiers | ε</prod>
           <prod nt='Stringifier'>"stringifier" StringifierRest</prod>
-          <prod nt='StringifierRest'>Readonly AttributeRest | ReturnType OperationRest | ";"</prod>
+          <prod nt='StringifierRest'>ReadOnly AttributeRest | ReturnType OperationRest | ";"</prod>
           <prod nt='StaticMember'>"static" StaticMemberRest</prod>
-          <prod nt='StaticMemberRest'>Readonly AttributeRest | ReturnType OperationRest</prod>
+          <prod nt='StaticMemberRest'>ReadOnly AttributeRest | ReturnType OperationRest</prod>
           <prod nt='ReadonlyMember'>"readonly" ReadonlyMemberRest</prod>
           <prod nt='ReadonlyMemberRest'>AttributeRest | ReadWriteMaplike | ReadWriteSetlike</prod>
           <prod nt='ReadWriteAttribute'>"inherit" Readonly AttributeRest | AttributeRest</prod>

--- a/index.xml
+++ b/index.xml
@@ -4076,7 +4076,7 @@ dictionary <i>Derived</i> : <em>Base</em> {
           </p>
           <ul>
             <li>the type is <var>D</var></li>
-            <li>the type is a dictionary that <a class='dfnref' href='#dfn-dictionary-inherit'>inherits</a> from <var>D</var></li>
+            <li>the type is a dictionary that <a class='dfnref' href='#dfn-inherit-dictionary'>inherits</a> from <var>D</var></li>
             <li>the type is a <a class='dfnref' href='#dfn-nullable-type'>nullable type</a>
             whose <a class='dfnref' href='#dfn-inner-type'>inner type</a> includes <var>D</var></li>
             <li>the type is a <a href='#idl-sequence'>sequence type</a> or <a href='#idl-frozen-array'>frozen array</a> 

--- a/index.xml
+++ b/index.xml
@@ -4043,7 +4043,7 @@ dictionary <i>Derived</i> : <em>Base</em> {
             When a boolean literal token (<code>true</code> or <code>false</code>),
             the <code>null</code> token,
             an <a class='sym' href='#prod-integer'>integer</a> token, a
-            <a class='sym' href='#prod-double'>double</a> token,
+            <a class='sym' href='#prod-float'>float</a> token,
             one of the three special floating point literal values (<code>Infinity</code>,
             <code>-Infinity</code> or <code>NaN</code>),
             a <a class='sym' href='#prod-string'>string</a> token or

--- a/index.xml
+++ b/index.xml
@@ -5670,7 +5670,7 @@ interface Person {
               another nullable type, or a <a class='dfnref' href='#dfn-union-type'>union type</a>
               that itself has <a class='dfnref' href='#dfn-includes-a-nullable-type'>includes a nullable type</a>
               or has a dictionary type as one of its
-              <a class='dfnref' href='#dfn-flattened-union-member-type'>flattened member types</a>.
+              <a class='dfnref' href='#dfn-flattened-union-member-types'>flattened member types</a>.
             </p>
             <div class="note">
               <p>Although dictionary types can in general be nullable, they cannot when used

--- a/index.xml
+++ b/index.xml
@@ -1746,7 +1746,7 @@ s.union(1, 4, 7);         <span class='comment'>// Passing three arguments corre
               <a class='dfnref' href='#dfn-optional-argument'>optional arguments</a>, then
               the argument <span class='rfc2119'>MUST</span> be specified as optional.
               Such arguments are always considered to have a
-              <a class='dfnref' href='#dfn-default-value'>default value</a> of an empty dictionary,
+              <a class='dfnref' href='#dfn-dictionary-member-default-value'>default value</a> of an empty dictionary,
               unless otherwise specified.
             </p>
             <div class='note'>
@@ -4006,7 +4006,7 @@ dictionary <i>Derived</i> : <em>Base</em> {
               is strongly suggested not to use of <span class='idlvalue'>true</span> as the
               <a class='dfnref' href='#dfn-dictionary-member-default-value'>default value</a> for
               <span class='estype'>boolean</span>-typed
-              <a class='dfnref' href='#dfn-dictioanry-member'>dictionary members</a>,
+              <a class='dfnref' href='#dfn-dictionary-member'>dictionary members</a>,
               as this can be confusing for authors who might otherwise expect the default
               conversion of <span class='esvalue'>undefined</span> to be used (i.e., <span class='idlvalue'>false</span>).
             </p>

--- a/index.xml
+++ b/index.xml
@@ -1482,7 +1482,7 @@ attribute <i>type</i> <i>identifier</i> inherits getter setraises(<i>scoped-name
               <a class='xattr' href='#Unforgeable'>[Unforgeable]</a>.
             </p>
 
-            <?productions grammar ReadonlyMember ReadOnlyMemberRest ReadWriteAttribute AttributeRest AttributeName AttributeNameKeyword Inherit ReadOnly?>
+            <?productions grammar ReadOnlyMember ReadOnlyMemberRest ReadWriteAttribute AttributeRest AttributeName AttributeNameKeyword Inherit ReadOnly?>
 
             <div class='example'>
               <p>
@@ -3851,7 +3851,7 @@ maplike&lt;<i>key-type</i>, <i>value-type</i>&gt;;</pre>
               <a class='dfnref' href='#dfn-iterable-declaration'>iterable declaration</a> or
               <a class='dfnref' href='#dfn-setlike-declaration'>setlike declaration</a>.
             </p>
-            <?productions grammar ReadonlyMember ReadonlyMemberRest Maplike ReadWriteMaplike MaplikeRest ?>
+            <?productions grammar ReadOnlyMember ReadOnlyMemberRest Maplike ReadWriteMaplike MaplikeRest ?>
             <p>
               No <a class='dfnref' href='#dfn-extended-attribute'>extended attributes</a>
               defined in this specification are applicable to <a class='dfnref' href='#dfn-maplike-declaration'>maplike declarations</a>.
@@ -3932,7 +3932,7 @@ setlike&lt;<i>type</i>&gt;;</pre>
               <a class='dfnref' href='#dfn-iterable-declaration'>iterable declaration</a> or
               <a class='dfnref' href='#dfn-maplike-declaration'>maplike declaration</a>.
             </p>
-            <?productions grammar ReadonlyMember ReadonlyMemberRest Setlike ReadWriteSetlike SetlikeRest?>
+            <?productions grammar ReadOnlyMember ReadOnlyMemberRest Setlike ReadWriteSetlike SetlikeRest?>
             <p>
               No <a class='dfnref' href='#dfn-extended-attribute'>extended attributes</a>
               defined in this specification are applicable to <a class='dfnref' href='#dfn-setlike-declaration'>setlike declarations</a>.
@@ -14590,7 +14590,7 @@ d.type = et;
           <prod nt='PartialDefinition'>PartialInterface | PartialDictionary</prod>
           <prod nt='PartialInterface'>"interface" identifier "{" InterfaceMembers "}" ";"</prod>
           <prod nt='InterfaceMembers'>ExtendedAttributeList InterfaceMember InterfaceMembers | ε</prod>
-          <prod nt='InterfaceMember'>Const | Operation | Serializer | Stringifier | StaticMember | Iterable | ReadonlyMember | ReadWriteAttribute | ReadWriteMaplike | ReadWriteSetlike</prod>
+          <prod nt='InterfaceMember'>Const | Operation | Serializer | Stringifier | StaticMember | Iterable | ReadOnlyMember | ReadWriteAttribute | ReadWriteMaplike | ReadWriteSetlike</prod>
           <prod nt='Dictionary'>"dictionary" identifier Inheritance "{" DictionaryMembers "}" ";"</prod>
           <prod nt='DictionaryMembers'>ExtendedAttributeList DictionaryMember DictionaryMembers | ε</prod>
           <prod nt='DictionaryMember'>Required Type identifier Default ";"</prod>
@@ -14619,9 +14619,9 @@ d.type = et;
           <prod nt='StringifierRest'>ReadOnly AttributeRest | ReturnType OperationRest | ";"</prod>
           <prod nt='StaticMember'>"static" StaticMemberRest</prod>
           <prod nt='StaticMemberRest'>ReadOnly AttributeRest | ReturnType OperationRest</prod>
-          <prod nt='ReadonlyMember'>"readonly" ReadonlyMemberRest</prod>
-          <prod nt='ReadonlyMemberRest'>AttributeRest | ReadWriteMaplike | ReadWriteSetlike</prod>
-          <prod nt='ReadWriteAttribute'>"inherit" Readonly AttributeRest | AttributeRest</prod>
+          <prod nt='ReadOnlyMember'>"readonly" ReadOnlyMemberRest</prod>
+          <prod nt='ReadOnlyMemberRest'>AttributeRest | ReadWriteMaplike | ReadWriteSetlike</prod>
+          <prod nt='ReadWriteAttribute'>"inherit" ReadOnly AttributeRest | AttributeRest</prod>
           <prod nt='AttributeRest'>"attribute" Type AttributeName ";"</prod>
           <prod nt='AttributeName'>AttributeNameKeyword | identifier</prod>
           <prod nt='AttributeNameKeyword'>"required"</prod>


### PR DESCRIPTION
Fixes some internal link issues.
It fixes also part of #29 
Still broken:
* References to "dfn-platform-array-object" and "platform-array-object-defineownproperty", (leftover from the T[] edits?)
 * Exception/Errors issue (missing pointers to "es-exception-call", "dfn-exception-create", "idl-error-names-table", "dfn-exception-field-getter").
* Grammar issue: Missing proddefs ("Required", "BufferRelatedType"), wrong link to "prod-Attribute".