### PR TITLE
Fix some problems with iterable declarations.

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED" type="text/css" /></head>
 
   <body>
-    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL (Second Edition)</h1><h2>W3C Editor’s Draft <em>18 January 2016</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/">http://heycam.github.io/webidl/</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
+    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL (Second Edition)</h1><h2>W3C Editor’s Draft <em>10 February 2016</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/">http://heycam.github.io/webidl/</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
               Send feedback to <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a> or <a href="https://www.w3.org/Bugs/Public/enter_bug.cgi?product=WebAppsWG&amp;component=WebIDL">file a bug</a> (<a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=WebIDL&amp;resolution=---">open bugs</a>)
             </dd><dt>Editors:</dt><dd><a href="http://mcc.id.au/">Cameron McCormack</a>, Mozilla Corporation &lt;cam@mcc.id.au&gt;</dd><dd>Boris Zbarsky, Mozilla Corporation &lt;bzbarsky@mit.edu&gt;</dd></dl><p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &copy; 2016 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>&reg;</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p></div><hr /><script async="" src="file-bug.js"></script>
 
@@ -72,7 +72,7 @@
         report can be found in the <a href="http://www.w3.org/TR/">W3C technical
           reports index</a> at http://www.w3.org/TR/.
       </em></p><p>
-        This document is the 18 January 2016 <b>Editor’s Draft</b> of the
+        This document is the 10 February 2016 <b>Editor’s Draft</b> of the
         <cite>Web IDL (Second Edition)</cite> specification.
       
       Please send comments about this document to
@@ -3604,7 +3604,7 @@ iterable&lt;<i>key-type</i>, <i>value-type</i>&gt;;</pre>
             </p>
             <div class="note"><div class="noteHeader">Note</div>
               <p>In the ECMAScript language binding, an interface that is iterable
-              will have “entries”, “keys”, “values” and <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@iterator</a>
+              will have “entries”, “forEach”, “keys”, “values” and <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@iterator</a>
               properties on its <a class="dfnref" href="#dfn-interface-prototype-object">interface prototype object</a>.</p>
             </div>
             <p>
@@ -3617,31 +3617,49 @@ iterable&lt;<i>key-type</i>, <i>value-type</i>&gt;;</pre>
               value associated with the key.
             </p>
             <p>
-              Prose accompanying an interface with a <a class="dfnref" href="#dfn-value-iterator">value iterator</a>
-              <span class="rfc2119">MUST</span> define what the
-              list of <dfn id="dfn-values-to-iterate-over">values to iterate over</dfn> is,
-              unless the interface also
-              <a class="dfnref" href="#dfn-support-indexed-properties">supports indexed properties</a>,
-              in which case the values of the indexed properties are implicitly
-              iterated over.  Prose accompanying an interface with a
+              A <a class="dfnref" href="#dfn-value-iterator">value iterator</a>
+              <span class="rfc2119">MUST</span> only be declared on an interface
+              that <a class="dfnref" href="#dfn-support-indexed-properties">supports indexed properties</a>
+              and has an <a class="dfnref" href="#dfn-integer-type">integer-typed</a>
+              <a class="dfnref" href="#dfn-attribute">attribute</a> named “length”.
+              The value-type of the <a class="dfnref" href="#dfn-value-iterator">value iterator</a>
+              <span class="rfc2119">MUST</span> be the same as the type returned by
+              the <a class="dfnref" href="#dfn-indexed-property-getter">indexed property getter</a>.
+              A <a class="dfnref" href="#dfn-value-iterator">value iterator</a> is implicitly
+              defined to iterate over the object’s indexed properties.
+            </p>
+            <p>
+              A <a class="dfnref" href="#dfn-pair-iterator">pair iterator</a>
+              <span class="rfc2119">MUST NOT</span> be declared on an interface
+              that <a class="dfnref" href="#dfn-support-indexed-properties">supports indexed properties</a>.
+              Prose accompanying an interface with a
               <a class="dfnref" href="#dfn-pair-iterator">pair iterator</a>
               <span class="rfc2119">MUST</span> define what the list of
               <dfn id="dfn-value-pairs-to-iterate-over">value pairs to iterate over</dfn>
               is.
             </p>
             <div class="note"><div class="noteHeader">Note</div>
-              <p>Interfaces that <a class="dfnref" href="#dfn-support-indexed-properties">support indexed properties</a>
-                need to have a “length” attribute for the iterator to work correctly.</p>
+              <p>
+                The ECMAScript forEach method that is generated for a
+                <a class="dfnref" href="#dfn-value-iterator">value iterator</a>
+                invokes its callback like Array.prototype.forEach does, and the forEach
+                method for a <a class="dfnref" href="#dfn-pair-iterator">pair iterator</a>
+                invokes its callback like Map.prototype.forEach does.
+              </p>
+              <p>
+                Since <a class="dfnref" href="#dfn-value-iterator">value iterators</a>
+                are currently allowed only on interfaces that
+                <a class="dfnref" href="#dfn-support-indexed-properties">support indexed properties</a>,
+                it makes sense to use an Array-like forEach method.
+                There may be a need for <a class="dfnref" href="#dfn-value-iterator">value iterators</a>
+                (a) on interfaces that do not 
+                <a class="dfnref" href="#dfn-support-indexed-properties">support indexed properties</a>,
+                or (b) with a forEach method that instead invokes its callback like
+                Set.protoype.forEach (where the key is the same as the value).
+                If you’re creating an API that needs such a forEach method, please send a request to
+                <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>.
+              </p>
             </div>
-            <p>
-              The prose is responsible for defining that the list of values
-              or value pairs to iterate over is snapshotted at the time
-              iteration begins, if that is desired.  To handle lists that
-              can change during iteration, the behavior of an
-              iterator defined to to loop through the items in order, starting
-              at index 0, and advancing this index on each iteration.  Iteration ends when
-              the index has gone past the end of the list.
-            </p>
             <div class="note"><div class="noteHeader">Note</div>
               <p>This is how <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array-iterator-objects">array iterator objects</a> work.
                 For interfaces that <a class="dfnref" href="#dfn-support-indexed-properties">support indexed properties</a>,
@@ -3677,7 +3695,7 @@ interface Session {
               <blockquote>
                 <p>
                   The <a class="dfnref" href="#dfn-values-to-iterate-over">values to iterate over</a>
-                  are a snapshot of the open <span class="idltype">Session</span> objects
+                  are the open <span class="idltype">Session</span> objects
                   on the <span class="idltype">SessionManager</span> sorted by username.
                 </p>
               </blockquote>
@@ -3715,12 +3733,6 @@ for (;;) {
 for (let session of sm) {
   window.alert(session.username);
 }</code></pre></div></div>
-              <p>
-                If the <span class="idltype">SessionManager</span> interface <a class="dfnref" href="#dfn-supports-indexed-properties">supported indexed properties</a>
-                and had an <a class="dfnref" href="#dfn-attribute">attribute</a> named “length”
-                that reflected the number of session objects, we could avoid defining the
-                <a class="dfnref" href="#dfn-values-to-iterate-over">values to iterate over</a>.
-              </p>
             </div>
 
             <p>
@@ -12018,7 +12030,11 @@ interface
                 <li>Otherwise, the property exists solely on the interface’s <a class="dfnref" href="#dfn-interface-prototype-object">interface prototype object</a>.</li>
               </ul>
               <p>
-                If the interface has an <a class="dfnref" href="#dfn-iterable-declaration">iterable declaration</a>,
+                If the interface defines an <a class="dfnref" href="#dfn-indexed-property-getter">indexed property getter</a>,
+                then the <span class="estype">Function</span> object is <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%ArrayProto_values%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
+              </p>
+              <p>
+                If the interface has a <a class="dfnref" href="#dfn-pair-iterator">pair iterator</a>,
                 then the <span class="estype">Function</span>, when invoked,
                 <span class="rfc2119">MUST</span> behave as follows:
               </p>
@@ -12042,11 +12058,6 @@ interface
                   for <var>interface</var> with <var>object</var> as its target and iterator kind “value”.</li>
                 <li>Return <var>iterator</var>.</li>
               </ol>
-              <p>
-                If the interface does not have an <a class="dfnref" href="#dfn-iterable-declaration">iterable declaration</a>
-                but does define an <a class="dfnref" href="#dfn-indexed-property-getter">indexed property getter</a>,
-                then the <span class="estype">Function</span> object is <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%ArrayProto_values%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
-              </p>
               <p>
                 If the interface has a <a class="dfnref" href="#dfn-maplike-declaration">maplike declaration</a>
                 or <a class="dfnref" href="#dfn-setlike-declaration">setlike declaration</a>,
@@ -12121,26 +12132,36 @@ interface
                 <li>Otherwise, the property exists solely on the interface’s <a class="dfnref" href="#dfn-interface-prototype-object">interface prototype object</a>.</li>
               </ul>
               <p>
-                If the interface has an <a class="dfnref" href="#dfn-iterable-declaration">iterable declaration</a>,
+                If the interface defines an <a class="dfnref" href="#dfn-indexed-property-getter">indexed property getter</a>,
+                then the <span class="estype">Function</span> object is
+                the initial value of the “forEach” data property of <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%ArrayPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
+              </p>
+              <p>
+                If the interface has a <a class="dfnref" href="#dfn-pair-iterator">pair iterator</a>,
                 then the <span class="estype">Function</span> <span class="rfc2119">MUST</span>
                 have the same behavior as one that would exist assuming the interface had
                 this <a class="dfnref" href="#dfn-operation">operation</a> instead of the
                 <a class="dfnref" href="#dfn-iterable-declaration">iterable declaration</a>:
               </p>
-              <div class="block"><div class="blockTitleDiv"><span class="blockTitle">IDL</span></div><div class="blockContent"><pre class="code"><code class="idl-code">void forEach(Function callback, optional any thisArg = undefined);</code></pre></div></div>
+              <div class="block"><div class="blockTitleDiv"><span class="blockTitle">IDL</span></div><div class="blockContent"><pre class="code"><code class="idl-code">void forEach(Function callback, optional any thisArg);</code></pre></div></div>
               <p>
                 with the following prose definition:
               </p>
               <ol class="algorithm">
-                <li>Let <var>values</var> be the list of <a class="dfnref" href="#dfn-values-to-iterate-over">values to iterate over</a>.</li>
-                <li>Let <var>len</var> be the length of <var>values</var>.</li>
-                <li>Initialize <var>k</var> to 0.</li>
-                <li>While <var>k</var> &lt; <var>len</var>:
+                <li>Let <var>O</var> be the <strong>this</strong> value.</li>
+                <li>Let <var>pairs</var> be the list of <a class="dfnref" href="#dfn-value-pairs-to-iterate-over">value pairs to iterate over</a>.</li>
+                <li>Let <var>i</var> be 0.</li>
+                <li>While <var>i</var> is less than the length of <var>pairs</var>:
                   <ol>
-                    <li>Let <var>kValue</var> be the value in <var>values</var> at index <var>k</var>.</li>
+                    <li>Let <var>pair</var> be the entry in <var>pairs</var> at index <var>i</var>.</li>
+                    <li>Let <var>key</var> be <var>pair</var>’s key.</li>
+                    <li>Let <var>value</var> be <var>pair</var>’s value.</li>
                     <li><a href="#es-invoking-callback-functions">Invoke</a> <var>callback</var> with <var>thisArg</var>
+                      (or <span class="esvalue">undefined</span>, if the argument was not supplied)
                       as the <a class="dfnref" href="#dfn-callback-this-value">callback this value</a> and
-                      <var>k</var> and <var>value</var> as its arguments.</li>
+                      <var>value</var>, <var>key</var> and <var>O</var> as its arguments.</li>
+                    <li>Update <var>pairs</var> to the current list of <a class="dfnref" href="#dfn-value-pairs-to-iterate-over">value pairs to iterate over</a>.</li>
+                    <li>Set <var>i</var> to <var>i</var> + 1.</li>
                   </ol>
                 </li>
               </ol>
@@ -12233,7 +12254,13 @@ interface
                 <li>Otherwise, the property exists solely on the interface’s <a class="dfnref" href="#dfn-interface-prototype-object">interface prototype object</a>.</li>
               </ul>
               <p>
-                The <span class="estype">Function</span>, when invoked, <span class="rfc2119">MUST</span> behave as follows:
+                If the interface has a <a class="dfnref" href="#dfn-value-iterator">value iterator</a>,
+                then the <span class="estype">Function</span> object is
+                the initial value of the “entries” data property of <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%ArrayPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
+              </p>
+              <p>
+                If the interface has a <a class="dfnref" href="#dfn-pair-iterator">pair iterator</a>,
+                then the <span class="estype">Function</span>, when invoked, <span class="rfc2119">MUST</span> behave as follows:
               </p>
               <ol class="algorithm">
                 <li>Let <var>object</var> be the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toobject">ToObject</a> on the <span class="esvalue">this</span> value.</li>
@@ -12283,7 +12310,13 @@ interface
                 <li>Otherwise, the property exists solely on the interface’s <a class="dfnref" href="#dfn-interface-prototype-object">interface prototype object</a>.</li>
               </ul>
               <p>
-                The <span class="estype">Function</span>, when invoked, <span class="rfc2119">MUST</span> behave as follows:
+                If the interface has a <a class="dfnref" href="#dfn-value-iterator">value iterator</a>,
+                then the <span class="estype">Function</span> object is
+                the initial value of the “keys” data property of <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%ArrayPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
+              </p>
+              <p>
+                If the interface has a <a class="dfnref" href="#dfn-pair-iterator">pair iterator</a>,
+                then the <span class="estype">Function</span>, when invoked, <span class="rfc2119">MUST</span> behave as follows:
               </p>
               <ol class="algorithm">
                 <li>Let <var>object</var> be the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toobject">ToObject</a> on the <span class="esvalue">this</span> value.</li>
@@ -12354,6 +12387,15 @@ interface
                 <li>its <em>kind</em>, which is the iteration kind,</li>
                 <li>its <em>index</em>, which is the current index into the values value to be iterated.</li>
               </ol>
+              <div class="note"><div class="noteHeader">Note</div>
+                <p>
+                  Default iterator objects are only used for <a class="dfnref" href="#dfn-pair-iterator">pair iterators</a>;
+                  <a class="dfnref" href="#dfn-value-iterator">value iterators</a>, as they are currently
+                  restricted to iterating over an object’s
+                  <a class="dfnref" href="#dfn-supported-indexed-properties">supported indexed properties</a>,
+                  use standard ECMAScript Array iterator objects.
+                </p>
+              </div>
               <p>
                 When a <a class="dfnref" href="#dfn-default-iterator-object">default iterator object</a> is first created,
                 its index is set to 0.
@@ -12374,8 +12416,8 @@ interface
               <p>
                 The <dfn id="dfn-iterator-prototype-object">iterator prototype object</dfn>
                 for a given <a class="dfnref" href="#dfn-interface">interface</a>
-                is an object that exists for every interface that has an
-                <a class="dfnref" href="#dfn-iterable-declaration">iterable declaration</a>.  It serves as the
+                is an object that exists for every interface that has a
+                <a class="dfnref" href="#dfn-pair-iterator">pair iterator</a>.  It serves as the
                 prototype for <a class="dfnref" href="#dfn-default-iterator-object">default iterator objects</a>
                 for the interface.
               </p>
@@ -12408,29 +12450,25 @@ interface
                 <li>Let <var>target</var> be <var>object</var>’s target.</li>
                 <li>Let <var>index</var> be <var>object</var>’s index.</li>
                 <li>Let <var>kind</var> be <var>object</var>’s kind.</li>
-                <li>Let <var>values</var> be the list of <a class="dfnref" href="#dfn-values-to-iterate-over">values to iterate over</a>.
-                  <div class="note"><div class="noteHeader">Note</div>
-                    <p>Depending on whether prose accompanying the interface defined this to be a snapshot at the time
-                      iteration begins, the list of values might be different from the previous time the <code>next</code>
-                      method was called on this iterator object.</p>
-                  </div>
-                </li>
+                <li>Let <var>values</var> be the list of <a class="dfnref" href="#dfn-value-pairs-to-iterate-over">value pairs to iterate over</a>.</li>
                 <li>Let <var>len</var> be the length of <var>values</var>.</li>
                 <li>If <var>object</var>’s index is greater than or equal to <var>len</var>, then
                   return <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-createiterresultobject">CreateIterResultObject</a>(<span class="esvalue">undefined</span>, <span class="esvalue">true</span>).</li>
+                <li>Let <var>pair</var> be the entry in <var>values</var> at index <var>index</var>.</li>
                 <li>Let <var>result</var> be a value determined by the value of <var>kind</var>:
                   <dl class="switch">
                     <dt>key</dt>
                     <dd>
                       <ol class="algorithm">
-                        <li>Let <var>key</var> be the ECMAScript <span class="estype">Number</span> value <var>index</var>.</li>
+                        <li>Let <var>idlKey</var> be <var>pair</var>’s key.</li>
+                        <li>Let <var>key</var> be the result of <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a> <var>idlKey</var> to an ECMAScript value.</li>
                         <li><var>result</var> is <var>key</var>.</li>
                       </ol>
                     </dd>
                     <dt>value</dt>
                     <dd>
                       <ol class="algorithm">
-                        <li>Let <var>idlValue</var> be the value in <var>values</var> at index <var>index</var>.</li>
+                        <li>Let <var>idlValue</var> be <var>pair</var>’s value.</li>
                         <li>Let <var>value</var> be the result of <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a> <var>idlValue</var> to an ECMAScript value.</li>
                         <li><var>result</var> is <var>value</var>.</li>
                       </ol>
@@ -12438,8 +12476,9 @@ interface
                     <dt>key+value</dt>
                     <dd>
                       <ol class="algorithm">
-                        <li>Let <var>key</var> be the ECMAScript <span class="estype">Number</span> value <var>index</var>.</li>
-                        <li>Let <var>idlValue</var> be the value in <var>values</var> at index <var>index</var>.</li>
+                        <li>Let <var>idlKey</var> be <var>pair</var>’s key.</li>
+                        <li>Let <var>idlValue</var> be <var>pair</var>’s value.</li>
+                        <li>Let <var>key</var> be the result of <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a> <var>idlKey</var> to an ECMAScript value.</li>
                         <li>Let <var>value</var> be the result of <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a> <var>idlValue</var> to an ECMAScript value.</li>
                         <li>Let <var>array</var> be the result of performing <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arraycreate">ArrayCreate</a>(2).</li>
                         <li>Call <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-createdataproperty">CreateDataProperty</a>(<var>array</var>, "0", <var>key</var>).</li>

--- a/index.xml
+++ b/index.xml
@@ -3584,7 +3584,7 @@ iterable&lt;<i>key-type</i>, <i>value-type</i>&gt;;</pre>
             </p>
             <div class='note'>
               <p>In the ECMAScript language binding, an interface that is iterable
-              will have “entries”, “keys”, “values” and <a>@@iterator</a>
+              will have “entries”, “forEach”, “keys”, “values” and <a>@@iterator</a>
               properties on its <a class='dfnref' href='#dfn-interface-prototype-object'>interface prototype object</a>.</p>
             </div>
             <p>
@@ -3597,31 +3597,49 @@ iterable&lt;<i>key-type</i>, <i>value-type</i>&gt;;</pre>
               value associated with the key.
             </p>
             <p>
-              Prose accompanying an interface with a <a class='dfnref' href='#dfn-value-iterator'>value iterator</a>
-              <span class='rfc2119'>MUST</span> define what the
-              list of <dfn id='dfn-values-to-iterate-over'>values to iterate over</dfn> is,
-              unless the interface also
-              <a class='dfnref' href='#dfn-support-indexed-properties'>supports indexed properties</a>,
-              in which case the values of the indexed properties are implicitly
-              iterated over.  Prose accompanying an interface with a
+              A <a class='dfnref' href='#dfn-value-iterator'>value iterator</a>
+              <span class='rfc2119'>MUST</span> only be declared on an interface
+              that <a class='dfnref' href='#dfn-support-indexed-properties'>supports indexed properties</a>
+              and has an <a class='dfnref' href='#dfn-integer-type'>integer-typed</a>
+              <a class='dfnref' href='#dfn-attribute'>attribute</a> named “length”.
+              The value-type of the <a class='dfnref' href='#dfn-value-iterator'>value iterator</a>
+              <span class='rfc2119'>MUST</span> be the same as the type returned by
+              the <a class='dfnref' href='#dfn-indexed-property-getter'>indexed property getter</a>.
+              A <a class='dfnref' href='#dfn-value-iterator'>value iterator</a> is implicitly
+              defined to iterate over the object’s indexed properties.
+            </p>
+            <p>
+              A <a class='dfnref' href='#dfn-pair-iterator'>pair iterator</a>
+              <span class='rfc2119'>MUST NOT</span> be declared on an interface
+              that <a class='dfnref' href='#dfn-support-indexed-properties'>supports indexed properties</a>.
+              Prose accompanying an interface with a
               <a class='dfnref' href='#dfn-pair-iterator'>pair iterator</a>
               <span class='rfc2119'>MUST</span> define what the list of
               <dfn id='dfn-value-pairs-to-iterate-over'>value pairs to iterate over</dfn>
               is.
             </p>
-            <div class="note">
-              <p>Interfaces that <a class='dfnref' href='#dfn-support-indexed-properties'>support indexed properties</a>
-                need to have a “length” attribute for the iterator to work correctly.</p>
+            <div class='note'>
+              <p>
+                The ECMAScript forEach method that is generated for a
+                <a class='dfnref' href='#dfn-value-iterator'>value iterator</a>
+                invokes its callback like Array.prototype.forEach does, and the forEach
+                method for a <a class='dfnref' href='#dfn-pair-iterator'>pair iterator</a>
+                invokes its callback like Map.prototype.forEach does.
+              </p>
+              <p>
+                Since <a class='dfnref' href='#dfn-value-iterator'>value iterators</a>
+                are currently allowed only on interfaces that
+                <a class='dfnref' href='#dfn-support-indexed-properties'>support indexed properties</a>,
+                it makes sense to use an Array-like forEach method.
+                There may be a need for <a class='dfnref' href='#dfn-value-iterator'>value iterators</a>
+                (a) on interfaces that do not 
+                <a class='dfnref' href='#dfn-support-indexed-properties'>support indexed properties</a>,
+                or (b) with a forEach method that instead invokes its callback like
+                Set.protoype.forEach (where the key is the same as the value).
+                If you’re creating an API that needs such a forEach method, please send a request to
+                <a href='mailto:public-script-coord@w3.org'>public-script-coord@w3.org</a>.
+              </p>
             </div>
-            <p>
-              The prose is responsible for defining that the list of values
-              or value pairs to iterate over is snapshotted at the time
-              iteration begins, if that is desired.  To handle lists that
-              can change during iteration, the behavior of an
-              iterator defined to to loop through the items in order, starting
-              at index 0, and advancing this index on each iteration.  Iteration ends when
-              the index has gone past the end of the list.
-            </p>
             <div class="note">
               <p>This is how <a>array iterator objects</a> work.
                 For interfaces that <a class='dfnref' href='#dfn-support-indexed-properties'>support indexed properties</a>,
@@ -3657,7 +3675,7 @@ interface Session {
               <blockquote>
                 <p>
                   The <a class='dfnref' href='#dfn-values-to-iterate-over'>values to iterate over</a>
-                  are a snapshot of the open <span class='idltype'>Session</span> objects
+                  are the open <span class='idltype'>Session</span> objects
                   on the <span class='idltype'>SessionManager</span> sorted by username.
                 </p>
               </blockquote>
@@ -3695,12 +3713,6 @@ for (;;) {
 for (let session of sm) {
   window.alert(session.username);
 }</x:codeblock>
-              <p>
-                If the <span class='idltype'>SessionManager</span> interface <a class='dfnref' href='#dfn-supports-indexed-properties'>supported indexed properties</a>
-                and had an <a class='dfnref' href='#dfn-attribute'>attribute</a> named “length”
-                that reflected the number of session objects, we could avoid defining the
-                <a class='dfnref' href='#dfn-values-to-iterate-over'>values to iterate over</a>.
-              </p>
             </div>
 
             <p>
@@ -11887,7 +11899,11 @@ interface
                 <li>Otherwise, the property exists solely on the interface’s <a class='dfnref' href='#dfn-interface-prototype-object'>interface prototype object</a>.</li>
               </ul>
               <p>
-                If the interface has an <a class='dfnref' href='#dfn-iterable-declaration'>iterable declaration</a>,
+                If the interface defines an <a class='dfnref' href='#dfn-indexed-property-getter'>indexed property getter</a>,
+                then the <span class='estype'>Function</span> object is <a>%ArrayProto_values%</a>.
+              </p>
+              <p>
+                If the interface has a <a class='dfnref' href='#dfn-pair-iterator'>pair iterator</a>,
                 then the <span class='estype'>Function</span>, when invoked,
                 <span class='rfc2119'>MUST</span> behave as follows:
               </p>
@@ -11911,11 +11927,6 @@ interface
                   for <var>interface</var> with <var>object</var> as its target and iterator kind “value”.</li>
                 <li>Return <var>iterator</var>.</li>
               </ol>
-              <p>
-                If the interface does not have an <a class='dfnref' href='#dfn-iterable-declaration'>iterable declaration</a>
-                but does define an <a class='dfnref' href='#dfn-indexed-property-getter'>indexed property getter</a>,
-                then the <span class='estype'>Function</span> object is <a>%ArrayProto_values%</a>.
-              </p>
               <p>
                 If the interface has a <a class='dfnref' href='#dfn-maplike-declaration'>maplike declaration</a>
                 or <a class='dfnref' href='#dfn-setlike-declaration'>setlike declaration</a>,
@@ -11990,26 +12001,36 @@ interface
                 <li>Otherwise, the property exists solely on the interface’s <a class='dfnref' href='#dfn-interface-prototype-object'>interface prototype object</a>.</li>
               </ul>
               <p>
-                If the interface has an <a class='dfnref' href='#dfn-iterable-declaration'>iterable declaration</a>,
+                If the interface defines an <a class='dfnref' href='#dfn-indexed-property-getter'>indexed property getter</a>,
+                then the <span class='estype'>Function</span> object is
+                the initial value of the “forEach” data property of <a>%ArrayPrototype%</a>.
+              </p>
+              <p>
+                If the interface has a <a class='dfnref' href='#dfn-pair-iterator'>pair iterator</a>,
                 then the <span class='estype'>Function</span> <span class='rfc2119'>MUST</span>
                 have the same behavior as one that would exist assuming the interface had
                 this <a class='dfnref' href='#dfn-operation'>operation</a> instead of the
                 <a class='dfnref' href='#dfn-iterable-declaration'>iterable declaration</a>:
               </p>
-              <x:codeblock language='idl'>void forEach(Function callback, optional any thisArg = undefined);</x:codeblock>
+              <x:codeblock language='idl'>void forEach(Function callback, optional any thisArg);</x:codeblock>
               <p>
                 with the following prose definition:
               </p>
               <ol class='algorithm'>
-                <li>Let <var>values</var> be the list of <a class='dfnref' href='#dfn-values-to-iterate-over'>values to iterate over</a>.</li>
-                <li>Let <var>len</var> be the length of <var>values</var>.</li>
-                <li>Initialize <var>k</var> to 0.</li>
-                <li>While <var>k</var> &lt; <var>len</var>:
+                <li>Let <var>O</var> be the <strong>this</strong> value.</li>
+                <li>Let <var>pairs</var> be the list of <a class='dfnref' href='#dfn-value-pairs-to-iterate-over'>value pairs to iterate over</a>.</li>
+                <li>Let <var>i</var> be 0.</li>
+                <li>While <var>i</var> is less than the length of <var>pairs</var>:
                   <ol>
-                    <li>Let <var>kValue</var> be the value in <var>values</var> at index <var>k</var>.</li>
+                    <li>Let <var>pair</var> be the entry in <var>pairs</var> at index <var>i</var>.</li>
+                    <li>Let <var>key</var> be <var>pair</var>’s key.</li>
+                    <li>Let <var>value</var> be <var>pair</var>’s value.</li>
                     <li><a href='#es-invoking-callback-functions'>Invoke</a> <var>callback</var> with <var>thisArg</var>
+                      (or <span class='esvalue'>undefined</span>, if the argument was not supplied)
                       as the <a class='dfnref' href='#dfn-callback-this-value'>callback this value</a> and
-                      <var>k</var> and <var>value</var> as its arguments.</li>
+                      <var>value</var>, <var>key</var> and <var>O</var> as its arguments.</li>
+                    <li>Update <var>pairs</var> to the current list of <a class='dfnref' href='#dfn-value-pairs-to-iterate-over'>value pairs to iterate over</a>.</li>
+                    <li>Set <var>i</var> to <var>i</var> + 1.</li>
                   </ol>
                 </li>
               </ol>
@@ -12102,7 +12123,13 @@ interface
                 <li>Otherwise, the property exists solely on the interface’s <a class='dfnref' href='#dfn-interface-prototype-object'>interface prototype object</a>.</li>
               </ul>
               <p>
-                The <span class='estype'>Function</span>, when invoked, <span class='rfc2119'>MUST</span> behave as follows:
+                If the interface has a <a class='dfnref' href='#dfn-value-iterator'>value iterator</a>,
+                then the <span class='estype'>Function</span> object is
+                the initial value of the “entries” data property of <a>%ArrayPrototype%</a>.
+              </p>
+              <p>
+                If the interface has a <a class='dfnref' href='#dfn-pair-iterator'>pair iterator</a>,
+                then the <span class='estype'>Function</span>, when invoked, <span class='rfc2119'>MUST</span> behave as follows:
               </p>
               <ol class='algorithm'>
                 <li>Let <var>object</var> be the result of calling <a>ToObject</a> on the <span class='esvalue'>this</span> value.</li>
@@ -12152,7 +12179,13 @@ interface
                 <li>Otherwise, the property exists solely on the interface’s <a class='dfnref' href='#dfn-interface-prototype-object'>interface prototype object</a>.</li>
               </ul>
               <p>
-                The <span class='estype'>Function</span>, when invoked, <span class='rfc2119'>MUST</span> behave as follows:
+                If the interface has a <a class='dfnref' href='#dfn-value-iterator'>value iterator</a>,
+                then the <span class='estype'>Function</span> object is
+                the initial value of the “keys” data property of <a>%ArrayPrototype%</a>.
+              </p>
+              <p>
+                If the interface has a <a class='dfnref' href='#dfn-pair-iterator'>pair iterator</a>,
+                then the <span class='estype'>Function</span>, when invoked, <span class='rfc2119'>MUST</span> behave as follows:
               </p>
               <ol class='algorithm'>
                 <li>Let <var>object</var> be the result of calling <a>ToObject</a> on the <span class='esvalue'>this</span> value.</li>
@@ -12223,6 +12256,15 @@ interface
                 <li>its <em>kind</em>, which is the iteration kind,</li>
                 <li>its <em>index</em>, which is the current index into the values value to be iterated.</li>
               </ol>
+              <div class='note'>
+                <p>
+                  Default iterator objects are only used for <a class='dfnref' href='#dfn-pair-iterator'>pair iterators</a>;
+                  <a class='dfnref' href='#dfn-value-iterator'>value iterators</a>, as they are currently
+                  restricted to iterating over an object’s
+                  <a class='dfnref' href='#dfn-supported-indexed-properties'>supported indexed properties</a>,
+                  use standard ECMAScript Array iterator objects.
+                </p>
+              </div>
               <p>
                 When a <a class='dfnref' href='#dfn-default-iterator-object'>default iterator object</a> is first created,
                 its index is set to 0.
@@ -12243,8 +12285,8 @@ interface
               <p>
                 The <dfn id='dfn-iterator-prototype-object'>iterator prototype object</dfn>
                 for a given <a class='dfnref' href='#dfn-interface'>interface</a>
-                is an object that exists for every interface that has an
-                <a class='dfnref' href='#dfn-iterable-declaration'>iterable declaration</a>.  It serves as the
+                is an object that exists for every interface that has a
+                <a class='dfnref' href='#dfn-pair-iterator'>pair iterator</a>.  It serves as the
                 prototype for <a class='dfnref' href='#dfn-default-iterator-object'>default iterator objects</a>
                 for the interface.
               </p>
@@ -12277,29 +12319,25 @@ interface
                 <li>Let <var>target</var> be <var>object</var>’s target.</li>
                 <li>Let <var>index</var> be <var>object</var>’s index.</li>
                 <li>Let <var>kind</var> be <var>object</var>’s kind.</li>
-                <li>Let <var>values</var> be the list of <a class='dfnref' href='#dfn-values-to-iterate-over'>values to iterate over</a>.
-                  <div class='note'>
-                    <p>Depending on whether prose accompanying the interface defined this to be a snapshot at the time
-                      iteration begins, the list of values might be different from the previous time the <code>next</code>
-                      method was called on this iterator object.</p>
-                  </div>
-                </li>
+                <li>Let <var>values</var> be the list of <a class='dfnref' href='#dfn-value-pairs-to-iterate-over'>value pairs to iterate over</a>.</li>
                 <li>Let <var>len</var> be the length of <var>values</var>.</li>
                 <li>If <var>object</var>’s index is greater than or equal to <var>len</var>, then
                   return <a>CreateIterResultObject</a>(<span class='esvalue'>undefined</span>, <span class='esvalue'>true</span>).</li>
+                <li>Let <var>pair</var> be the entry in <var>values</var> at index <var>index</var>.</li>
                 <li>Let <var>result</var> be a value determined by the value of <var>kind</var>:
                   <dl class='switch'>
                     <dt>key</dt>
                     <dd>
                       <ol class='algorithm'>
-                        <li>Let <var>key</var> be the ECMAScript <span class='estype'>Number</span> value <var>index</var>.</li>
+                        <li>Let <var>idlKey</var> be <var>pair</var>’s key.</li>
+                        <li>Let <var>key</var> be the result of <a class='dfnref' href='#dfn-convert-idl-to-ecmascript-value'>converting</a> <var>idlKey</var> to an ECMAScript value.</li>
                         <li><var>result</var> is <var>key</var>.</li>
                       </ol>
                     </dd>
                     <dt>value</dt>
                     <dd>
                       <ol class='algorithm'>
-                        <li>Let <var>idlValue</var> be the value in <var>values</var> at index <var>index</var>.</li>
+                        <li>Let <var>idlValue</var> be <var>pair</var>’s value.</li>
                         <li>Let <var>value</var> be the result of <a class='dfnref' href='#dfn-convert-idl-to-ecmascript-value'>converting</a> <var>idlValue</var> to an ECMAScript value.</li>
                         <li><var>result</var> is <var>value</var>.</li>
                       </ol>
@@ -12307,8 +12345,9 @@ interface
                     <dt>key+value</dt>
                     <dd>
                       <ol class='algorithm'>
-                        <li>Let <var>key</var> be the ECMAScript <span class='estype'>Number</span> value <var>index</var>.</li>
-                        <li>Let <var>idlValue</var> be the value in <var>values</var> at index <var>index</var>.</li>
+                        <li>Let <var>idlKey</var> be <var>pair</var>’s key.</li>
+                        <li>Let <var>idlValue</var> be <var>pair</var>’s value.</li>
+                        <li>Let <var>key</var> be the result of <a class='dfnref' href='#dfn-convert-idl-to-ecmascript-value'>converting</a> <var>idlKey</var> to an ECMAScript value.</li>
                         <li>Let <var>value</var> be the result of <a class='dfnref' href='#dfn-convert-idl-to-ecmascript-value'>converting</a> <var>idlValue</var> to an ECMAScript value.</li>
                         <li>Let <var>array</var> be the result of performing <a>ArrayCreate</a>(2).</li>
                         <li>Call <a>CreateDataProperty</a>(<var>array</var>, "0", <var>key</var>).</li>


### PR DESCRIPTION
1. iterable<> declarations with a single type ("value iterators") now
   always iterates over the object's indexed properties, and disallows
   its use on objects that don't support indexed properties (and have a
   "length" attribute).

2. The entries and keys properties of interface prototypes for
   interfaces that have value iterators are now defined to have values
   equal to the initial values of Array.prototype.{entries,keys},
   similarly to how @@iterator was already defined when indexed
   properties were present.

3. The definitions of @@iterator and forEach for iterable<> declarations
   with two types ("pair iterators") are fixed.  "Default iterator
   objects" now work only for pair iterators, since we don't support
   prose-defined value iterators now.