### PR TITLE
Make all the WebIDL dfns Bikeshed-friendly

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -318,7 +318,7 @@ window.onload = function() { window.alert("loaded"); };</x:codeblock></li>
           The following conformance classes are defined by this specification:
         </p>
         <dl>
-          <dt><dfn data-export id='dfn-conforming-set-of-idl-fragments'>conforming set of IDL fragments</dfn></dt>
+          <dt><dfn data-export="" id='dfn-conforming-set-of-idl-fragments'>conforming set of IDL fragments</dfn></dt>
           <dd>
             <p>
               A set of <a class='dfnref' href='#dfn-idl-fragment'>IDL fragments</a> is considered
@@ -329,7 +329,7 @@ window.onload = function() { window.alert("loaded"); };</x:codeblock></li>
               criteria in this specification that apply to IDL fragments.
             </p>
           </dd>
-          <dt><dfn data-export id='dfn-conforming-implementation'>conforming implementation</dfn></dt>
+          <dt><dfn data-export="" id='dfn-conforming-implementation'>conforming implementation</dfn></dt>
           <dd>
             <p>
               A user agent is considered to be a
@@ -341,7 +341,7 @@ window.onload = function() { window.alert("loaded"); };</x:codeblock></li>
               bindings that the user agent supports.
             </p>
           </dd>
-          <dt><dfn data-export id='dfn-conforming-ecmascript-implementation'>conforming ECMAScript implementation</dfn></dt>
+          <dt><dfn data-export="" id='dfn-conforming-ecmascript-implementation'>conforming ECMAScript implementation</dfn></dt>
           <dd>
             <p>
               A user agent is considered to be a
@@ -362,7 +362,7 @@ window.onload = function() { window.alert("loaded"); };</x:codeblock></li>
         <p>
           This section describes a language, <em>Web IDL</em>, which can be used to define
           interfaces for APIs in the Web platform.  A specification that defines Web APIs
-          can include one or more <dfn data-export data-lt="IDL fragment" id='dfn-idl-fragment'>IDL fragments</dfn> that
+          can include one or more <dfn data-export="" data-lt="IDL fragment" id='dfn-idl-fragment'>IDL fragments</dfn> that
           describe the interfaces (the state and behavior that objects can exhibit)
           for the APIs defined by that specification.
           An <a class='dfnref' href='#dfn-idl-fragment'>IDL fragment</a> is
@@ -479,11 +479,11 @@ interface GraphicalWindow {
             <a class='dfnref' href='#dfn-partial-dictionary'>partial dictionary definition</a>,
             <a class='dfnref' href='#dfn-enumeration'>enumeration</a>,
             <a class='dfnref' href='#dfn-callback-function'>callback function</a> and
-            <a class='dfnref' href='#dfn-typedef'>typedef</a> (together called <dfn data-export data-lt="named definition" id='dfn-named-definition'>named definitions</dfn>)
+            <a class='dfnref' href='#dfn-typedef'>typedef</a> (together called <dfn data-export="" data-lt="named definition" id='dfn-named-definition'>named definitions</dfn>)
             and every <a class='dfnref' href='#dfn-constant'>constant</a>,
             <a class='dfnref' href='#dfn-attribute'>attribute</a>,
             and <a class='dfnref' href='#dfn-dictionary-member'>dictionary member</a> has an
-            <dfn data-export id='dfn-identifier'>identifier</dfn>, as do some
+            <dfn data-export="" id='dfn-identifier'>identifier</dfn>, as do some
             <a class='dfnref' href='#dfn-operation'>operations</a>.
             The identifier is determined by an
             <a class='sym' href='#prod-identifier'>identifier</a> token somewhere
@@ -580,7 +580,7 @@ dictionary <i>identifier</i> {
             IDL constructs <span class='rfc2119'>MUST NOT</span> be “constructor”,
             “toString”, “toJSON”,
             or begin with a <span class='char'>U+005F LOW LINE ("_")</span> character.  These
-            are known as <dfn data-export id='dfn-reserved-identifier'>reserved identifiers</dfn>.
+            are known as <dfn data-export="" id='dfn-reserved-identifier'>reserved identifiers</dfn>.
           </p>
           <div class="note">
             <p>Further restrictions on identifier names for particular constructs may be made
@@ -670,7 +670,7 @@ interface TextField {
             <a class='dfnref' href='#dfn-idl-fragment'>IDL fragments</a> are used to
             describe object oriented systems.  In such systems, objects are entities
             that have identity and which are encapsulations of state and behavior.
-            An <dfn data-export id='dfn-interface'>interface</dfn> is a definition (matching
+            An <dfn data-export="" id='dfn-interface'>interface</dfn> is a definition (matching
             <a class='sym' href='#prod-Interface'>Interface</a> or
             <span class='sym'>"callback"</span> <a class='sym' href='#prod-Interface'>Interface</a>) that declares some
             state and behavior that an object implementing that interface will expose.
@@ -680,7 +680,7 @@ interface TextField {
 };</pre>
           <p>
             An interface is a specification of a set of
-            <dfn data-export data-lt="interface member" id='dfn-interface-member'>interface members</dfn>
+            <dfn data-export="" data-lt="interface member" id='dfn-interface-member'>interface members</dfn>
             (matching <a class='sym' href='#prod-InterfaceMembers'>InterfaceMembers</a>),
             which are the <a class='dfnref' href='#dfn-constant'>constants</a>,
             <a class='dfnref' href='#dfn-attribute'>attributes</a>,
@@ -709,7 +709,7 @@ interface TextField {
           </div>
           -->
           <p>
-            An interface can be defined to <dfn data-export data-dfn-for="interface" id='dfn-inherit'>inherit</dfn> from another interface.
+            An interface can be defined to <dfn data-export="" data-dfn-for="interface" id='dfn-inherit'>inherit</dfn> from another interface.
             If the identifier of the interface is followed by a
             <span class='char'>U+003A COLON (":")</span> character
             and an <a class='dfnref' href='#dfn-identifier'>identifier</a>,
@@ -794,7 +794,7 @@ public interface B extends A {
             -->
           </div>
           <p>
-            The <dfn data-export id='dfn-inherited-interfaces'>inherited interfaces</dfn> of
+            The <dfn data-export="" id='dfn-inherited-interfaces'>inherited interfaces</dfn> of
             a given interface <var>A</var> is the set of all interfaces that <var>A</var>
             inherits from, directly or indirectly.  If <var>A</var> does not <a class='dfnref' href='#dfn-inherit'>inherit</a>
             from another interface, then the set is empty.  Otherwise, the set
@@ -835,7 +835,7 @@ public interface B extends A {
 };</pre>
 
           <p>
-            A <dfn data-export id='dfn-callback-interface'>callback interface</dfn> is
+            A <dfn data-export="" id='dfn-callback-interface'>callback interface</dfn> is
             an <a class='dfnref' href='#dfn-interface'>interface</a>
             that uses the <code>callback</code> keyword at the start of
             its definition.  Callback interfaces are ones that can be
@@ -943,7 +943,7 @@ interface A {
 
           <p>
             The IDL for interfaces can be split into multiple parts by using
-            <dfn data-export id='dfn-partial-interface'>partial interface</dfn> definitions
+            <dfn data-export="" id='dfn-partial-interface'>partial interface</dfn> definitions
             (matching <span class='sym'>"partial"</span> <a class='sym' href='#prod-PartialInterface'>PartialInterface</a>).
             The <a class='dfnref' href='#dfn-identifier'>identifier</a> of a partial
             interface definition <span class='rfc2119'>MUST</span> be the same
@@ -1125,7 +1125,7 @@ node.appendChild(newNode);  <span class='comment'>// This will throw a TypeError
             <h4>Constants</h4>
 
             <p>
-              A <dfn data-export id='dfn-constant'>constant</dfn> is a declaration (matching
+              A <dfn data-export="" id='dfn-constant'>constant</dfn> is a declaration (matching
               <a class='sym' href='#prod-Const'>Const</a>) used to bind a constant value to a name.
               Constants can appear on <a class='dfnref' href='#dfn-interface'>interfaces</a>.
             </p>
@@ -1340,7 +1340,7 @@ node.appendChild(newNode);  <span class='comment'>// This will throw a TypeError
             <h4>Attributes</h4>
 
             <p>
-              An <dfn data-export id='dfn-attribute'>attribute</dfn> is an <a class='dfnref' href='#dfn-interface-member'>interface member</a>
+              An <dfn data-export="" id='dfn-attribute'>attribute</dfn> is an <a class='dfnref' href='#dfn-interface-member'>interface member</a>
               (matching
               <span class='sym'>"inherit"</span> <a class='sym' href='#prod-ReadOnly'>ReadOnly</a> <a class='sym' href='#prod-AttributeRest'>AttributeRest</a>,
               <span class='sym'>"static"</span> <a class='sym' href='#prod-ReadOnly'>ReadOnly</a> <a class='sym' href='#prod-AttributeRest'>AttributeRest</a>,
@@ -1361,7 +1361,7 @@ node.appendChild(newNode);  <span class='comment'>// This will throw a TypeError
             </ol>
             <p>
               If an attribute has no <code>static</code> keyword, then it declares a
-              <dfn data-export id='dfn-regular-attribute'>regular attribute</dfn>.  Otherwise,
+              <dfn data-export="" id='dfn-regular-attribute'>regular attribute</dfn>.  Otherwise,
               it declares a <a class='dfnref' href='#dfn-static-attribute'>static attribute</a>.
             </p>
             <p>
@@ -1394,7 +1394,7 @@ node.appendChild(newNode);  <span class='comment'>// This will throw a TypeError
                 as one of its <a class='dfnref' href='#dfn-flattened-union-member-types'>flattened member types</a></li>
             </ul>
             <p>
-              The attribute is <dfn data-export id='dfn-read-only'>read only</dfn> if the
+              The attribute is <dfn data-export="" id='dfn-read-only'>read only</dfn> if the
               <code>readonly</code> keyword is used before the <code>attribute</code> keyword.
               An object that implements the interface on which a read only attribute
               is defined will not allow assignment to that attribute.  It is language
@@ -1405,7 +1405,7 @@ node.appendChild(newNode);  <span class='comment'>// This will throw a TypeError
             <p>
               A <a class='dfnref' href='#dfn-regular-attribute'>regular attribute</a>
               that is not <a class='dfnref' href='#dfn-read-only'>read only</a>
-              can be declared to <dfn data-export id='dfn-inherit-getter'>inherit its getter</dfn>
+              can be declared to <dfn data-export="" id='dfn-inherit-getter'>inherit its getter</dfn>
               from an ancestor interface.  This can be used to make a read only attribute
               in an ancestor interface be writable on a derived interface.  An attribute
               <a class='dfnref' href='#dfn-inherit-getter'>inherits its getter</a> if
@@ -1522,7 +1522,7 @@ interface Person : Animal {
             <h4>Operations</h4>
 
             <p>
-              An <dfn data-export id='dfn-operation'>operation</dfn> is an <a class='dfnref' href='#dfn-interface-member'>interface member</a>
+              An <dfn data-export="" id='dfn-operation'>operation</dfn> is an <a class='dfnref' href='#dfn-interface-member'>interface member</a>
               (matching <span class='sym'>"static"</span> <a class='sym' href='#prod-OperationRest'>OperationRest</a>,
               <span class='sym'>"stringifier"</span> <a class='sym' href='#prod-OperationRest'>OperationRest</a>,
               <span class='sym'>"serializer"</span> <a class='sym' href='#prod-OperationRest'>OperationRest</a>,
@@ -1549,7 +1549,7 @@ interface Person : Animal {
             </ol>
             <p>
               If an operation has an identifier but no <code>static</code>
-              keyword, then it declares a <dfn data-export id='dfn-regular-operation'>regular operation</dfn>.
+              keyword, then it declares a <dfn data-export="" id='dfn-regular-operation'>regular operation</dfn>.
               If the operation has one or more
               <a class='dfnref' href='#dfn-special-keyword'>special keywords</a>
               used in its declaration (that is, any keyword matching
@@ -1590,7 +1590,7 @@ interface Person : Animal {
               defined on the same <a class='dfnref' href='#dfn-interface'>interface</a>.
             </p>
             <p>
-              The <dfn data-export id='dfn-return-type'>return type</dfn> of the operation is given
+              The <dfn data-export="" id='dfn-return-type'>return type</dfn> of the operation is given
               by the type (matching <a class='sym' href='#prod-ReturnType'>ReturnType</a>)
               that appears before the operation’s optional <a class='dfnref' href='#dfn-identifier'>identifier</a>.
               A return type of <code id='idl-void'>void</code> indicates that the operation returns no value.
@@ -1659,7 +1659,7 @@ interface Button {
             </div>
 
             <p>
-              An operation is considered to be <dfn data-export id='dfn-variadic'>variadic</dfn>
+              An operation is considered to be <dfn data-export="" id='dfn-variadic'>variadic</dfn>
               if the final argument uses the <code>...</code> token just
               after the argument type.  Declaring an operation to be variadic indicates that
               the operation can be invoked with any number of arguments after that final argument.
@@ -1708,7 +1708,7 @@ s.union(1, 4, 7);         <span class='comment'>// Passing three arguments corre
             </div>
 
             <p>
-              An argument is considered to be an <dfn data-export id='dfn-optional-argument'>optional argument</dfn>
+              An argument is considered to be an <dfn data-export="" id='dfn-optional-argument'>optional argument</dfn>
               if it is declared with the <code>optional</code> keyword.
               The final argument of a <a class='dfnref' href='#dfn-variadic'>variadic</a> operation
               is also considered to be an optional argument. Declaring an argument
@@ -1720,7 +1720,7 @@ s.union(1, 4, 7);         <span class='comment'>// Passing three arguments corre
             <pre class='syntax'><i>return-type</i> <i>identifier</i>(<i>type</i> <i>identifier</i>, optional <i>type</i> <i>identifier</i>);</pre>
 
             <p>
-              Optional arguments can also have a <dfn data-export data-dfn-for="optional argument" id='dfn-optional-argument-default-value'>default value</dfn>
+              Optional arguments can also have a <dfn data-export="" data-dfn-for="optional argument" id='dfn-optional-argument-default-value'>default value</dfn>
               specified.  If the argument’s identifier is followed by a <span class='char'>U+003D EQUALS SIGN ("=")</span>
               and a value (matching <a class='sym' href='#prod-DefaultValue'>DefaultValue</a>),
               then that gives the optional argument its <a class='dfnref' href='#dfn-optional-argument-default-value'>default value</a>.
@@ -1875,11 +1875,11 @@ s.union(1, 4, 7);         <span class='comment'>// Passing three arguments corre
             <h4>Special operations</h4>
 
             <p>
-              A <dfn data-export id='dfn-special-operation'>special operation</dfn> is a
+              A <dfn data-export="" id='dfn-special-operation'>special operation</dfn> is a
               declaration of a certain kind of special behavior on objects implementing
               the interface on which the special operation declarations appear.
               Special operations are declared by using one or more
-              <dfn data-export id='dfn-special-keyword'>special keywords</dfn>
+              <dfn data-export="" id='dfn-special-keyword'>special keywords</dfn>
               in an operation declaration.
             </p>
             <p>
@@ -1894,33 +1894,33 @@ s.union(1, 4, 7);         <span class='comment'>// Passing three arguments corre
                 <th>Purpose</th>
               </tr>
               <tr>
-                <td><dfn data-export data-lt="getter" id='dfn-getter'>Getters</dfn></td>
+                <td><dfn data-export="" data-lt="getter" id='dfn-getter'>Getters</dfn></td>
                 <td><code>getter</code></td>
                 <td>Defines behavior for when an object is indexed for property retrieval.</td>
               </tr>
               <tr>
-                <td><dfn data-export data-lt="setter" id='dfn-setter'>Setters</dfn></td>
+                <td><dfn data-export="" data-lt="setter" id='dfn-setter'>Setters</dfn></td>
                 <td><code>setter</code></td>
                 <td>Defines behavior for when an object is indexed for property
                 assignment or creation.</td>
               </tr>
               <tr>
-                <td><dfn data-export data-lt="deleter" id='dfn-deleter'>Deleters</dfn></td>
+                <td><dfn data-export="" data-lt="deleter" id='dfn-deleter'>Deleters</dfn></td>
                 <td><code>deleter</code></td>
                 <td>Defines behavior for when an object is indexed for property deletion.</td>
               </tr>
               <tr>
-                <td><dfn data-export data-lt="legacy" id='dfn-legacy-caller'>Legacy callers</dfn></td>
+                <td><dfn data-export="" data-lt="legacy" id='dfn-legacy-caller'>Legacy callers</dfn></td>
                 <td><code>legacycaller</code></td>
                 <td>Defines behavior for when an object is called as if it were a function.</td>
               </tr>
               <tr>
-                <td><dfn data-export data-lt="stringifier" id='dfn-stringifier'>Stringifiers</dfn></td>
+                <td><dfn data-export="" data-lt="stringifier" id='dfn-stringifier'>Stringifiers</dfn></td>
                 <td><code>stringifier</code></td>
                 <td>Defines how an object is converted into a <span class='idltype'>DOMString</span>.</td>
               </tr>
               <tr>
-                <td><dfn data-export data-lt="serializer" id='dfn-serializer'>Serializers</dfn></td>
+                <td><dfn data-export="" data-lt="serializer" id='dfn-serializer'>Serializers</dfn></td>
                 <td><code>serializer</code></td>
                 <td>Defines how an object is converted into a serialized form.</td>
               </tr>
@@ -2029,14 +2029,14 @@ dictionary.x = 1;                  <span class='comment'>// Invokes the property
               Getters and setters come in two varieties: ones that
               take a <span class='idltype'>DOMString</span> as a property name,
               known as
-              <dfn data-export data-lt="named property getter" id='dfn-named-property-getter'>named property getters</dfn> and
-              <dfn data-export data-lt="named property setter" id='dfn-named-property-setter'>named property setters</dfn>,
+              <dfn data-export="" data-lt="named property getter" id='dfn-named-property-getter'>named property getters</dfn> and
+              <dfn data-export="" data-lt="named property setter" id='dfn-named-property-setter'>named property setters</dfn>,
               and ones that take an <span class='idltype'>unsigned long</span>
               as a property index, known as
-              <dfn data-export data-lt="indexed property getter" id='dfn-indexed-property-getter'>indexed property getters</dfn> and
-              <dfn data-export data-lt="indexed property setter" id='dfn-indexed-property-setter'>indexed property setters</dfn>.
+              <dfn data-export="" data-lt="indexed property getter" id='dfn-indexed-property-getter'>indexed property getters</dfn> and
+              <dfn data-export="" data-lt="indexed property setter" id='dfn-indexed-property-setter'>indexed property setters</dfn>.
               There is only one variety of deleter:
-              <dfn data-export data-lt="named property deleter" id='dfn-named-property-deleter'>named property deleters</dfn>.
+              <dfn data-export="" data-lt="named property deleter" id='dfn-named-property-deleter'>named property deleters</dfn>.
               See <a href='#idl-indexed-properties'>section <?sref idl-indexed-properties?></a>
               and <a href='#idl-named-properties'>section <?sref idl-named-properties?></a>
               for details.
@@ -2145,7 +2145,7 @@ omittable stringifier DOMString <i>identifier</i>();--></pre>
                 If an operation used to declare a stringifier does not have an
                 <a class='dfnref' href='#dfn-identifier'>identifier</a>, then prose
                 accompanying the interface <span class='rfc2119'>MUST</span> define
-                the <dfn data-export id='dfn-stringification-behavior'>stringification behavior</dfn>
+                the <dfn data-export="" id='dfn-stringification-behavior'>stringification behavior</dfn>
                 of the interface.  If the operation does have an identifier,
                 then the object is converted to a string by invoking the
                 operation to obtain the string.
@@ -2263,9 +2263,9 @@ var greeting = 'Hi ' + s;  <span class='comment'>// Now greeting == 'Hi Alan Smi
               <p>
                 Prose accompanying an interface that declares a serializer in this
                 way <span class='rfc2119'>MUST</span> define the
-                <dfn data-export id='dfn-serialization-behavior'>serialization behavior</dfn>
+                <dfn data-export="" id='dfn-serialization-behavior'>serialization behavior</dfn>
                 of the interface.  Serialization behavior is defined as returning
-                a <dfn data-export id='dfn-serialized-value'>serialized value</dfn> of one of the following types:
+                a <dfn data-export="" id='dfn-serialized-value'>serialized value</dfn> of one of the following types:
               </p>
               <ul>
                 <li>a <em>map</em> of key–value pairs, where the keys are
@@ -2297,7 +2297,7 @@ var greeting = 'Hi ' + s;  <span class='comment'>// Now greeting == 'Hi Alan Smi
                 can also be specified directly in IDL, rather than separately as prose.
                 This is done by following the <code>serializer</code> keyword with
                 a <span class='char'>U+003D EQUALS SIGN ("=")</span> character and
-                a <dfn data-export id='dfn-serialization-pattern'>serialization pattern</dfn>,
+                a <dfn data-export="" id='dfn-serialization-pattern'>serialization pattern</dfn>,
                 which can take one of the following six forms:
               </p>
               <ul>
@@ -2453,8 +2453,8 @@ serializer = { inherit, attribute };</pre>
                 </p>
               </div>
 
-              <p>The list of <dfn data-export data-lt="serializable type" id='dfn-serializable-type'>serializable types</dfn> and how they are
-              <dfn data-export data-lt="converted to a serialized value|converted to serialized values" id='dfn-convert-to-serialized-value'>converted to serialized values</dfn> is as follows:</p>
+              <p>The list of <dfn data-export="" data-lt="serializable type" id='dfn-serializable-type'>serializable types</dfn> and how they are
+              <dfn data-export="" data-lt="converted to a serialized value|converted to serialized values" id='dfn-convert-to-serialized-value'>converted to serialized values</dfn> is as follows:</p>
               <dl class='switch'>
                 <dt><span class='idltype'>long long</span></dt>
                 <dd>converted by choosing the closest equivalent <a class='idltype' href='#idl-double'>double</a> value
@@ -2615,13 +2615,13 @@ JSON.stringify(txn);</x:codeblock>
               <p>
                 An <a class='dfnref' href='#dfn-interface'>interface</a> that defines
                 an <a class='dfnref' href='#dfn-indexed-property-getter'>indexed property getter</a>
-                is said to <dfn data-export id='dfn-support-indexed-properties'>support indexed properties</dfn>.
+                is said to <dfn data-export="" id='dfn-support-indexed-properties'>support indexed properties</dfn>.
               </p>
               <p>
                 If an interface <a class='dfnref' href='#dfn-support-indexed-properties'>supports indexed properties</a>,
                 then the interface definition <span class='rfc2119'>MUST</span> be accompanied by
                 a description of what indices the object can be indexed with at
-                any given time. These indices are called the <dfn data-export id='dfn-supported-property-indices'>supported property indices</dfn>.
+                any given time. These indices are called the <dfn data-export="" id='dfn-supported-property-indices'>supported property indices</dfn>.
               </p>
               <p>
                 Indexed property getters <span class='rfc2119'>MUST</span>
@@ -2645,7 +2645,7 @@ setter <i>type</i> (unsigned long <i>identifier</i>, <i>type</i> <i>identifier</
                   is the value that would be returned by invoking the operation, passing
                   the index as its only argument.  If the operation used to declare the indexed property getter
                   did not have an identifier, then the interface definition must be accompanied
-                  by a description of how to <dfn data-export id='dfn-determine-the-value-of-an-indexed-property'>determine the value of an indexed property</dfn>
+                  by a description of how to <dfn data-export="" id='dfn-determine-the-value-of-an-indexed-property'>determine the value of an indexed property</dfn>
                   for a given index.
                 </li>
                 <li>
@@ -2655,8 +2655,8 @@ setter <i>type</i> (unsigned long <i>identifier</i>, <i>type</i> <i>identifier</
                   is the same as if the operation is invoked, passing
                   the index as the first argument and the value as the second argument.  If the operation used to declare the indexed property setter
                   did not have an identifier, then the interface definition must be accompanied
-                  by a description of how to <dfn data-export id='dfn-set-the-value-of-an-existing-indexed-property'>set the value of an existing indexed property</dfn>
-                  and how to <dfn data-export id='dfn-set-the-value-of-a-new-indexed-property'>set the value of a new indexed property</dfn>
+                  by a description of how to <dfn data-export="" id='dfn-set-the-value-of-an-existing-indexed-property'>set the value of an existing indexed property</dfn>
+                  and how to <dfn data-export="" id='dfn-set-the-value-of-a-new-indexed-property'>set the value of a new indexed property</dfn>
                   for a given property index and value.
                 </li>
               </ul>
@@ -2781,14 +2781,14 @@ delete map.cake;  <span class='comment'>// If a named property named "cake" exis
               <p>
                 An <a class='dfnref' href='#dfn-interface'>interface</a> that defines
                 a <a class='dfnref' href='#dfn-named-property-getter'>named property getter</a>
-                is said to <dfn data-export id='dfn-support-named-properties'>support named properties</dfn>.
+                is said to <dfn data-export="" id='dfn-support-named-properties'>support named properties</dfn>.
               </p>
               <p>
                 If an interface <a class='dfnref' href='#dfn-support-named-properties'>supports named properties</a>,
                 then the interface definition <span class='rfc2119'>MUST</span> be accompanied by
                 a description of the ordered set of names that can be used to index the object
                 at any given time.  These names are called the
-                <dfn data-export id='dfn-supported-property-names'>supported property names</dfn>.
+                <dfn data-export="" id='dfn-supported-property-names'>supported property names</dfn>.
               </p>
               <p>
                 Named property getters and deleters <span class='rfc2119'>MUST</span>
@@ -2814,7 +2814,7 @@ deleter <i>type</i> (DOMString <i>identifier</i>);</pre>
                   is the value that would be returned by invoking the operation, passing
                   the name as its only argument.  If the operation used to declare the named property getter
                   did not have an identifier, then the interface definition must be accompanied
-                  by a description of how to <dfn data-export id='dfn-determine-the-value-of-a-named-property'>determine the value of a named property</dfn>
+                  by a description of how to <dfn data-export="" id='dfn-determine-the-value-of-a-named-property'>determine the value of a named property</dfn>
                   for a given property name.
                 </li>
                 <li>
@@ -2824,8 +2824,8 @@ deleter <i>type</i> (DOMString <i>identifier</i>);</pre>
                   is the same as if the operation is invoked, passing
                   the name as the first argument and the value as the second argument.  If the operation used to declare the named property setter
                   did not have an identifier, then the interface definition must be accompanied
-                  by a description of how to <dfn data-export id='dfn-set-the-value-of-an-existing-named-property'>set the value of an existing named property</dfn>
-                  and how to <dfn data-export id='dfn-set-the-value-of-a-new-named-property'>set the value of a new named property</dfn>
+                  by a description of how to <dfn data-export="" id='dfn-set-the-value-of-an-existing-named-property'>set the value of an existing named property</dfn>
+                  and how to <dfn data-export="" id='dfn-set-the-value-of-a-new-named-property'>set the value of a new named property</dfn>
                   for a given property name and value.
                 </li>
                 <li>
@@ -2835,7 +2835,7 @@ deleter <i>type</i> (DOMString <i>identifier</i>);</pre>
                   is the same as if the operation is invoked, passing
                   the name as the only argument.  If the operation used to declare the named property deleter
                   did not have an identifier, then the interface definition must be accompanied
-                  by a description of how to <dfn data-export id='dfn-delete-an-existing-named-property'>delete an existing named property</dfn>
+                  by a description of how to <dfn data-export="" id='dfn-delete-an-existing-named-property'>delete an existing named property</dfn>
                   for a given property name.
                 </li>
               </ul>
@@ -2859,8 +2859,8 @@ deleter <i>type</i> (DOMString <i>identifier</i>);</pre>
             <h4>Static attributes and operations</h4>
 
             <p>
-              <dfn data-export id='dfn-static-attribute'>Static attributes</dfn> and
-              <dfn data-export id='dfn-static-operation'>static operations</dfn> are ones that
+              <dfn data-export="" id='dfn-static-attribute'>Static attributes</dfn> and
+              <dfn data-export="" id='dfn-static-operation'>static operations</dfn> are ones that
               are not associated with a particular instance of the
               <a class='dfnref' href='#dfn-interface'>interface</a>
               on which it is declared, and is instead associated with the interface
@@ -2938,7 +2938,7 @@ Point triangulationPoint = CircleUtils.triangulate(circles[0], circles[1], circl
               has an <a class='dfnref' href='#dfn-identifier'>identifier</a>
               that is the same as the identifier of another operation on that
               interface of the same kind (regular or static), then the operation is said to be
-              <dfn data-export id='dfn-overloaded'>overloaded</dfn>.  When the identifier
+              <dfn data-export="" id='dfn-overloaded'>overloaded</dfn>.  When the identifier
               of an overloaded operation is used to invoke one of the
               operations on an object that implements the interface, the
               number and types of the arguments passed to the operation
@@ -2981,7 +2981,7 @@ partial interface A {
                 so there is no need to also disallow overloading for constructors.</p>
             </div>
             <p>
-              An <dfn data-export id='dfn-effective-overload-set'>effective overload set</dfn>
+              An <dfn data-export="" id='dfn-effective-overload-set'>effective overload set</dfn>
               represents the allowable invocations for a particular
               <a class='dfnref' href='#dfn-operation'>operation</a>,
               constructor (specified with <a class='xattr' href='#Constructor'>[Constructor]</a>
@@ -3043,7 +3043,7 @@ partial interface A {
               if it is for constructors or named constructors, then <var>callable</var> is an
               extended attribute; and if it is for callback functions, then <var>callable</var>
               is the callback function itself.  In all cases, <var>type list</var> is a list
-              of IDL types, and <var>optionality list</var> is a list of three possible <dfn data-export id='dfn-optionality-value'>optionality values</dfn> –
+              of IDL types, and <var>optionality list</var> is a list of three possible <dfn data-export="" id='dfn-optionality-value'>optionality values</dfn> –
               “required”, “optional” or “variadic” – indicating whether
               the argument at a given index was declared as being <a class='dfnref' href='#dfn-optional-argument'>optional</a>
               or corresponds to a <a class='dfnref' href='#dfn-variadic'>variadic</a> argument.
@@ -3227,7 +3227,7 @@ partial interface A {
             </ul>
             -->
             <p>
-              Two types are <dfn data-export id='dfn-distinguishable'>distinguishable</dfn> if
+              Two types are <dfn data-export="" id='dfn-distinguishable'>distinguishable</dfn> if
               at most one of the two <a class='dfnref' href='#dfn-includes-a-nullable-type'>includes a nullable type</a>
               or is a <a href='#idl-dictionary'>dictionary type</a>,
               and at least one of the following three conditions is true:
@@ -3472,7 +3472,7 @@ partial interface A {
               <li>there is only one such index <var>i</var>-->.<!--</li>
             </ol>
             <p>-->
-              The lowest such index is termed the <dfn data-export id='dfn-distinguishing-argument-index'>distinguishing argument index</dfn>
+              The lowest such index is termed the <dfn data-export="" id='dfn-distinguishing-argument-index'>distinguishing argument index</dfn>
               for the entries of the effective overload set with the given type list length.
             </p>
             <div class='example'>
@@ -3574,7 +3574,7 @@ interface C {
 
             <p>
               An <a class='dfnref' href='#dfn-interface'>interface</a> can be declared to be
-              <dfn data-export id='dfn-iterable'>iterable</dfn> by using an <dfn data-export id='dfn-iterable-declaration'>iterable declaration</dfn>
+              <dfn data-export="" id='dfn-iterable'>iterable</dfn> by using an <dfn data-export="" id='dfn-iterable-declaration'>iterable declaration</dfn>
               (matching <a class='sym' href='#prod-Iterable'>Iterable</a>) in the body of the interface.
             </p>
             <pre class='syntax'>iterable&lt;<i>value-type</i>&gt;;
@@ -3590,10 +3590,10 @@ iterable&lt;<i>key-type</i>, <i>value-type</i>&gt;;</pre>
             </div>
             <p>
               If a single type parameter is given, then the interface has a
-              <dfn data-export id='dfn-value-iterator'>value iterator</dfn> and provides
+              <dfn data-export="" id='dfn-value-iterator'>value iterator</dfn> and provides
               values of the specified type.
               If two type parameters are given, then the interface has a
-              <dfn data-export id='dfn-pair-iterator'>pair iterator</dfn> and provides
+              <dfn data-export="" id='dfn-pair-iterator'>pair iterator</dfn> and provides
               value pairs, where the first value is a key and the second is the
               value associated with the key.
             </p>
@@ -3616,7 +3616,7 @@ iterable&lt;<i>key-type</i>, <i>value-type</i>&gt;;</pre>
               Prose accompanying an interface with a
               <a class='dfnref' href='#dfn-pair-iterator'>pair iterator</a>
               <span class='rfc2119'>MUST</span> define what the list of
-              <dfn data-export id='dfn-value-pairs-to-iterate-over'>value pairs to iterate over</dfn>
+              <dfn data-export="" id='dfn-value-pairs-to-iterate-over'>value pairs to iterate over</dfn>
               is.
             </p>
             <div class='note'>
@@ -3751,7 +3751,7 @@ for (let session of sm) {
 
             <p>
               An <a class='dfnref' href='#dfn-interface'>interface</a> can be declared to be
-              <dfn data-export id='dfn-maplike'>maplike</dfn> by using a <dfn data-export id='dfn-maplike-declaration'>maplike declaration</dfn>
+              <dfn data-export="" id='dfn-maplike'>maplike</dfn> by using a <dfn data-export="" id='dfn-maplike-declaration'>maplike declaration</dfn>
               (matching <a class='sym' href='#prod-ReadWriteMaplike'>ReadWriteMaplike</a> or
               <span class='sym'>"readonly"</span> <a class='sym' href='#prod-MaplikeRest'>MaplikeRest</a>) in the body of the interface.
             </p>
@@ -3759,7 +3759,7 @@ for (let session of sm) {
 maplike&lt;<i>key-type</i>, <i>value-type</i>&gt;;</pre>
             <p>
               Objects implementing an interface that is declared to be maplike
-              represent an ordered list of key–value pairs known as its <dfn data-export id='dfn-map-entries'>map entries</dfn>.
+              represent an ordered list of key–value pairs known as its <dfn data-export="" id='dfn-map-entries'>map entries</dfn>.
               The types used for the keys and values are given in the angle
               brackets of the maplike declaration.  Keys are required to be unique.
             </p>
@@ -3833,7 +3833,7 @@ maplike&lt;<i>key-type</i>, <i>value-type</i>&gt;;</pre>
 
             <p>
               An <a class='dfnref' href='#dfn-interface'>interface</a> can be declared to be
-              <dfn data-export id='dfn-setlike'>setlike</dfn> by using a <dfn data-export id='dfn-setlike-declaration'>setlike declaration</dfn>
+              <dfn data-export="" id='dfn-setlike'>setlike</dfn> by using a <dfn data-export="" id='dfn-setlike-declaration'>setlike declaration</dfn>
               (matching <a class='sym' href='#prod-ReadWriteSetlike'>ReadWriteSetlike</a> or
               <span class='sym'>"readonly"</span> <a class='sym' href='#prod-SetlikeRest'>SetlikeRest</a>) in the body of the interface.
             </p>
@@ -3841,7 +3841,7 @@ maplike&lt;<i>key-type</i>, <i>value-type</i>&gt;;</pre>
 setlike&lt;<i>type</i>&gt;;</pre>
             <p>
               Objects implementing an interface that is declared to be setlike
-              represent an ordered list of values known as its <dfn data-export id='dfn-set-entries'>set entries</dfn>.
+              represent an ordered list of values known as its <dfn data-export="" id='dfn-set-entries'>set entries</dfn>.
               The type of the values is given in the angle
               brackets of the setlike declaration.  Values are required to be unique.
             </p>
@@ -3914,10 +3914,10 @@ setlike&lt;<i>type</i>&gt;;</pre>
           <h3>Dictionaries</h3>
 
           <p>
-            A <dfn data-export id='dfn-dictionary'>dictionary</dfn> is a definition (matching
+            A <dfn data-export="" id='dfn-dictionary'>dictionary</dfn> is a definition (matching
             <a class='sym' href='#prod-Dictionary'>Dictionary</a>)
             used to define an associative array data type with a fixed, ordered set of key–value pairs,
-            termed <dfn data-export id='dfn-dictionary-member'>dictionary members</dfn>,
+            termed <dfn data-export="" id='dfn-dictionary-member'>dictionary members</dfn>,
             where keys are strings and values are of a particular type specified in the definition.
           </p>
           <pre class='syntax'>dictionary <i>identifier</i> {
@@ -3929,7 +3929,7 @@ setlike&lt;<i>type</i>&gt;;</pre>
             Similarly, any dictionary returned from a platform object will be a copy and modifications made to it will not be visible to the platform object.
           </p>
           <p>
-            A dictionary can be defined to <dfn data-export data-dfn-for="dictionary" id='dfn-inherit-dictionary'>inherit</dfn> from another dictionary.
+            A dictionary can be defined to <dfn data-export="" data-dfn-for="dictionary" id='dfn-inherit-dictionary'>inherit</dfn> from another dictionary.
             If the identifier of the dictionary is followed by a colon and a <a class='dfnref' href='#dfn-identifier'>identifier</a>,
             then that identifier identifies the inherited dictionary.  The identifier
             <span class='rfc2119'>MUST</span> identify a dictionary.
@@ -3948,7 +3948,7 @@ dictionary <i>Derived</i> : <em>Base</em> {
   <i>dictionary-members…</i>
 };</pre>
           <p>
-            The <dfn data-export id='dfn-inherited-dictionaries'>inherited dictionaries</dfn> of
+            The <dfn data-export="" id='dfn-inherited-dictionaries'>inherited dictionaries</dfn> of
             a given dictionary <var>D</var> is the set of all dictionaries that <var>D</var>
             inherits from, directly or indirectly.  If <var>D</var> does not <a class='dfnref' href='#dfn-inherit-dictionary'>inherit</a>
             from another dictionary, then the set is empty.  Otherwise, the set
@@ -3962,8 +3962,8 @@ dictionary <i>Derived</i> : <em>Base</em> {
             On a given dictionary value, the presence of each dictionary member
             is optional, unless that member is specified as required.
             When specified in the dictionary value, a dictionary member is said to be
-            <dfn data-export id='dfn-present'>present</dfn>, otherwise it is <a class='dfnref' href='#dfn-present'>not present</a>.
-            Dictionary members can also optionally have a <dfn data-export data-dfn-for="dictionary member" id='dfn-dictionary-member-default-value'>default value</dfn>, which is
+            <dfn data-export="" id='dfn-present'>present</dfn>, otherwise it is <a class='dfnref' href='#dfn-present'>not present</a>.
+            Dictionary members can also optionally have a <dfn data-export="" data-dfn-for="dictionary member" id='dfn-dictionary-member-default-value'>default value</dfn>, which is
             the value to use for the dictionary member when passing a value to a
             <a class='dfnref' href='#dfn-platform-object'>platform object</a> that does
             not have a specified value.  Dictionary members with default values are
@@ -4030,7 +4030,7 @@ dictionary <i>Derived</i> : <em>Base</em> {
           <p>
             If the type of the dictionary member is preceded by the
             <code>required</code> keyword, the member is considered a
-            <dfn data-export id="required-dictionary-member">required dictionary member</dfn>
+            <dfn data-export="" id="required-dictionary-member">required dictionary member</dfn>
             and must be present on the dictionary.  A
             <a class='dfnref' href='#required-dictionary-member'>required dictionary
             member</a> <span class="rfc2119">MUST NOT</span> have a default value.
@@ -4058,7 +4058,7 @@ dictionary <i>Derived</i> : <em>Base</em> {
           </ul>
           <p>
             As with interfaces, the IDL for dictionaries can be split into multiple parts
-            by using <dfn data-export id='dfn-partial-dictionary'>partial dictionary</dfn> definitions
+            by using <dfn data-export="" id='dfn-partial-dictionary'>partial dictionary</dfn> definitions
             (matching <span class='sym'>"partial"</span> <a class='sym' href='#prod-Dictionary'>Dictionary</a>).
             The <a class='dfnref' href='#dfn-identifier'>identifier</a> of a partial
             dictionary definition <span class='rfc2119'>MUST</span> be the same as the
@@ -4205,21 +4205,21 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
           <h3>Exceptions</h3>
 
           <p>
-            An <dfn data-export id='dfn-exception'>exception</dfn> is a type of object that
+            An <dfn data-export="" id='dfn-exception'>exception</dfn> is a type of object that
             represents an error and which can be thrown or treated as a first
             class value by implementations.  Web IDL does not allow exceptions
             to be defined, but instead has a number of pre-defined exceptions
             that specifications can reference and throw in their definition of
             operations, attributes, and so on.  Exceptions have an
-            <dfn data-export data-dfn-for="exception" id='dfn-exception-error-name'>error name</dfn>,
+            <dfn data-export="" data-dfn-for="exception" id='dfn-exception-error-name'>error name</dfn>,
             a <a class='idltype' href='#idl-DOMString'>DOMString</a>,
             which is the type of error the exception represents, and a
-            <dfn data-export data-dfn-for="exception" id='dfn-exception-message'>message</dfn>, which is an optional,
+            <dfn data-export="" data-dfn-for="exception" id='dfn-exception-message'>message</dfn>, which is an optional,
             user agent-defined value that provides human readable details of the error.
           </p>
           <p>
             There are two kinds of exceptions available to be thrown from specifications.
-            The first is a <dfn data-export id='dfn-simple-exception'>simple exception</dfn>, which
+            The first is a <dfn data-export="" id='dfn-simple-exception'>simple exception</dfn>, which
             is identified by one of the following names:
           </p>
           <ul>
@@ -4240,7 +4240,7 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
             ECMAScript specification.
           </p>
           <p>
-            The second kind of exception is a <dfn data-export data-dfn-type="interface" id='dfn-DOMException'>DOMException</dfn>,
+            The second kind of exception is a <dfn data-export="" data-dfn-type="interface" id='dfn-DOMException'>DOMException</dfn>,
             which is an exception that encapsulates a name and an optional integer code,
             for compatibility with historically defined exceptions in the DOM.
           </p>
@@ -4264,9 +4264,9 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
             to be of type <span class='idltype'>Error</span>.
           </p>
           <p>
-            Exceptions can be <dfn data-export data-dfn-for="exception" id='dfn-create-exception'>created</dfn> by providing its
+            Exceptions can be <dfn data-export="" data-dfn-for="exception" id='dfn-create-exception'>created</dfn> by providing its
             <a class='dfnref' href='#dfn-exception-error-name'>error name</a>.
-            Exceptions can also be <dfn data-export data-dfn-for="exception" data-lt="throw|thrown" id='dfn-throw'>thrown</dfn>, by providing the
+            Exceptions can also be <dfn data-export="" data-dfn-for="exception" data-lt="throw|thrown" id='dfn-throw'>thrown</dfn>, by providing the
             same details required to <a class='dfnref' href='#dfn-create-exception'>create</a> one.
           </p>
           <p>
@@ -4310,7 +4310,7 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
             <h4>Error names</h4>
 
             <p>
-              The <dfn data-export id='dfn-error-names-table'>error names table</dfn> below lists all the allowed error names
+              The <dfn data-export="" id='dfn-error-names-table'>error names table</dfn> below lists all the allowed error names
               for <a class='dfnref' href='#dfn-DOMException'>DOMExceptions</a>, a description,
               and legacy code values.
             </p>
@@ -4325,175 +4325,175 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
               </thead>
               <tbody>
                 <tr>
-                  <td>"<dfn data-export data-dfn-type="interface" id="indexsizeerror"><code>IndexSizeError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="indexsizeerror"><code>IndexSizeError</code></dfn>"</td>
                   <td>The index is not in the allowed range.</td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-index_size_err" title="dom-DOMException-INDEX_SIZE_ERR"><code>INDEX_SIZE_ERR</code></dfn> (1)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-index_size_err" title="dom-DOMException-INDEX_SIZE_ERR"><code>INDEX_SIZE_ERR</code></dfn> (1)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export data-dfn-type="interface" id="hierarchyrequesterror"><code>HierarchyRequestError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="hierarchyrequesterror"><code>HierarchyRequestError</code></dfn>"</td>
                   <td>The operation would yield an incorrect <a href="https://dom.spec.whatwg.org/#concept-node-tree" title="concept-node-tree">node tree</a>.</td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-hierarchy_request_err" title="dom-DOMException-HIERARCHY_REQUEST_ERR"><code>HIERARCHY_REQUEST_ERR</code></dfn> (3)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-hierarchy_request_err" title="dom-DOMException-HIERARCHY_REQUEST_ERR"><code>HIERARCHY_REQUEST_ERR</code></dfn> (3)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export data-dfn-type="interface" id="wrongdocumenterror"><code>WrongDocumentError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="wrongdocumenterror"><code>WrongDocumentError</code></dfn>"</td>
                   <td>The object is in the wrong <a href="https://dom.spec.whatwg.org/#concept-document" title="concept-document">document</a>.</td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-wrong_document_err" title="dom-DOMException-WRONG_DOCUMENT_ERR"><code>WRONG_DOCUMENT_ERR</code></dfn> (4)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-wrong_document_err" title="dom-DOMException-WRONG_DOCUMENT_ERR"><code>WRONG_DOCUMENT_ERR</code></dfn> (4)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export data-dfn-type="interface" id="invalidcharactererror"><code>InvalidCharacterError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="invalidcharactererror"><code>InvalidCharacterError</code></dfn>"</td>
                   <td>The string contains invalid characters.</td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-invalid_character_err" title="dom-DOMException-INVALID_CHARACTER_ERR"><code>INVALID_CHARACTER_ERR</code></dfn> (5)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-invalid_character_err" title="dom-DOMException-INVALID_CHARACTER_ERR"><code>INVALID_CHARACTER_ERR</code></dfn> (5)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export data-dfn-type="interface" id="nomodificationallowederror"><code>NoModificationAllowedError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="nomodificationallowederror"><code>NoModificationAllowedError</code></dfn>"</td>
                   <td>The object can not be modified.</td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-no_modification_allowed_err" title="dom-DOMException-NO_MODIFICATION_ALLOWED_ERR"><code>NO_MODIFICATION_ALLOWED_ERR</code></dfn> (7)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-no_modification_allowed_err" title="dom-DOMException-NO_MODIFICATION_ALLOWED_ERR"><code>NO_MODIFICATION_ALLOWED_ERR</code></dfn> (7)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export data-dfn-type="interface" id="notfounderror"><code>NotFoundError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="notfounderror"><code>NotFoundError</code></dfn>"</td>
                   <td>The object can not be found here.</td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-not_found_err" title="dom-DOMException-NOT_FOUND_ERR"><code>NOT_FOUND_ERR</code></dfn> (8)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-not_found_err" title="dom-DOMException-NOT_FOUND_ERR"><code>NOT_FOUND_ERR</code></dfn> (8)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export data-dfn-type="interface" id="notsupportederror"><code>NotSupportedError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="notsupportederror"><code>NotSupportedError</code></dfn>"</td>
                   <td>The operation is not supported.</td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-not_supported_err" title="dom-DOMException-NOT_SUPPORTED_ERR"><code>NOT_SUPPORTED_ERR</code></dfn> (9)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-not_supported_err" title="dom-DOMException-NOT_SUPPORTED_ERR"><code>NOT_SUPPORTED_ERR</code></dfn> (9)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export data-dfn-type="interface" id="inuseattributeerror"><code>InUseAttributeError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="inuseattributeerror"><code>InUseAttributeError</code></dfn>"</td>
                   <td>The attribute is in use.</td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-inuse_attribute_err" title="dom-DOMException-INUSE_ATTRIBUTE_ERR"><code>INUSE_ATTRIBUTE_ERR</code></dfn> (10)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-inuse_attribute_err" title="dom-DOMException-INUSE_ATTRIBUTE_ERR"><code>INUSE_ATTRIBUTE_ERR</code></dfn> (10)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export data-dfn-type="interface" id="invalidstateerror"><code>InvalidStateError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="invalidstateerror"><code>InvalidStateError</code></dfn>"</td>
                   <td>The object is in an invalid state.</td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-invalid_state_err" title="dom-DOMException-INVALID_STATE_ERR"><code>INVALID_STATE_ERR</code></dfn> (11)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-invalid_state_err" title="dom-DOMException-INVALID_STATE_ERR"><code>INVALID_STATE_ERR</code></dfn> (11)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export data-dfn-type="interface" id="syntaxerror"><code>SyntaxError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="syntaxerror"><code>SyntaxError</code></dfn>"</td>
                   <td>The string did not match the expected pattern.</td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-syntax_err" title="dom-DOMException-SYNTAX_ERR"><code>SYNTAX_ERR</code></dfn> (12)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-syntax_err" title="dom-DOMException-SYNTAX_ERR"><code>SYNTAX_ERR</code></dfn> (12)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export data-dfn-type="interface" id="invalidmodificationerror"><code>InvalidModificationError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="invalidmodificationerror"><code>InvalidModificationError</code></dfn>"</td>
                   <td>The object can not be modified in this way.</td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-invalid_modification_err" title="dom-DOMException-INVALID_MODIFICATION_ERR"><code>INVALID_MODIFICATION_ERR</code></dfn> (13)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-invalid_modification_err" title="dom-DOMException-INVALID_MODIFICATION_ERR"><code>INVALID_MODIFICATION_ERR</code></dfn> (13)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export data-dfn-type="interface" id="namespaceerror"><code>NamespaceError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="namespaceerror"><code>NamespaceError</code></dfn>"</td>
                   <td>The operation is not allowed by <cite>Namespaces in XML</cite>. <a href="#ref-XMLNS">[XMLNS]</a></td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-namespace_err" title="dom-DOMException-NAMESPACE_ERR"><code>NAMESPACE_ERR</code></dfn> (14)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-namespace_err" title="dom-DOMException-NAMESPACE_ERR"><code>NAMESPACE_ERR</code></dfn> (14)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export data-dfn-type="interface" id="invalidaccesserror"><code>InvalidAccessError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="invalidaccesserror"><code>InvalidAccessError</code></dfn>"</td>
                   <td>The object does not support the operation or argument.</td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-invalid_access_err" title="dom-DOMException-INVALID_ACCESS_ERR"><code>INVALID_ACCESS_ERR</code></dfn> (15)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-invalid_access_err" title="dom-DOMException-INVALID_ACCESS_ERR"><code>INVALID_ACCESS_ERR</code></dfn> (15)</td>
                 </tr>
                 <tr>
                   <!-- XHR -->
-                  <td>"<dfn data-export data-dfn-type="interface" id="securityerror"><code>SecurityError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="securityerror"><code>SecurityError</code></dfn>"</td>
                   <td>The operation is insecure.</td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-security_err" title="dom-DOMException-SECURITY_ERR"><code>SECURITY_ERR</code></dfn> (18)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-security_err" title="dom-DOMException-SECURITY_ERR"><code>SECURITY_ERR</code></dfn> (18)</td>
                 </tr>
                 <tr>
                   <!-- XHR -->
-                  <td>"<dfn data-export data-dfn-type="interface" id="networkerror"><code>NetworkError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="networkerror"><code>NetworkError</code></dfn>"</td>
                   <td>A network error occurred.</td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-network_err" title="dom-DOMException-NETWORK_ERR"><code>NETWORK_ERR</code></dfn> (19)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-network_err" title="dom-DOMException-NETWORK_ERR"><code>NETWORK_ERR</code></dfn> (19)</td>
                 </tr>
                 <tr>
                   <!-- XHR -->
-                  <td>"<dfn data-export data-dfn-type="interface" id="aborterror"><code>AbortError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="aborterror"><code>AbortError</code></dfn>"</td>
                   <td>The operation was aborted.</td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-abort_err" title="dom-DOMException-ABORT_ERR"><code>ABORT_ERR</code></dfn> (20)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-abort_err" title="dom-DOMException-ABORT_ERR"><code>ABORT_ERR</code></dfn> (20)</td>
                 </tr>
                 <tr>
                   <!-- Workers -->
-                  <td>"<dfn data-export data-dfn-type="interface" id="urlmismatcherror"><code>URLMismatchError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="urlmismatcherror"><code>URLMismatchError</code></dfn>"</td>
                   <td>The given URL does not match another URL.</td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-url_mismatch_err" title="dom-DOMException-URL_MISMATCH_ERR"><code>URL_MISMATCH_ERR</code></dfn> (21)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-url_mismatch_err" title="dom-DOMException-URL_MISMATCH_ERR"><code>URL_MISMATCH_ERR</code></dfn> (21)</td>
                 </tr>
                 <tr>
                   <!-- HTML -->
-                  <td>"<dfn data-export data-dfn-type="interface" id="quotaexceedederror"><code>QuotaExceededError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="quotaexceedederror"><code>QuotaExceededError</code></dfn>"</td>
                   <td>The quota has been exceeded.</td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-quota_exceeded_err" title="dom-DOMException-QUOTA_EXCEEDED_ERR"><code>QUOTA_EXCEEDED_ERR</code></dfn> (22)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-quota_exceeded_err" title="dom-DOMException-QUOTA_EXCEEDED_ERR"><code>QUOTA_EXCEEDED_ERR</code></dfn> (22)</td>
                 </tr>
                 <tr>
                   <!-- XHR -->
-                  <td>"<dfn data-export data-dfn-type="interface" id="timeouterror"><code>TimeoutError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="timeouterror"><code>TimeoutError</code></dfn>"</td>
                   <td>The operation timed out.</td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-timeout_err" title="dom-DOMException-TIMEOUT_ERR"><code>TIMEOUT_ERR</code></dfn> (23)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-timeout_err" title="dom-DOMException-TIMEOUT_ERR"><code>TIMEOUT_ERR</code></dfn> (23)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export data-dfn-type="interface" id="invalidnodetypeerror"><code>InvalidNodeTypeError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="invalidnodetypeerror"><code>InvalidNodeTypeError</code></dfn>"</td>
                   <td>The supplied node is incorrect or has an incorrect ancestor for this operation.</td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-invalid_node_type_err" title="dom-DOMException-INVALID_NODE_TYPE_ERR"><code>INVALID_NODE_TYPE_ERR</code></dfn> (24)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-invalid_node_type_err" title="dom-DOMException-INVALID_NODE_TYPE_ERR"><code>INVALID_NODE_TYPE_ERR</code></dfn> (24)</td>
                 </tr>
                 <tr>
                   <!-- HTML -->
-                  <td>"<dfn data-export data-dfn-type="interface" id="datacloneerror"><code>DataCloneError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="datacloneerror"><code>DataCloneError</code></dfn>"</td>
                   <td>The object can not be cloned.</td>
-                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-data_clone_err" title="dom-DOMException-DATA_CLONE_ERR"><code>DATA_CLONE_ERR</code></dfn> (25)</td>
+                  <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-data_clone_err" title="dom-DOMException-DATA_CLONE_ERR"><code>DATA_CLONE_ERR</code></dfn> (25)</td>
                 </tr>
                 <tr>
                   <!-- Encoding -->
-                  <td>"<dfn data-export data-dfn-type="interface" id="encodingerror"><code>EncodingError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="encodingerror"><code>EncodingError</code></dfn>"</td>
                   <td>The encoding operation (either encoded or decoding) failed.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- File API -->
-                  <td>"<dfn data-export data-dfn-type="interface" id="notreadableerror"><code>NotReadableError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="notreadableerror"><code>NotReadableError</code></dfn>"</td>
                   <td>The I/O read operation failed.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Indexed DB / Web Crypto -->
-                  <td>"<dfn data-export data-dfn-type="interface" id="unknownerror"><code>UnknownError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="unknownerror"><code>UnknownError</code></dfn>"</td>
                   <td>The operation failed for an unknown transient reason (e.g. out of memory).</td>
                   <!-- The operation failed for reasons unrelated to the database itself and not covered by any other errors. -->
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Indexed DB -->
-                  <td>"<dfn data-export data-dfn-type="interface" id="constrainterror"><code>ConstraintError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="constrainterror"><code>ConstraintError</code></dfn>"</td>
                   <td>A mutation operation in a transaction failed because a constraint was not satisfied.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Indexed DB / Web Crypto -->
-                  <td>"<dfn data-export data-dfn-type="interface" id="dataerror"><code>DataError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="dataerror"><code>DataError</code></dfn>"</td>
                   <td>Provided data is inadequate.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Indexed DB -->
-                  <td>"<dfn data-export data-dfn-type="interface" id="transactioninactiveerror"><code>TransactionInactiveError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="transactioninactiveerror"><code>TransactionInactiveError</code></dfn>"</td>
                   <td>A request was placed against a transaction which is currently not active, or which is finished.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Indexed DB -->
-                  <td>"<dfn data-export data-dfn-type="interface" id="readonlyerror"><code>ReadOnlyError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="readonlyerror"><code>ReadOnlyError</code></dfn>"</td>
                   <td>The mutating operation was attempted in a "readonly" transaction.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Indexed DB -->
-                  <td>"<dfn data-export data-dfn-type="interface" id="versionerror"><code>VersionError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="versionerror"><code>VersionError</code></dfn>"</td>
                   <td>An attempt was made to open a database using a lower version than the existing version.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Web Crypto -->
-                  <td>"<dfn data-export data-dfn-type="interface" id="operationerror"><code>OperationError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="operationerror"><code>OperationError</code></dfn>"</td>
                   <td>The operation failed for an operation-specific reason.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- HTML -->
-                  <td>"<dfn data-export data-dfn-type="interface" id="notallowederror"><code>NotAllowedError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="interface" id="notallowederror"><code>NotAllowedError</code></dfn>"</td>
                   <td>The request is not allowed by the user agent or the platform in the current context.</td>
                   <td>—</td>
                 </tr>
@@ -4506,7 +4506,7 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
           <h3>Enumerations</h3>
 
           <p>
-            An <dfn data-export id='dfn-enumeration'>enumeration</dfn> is a definition (matching
+            An <dfn data-export="" id='dfn-enumeration'>enumeration</dfn> is a definition (matching
             <a class='sym' href='#prod-Enum'>Enum</a>) used to declare a type
             whose valid values are a set of predefined strings.  Enumerations
             can be used to restrict the possible
@@ -4516,7 +4516,7 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
           </p>
           <pre class='syntax'>enum <i>identifier</i> { <i>enumeration-values…</i> };</pre>
           <p>
-            The <dfn data-export data-lt="enumeration value" id='dfn-enumeration-value'>enumeration values</dfn> are specified
+            The <dfn data-export="" data-lt="enumeration value" id='dfn-enumeration-value'>enumeration values</dfn> are specified
             as a comma-separated list of <a class='sym' href='#prod-string'>string</a> literals.
             The list of <a class='dfnref' href='#dfn-enumeration-value'>enumeration values</a>
             <span class='rfc2119'>MUST NOT</span> include duplicates.
@@ -4599,7 +4599,7 @@ meal.type == "noodles";              <span class='comment'>// Evaluates to true.
             just “functions” to make it clear that they can be used for both purposes?</p>
           </div>
           <p>
-            A <dfn data-export id='dfn-callback-function'>callback function</dfn> is a definition (matching
+            A <dfn data-export="" id='dfn-callback-function'>callback function</dfn> is a definition (matching
             <span class='sym'>"callback"</span> <a class='sym' href='#prod-CallbackRest'>CallbackRest</a>) used to declare a function type.
           </p>
           <pre class='syntax'>callback <i>identifier</i> = <i>return-type</i> (<i>arguments…</i>);</pre>
@@ -4651,7 +4651,7 @@ ops.performOperation(function(status) {
           <h3>Typedefs</h3>
 
           <p>
-            A <dfn data-export id='dfn-typedef'>typedef</dfn> is a definition (matching
+            A <dfn data-export="" id='dfn-typedef'>typedef</dfn> is a definition (matching
             <a class='sym' href='#prod-Typedef'>Typedef</a>)
             used to declare a new name for a type.  This new name is not exposed
             by language bindings; it is purely used as a shorthand for referencing
@@ -4701,7 +4701,7 @@ interface Widget {
           <h3>Implements statements</h3>
 
           <p>
-            An <dfn data-export id='dfn-implements-statement'>implements statement</dfn> is a definition
+            An <dfn data-export="" id='dfn-implements-statement'>implements statement</dfn> is a definition
             (matching <a class='sym' href='#prod-ImplementsStatement'>ImplementsStatement</a>)
             used to declare that all objects implementing an interface <var>A</var>
             (identified by the first <a class='dfnref' href='#dfn-identifier'>identifier</a>)
@@ -4735,7 +4735,7 @@ interface Widget {
           </p>
           <p>
             Interfaces that a given object implements are partitioned into those that are considered
-            <dfn data-export data-lt="supplemental interface" id='dfn-supplemental-interface'>supplemental interfaces</dfn> and those that are not.
+            <dfn data-export="" data-lt="supplemental interface" id='dfn-supplemental-interface'>supplemental interfaces</dfn> and those that are not.
             An interface <var>A</var> is considered to be a
             <a class='dfnref' href='#dfn-supplemental-interface'>supplemental interface</a> of an object
             <var>O</var> if:
@@ -4779,7 +4779,7 @@ Gizmo implements SomeFunctionality;
 Gizmo implements MoreFunctionality;</x:codeblock>
           </div>
           <p>
-            The <dfn data-export id='dfn-consequential-interfaces'>consequential interfaces</dfn> of an interface
+            The <dfn data-export="" id='dfn-consequential-interfaces'>consequential interfaces</dfn> of an interface
             <var>A</var> are:
           </p>
           <ul>
@@ -4864,8 +4864,8 @@ EventTarget et = (EventTarget) n; <span class='comment'>// This should never thr
 
           <p>
             In a given implementation of a set of <a class='dfnref' href='#dfn-idl-fragment'>IDL fragments</a>,
-            an object can be described as being a <dfn data-export id='dfn-platform-object'>platform object</dfn>, a
-            <dfn data-export id='dfn-user-object'>user object</dfn>, or neither.  There are two kinds of
+            an object can be described as being a <dfn data-export="" id='dfn-platform-object'>platform object</dfn>, a
+            <dfn data-export="" id='dfn-user-object'>user object</dfn>, or neither.  There are two kinds of
             object that are considered to be platform objects:
           </p>
           <ul>
@@ -4986,7 +4986,7 @@ interface Person {
             of that type are represented.
           </p>
           <p>
-            The following types are known as <dfn data-export id='dfn-integer-type'>integer types</dfn>:
+            The following types are known as <dfn data-export="" id='dfn-integer-type'>integer types</dfn>:
             <a class='idltype' href='#idl-byte'>byte</a>,
             <a class='idltype' href='#idl-octet'>octet</a>,
             <a class='idltype' href='#idl-short'>short</a>,
@@ -4997,7 +4997,7 @@ interface Person {
             <a class='idltype' href='#idl-unsigned-long-long'>unsigned long long</a>.
           </p>
           <p>
-            The following types are known as <dfn data-export id='dfn-numeric-type'>numeric types</dfn>:
+            The following types are known as <dfn data-export="" id='dfn-numeric-type'>numeric types</dfn>:
             the <a class='dfnref' href='#dfn-integer-type'>integer types</a>,
             <a class='idltype' href='#idl-float'>float</a>,
             <a class='idltype' href='#idl-unrestricted-float'>unresticted float</a>,
@@ -5005,20 +5005,20 @@ interface Person {
             <a class='idltype' href='#idl-unrestricted-double'>unrestricted double</a>.
           </p>
           <p>
-            The <dfn data-export id='dfn-primitive-type'>primitive types</dfn> are
+            The <dfn data-export="" id='dfn-primitive-type'>primitive types</dfn> are
             <span class='idltype'>boolean</span> and the <a class='dfnref' href='#dfn-numeric-type'>numeric types</a>.
           </p>
           <p>
-            The <dfn data-export id='dfn-string-type'>string types</dfn> are
+            The <dfn data-export="" id='dfn-string-type'>string types</dfn> are
             <span class='idltype'>DOMString</span>, all <a href='#idl-enumeration'>enumeration types</a>,
             <span class='idltype'>ByteString</span> and <span class='idltype'>USVString</span>.
           </p>
           <p>
-            The <dfn data-export id='dfn-exception-type'>exception types</dfn> are
+            The <dfn data-export="" id='dfn-exception-type'>exception types</dfn> are
             <span class='idltype'>Error</span> and <span class='idltype'>DOMException</span>.
           </p>
           <p>
-            The <dfn data-export id='dfn-typed-array-type'>typed array types</dfn> are
+            The <dfn data-export="" id='dfn-typed-array-type'>typed array types</dfn> are
             <span class='idltype'>Int8Array</span>,
             <span class='idltype'>Int16Array</span>,
             <span class='idltype'>Int32Array</span>,
@@ -5030,7 +5030,7 @@ interface Person {
             <span class='idltype'>Float64Array</span>.
           </p>
           <p>
-            The <dfn data-export id='dfn-buffer-source-type'>buffer source types</dfn>
+            The <dfn data-export="" id='dfn-buffer-source-type'>buffer source types</dfn>
             are <span class='idltype'>ArrayBuffer</span>,
             <span class='idltype'>DataView</span>,
             and the <a class='dfnref' href='#dfn-typed-array-type'>typed array types</a>.
@@ -5039,10 +5039,10 @@ interface Person {
             The <a class='idltype' href='#idl-object'>object</a> type,
             all <a class='dfnref' href='#idl-interface'>interface types</a>
             and the <a class='dfnref' href='#dfn-exception-type'>exception types</a>
-            are known as <dfn data-export id='dfn-object-type'>object types</dfn>.
+            are known as <dfn data-export="" id='dfn-object-type'>object types</dfn>.
           </p>
           <p>
-            Every type has a <dfn data-export id='dfn-type-name'>type name</dfn>, which
+            Every type has a <dfn data-export="" id='dfn-type-name'>type name</dfn>, which
             is a string, not necessarily unique, that identifies the type.
             Each sub-section below defines what the type name is for each
             type.
@@ -5084,7 +5084,7 @@ interface Person {
             </p>
             <p>
               The particular type of an <a class='idltype' href='#idl-any'>any</a>
-              value is known as its <dfn data-export id='dfn-specific-type'>specific type</dfn>.
+              value is known as its <dfn data-export="" id='dfn-specific-type'>specific type</dfn>.
               (Values of <a href='#idl-union'>union types</a> also have
               <a class='dfnref' href='#dfn-specific-type'>specific types</a>.)
             </p>
@@ -5370,7 +5370,7 @@ interface Person {
               <a>Unicode scalar values</a> given a particular sequence of
               <a class='dfnref' href='#dfn-code-unit'>code units</a>.
               The following algorithm defines a way to
-              <dfn data-export data-lt="obtain Unicode|convert to a sequence of Unicode scalar values" id='dfn-obtain-unicode'>convert a DOMString to a sequence of Unicode scalar values</dfn>:
+              <dfn data-export="" data-lt="obtain Unicode|convert to a sequence of Unicode scalar values" id='dfn-obtain-unicode'>convert a DOMString to a sequence of Unicode scalar values</dfn>:
             </p>
             <ol class='algorithm'>
               <li>Let <var>S</var> be the <span class='idltype'>DOMString</span> value.</li>
@@ -5532,7 +5532,7 @@ interface Person {
             <p>
               For non-callback interfaces, an IDL value of the interface type is represented just
               by an object reference.  For <a class='dfnref' href='#dfn-callback-interface'>callback interfaces</a>, an IDL value of the interface type
-              is represented by a tuple of an object reference and a <dfn data-export id='dfn-callback-context'>callback context</dfn>.
+              is represented by a tuple of an object reference and a <dfn data-export="" id='dfn-callback-context'>callback context</dfn>.
               The <a class='dfnref' href='#dfn-callback-context'>callback context</a> is a language
               binding specific value, and is used to store information about the execution context at
               the time the language binding specific object reference is converted to an IDL value.
@@ -5635,8 +5635,8 @@ interface Person {
             <h4>Nullable types — <var>T</var>?</h4>
 
             <p>
-              A <dfn data-export id='dfn-nullable-type'>nullable type</dfn> is an IDL type constructed
-              from an existing type (called the <dfn data-export id='dfn-inner-type'>inner type</dfn>),
+              A <dfn data-export="" id='dfn-nullable-type'>nullable type</dfn> is an IDL type constructed
+              from an existing type (called the <dfn data-export="" id='dfn-inner-type'>inner type</dfn>),
               which just allows the additional value <span class='idlvalue'>null</span>
               to be a member of its set of values.  <a class='dfnref' href='#dfn-nullable-type'>Nullable types</a>
               are represented in IDL by placing a <span class='char'>U+003F QUESTION MARK ("?")</span>
@@ -5730,7 +5730,7 @@ interface Person {
             <h4 data-dfn-type="interface" id="dom-promise" data-lt="Promise">Promise types — Promise&lt;<var>T</var>&gt;</h4>
 
             <p>
-              A <dfn data-export id='dfn-promise-type'>promise type</dfn> is a parameterized type
+              A <dfn data-export="" id='dfn-promise-type'>promise type</dfn> is a parameterized type
               whose values are references to objects that “is used as a place holder
               for the eventual results of a deferred (and possibly asynchronous) computation
               result of an asynchronous operation” <a href='#ref-ECMA-262'>[ECMA-262]</a>.
@@ -5751,13 +5751,13 @@ interface Person {
             <h4>Union types</h4>
 
             <p>
-              A <dfn data-export id='dfn-union-type'>union type</dfn> is a type whose set of values
+              A <dfn data-export="" id='dfn-union-type'>union type</dfn> is a type whose set of values
               is the union of those in two or more other types.  Union types (matching
               <a class='sym' href='#prod-UnionType'>UnionType</a>)
               are written as a series of types separated by the <code>or</code> keyword
               with a set of surrounding parentheses.
               The types which comprise the union type are known as the
-              union’s <dfn data-export data-dfn-for="union" id='dfn-union-member-type'>member types</dfn>.
+              union’s <dfn data-export="" data-dfn-for="union" id='dfn-union-member-type'>member types</dfn>.
             </p>
             <div class='note'>
               <p>
@@ -5783,7 +5783,7 @@ interface Person {
               that matches the value.
             </p>
             <p>
-              The <dfn data-export data-dfn-for="union" id='dfn-flattened-union-member-types'>flattened member types</dfn>
+              The <dfn data-export="" data-dfn-for="union" id='dfn-flattened-union-member-types'>flattened member types</dfn>
               of a <a class='dfnref' href='#dfn-union-type'>union type</a> is a set of types
               determined as follows:
             </p>
@@ -5814,7 +5814,7 @@ interface Person {
               </p>
             </div>
             <p>
-              The <dfn data-export id='dfn-number-of-nullable-member-types'>number of nullable member types</dfn>
+              The <dfn data-export="" id='dfn-number-of-nullable-member-types'>number of nullable member types</dfn>
               of a <a class='dfnref' href='#dfn-union-type'>union type</a> is an integer
               determined as follows:
             </p>
@@ -5851,7 +5851,7 @@ interface Person {
               <a class='dfnref' href='#dfn-flattened-union-member-types'>flattened member types</a>.
             </p>
             <p>
-              A type <dfn data-export id='dfn-includes-a-nullable-type'>includes a nullable type</dfn> if:
+              A type <dfn data-export="" id='dfn-includes-a-nullable-type'>includes a nullable type</dfn> if:
             </p>
             <ul>
               <li>the type is a <a class='dfnref' href='#dfn-nullable-type'>nullable type</a>, or</li>
@@ -5962,7 +5962,7 @@ interface Person {
               <p>These types all correspond to classes defined in ECMAScript.</p>
             </div>
             <p>
-              To <dfn data-export data-dfn-for="ArrayBuffer" id='dfn-detach'>detach</dfn> an <span class='idltype'>ArrayBuffer</span>
+              To <dfn data-export="" data-dfn-for="ArrayBuffer" id='dfn-detach'>detach</dfn> an <span class='idltype'>ArrayBuffer</span>
               is to set its buffer pointer to <span class='idlvalue'>null</span>.
             </p>
             <p>
@@ -5976,8 +5976,8 @@ interface Person {
               At the specification prose level, IDL <a class='dfnref' href='#dfn-buffer-source-type'>buffer source types</a>
               are simply references to objects.  To inspect or manipulate the bytes inside the buffer,
               specification prose <span class='rfc2119'>MUST</span> first either
-              <dfn data-export data-lt="get a reference to the buffer source" id='dfn-get-buffer-source-reference'>get a reference to the bytes held by the buffer source</dfn>
-              or <dfn data-export data-lt="get a copy of the buffer source" id='dfn-get-buffer-source-copy'>get a copy of the bytes held by the buffer source</dfn>.
+              <dfn data-export="" data-lt="get a reference to the buffer source" id='dfn-get-buffer-source-reference'>get a reference to the bytes held by the buffer source</dfn>
+              or <dfn data-export="" data-lt="get a copy of the buffer source" id='dfn-get-buffer-source-copy'>get a copy of the bytes held by the buffer source</dfn>.
               With a reference to the buffer source’s bytes, specification prose can get or set individual
               byte values using that reference.
             </p>
@@ -6026,7 +6026,7 @@ interface Person {
             <h4 data-dfn-type="interface" id="dom-FrozenArray" lt="FrozenArray|FrozenArray<T>">Frozen arrays — FrozenArray&lt;<var>T</var>&gt;</h4>
 
             <p>
-              A <dfn data-export id='dfn-frozen-array-type'>frozen array type</dfn> is a parameterized
+              A <dfn data-export="" id='dfn-frozen-array-type'>frozen array type</dfn> is a parameterized
               type whose values are references to objects that hold a fixed length array
               of unmodifiable values.  The values in the array are of type <var>T</var>.
             </p>
@@ -6050,7 +6050,7 @@ interface Person {
           <h3>Extended attributes</h3>
 
           <p>
-            An <dfn data-export id='dfn-extended-attribute'>extended attribute</dfn> is an annotation
+            An <dfn data-export="" id='dfn-extended-attribute'>extended attribute</dfn> is an annotation
             that can appear on
             <!--a class='dfnref' href='#dfn-definition'-->definitions<!--/a-->,
             <a class='dfnref' href='#dfn-interface-member'>interface members</a>,
@@ -6086,7 +6086,7 @@ interface Person {
                 <a class='sym' href='#prod-ExtendedAttributeNoArgs'>ExtendedAttributeNoArgs</a>
               </td>
               <td>
-                <dfn data-export data-dfn-for="extended attribute" id='dfn-xattr-no-arguments'>takes no arguments</dfn>
+                <dfn data-export="" data-dfn-for="extended attribute" id='dfn-xattr-no-arguments'>takes no arguments</dfn>
               </td>
               <td>
                 <code>[Replaceable]</code>
@@ -6097,7 +6097,7 @@ interface Person {
                 <a class='sym' href='#prod-ExtendedAttributeArgList'>ExtendedAttributeArgList</a>
               </td>
               <td>
-                <dfn data-export data-dfn-for="extended attribute" id='dfn-xattr-argument-list'>takes an argument list</dfn>
+                <dfn data-export="" data-dfn-for="extended attribute" id='dfn-xattr-argument-list'>takes an argument list</dfn>
               </td>
               <td>
                 <code>[Constructor(double x, double y)]</code>
@@ -6108,7 +6108,7 @@ interface Person {
                 <a class='sym' href='#prod-ExtendedAttributeNamedArgList'>ExtendedAttributeNamedArgList</a>
               </td>
               <td>
-                <dfn data-export data-dfn-for="extended attribute" id='dfn-xattr-named-argument-list'>takes a named argument list</dfn>
+                <dfn data-export="" data-dfn-for="extended attribute" id='dfn-xattr-named-argument-list'>takes a named argument list</dfn>
               </td>
               <td>
                 <code>[NamedConstructor=Image(DOMString src)]</code>
@@ -6119,7 +6119,7 @@ interface Person {
                 <a class='sym' href='#prod-ExtendedAttributeIdent'>ExtendedAttributeIdent</a>
               </td>
               <td>
-                <dfn data-export data-dfn-for="extended attribute" id='dfn-xattr-identifier'>takes an identifier</dfn>
+                <dfn data-export="" data-dfn-for="extended attribute" id='dfn-xattr-identifier'>takes an identifier</dfn>
               </td>
               <td>
                 <code>[PutForwards=name]</code>
@@ -6130,7 +6130,7 @@ interface Person {
                 <a class='sym' href='#prod-ExtendedAttributeIdentList'>ExtendedAttributeIdentList</a>
               </td>
               <td>
-                <dfn data-export data-dfn-for="extended attribute" id='dfn-xattr-identifier-list'>takes an identifier list</dfn>
+                <dfn data-export="" data-dfn-for="extended attribute" id='dfn-xattr-identifier-list'>takes an identifier list</dfn>
               </td>
               <td>
                 <code>[Exposed=(Window,Worker)]</code>
@@ -6211,7 +6211,7 @@ interface Person {
           of objects defined in this section is the <span class='esvalue'>Object</span> prototype object.
         </p>
         <p>
-          Some objects described in this section are defined to have a <dfn data-export id='dfn-class-string'>class string</dfn>,
+          Some objects described in this section are defined to have a <dfn data-export="" id='dfn-class-string'>class string</dfn>,
           which is the string to include in the string returned from Object.prototype.toString.
           If an object has a class string, then the object <span class='rfc2119'>MUST</span>,
           at the time it is created, have a property whose name is the <a>@@toStringTag</a> symbol
@@ -6223,7 +6223,7 @@ interface Person {
             and configurable.</p>
         </div>
         <p>
-          If an object is defined to be a <dfn data-export id='dfn-function-object'>function object</dfn>, then
+          If an object is defined to be a <dfn data-export="" id='dfn-function-object'>function object</dfn>, then
           it has characteristics as follows:
         </p>
         <ul>
@@ -6289,7 +6289,7 @@ interface Person {
             <a class='dfnref' href='#dfn-idl-fragment'>IDL fragments</a>,
             there will exist a number of ECMAScript objects that correspond to
             definitions in those <a class='dfnref' href='#dfn-idl-fragment'>IDL fragments</a>.
-            These objects are termed the <dfn data-export id='dfn-initial-object'>initial objects</dfn>,
+            These objects are termed the <dfn data-export="" id='dfn-initial-object'>initial objects</dfn>,
             and comprise the following:
           </p>
           <ul>
@@ -6343,7 +6343,7 @@ iframe.appendChild instanceof w.Function;  <span class='comment'>// Evaluates to
 &lt;/script></x:codeblock>
           </div>
           <p>
-            Unless otherwise specified, each ECMAScript global environment <dfn data-export data-dfn-for="ECMAScript global environment" id='dfn-expose'>exposes</dfn>
+            Unless otherwise specified, each ECMAScript global environment <dfn data-export="" data-dfn-for="ECMAScript global environment" id='dfn-expose'>exposes</dfn>
             all <a class='dfnref' href='#dfn-interface'>interfaces</a>
             that the implementation supports.  If a given ECMAScript global environment does not
             expose an interface, then the requirements given in
@@ -6368,9 +6368,9 @@ iframe.appendChild instanceof w.Function;  <span class='comment'>// Evaluates to
           <p>
             Each sub-section below describes how values of a given IDL type are represented
             in ECMAScript.  For each IDL type, it is described how ECMAScript values are
-            <dfn data-export data-lt="converted to an IDL value|converted to IDL values" id='dfn-convert-ecmascript-to-idl-value'>converted to an IDL value</dfn>
+            <dfn data-export="" data-lt="converted to an IDL value|converted to IDL values" id='dfn-convert-ecmascript-to-idl-value'>converted to an IDL value</dfn>
             when passed to a <a class='dfnref' href='#dfn-platform-object'>platform object</a> expecting that type, and how IDL values
-            of that type are <dfn data-export data-lt="converted to an ECMAScript value|converted to ECMAScript values" id='dfn-convert-idl-to-ecmascript-value'>converted to ECMAScript values</dfn>
+            of that type are <dfn data-export="" data-lt="converted to an ECMAScript value|converted to ECMAScript values" id='dfn-convert-idl-to-ecmascript-value'>converted to ECMAScript values</dfn>
             when returned from a platform object.
           </p>
 
@@ -7759,7 +7759,7 @@ alert(b[4]);    <span class='comment'>// This would alert "50".</span></x:codebl
               IDL <a href='#idl-promise'>promise type</a> represents.
             </p>
             <p>
-              One can <dfn data-export data-lt="upon settling" id='dfn-perform-steps-once-promise-is-settled'>perform some steps once a promise is settled</dfn>.
+              One can <dfn data-export="" data-lt="upon settling" id='dfn-perform-steps-once-promise-is-settled'>perform some steps once a promise is settled</dfn>.
               There can be one or two sets of steps to perform, covering when the promise is fulfilled, rejected, or both.
               When a specification says to perform some steps once a promise is settled, the following steps
               <span class='rfc2119'>MUST</span> be followed:
@@ -8232,7 +8232,7 @@ alert(b[4]);    <span class='comment'>// This would alert "50".</span></x:codebl
                 from <var>values</var>.</li>
             </ol>
             <p>
-              To <dfn data-export id='dfn-create-frozen-array'>create a frozen array</dfn> from a sequence
+              To <dfn data-export="" id='dfn-create-frozen-array'>create a frozen array</dfn> from a sequence
               of values of type <var>T</var>, follow these steps:
             </p>
             <ol class='algorithm'>
@@ -8571,7 +8571,7 @@ context.setColorEnforcedRange(-1, 255, 256);</x:codeblock>
             <p>
               Every construct that the <a class='xattr' href='#Exposed'>[Exposed]</a>
               <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a>
-              can be specified on has an <dfn data-export id="dfn-exposure-set">exposure set</dfn>,
+              can be specified on has an <dfn data-export="" id="dfn-exposure-set">exposure set</dfn>,
               which is a set of <a class='dfnref' href='#dfn-interface'>interfaces</a>
               defining which global environments the construct can be used in.
               The <a class='dfnref' href='#dfn-exposure-set'>exposure set</a>
@@ -8651,7 +8651,7 @@ context.setColorEnforcedRange(-1, 255, 256);</x:codeblock>
               An <a class='dfnref' href='#dfn-interface'>interface</a>,
               <a class='dfnref' href='#dfn-interface-member'>interface member</a> or
               <a class='dfnref' href='#dfn-dictionary'>dictionary</a>
-              is <dfn data-export id='dfn-exposed'>exposed</dfn> in a given ECMAScript global environment if
+              is <dfn data-export="" id='dfn-exposed'>exposed</dfn> in a given ECMAScript global environment if
               the ECMAScript global object implements an interface that is in the
               interface, interface member or dictionary's
               <a class='dfnref' href='#dfn-exposure-set'>exposure set</a>.
@@ -8893,7 +8893,7 @@ var requestAnimationFrame = window.requestAnimationFrame ||
               <a class='xattr' href='#PrimaryGlobal'>[PrimaryGlobal]</a>
               <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a>
               is declared with an identifier list argument, then those identifiers are the interface’s
-              <dfn data-export id='dfn-global-name'>global names</dfn>; otherwise, the interface has
+              <dfn data-export="" id='dfn-global-name'>global names</dfn>; otherwise, the interface has
               a single global name, which is the interface's identifier.
             </p>
             <div class='note'>
@@ -8909,7 +8909,7 @@ var requestAnimationFrame = window.requestAnimationFrame ||
               interface.  The <a class='xattr' href='#PrimaryGlobal'>[PrimaryGlobal]</a>
               extended attribute <span class='rfc2119'>MUST</span> be declared on
               at most one interface.  The interface <a class='xattr' href='#PrimaryGlobal'>[PrimaryGlobal]</a>
-              is declared on, if any, is known as the <dfn data-export id='dfn-primary-global-interface'>primary global interface</dfn>.
+              is declared on, if any, is known as the <dfn data-export="" id='dfn-primary-global-interface'>primary global interface</dfn>.
             </p>
             <p>
               See <a href='#named-properties-object'>section <?sref named-properties-object?></a>,
@@ -9959,7 +9959,7 @@ d.isMemberOfBreed(null);  <span class='comment'>// This passes the string "" to 
               that implement the interface, rather than on the prototype.
             </p>
             <p>
-              An attribute or operation is said to be <dfn data-export id='dfn-unforgeable-on-an-interface'>unforgeable</dfn>
+              An attribute or operation is said to be <dfn data-export="" id='dfn-unforgeable-on-an-interface'>unforgeable</dfn>
               on a given interface <var>A</var> if any of the following are true:
             </p>
             <ul>
@@ -10136,7 +10136,7 @@ with (thing) {
 
           <p>
             Certain algorithms in the sections below are defined to
-            <dfn data-export id='dfn-perform-a-security-check'>perform a security check</dfn> on a given
+            <dfn data-export="" id='dfn-perform-a-security-check'>perform a security check</dfn> on a given
             object.  This check is used to determine whether a given
             <a class='dfnref' href='#dfn-operation'>operation</a> invocation or
             <a class='dfnref' href='#dfn-attribute'>attribute</a> access should be
@@ -10167,7 +10167,7 @@ with (thing) {
 
           <p>
             In order to define how overloaded function invocations are resolved, the
-            <dfn data-export id='dfn-overload-resolution-algorithm'>overload resolution algorithm</dfn>
+            <dfn data-export="" id='dfn-overload-resolution-algorithm'>overload resolution algorithm</dfn>
             is defined.  Its input is an <a class='dfnref' href='#dfn-effective-overload-set'>effective overload set</a>,
             <var>S</var>, and a list of ECMAScript values, <var>arg</var><sub>0..<var>n</var>−1</sub>.
             Its output is a pair consisting of the <a class='dfnref' href='#dfn-operation'>operation</a> or
@@ -10609,7 +10609,7 @@ with (thing) {
             a corresponding property <span class='rfc2119'>MUST</span> exist on the
             ECMAScript environment's global object.
             The name of the property is the <a class='dfnref' href='#dfn-identifier'>identifier</a> of the interface,
-            and its value is an object called the <dfn data-export id='dfn-interface-object'>interface object</dfn>.
+            and its value is an object called the <dfn data-export="" id='dfn-interface-object'>interface object</dfn>.
           </p>
           <p>
             The property has the attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>true</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>true</span> }</span>.
@@ -10623,7 +10623,7 @@ with (thing) {
             exist on the ECMAScript global object.  The name of the property is the
             <a class='sym' href='#prod-identifier'>identifier</a> that occurs directly after the
             “<span class='sym'>=</span>”, and its value is an object called a
-            <dfn data-export id='dfn-named-constructor'>named constructor</dfn>, which allows
+            <dfn data-export="" id='dfn-named-constructor'>named constructor</dfn>, which allows
             construction of objects that implement the interface.  The property has the
             attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>true</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>true</span> }</span>.
             The characteristics of a named constructor are described in
@@ -10667,7 +10667,7 @@ with (thing) {
               class='rfc2119'>MUST</span> have a property named “prototype”
               with attributes
               <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>false</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>false</span> }</span>
-              whose value is an object called the <dfn data-export id='dfn-interface-prototype-object'>interface prototype object</dfn>.  This object has properties
+              whose value is an object called the <dfn data-export="" id='dfn-interface-prototype-object'>interface prototype object</dfn>.  This object has properties
               that correspond to the <a class='dfnref' href='#dfn-regular-attribute'>regular attributes</a> and
               <a class='dfnref' href='#dfn-regular-operation'>regular operations</a> defined on the interface,
               and is described in more detail in
@@ -10929,7 +10929,7 @@ with (thing) {
               ECMAScript environment's global object.  The name of the property is the
               <a class='dfnref' href='#dfn-identifier'>identifier</a> of the dictionary,
               and its value is a <a class='dfnref' href='#dfn-function-object'>function object</a>
-              called the <dfn data-export id='dfn-dictionary-constructor'>dictionary constructor</dfn>.
+              called the <dfn data-export="" id='dfn-dictionary-constructor'>dictionary constructor</dfn>.
             </p>
             <p>
               The property has the attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>true</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>true</span> }</span>.
@@ -11134,7 +11134,7 @@ partial interface Window {
               <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a>
               that <a class='dfnref' href='#dfn-support-named-properties'>supports named properties</a>,
               there <span class='rfc2119'>MUST</span> exist an object known as the
-              <dfn data-export id='dfn-named-properties-object'>named properties object</dfn> for that
+              <dfn data-export="" id='dfn-named-properties-object'>named properties object</dfn> for that
               interface.
             </p>
             <p>
@@ -11378,7 +11378,7 @@ interface
                 </ul>
               </li>
               <li>
-                The <dfn data-export id='dfn-attribute-getter'>attribute getter</dfn> is a <span class='estype'>Function</span>
+                The <dfn data-export="" id='dfn-attribute-getter'>attribute getter</dfn> is a <span class='estype'>Function</span>
                 object whose behavior when invoked is as follows:
                 <ol class='algorithm'>
                   <li>Let <var>idlValue</var> be an IDL value determined as follows.</li>
@@ -11438,7 +11438,7 @@ interface
                   concatenation of “get ” and the identifier of the attribute.</p>
               </li>
               <li>
-                The <dfn data-export id='dfn-attribute-setter'>attribute setter</dfn> is <span class='esvalue'>undefined</span>
+                The <dfn data-export="" id='dfn-attribute-setter'>attribute setter</dfn> is <span class='esvalue'>undefined</span>
                 if the attribute is declared <code>readonly</code> and has neither a
                 <a class='xattr' href='#PutForwards'>[PutForwards]</a> nor a <a class='xattr' href='#Replaceable'>[Replaceable]</a>
                 <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a> declared on it.
@@ -11842,7 +11842,7 @@ interface
               <p>The value of the <span class='estype'>Function</span> object’s “name”
                 property is the <span class='estype'>String</span> value “toJSON”.</p>
               <p>
-                The following steps define how to <dfn data-export id='dfn-convert-serialized-value-to-ecmascript-value'>convert a serialized value to an ECMAScript value</dfn>:
+                The following steps define how to <dfn data-export="" id='dfn-convert-serialized-value-to-ecmascript-value'>convert a serialized value to an ECMAScript value</dfn>:
               </p>
               <ol class='algorithm'>
                 <li>Let <var>S</var> be the <a class='dfnref' href='#dfn-serialized-value'>serialized value</a>.</li>
@@ -12298,7 +12298,7 @@ interface
               <h5>Default iterator objects</h5>
 
               <p>
-                A <dfn data-export id='dfn-default-iterator-object'>default iterator object</dfn> for a given
+                A <dfn data-export="" id='dfn-default-iterator-object'>default iterator object</dfn> for a given
                 <a class='dfnref' href='#dfn-interface'>interface</a>, target and iteration kind
                 is an object whose internal [[Prototype]] property is the
                 <a class='dfnref' href='#dfn-iterator-prototype-object'>iterator prototype object</a>
@@ -12340,7 +12340,7 @@ interface
               <h5>Iterator prototype object</h5>
 
               <p>
-                The <dfn data-export id='dfn-iterator-prototype-object'>iterator prototype object</dfn>
+                The <dfn data-export="" id='dfn-iterator-prototype-object'>iterator prototype object</dfn>
                 for a given <a class='dfnref' href='#dfn-interface'>interface</a>
                 is an object that exists for every interface that has a
                 <a class='dfnref' href='#dfn-pair-iterator'>pair iterator</a>.  It serves as the
@@ -12449,7 +12449,7 @@ interface
 
             <p>
               Some of the properties below are defined to have a <a class='dfnref' href='#dfn-function-object'>function object</a> value
-              that <dfn data-export id="dfn-forwards-to-the-internal-map-object">forwards to the internal map object</dfn>
+              that <dfn data-export="" id="dfn-forwards-to-the-internal-map-object">forwards to the internal map object</dfn>
               for a given function name.  Such functions behave as follows when invoked:
             </p>
             <ol class="algorithm">
@@ -12482,7 +12482,7 @@ interface
               </p>
               <ul>
                 <li>The property has attributes <span class='descriptor'>{ [[Get]]: <var>G</var>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>true</span> }</span>,
-                  where <var>G</var> is the interface’s <dfn data-export id='dfn-map-size-getter'>map size getter</dfn>,
+                  where <var>G</var> is the interface’s <dfn data-export="" id='dfn-map-size-getter'>map size getter</dfn>,
                   defined below.</li>
                 <li><p>The <a class='dfnref' href='#dfn-map-size-getter'>map size getter</a> is
                   a <span class='estype'>Function</span> object whose
@@ -12707,7 +12707,7 @@ interface
 
             <p>
               Some of the properties below are defined to have a <a class='dfnref' href='#dfn-function-object'>function object</a> value
-              that <dfn data-export id="dfn-forwards-to-the-internal-set-object">forwards to the internal set object</dfn>
+              that <dfn data-export="" id="dfn-forwards-to-the-internal-set-object">forwards to the internal set object</dfn>
               for a given function name.  Such functions behave as follows when invoked:
             </p>
             <ol class="algorithm">
@@ -12740,7 +12740,7 @@ interface
               </p>
               <ul>
                 <li>The property has attributes <span class='descriptor'>{ [[Get]]: <var>G</var>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>true</span> }</span>,
-                  where <var>G</var> is the interface’s <dfn data-export id='dfn-set-size-getter'>set size getter</dfn>,
+                  where <var>G</var> is the interface’s <dfn data-export="" id='dfn-set-size-getter'>set size getter</dfn>,
                   defined below.</li>
                 <li><p>The <a class='dfnref' href='#dfn-set-size-getter'>set size getter</a> is
                   a <span class='estype'>Function</span> object whose
@@ -12925,7 +12925,7 @@ interface
             </p>
 
             <p>
-              To <dfn data-export id='add-map-elements-from-iterable'>add map elements from an iterable</dfn> <var>iterable</var> to
+              To <dfn data-export="" id='add-map-elements-from-iterable'>add map elements from an iterable</dfn> <var>iterable</var> to
               an object <var>destination</var> with adder method name <var>adder</var>, perform the following steps:
             </p>
             <ol class='algorithm'>
@@ -13036,7 +13036,7 @@ C implements A;</x:codeblock>
             object is associated with.
           </p>
           <p>
-            The <dfn data-export id='dfn-primary-interface'>primary interface</dfn> of a platform object
+            The <dfn data-export="" id='dfn-primary-interface'>primary interface</dfn> of a platform object
             that implements one or more interfaces is the most-derived <a class='dfnref' href='#dfn-supplemental-interface'>non-supplemental interface</a>
             that it implements.  The value of the internal <span class='prop'>[[Prototype]]</span>
             property of the platform object is the <a class='dfnref' href='#dfn-interface-prototype-object'>interface prototype object</a>
@@ -13045,7 +13045,7 @@ C implements A;</x:codeblock>
           </p>
           <p>
             The global environment that a given <a class='dfnref' href='#dfn-platform-object'>platform object</a>
-            is associated with can <dfn data-export data-dfn-for="global environment" id="dfn-change-global-environment">change</dfn> after it has been created.  When
+            is associated with can <dfn data-export="" data-dfn-for="global environment" id="dfn-change-global-environment">change</dfn> after it has been created.  When
             the global environment associated with a platform object is changed, its internal
             <span class='prop'>[[Prototype]]</span> property <span class='rfc2119'>MUST</span> be immediately
             updated to be the <a class='dfnref' href='#dfn-interface-prototype-object'>interface prototype object</a>
@@ -13199,7 +13199,7 @@ C implements A;</x:codeblock>
                 <li>Return the <span class='esvalue'>this</span> value.</li>
               </ol>
               This <span class='estype'>Function</span> object is the
-              <dfn data-export id='dfn-default-unforgeable-valueOf-function'>default unforgeable valueOf function</dfn>.
+              <dfn data-export="" id='dfn-default-unforgeable-valueOf-function'>default unforgeable valueOf function</dfn>.
             </li>
             <li>The value of the <span class='estype'>Function</span> object’s “length”
               property is the <span class='estype'>Number</span> value <span class='esvalue'>0</span>.</li>
@@ -13266,7 +13266,7 @@ C implements A;</x:codeblock>
 
             <p>
               The name of each property that appears to exist due to an object supporting indexed properties
-              is an <dfn data-export id='dfn-array-index-property-name'>array index property name</dfn>, which is a property
+              is an <dfn data-export="" id='dfn-array-index-property-name'>array index property name</dfn>, which is a property
               name <var>P</var> such that <a>Type</a>(<var>P</var>) is String
               and for which the following algorithm returns <span class='esvalue'>true</span>:
             </p>
@@ -13293,7 +13293,7 @@ C implements A;</x:codeblock>
             </div>
             -->
             <p>
-              A property name is an <dfn data-export id='dfn-unforgeable-property-name'>unforgeable property name</dfn> on a
+              A property name is an <dfn data-export="" id='dfn-unforgeable-property-name'>unforgeable property name</dfn> on a
               given platform object if the object implements an <a class='dfnref' href='#dfn-interface'>interface</a> that
               has an <a class='dfnref' href='#dfn-interface-member'>interface member</a> with that identifier
               and that interface member is <a class='dfnref' href='#dfn-unforgeable-on-an-interface'>unforgeable</a> on any of
@@ -13304,7 +13304,7 @@ C implements A;</x:codeblock>
               on that object.
             </p>
             <p>
-              The <dfn data-export id='dfn-named-property-visibility'>named property visibility algorithm</dfn> is used to determine if
+              The <dfn data-export="" id='dfn-named-property-visibility'>named property visibility algorithm</dfn> is used to determine if
               a given named property is exposed on an object.  Some named properties are not exposed on an object
               depending on whether the <a class='xattr' href='#OverrideBuiltins'>[OverrideBuiltins]</a>
               <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a> was used.  The algorithm
@@ -13475,7 +13475,7 @@ C implements A;</x:codeblock>
           <div id='invoking-indexed-setter' class='section'>
             <h4>Invoking a platform object indexed property setter</h4>
             <p>
-              To <dfn data-export data-lt="invoke the indexed property setter" id='invoke-indexed-setter'>invoke an indexed property
+              To <dfn data-export="" data-lt="invoke the indexed property setter" id='invoke-indexed-setter'>invoke an indexed property
               setter</dfn> with property name <var>P</var> and ECMAScript value
               <var>V</var>, the following steps <span
               class='rfc2119'>MUST</span> be performed:
@@ -13504,7 +13504,7 @@ C implements A;</x:codeblock>
           <div id='invoking-named-setter' class='section'>
             <h4>Invoking a platform object named property setter</h4>
             <p>
-              To <dfn data-export data-lt="invoke the named property setter" id='invoke-named-setter'>invoke a named property
+              To <dfn data-export="" data-lt="invoke the named property setter" id='invoke-named-setter'>invoke a named property
               setter</dfn> with property name <var>P</var> and ECMAScript value
               <var>V</var>, the following steps <span
               class='rfc2119'>MUST</span> be performed:
@@ -13838,7 +13838,7 @@ C implements A;</x:codeblock>
             </li>
           </ul>
           <p>
-            A <dfn data-export id='dfn-single-operation-callback-interface'>single operation callback interface</dfn> is
+            A <dfn data-export="" id='dfn-single-operation-callback-interface'>single operation callback interface</dfn> is
             a <a class='dfnref' href='#dfn-callback-interface'>callback interface</a> that:
           </p>
           <ul>
@@ -13851,7 +13851,7 @@ C implements A;</x:codeblock>
             A <a class='dfnref' href='#dfn-user-object'>user object</a>’s
             <a class='dfnref' href='#dfn-operation'>operation</a> is called
             with a list of IDL argument values <var>idlarg</var><sub>0..<var>n</var>−1</sub> by
-            following the algorithm below.  The <dfn data-export id='dfn-callback-this-value'>callback this value</dfn>
+            following the algorithm below.  The <dfn data-export="" id='dfn-callback-this-value'>callback this value</dfn>
             is the value to use as the <span class='esvalue'>this</span> value
             when a <a>callable</a>
             object was supplied as the implementation of a
@@ -14063,7 +14063,7 @@ C implements A;</x:codeblock>
           <p>
             There <span class='rfc2119'>MUST</span> exist a property on the ECMAScript global object
             whose name is “DOMException” and value is an object called the
-            <dfn data-export data-dfn-for="DOMException" id='dfn-DOMException-constructor-object'>DOMException constructor object</dfn>,
+            <dfn data-export="" data-dfn-for="DOMException" id='dfn-DOMException-constructor-object'>DOMException constructor object</dfn>,
             which provides access to legacy DOMException code constants and allows construction of
             DOMException instances.
             The property has the attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>true</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>true</span> }</span>.
@@ -14086,7 +14086,7 @@ C implements A;</x:codeblock>
               The DOMException constructor object <span class='rfc2119'>MUST</span> also have a property named
               “prototype” with attributes
               <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>false</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>false</span> }</span>
-              whose value is an object called the <dfn data-export data-dfn-for="DOMException" id='dfn-DOMException-prototype-object'>DOMException prototype object</dfn>.
+              whose value is an object called the <dfn data-export="" data-dfn-for="DOMException" id='dfn-DOMException-prototype-object'>DOMException prototype object</dfn>.
               This object also provides access to the legacy code values.
             </p>
 
@@ -14191,7 +14191,7 @@ C implements A;</x:codeblock>
           <h3>Creating and throwing exceptions</h3>
 
           <p>
-            First, we define the <dfn data-export id='dfn-current-global-environment'>current global environment</dfn>
+            First, we define the <dfn data-export="" id='dfn-current-global-environment'>current global environment</dfn>
             as the result of running the following algorithm:
           </p>
           <ol class='algorithm'>

--- a/index.xml
+++ b/index.xml
@@ -5686,7 +5686,7 @@ interface Person {
           </div>
 
           <div id='idl-sequence' class='section'>
-            <h4 data-dfn-type="interface" id="dom-sequence" data-lt="sequence|sequence<T>">Sequences — sequence&lt;<var>T</var>></h4>
+            <h4 data-dfn-type="interface" id="dom-sequence" data-lt="sequence|sequence&lt;T>">Sequences — sequence&lt;<var>T</var>></h4>
 
             <p>
               The <a class='idltype' href='#idl-sequence'>sequence&lt;<var>T</var>></a>
@@ -5727,7 +5727,7 @@ interface Person {
           </div>
 
           <div id='idl-promise' class='section'>
-            <h4 data-dfn-type="interface" id="dom-promise" data-lt="Promise">Promise types — Promise&lt;<var>T</var>&gt;</h4>
+            <h4 data-dfn-type="interface" id="dom-promise" data-lt="Promise|Promise&lt;T>">Promise types — Promise&lt;<var>T</var>&gt;</h4>
 
             <p>
               A <dfn data-export="" id='dfn-promise-type'>promise type</dfn> is a parameterized type
@@ -6023,7 +6023,7 @@ interface Person {
           </div>
 
           <div id='idl-frozen-array' class='section'>
-            <h4 data-dfn-type="interface" id="dom-FrozenArray" lt="FrozenArray|FrozenArray<T>">Frozen arrays — FrozenArray&lt;<var>T</var>&gt;</h4>
+            <h4 data-dfn-type="interface" id="dom-FrozenArray" lt="FrozenArray|FrozenArray&lt;T>">Frozen arrays — FrozenArray&lt;<var>T</var>&gt;</h4>
 
             <p>
               A <dfn data-export="" id='dfn-frozen-array-type'>frozen array type</dfn> is a parameterized

--- a/index.xml
+++ b/index.xml
@@ -318,7 +318,7 @@ window.onload = function() { window.alert("loaded"); };</x:codeblock></li>
           The following conformance classes are defined by this specification:
         </p>
         <dl>
-          <dt><dfn id='dfn-conforming-set-of-idl-fragments'>conforming set of IDL fragments</dfn></dt>
+          <dt><dfn data-export id='dfn-conforming-set-of-idl-fragments'>conforming set of IDL fragments</dfn></dt>
           <dd>
             <p>
               A set of <a class='dfnref' href='#dfn-idl-fragment'>IDL fragments</a> is considered
@@ -329,7 +329,7 @@ window.onload = function() { window.alert("loaded"); };</x:codeblock></li>
               criteria in this specification that apply to IDL fragments.
             </p>
           </dd>
-          <dt><dfn id='dfn-conforming-implementation'>conforming implementation</dfn></dt>
+          <dt><dfn data-export id='dfn-conforming-implementation'>conforming implementation</dfn></dt>
           <dd>
             <p>
               A user agent is considered to be a
@@ -341,7 +341,7 @@ window.onload = function() { window.alert("loaded"); };</x:codeblock></li>
               bindings that the user agent supports.
             </p>
           </dd>
-          <dt><dfn id='dfn-conforming-ecmascript-implementation'>conforming ECMAScript implementation</dfn></dt>
+          <dt><dfn data-export id='dfn-conforming-ecmascript-implementation'>conforming ECMAScript implementation</dfn></dt>
           <dd>
             <p>
               A user agent is considered to be a
@@ -362,7 +362,7 @@ window.onload = function() { window.alert("loaded"); };</x:codeblock></li>
         <p>
           This section describes a language, <em>Web IDL</em>, which can be used to define
           interfaces for APIs in the Web platform.  A specification that defines Web APIs
-          can include one or more <dfn id='dfn-idl-fragment'>IDL fragments</dfn> that
+          can include one or more <dfn data-export data-lt="IDL fragment" id='dfn-idl-fragment'>IDL fragments</dfn> that
           describe the interfaces (the state and behavior that objects can exhibit)
           for the APIs defined by that specification.
           An <a class='dfnref' href='#dfn-idl-fragment'>IDL fragment</a> is
@@ -479,11 +479,11 @@ interface GraphicalWindow {
             <a class='dfnref' href='#dfn-partial-dictionary'>partial dictionary definition</a>,
             <a class='dfnref' href='#dfn-enumeration'>enumeration</a>,
             <a class='dfnref' href='#dfn-callback-function'>callback function</a> and
-            <a class='dfnref' href='#dfn-typedef'>typedef</a> (together called <dfn id='dfn-named-definition'>named definitions</dfn>)
+            <a class='dfnref' href='#dfn-typedef'>typedef</a> (together called <dfn data-export data-lt="named definition" id='dfn-named-definition'>named definitions</dfn>)
             and every <a class='dfnref' href='#dfn-constant'>constant</a>,
             <a class='dfnref' href='#dfn-attribute'>attribute</a>,
             and <a class='dfnref' href='#dfn-dictionary-member'>dictionary member</a> has an
-            <dfn id='dfn-identifier'>identifier</dfn>, as do some
+            <dfn data-export id='dfn-identifier'>identifier</dfn>, as do some
             <a class='dfnref' href='#dfn-operation'>operations</a>.
             The identifier is determined by an
             <a class='sym' href='#prod-identifier'>identifier</a> token somewhere
@@ -580,7 +580,7 @@ dictionary <i>identifier</i> {
             IDL constructs <span class='rfc2119'>MUST NOT</span> be “constructor”,
             “toString”, “toJSON”,
             or begin with a <span class='char'>U+005F LOW LINE ("_")</span> character.  These
-            are known as <dfn id='dfn-reserved-identifier'>reserved identifiers</dfn>.
+            are known as <dfn data-export id='dfn-reserved-identifier'>reserved identifiers</dfn>.
           </p>
           <div class="note">
             <p>Further restrictions on identifier names for particular constructs may be made
@@ -670,7 +670,7 @@ interface TextField {
             <a class='dfnref' href='#dfn-idl-fragment'>IDL fragments</a> are used to
             describe object oriented systems.  In such systems, objects are entities
             that have identity and which are encapsulations of state and behavior.
-            An <dfn id='dfn-interface'>interface</dfn> is a definition (matching
+            An <dfn data-export id='dfn-interface'>interface</dfn> is a definition (matching
             <a class='sym' href='#prod-Interface'>Interface</a> or
             <span class='sym'>"callback"</span> <a class='sym' href='#prod-Interface'>Interface</a>) that declares some
             state and behavior that an object implementing that interface will expose.
@@ -680,7 +680,7 @@ interface TextField {
 };</pre>
           <p>
             An interface is a specification of a set of
-            <dfn id='dfn-interface-member'>interface members</dfn>
+            <dfn data-export data-lt="interface member" id='dfn-interface-member'>interface members</dfn>
             (matching <a class='sym' href='#prod-InterfaceMembers'>InterfaceMembers</a>),
             which are the <a class='dfnref' href='#dfn-constant'>constants</a>,
             <a class='dfnref' href='#dfn-attribute'>attributes</a>,
@@ -709,7 +709,7 @@ interface TextField {
           </div>
           -->
           <p>
-            An interface can be defined to <dfn id='dfn-inherit'>inherit</dfn> from another interface.
+            An interface can be defined to <dfn data-export data-dfn-for="interface" id='dfn-inherit'>inherit</dfn> from another interface.
             If the identifier of the interface is followed by a
             <span class='char'>U+003A COLON (":")</span> character
             and an <a class='dfnref' href='#dfn-identifier'>identifier</a>,
@@ -794,7 +794,7 @@ public interface B extends A {
             -->
           </div>
           <p>
-            The <dfn id='dfn-inherited-interfaces'>inherited interfaces</dfn> of
+            The <dfn data-export id='dfn-inherited-interfaces'>inherited interfaces</dfn> of
             a given interface <var>A</var> is the set of all interfaces that <var>A</var>
             inherits from, directly or indirectly.  If <var>A</var> does not <a class='dfnref' href='#dfn-inherit'>inherit</a>
             from another interface, then the set is empty.  Otherwise, the set
@@ -835,7 +835,7 @@ public interface B extends A {
 };</pre>
 
           <p>
-            A <dfn id='dfn-callback-interface'>callback interface</dfn> is
+            A <dfn data-export id='dfn-callback-interface'>callback interface</dfn> is
             an <a class='dfnref' href='#dfn-interface'>interface</a>
             that uses the <code>callback</code> keyword at the start of
             its definition.  Callback interfaces are ones that can be
@@ -943,7 +943,7 @@ interface A {
 
           <p>
             The IDL for interfaces can be split into multiple parts by using
-            <dfn id='dfn-partial-interface'>partial interface</dfn> definitions
+            <dfn data-export id='dfn-partial-interface'>partial interface</dfn> definitions
             (matching <span class='sym'>"partial"</span> <a class='sym' href='#prod-PartialInterface'>PartialInterface</a>).
             The <a class='dfnref' href='#dfn-identifier'>identifier</a> of a partial
             interface definition <span class='rfc2119'>MUST</span> be the same
@@ -1125,7 +1125,7 @@ node.appendChild(newNode);  <span class='comment'>// This will throw a TypeError
             <h4>Constants</h4>
 
             <p>
-              A <dfn id='dfn-constant'>constant</dfn> is a declaration (matching
+              A <dfn data-export id='dfn-constant'>constant</dfn> is a declaration (matching
               <a class='sym' href='#prod-Const'>Const</a>) used to bind a constant value to a name.
               Constants can appear on <a class='dfnref' href='#dfn-interface'>interfaces</a>.
             </p>
@@ -1340,7 +1340,7 @@ node.appendChild(newNode);  <span class='comment'>// This will throw a TypeError
             <h4>Attributes</h4>
 
             <p>
-              An <dfn id='dfn-attribute'>attribute</dfn> is an <a class='dfnref' href='#dfn-interface-member'>interface member</a>
+              An <dfn data-export id='dfn-attribute'>attribute</dfn> is an <a class='dfnref' href='#dfn-interface-member'>interface member</a>
               (matching
               <span class='sym'>"inherit"</span> <a class='sym' href='#prod-ReadOnly'>ReadOnly</a> <a class='sym' href='#prod-AttributeRest'>AttributeRest</a>,
               <span class='sym'>"static"</span> <a class='sym' href='#prod-ReadOnly'>ReadOnly</a> <a class='sym' href='#prod-AttributeRest'>AttributeRest</a>,
@@ -1361,7 +1361,7 @@ node.appendChild(newNode);  <span class='comment'>// This will throw a TypeError
             </ol>
             <p>
               If an attribute has no <code>static</code> keyword, then it declares a
-              <dfn id='dfn-regular-attribute'>regular attribute</dfn>.  Otherwise,
+              <dfn data-export id='dfn-regular-attribute'>regular attribute</dfn>.  Otherwise,
               it declares a <a class='dfnref' href='#dfn-static-attribute'>static attribute</a>.
             </p>
             <p>
@@ -1394,7 +1394,7 @@ node.appendChild(newNode);  <span class='comment'>// This will throw a TypeError
                 as one of its <a class='dfnref' href='#dfn-flattened-union-member-types'>flattened member types</a></li>
             </ul>
             <p>
-              The attribute is <dfn id='dfn-read-only'>read only</dfn> if the
+              The attribute is <dfn data-export id='dfn-read-only'>read only</dfn> if the
               <code>readonly</code> keyword is used before the <code>attribute</code> keyword.
               An object that implements the interface on which a read only attribute
               is defined will not allow assignment to that attribute.  It is language
@@ -1405,7 +1405,7 @@ node.appendChild(newNode);  <span class='comment'>// This will throw a TypeError
             <p>
               A <a class='dfnref' href='#dfn-regular-attribute'>regular attribute</a>
               that is not <a class='dfnref' href='#dfn-read-only'>read only</a>
-              can be declared to <dfn id='dfn-inherit-getter'>inherit its getter</dfn>
+              can be declared to <dfn data-export id='dfn-inherit-getter'>inherit its getter</dfn>
               from an ancestor interface.  This can be used to make a read only attribute
               in an ancestor interface be writable on a derived interface.  An attribute
               <a class='dfnref' href='#dfn-inherit-getter'>inherits its getter</a> if
@@ -1522,7 +1522,7 @@ interface Person : Animal {
             <h4>Operations</h4>
 
             <p>
-              An <dfn id='dfn-operation'>operation</dfn> is an <a class='dfnref' href='#dfn-interface-member'>interface member</a>
+              An <dfn data-export id='dfn-operation'>operation</dfn> is an <a class='dfnref' href='#dfn-interface-member'>interface member</a>
               (matching <span class='sym'>"static"</span> <a class='sym' href='#prod-OperationRest'>OperationRest</a>,
               <span class='sym'>"stringifier"</span> <a class='sym' href='#prod-OperationRest'>OperationRest</a>,
               <span class='sym'>"serializer"</span> <a class='sym' href='#prod-OperationRest'>OperationRest</a>,
@@ -1549,7 +1549,7 @@ interface Person : Animal {
             </ol>
             <p>
               If an operation has an identifier but no <code>static</code>
-              keyword, then it declares a <dfn id='dfn-regular-operation'>regular operation</dfn>.
+              keyword, then it declares a <dfn data-export id='dfn-regular-operation'>regular operation</dfn>.
               If the operation has one or more
               <a class='dfnref' href='#dfn-special-keyword'>special keywords</a>
               used in its declaration (that is, any keyword matching
@@ -1590,7 +1590,7 @@ interface Person : Animal {
               defined on the same <a class='dfnref' href='#dfn-interface'>interface</a>.
             </p>
             <p>
-              The <dfn id='dfn-return-type'>return type</dfn> of the operation is given
+              The <dfn data-export id='dfn-return-type'>return type</dfn> of the operation is given
               by the type (matching <a class='sym' href='#prod-ReturnType'>ReturnType</a>)
               that appears before the operation’s optional <a class='dfnref' href='#dfn-identifier'>identifier</a>.
               A return type of <code id='idl-void'>void</code> indicates that the operation returns no value.
@@ -1659,7 +1659,7 @@ interface Button {
             </div>
 
             <p>
-              An operation is considered to be <dfn id='dfn-variadic'>variadic</dfn>
+              An operation is considered to be <dfn data-export id='dfn-variadic'>variadic</dfn>
               if the final argument uses the <code>...</code> token just
               after the argument type.  Declaring an operation to be variadic indicates that
               the operation can be invoked with any number of arguments after that final argument.
@@ -1708,7 +1708,7 @@ s.union(1, 4, 7);         <span class='comment'>// Passing three arguments corre
             </div>
 
             <p>
-              An argument is considered to be an <dfn id='dfn-optional-argument'>optional argument</dfn>
+              An argument is considered to be an <dfn data-export id='dfn-optional-argument'>optional argument</dfn>
               if it is declared with the <code>optional</code> keyword.
               The final argument of a <a class='dfnref' href='#dfn-variadic'>variadic</a> operation
               is also considered to be an optional argument. Declaring an argument
@@ -1720,7 +1720,7 @@ s.union(1, 4, 7);         <span class='comment'>// Passing three arguments corre
             <pre class='syntax'><i>return-type</i> <i>identifier</i>(<i>type</i> <i>identifier</i>, optional <i>type</i> <i>identifier</i>);</pre>
 
             <p>
-              Optional arguments can also have a <dfn id='dfn-optional-argument-default-value'>default value</dfn>
+              Optional arguments can also have a <dfn data-export data-dfn-for="optional argument" id='dfn-optional-argument-default-value'>default value</dfn>
               specified.  If the argument’s identifier is followed by a <span class='char'>U+003D EQUALS SIGN ("=")</span>
               and a value (matching <a class='sym' href='#prod-DefaultValue'>DefaultValue</a>),
               then that gives the optional argument its <a class='dfnref' href='#dfn-optional-argument-default-value'>default value</a>.
@@ -1875,11 +1875,11 @@ s.union(1, 4, 7);         <span class='comment'>// Passing three arguments corre
             <h4>Special operations</h4>
 
             <p>
-              A <dfn id='dfn-special-operation'>special operation</dfn> is a
+              A <dfn data-export id='dfn-special-operation'>special operation</dfn> is a
               declaration of a certain kind of special behavior on objects implementing
               the interface on which the special operation declarations appear.
               Special operations are declared by using one or more
-              <dfn id='dfn-special-keyword'>special keywords</dfn>
+              <dfn data-export id='dfn-special-keyword'>special keywords</dfn>
               in an operation declaration.
             </p>
             <p>
@@ -1894,33 +1894,33 @@ s.union(1, 4, 7);         <span class='comment'>// Passing three arguments corre
                 <th>Purpose</th>
               </tr>
               <tr>
-                <td><dfn id='dfn-getter'>Getters</dfn></td>
+                <td><dfn data-export data-lt="getter" id='dfn-getter'>Getters</dfn></td>
                 <td><code>getter</code></td>
                 <td>Defines behavior for when an object is indexed for property retrieval.</td>
               </tr>
               <tr>
-                <td><dfn id='dfn-setter'>Setters</dfn></td>
+                <td><dfn data-export data-lt="setter" id='dfn-setter'>Setters</dfn></td>
                 <td><code>setter</code></td>
                 <td>Defines behavior for when an object is indexed for property
                 assignment or creation.</td>
               </tr>
               <tr>
-                <td><dfn id='dfn-deleter'>Deleters</dfn></td>
+                <td><dfn data-export data-lt="deleter" id='dfn-deleter'>Deleters</dfn></td>
                 <td><code>deleter</code></td>
                 <td>Defines behavior for when an object is indexed for property deletion.</td>
               </tr>
               <tr>
-                <td><dfn id='dfn-legacy-caller'>Legacy callers</dfn></td>
+                <td><dfn data-export data-lt="legacy" id='dfn-legacy-caller'>Legacy callers</dfn></td>
                 <td><code>legacycaller</code></td>
                 <td>Defines behavior for when an object is called as if it were a function.</td>
               </tr>
               <tr>
-                <td><dfn id='dfn-stringifier'>Stringifiers</dfn></td>
+                <td><dfn data-export data-lt="stringifier" id='dfn-stringifier'>Stringifiers</dfn></td>
                 <td><code>stringifier</code></td>
                 <td>Defines how an object is converted into a <span class='idltype'>DOMString</span>.</td>
               </tr>
               <tr>
-                <td><dfn id='dfn-serializer'>Serializers</dfn></td>
+                <td><dfn data-export data-lt="serializer" id='dfn-serializer'>Serializers</dfn></td>
                 <td><code>serializer</code></td>
                 <td>Defines how an object is converted into a serialized form.</td>
               </tr>
@@ -2029,14 +2029,14 @@ dictionary.x = 1;                  <span class='comment'>// Invokes the property
               Getters and setters come in two varieties: ones that
               take a <span class='idltype'>DOMString</span> as a property name,
               known as
-              <dfn id='dfn-named-property-getter'>named property getters</dfn> and
-              <dfn id='dfn-named-property-setter'>named property setters</dfn>,
+              <dfn data-export data-lt="named property getter" id='dfn-named-property-getter'>named property getters</dfn> and
+              <dfn data-export data-lt="named property setter" id='dfn-named-property-setter'>named property setters</dfn>,
               and ones that take an <span class='idltype'>unsigned long</span>
               as a property index, known as
-              <dfn id='dfn-indexed-property-getter'>indexed property getters</dfn> and
-              <dfn id='dfn-indexed-property-setter'>indexed property setters</dfn>.
+              <dfn data-export data-lt="indexed property getter" id='dfn-indexed-property-getter'>indexed property getters</dfn> and
+              <dfn data-export data-lt="indexed property setter" id='dfn-indexed-property-setter'>indexed property setters</dfn>.
               There is only one variety of deleter:
-              <dfn id='dfn-named-property-deleter'>named property deleters</dfn>.
+              <dfn data-export data-lt="named property deleter" id='dfn-named-property-deleter'>named property deleters</dfn>.
               See <a href='#idl-indexed-properties'>section <?sref idl-indexed-properties?></a>
               and <a href='#idl-named-properties'>section <?sref idl-named-properties?></a>
               for details.
@@ -2145,7 +2145,7 @@ omittable stringifier DOMString <i>identifier</i>();--></pre>
                 If an operation used to declare a stringifier does not have an
                 <a class='dfnref' href='#dfn-identifier'>identifier</a>, then prose
                 accompanying the interface <span class='rfc2119'>MUST</span> define
-                the <dfn id='dfn-stringification-behavior'>stringification behavior</dfn>
+                the <dfn data-export id='dfn-stringification-behavior'>stringification behavior</dfn>
                 of the interface.  If the operation does have an identifier,
                 then the object is converted to a string by invoking the
                 operation to obtain the string.
@@ -2263,9 +2263,9 @@ var greeting = 'Hi ' + s;  <span class='comment'>// Now greeting == 'Hi Alan Smi
               <p>
                 Prose accompanying an interface that declares a serializer in this
                 way <span class='rfc2119'>MUST</span> define the
-                <dfn id='dfn-serialization-behavior'>serialization behavior</dfn>
+                <dfn data-export id='dfn-serialization-behavior'>serialization behavior</dfn>
                 of the interface.  Serialization behavior is defined as returning
-                a <dfn id='dfn-serialized-value'>serialized value</dfn> of one of the following types:
+                a <dfn data-export id='dfn-serialized-value'>serialized value</dfn> of one of the following types:
               </p>
               <ul>
                 <li>a <em>map</em> of key–value pairs, where the keys are
@@ -2297,7 +2297,7 @@ var greeting = 'Hi ' + s;  <span class='comment'>// Now greeting == 'Hi Alan Smi
                 can also be specified directly in IDL, rather than separately as prose.
                 This is done by following the <code>serializer</code> keyword with
                 a <span class='char'>U+003D EQUALS SIGN ("=")</span> character and
-                a <dfn id='dfn-serialization-pattern'>serialization pattern</dfn>,
+                a <dfn data-export id='dfn-serialization-pattern'>serialization pattern</dfn>,
                 which can take one of the following six forms:
               </p>
               <ul>
@@ -2453,8 +2453,8 @@ serializer = { inherit, attribute };</pre>
                 </p>
               </div>
 
-              <p>The list of <dfn id='dfn-serializable-type'>serializable types</dfn> and how they are
-              <dfn id='dfn-convert-to-serialized-value'>converted to serialized values</dfn> is as follows:</p>
+              <p>The list of <dfn data-export data-lt="serializable type" id='dfn-serializable-type'>serializable types</dfn> and how they are
+              <dfn data-export data-lt="converted to a serialized value|converted to serialized values" id='dfn-convert-to-serialized-value'>converted to serialized values</dfn> is as follows:</p>
               <dl class='switch'>
                 <dt><span class='idltype'>long long</span></dt>
                 <dd>converted by choosing the closest equivalent <a class='idltype' href='#idl-double'>double</a> value
@@ -2615,13 +2615,13 @@ JSON.stringify(txn);</x:codeblock>
               <p>
                 An <a class='dfnref' href='#dfn-interface'>interface</a> that defines
                 an <a class='dfnref' href='#dfn-indexed-property-getter'>indexed property getter</a>
-                is said to <dfn id='dfn-support-indexed-properties'>support indexed properties</dfn>.
+                is said to <dfn data-export id='dfn-support-indexed-properties'>support indexed properties</dfn>.
               </p>
               <p>
                 If an interface <a class='dfnref' href='#dfn-support-indexed-properties'>supports indexed properties</a>,
                 then the interface definition <span class='rfc2119'>MUST</span> be accompanied by
                 a description of what indices the object can be indexed with at
-                any given time. These indices are called the <dfn id='dfn-supported-property-indices'>supported property indices</dfn>.
+                any given time. These indices are called the <dfn data-export id='dfn-supported-property-indices'>supported property indices</dfn>.
               </p>
               <p>
                 Indexed property getters <span class='rfc2119'>MUST</span>
@@ -2645,7 +2645,7 @@ setter <i>type</i> (unsigned long <i>identifier</i>, <i>type</i> <i>identifier</
                   is the value that would be returned by invoking the operation, passing
                   the index as its only argument.  If the operation used to declare the indexed property getter
                   did not have an identifier, then the interface definition must be accompanied
-                  by a description of how to <dfn id='dfn-determine-the-value-of-an-indexed-property'>determine the value of an indexed property</dfn>
+                  by a description of how to <dfn data-export id='dfn-determine-the-value-of-an-indexed-property'>determine the value of an indexed property</dfn>
                   for a given index.
                 </li>
                 <li>
@@ -2655,8 +2655,8 @@ setter <i>type</i> (unsigned long <i>identifier</i>, <i>type</i> <i>identifier</
                   is the same as if the operation is invoked, passing
                   the index as the first argument and the value as the second argument.  If the operation used to declare the indexed property setter
                   did not have an identifier, then the interface definition must be accompanied
-                  by a description of how to <dfn id='dfn-set-the-value-of-an-existing-indexed-property'>set the value of an existing indexed property</dfn>
-                  and how to <dfn id='dfn-set-the-value-of-a-new-indexed-property'>set the value of a new indexed property</dfn>
+                  by a description of how to <dfn data-export id='dfn-set-the-value-of-an-existing-indexed-property'>set the value of an existing indexed property</dfn>
+                  and how to <dfn data-export id='dfn-set-the-value-of-a-new-indexed-property'>set the value of a new indexed property</dfn>
                   for a given property index and value.
                 </li>
               </ul>
@@ -2781,14 +2781,14 @@ delete map.cake;  <span class='comment'>// If a named property named "cake" exis
               <p>
                 An <a class='dfnref' href='#dfn-interface'>interface</a> that defines
                 a <a class='dfnref' href='#dfn-named-property-getter'>named property getter</a>
-                is said to <dfn id='dfn-support-named-properties'>support named properties</dfn>.
+                is said to <dfn data-export id='dfn-support-named-properties'>support named properties</dfn>.
               </p>
               <p>
                 If an interface <a class='dfnref' href='#dfn-support-named-properties'>supports named properties</a>,
                 then the interface definition <span class='rfc2119'>MUST</span> be accompanied by
                 a description of the ordered set of names that can be used to index the object
                 at any given time.  These names are called the
-                <dfn id='dfn-supported-property-names'>supported property names</dfn>.
+                <dfn data-export id='dfn-supported-property-names'>supported property names</dfn>.
               </p>
               <p>
                 Named property getters and deleters <span class='rfc2119'>MUST</span>
@@ -2814,7 +2814,7 @@ deleter <i>type</i> (DOMString <i>identifier</i>);</pre>
                   is the value that would be returned by invoking the operation, passing
                   the name as its only argument.  If the operation used to declare the named property getter
                   did not have an identifier, then the interface definition must be accompanied
-                  by a description of how to <dfn id='dfn-determine-the-value-of-a-named-property'>determine the value of a named property</dfn>
+                  by a description of how to <dfn data-export id='dfn-determine-the-value-of-a-named-property'>determine the value of a named property</dfn>
                   for a given property name.
                 </li>
                 <li>
@@ -2824,8 +2824,8 @@ deleter <i>type</i> (DOMString <i>identifier</i>);</pre>
                   is the same as if the operation is invoked, passing
                   the name as the first argument and the value as the second argument.  If the operation used to declare the named property setter
                   did not have an identifier, then the interface definition must be accompanied
-                  by a description of how to <dfn id='dfn-set-the-value-of-an-existing-named-property'>set the value of an existing named property</dfn>
-                  and how to <dfn id='dfn-set-the-value-of-a-new-named-property'>set the value of a new named property</dfn>
+                  by a description of how to <dfn data-export id='dfn-set-the-value-of-an-existing-named-property'>set the value of an existing named property</dfn>
+                  and how to <dfn data-export id='dfn-set-the-value-of-a-new-named-property'>set the value of a new named property</dfn>
                   for a given property name and value.
                 </li>
                 <li>
@@ -2835,7 +2835,7 @@ deleter <i>type</i> (DOMString <i>identifier</i>);</pre>
                   is the same as if the operation is invoked, passing
                   the name as the only argument.  If the operation used to declare the named property deleter
                   did not have an identifier, then the interface definition must be accompanied
-                  by a description of how to <dfn id='dfn-delete-an-existing-named-property'>delete an existing named property</dfn>
+                  by a description of how to <dfn data-export id='dfn-delete-an-existing-named-property'>delete an existing named property</dfn>
                   for a given property name.
                 </li>
               </ul>
@@ -2859,8 +2859,8 @@ deleter <i>type</i> (DOMString <i>identifier</i>);</pre>
             <h4>Static attributes and operations</h4>
 
             <p>
-              <dfn id='dfn-static-attribute'>Static attributes</dfn> and
-              <dfn id='dfn-static-operation'>static operations</dfn> are ones that
+              <dfn data-export id='dfn-static-attribute'>Static attributes</dfn> and
+              <dfn data-export id='dfn-static-operation'>static operations</dfn> are ones that
               are not associated with a particular instance of the
               <a class='dfnref' href='#dfn-interface'>interface</a>
               on which it is declared, and is instead associated with the interface
@@ -2938,7 +2938,7 @@ Point triangulationPoint = CircleUtils.triangulate(circles[0], circles[1], circl
               has an <a class='dfnref' href='#dfn-identifier'>identifier</a>
               that is the same as the identifier of another operation on that
               interface of the same kind (regular or static), then the operation is said to be
-              <dfn id='dfn-overloaded'>overloaded</dfn>.  When the identifier
+              <dfn data-export id='dfn-overloaded'>overloaded</dfn>.  When the identifier
               of an overloaded operation is used to invoke one of the
               operations on an object that implements the interface, the
               number and types of the arguments passed to the operation
@@ -2981,7 +2981,7 @@ partial interface A {
                 so there is no need to also disallow overloading for constructors.</p>
             </div>
             <p>
-              An <dfn id='dfn-effective-overload-set'>effective overload set</dfn>
+              An <dfn data-export id='dfn-effective-overload-set'>effective overload set</dfn>
               represents the allowable invocations for a particular
               <a class='dfnref' href='#dfn-operation'>operation</a>,
               constructor (specified with <a class='xattr' href='#Constructor'>[Constructor]</a>
@@ -3043,7 +3043,7 @@ partial interface A {
               if it is for constructors or named constructors, then <var>callable</var> is an
               extended attribute; and if it is for callback functions, then <var>callable</var>
               is the callback function itself.  In all cases, <var>type list</var> is a list
-              of IDL types, and <var>optionality list</var> is a list of three possible <dfn id='dfn-optionality-value'>optionality values</dfn> –
+              of IDL types, and <var>optionality list</var> is a list of three possible <dfn data-export id='dfn-optionality-value'>optionality values</dfn> –
               “required”, “optional” or “variadic” – indicating whether
               the argument at a given index was declared as being <a class='dfnref' href='#dfn-optional-argument'>optional</a>
               or corresponds to a <a class='dfnref' href='#dfn-variadic'>variadic</a> argument.
@@ -3227,7 +3227,7 @@ partial interface A {
             </ul>
             -->
             <p>
-              Two types are <dfn id='dfn-distinguishable'>distinguishable</dfn> if
+              Two types are <dfn data-export id='dfn-distinguishable'>distinguishable</dfn> if
               at most one of the two <a class='dfnref' href='#dfn-includes-a-nullable-type'>includes a nullable type</a>
               or is a <a href='#idl-dictionary'>dictionary type</a>,
               and at least one of the following three conditions is true:
@@ -3472,7 +3472,7 @@ partial interface A {
               <li>there is only one such index <var>i</var>-->.<!--</li>
             </ol>
             <p>-->
-              The lowest such index is termed the <dfn id='dfn-distinguishing-argument-index'>distinguishing argument index</dfn>
+              The lowest such index is termed the <dfn data-export id='dfn-distinguishing-argument-index'>distinguishing argument index</dfn>
               for the entries of the effective overload set with the given type list length.
             </p>
             <div class='example'>
@@ -3574,7 +3574,7 @@ interface C {
 
             <p>
               An <a class='dfnref' href='#dfn-interface'>interface</a> can be declared to be
-              <dfn id='dfn-iterable'>iterable</dfn> by using an <dfn id='dfn-iterable-declaration'>iterable declaration</dfn>
+              <dfn data-export id='dfn-iterable'>iterable</dfn> by using an <dfn data-export id='dfn-iterable-declaration'>iterable declaration</dfn>
               (matching <a class='sym' href='#prod-Iterable'>Iterable</a>) in the body of the interface.
             </p>
             <pre class='syntax'>iterable&lt;<i>value-type</i>&gt;;
@@ -3590,10 +3590,10 @@ iterable&lt;<i>key-type</i>, <i>value-type</i>&gt;;</pre>
             </div>
             <p>
               If a single type parameter is given, then the interface has a
-              <dfn id='dfn-value-iterator'>value iterator</dfn> and provides
+              <dfn data-export id='dfn-value-iterator'>value iterator</dfn> and provides
               values of the specified type.
               If two type parameters are given, then the interface has a
-              <dfn id='dfn-pair-iterator'>pair iterator</dfn> and provides
+              <dfn data-export id='dfn-pair-iterator'>pair iterator</dfn> and provides
               value pairs, where the first value is a key and the second is the
               value associated with the key.
             </p>
@@ -3616,7 +3616,7 @@ iterable&lt;<i>key-type</i>, <i>value-type</i>&gt;;</pre>
               Prose accompanying an interface with a
               <a class='dfnref' href='#dfn-pair-iterator'>pair iterator</a>
               <span class='rfc2119'>MUST</span> define what the list of
-              <dfn id='dfn-value-pairs-to-iterate-over'>value pairs to iterate over</dfn>
+              <dfn data-export id='dfn-value-pairs-to-iterate-over'>value pairs to iterate over</dfn>
               is.
             </p>
             <div class='note'>
@@ -3633,7 +3633,7 @@ iterable&lt;<i>key-type</i>, <i>value-type</i>&gt;;</pre>
                 <a class='dfnref' href='#dfn-support-indexed-properties'>support indexed properties</a>,
                 it makes sense to use an Array-like forEach method.
                 There may be a need for <a class='dfnref' href='#dfn-value-iterator'>value iterators</a>
-                (a) on interfaces that do not 
+                (a) on interfaces that do not
                 <a class='dfnref' href='#dfn-support-indexed-properties'>support indexed properties</a>,
                 or (b) with a forEach method that instead invokes its callback like
                 Set.protoype.forEach (where the key is the same as the value).
@@ -3751,7 +3751,7 @@ for (let session of sm) {
 
             <p>
               An <a class='dfnref' href='#dfn-interface'>interface</a> can be declared to be
-              <dfn id='dfn-maplike'>maplike</dfn> by using a <dfn id='dfn-maplike-declaration'>maplike declaration</dfn>
+              <dfn data-export id='dfn-maplike'>maplike</dfn> by using a <dfn data-export id='dfn-maplike-declaration'>maplike declaration</dfn>
               (matching <a class='sym' href='#prod-ReadWriteMaplike'>ReadWriteMaplike</a> or
               <span class='sym'>"readonly"</span> <a class='sym' href='#prod-MaplikeRest'>MaplikeRest</a>) in the body of the interface.
             </p>
@@ -3759,7 +3759,7 @@ for (let session of sm) {
 maplike&lt;<i>key-type</i>, <i>value-type</i>&gt;;</pre>
             <p>
               Objects implementing an interface that is declared to be maplike
-              represent an ordered list of key–value pairs known as its <dfn id='dfn-map-entries'>map entries</dfn>.
+              represent an ordered list of key–value pairs known as its <dfn data-export id='dfn-map-entries'>map entries</dfn>.
               The types used for the keys and values are given in the angle
               brackets of the maplike declaration.  Keys are required to be unique.
             </p>
@@ -3833,7 +3833,7 @@ maplike&lt;<i>key-type</i>, <i>value-type</i>&gt;;</pre>
 
             <p>
               An <a class='dfnref' href='#dfn-interface'>interface</a> can be declared to be
-              <dfn id='dfn-setlike'>setlike</dfn> by using a <dfn id='dfn-setlike-declaration'>setlike declaration</dfn>
+              <dfn data-export id='dfn-setlike'>setlike</dfn> by using a <dfn data-export id='dfn-setlike-declaration'>setlike declaration</dfn>
               (matching <a class='sym' href='#prod-ReadWriteSetlike'>ReadWriteSetlike</a> or
               <span class='sym'>"readonly"</span> <a class='sym' href='#prod-SetlikeRest'>SetlikeRest</a>) in the body of the interface.
             </p>
@@ -3841,7 +3841,7 @@ maplike&lt;<i>key-type</i>, <i>value-type</i>&gt;;</pre>
 setlike&lt;<i>type</i>&gt;;</pre>
             <p>
               Objects implementing an interface that is declared to be setlike
-              represent an ordered list of values known as its <dfn id='dfn-set-entries'>set entries</dfn>.
+              represent an ordered list of values known as its <dfn data-export id='dfn-set-entries'>set entries</dfn>.
               The type of the values is given in the angle
               brackets of the setlike declaration.  Values are required to be unique.
             </p>
@@ -3914,10 +3914,10 @@ setlike&lt;<i>type</i>&gt;;</pre>
           <h3>Dictionaries</h3>
 
           <p>
-            A <dfn id='dfn-dictionary'>dictionary</dfn> is a definition (matching
+            A <dfn data-export id='dfn-dictionary'>dictionary</dfn> is a definition (matching
             <a class='sym' href='#prod-Dictionary'>Dictionary</a>)
             used to define an associative array data type with a fixed, ordered set of key–value pairs,
-            termed <dfn id='dfn-dictionary-member'>dictionary members</dfn>,
+            termed <dfn data-export id='dfn-dictionary-member'>dictionary members</dfn>,
             where keys are strings and values are of a particular type specified in the definition.
           </p>
           <pre class='syntax'>dictionary <i>identifier</i> {
@@ -3929,7 +3929,7 @@ setlike&lt;<i>type</i>&gt;;</pre>
             Similarly, any dictionary returned from a platform object will be a copy and modifications made to it will not be visible to the platform object.
           </p>
           <p>
-            A dictionary can be defined to <dfn id='dfn-inherit-dictionary'>inherit</dfn> from another dictionary.
+            A dictionary can be defined to <dfn data-export data-dfn-for="dictionary" id='dfn-inherit-dictionary'>inherit</dfn> from another dictionary.
             If the identifier of the dictionary is followed by a colon and a <a class='dfnref' href='#dfn-identifier'>identifier</a>,
             then that identifier identifies the inherited dictionary.  The identifier
             <span class='rfc2119'>MUST</span> identify a dictionary.
@@ -3948,7 +3948,7 @@ dictionary <i>Derived</i> : <em>Base</em> {
   <i>dictionary-members…</i>
 };</pre>
           <p>
-            The <dfn id='dfn-inherited-dictionaries'>inherited dictionaries</dfn> of
+            The <dfn data-export id='dfn-inherited-dictionaries'>inherited dictionaries</dfn> of
             a given dictionary <var>D</var> is the set of all dictionaries that <var>D</var>
             inherits from, directly or indirectly.  If <var>D</var> does not <a class='dfnref' href='#dfn-inherit-dictionary'>inherit</a>
             from another dictionary, then the set is empty.  Otherwise, the set
@@ -3962,8 +3962,8 @@ dictionary <i>Derived</i> : <em>Base</em> {
             On a given dictionary value, the presence of each dictionary member
             is optional, unless that member is specified as required.
             When specified in the dictionary value, a dictionary member is said to be
-            <dfn id='dfn-present'>present</dfn>, otherwise it is <a class='dfnref' href='#dfn-present'>not present</a>.
-            Dictionary members can also optionally have a <dfn id='dfn-dictionary-member-default-value'>default value</dfn>, which is
+            <dfn data-export id='dfn-present'>present</dfn>, otherwise it is <a class='dfnref' href='#dfn-present'>not present</a>.
+            Dictionary members can also optionally have a <dfn data-export data-dfn-for="dictionary member" id='dfn-dictionary-member-default-value'>default value</dfn>, which is
             the value to use for the dictionary member when passing a value to a
             <a class='dfnref' href='#dfn-platform-object'>platform object</a> that does
             not have a specified value.  Dictionary members with default values are
@@ -4030,7 +4030,7 @@ dictionary <i>Derived</i> : <em>Base</em> {
           <p>
             If the type of the dictionary member is preceded by the
             <code>required</code> keyword, the member is considered a
-            <dfn id="required-dictionary-member">required dictionary member</dfn>
+            <dfn data-export id="required-dictionary-member">required dictionary member</dfn>
             and must be present on the dictionary.  A
             <a class='dfnref' href='#required-dictionary-member'>required dictionary
             member</a> <span class="rfc2119">MUST NOT</span> have a default value.
@@ -4048,8 +4048,8 @@ dictionary <i>Derived</i> : <em>Base</em> {
             <li>the type is a dictionary that <a class='dfnref' href='#dfn-inherit-dictionary'>inherits</a> from <var>D</var></li>
             <li>the type is a <a class='dfnref' href='#dfn-nullable-type'>nullable type</a>
             whose <a class='dfnref' href='#dfn-inner-type'>inner type</a> includes <var>D</var></li>
-            <li>the type is a <a href='#idl-sequence'>sequence type</a> or <a href='#idl-frozen-array'>frozen array</a> 
-            whose element type includes <var>D</var></li> 
+            <li>the type is a <a href='#idl-sequence'>sequence type</a> or <a href='#idl-frozen-array'>frozen array</a>
+            whose element type includes <var>D</var></li>
             <li>the type is a <a class='dnfref' href='#dfn-union-type'>union type</a>,
             one of whose <a class='dfnref' href='#dfn-union-member-type'>member types</a>
             includes <var>D</var></li>
@@ -4058,7 +4058,7 @@ dictionary <i>Derived</i> : <em>Base</em> {
           </ul>
           <p>
             As with interfaces, the IDL for dictionaries can be split into multiple parts
-            by using <dfn id='dfn-partial-dictionary'>partial dictionary</dfn> definitions
+            by using <dfn data-export id='dfn-partial-dictionary'>partial dictionary</dfn> definitions
             (matching <span class='sym'>"partial"</span> <a class='sym' href='#prod-Dictionary'>Dictionary</a>).
             The <a class='dfnref' href='#dfn-identifier'>identifier</a> of a partial
             dictionary definition <span class='rfc2119'>MUST</span> be the same as the
@@ -4205,21 +4205,21 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
           <h3>Exceptions</h3>
 
           <p>
-            An <dfn id='dfn-exception'>exception</dfn> is a type of object that
+            An <dfn data-export id='dfn-exception'>exception</dfn> is a type of object that
             represents an error and which can be thrown or treated as a first
             class value by implementations.  Web IDL does not allow exceptions
             to be defined, but instead has a number of pre-defined exceptions
             that specifications can reference and throw in their definition of
             operations, attributes, and so on.  Exceptions have an
-            <dfn id='dfn-exception-error-name'>error name</dfn>,
+            <dfn data-export data-dfn-for="exception" id='dfn-exception-error-name'>error name</dfn>,
             a <a class='idltype' href='#idl-DOMString'>DOMString</a>,
             which is the type of error the exception represents, and a
-            <dfn id='dfn-exception-message'>message</dfn>, which is an optional,
+            <dfn data-export data-dfn-for="exception" id='dfn-exception-message'>message</dfn>, which is an optional,
             user agent-defined value that provides human readable details of the error.
           </p>
           <p>
             There are two kinds of exceptions available to be thrown from specifications.
-            The first is a <dfn id='dfn-simple-exception'>simple exception</dfn>, which
+            The first is a <dfn data-export id='dfn-simple-exception'>simple exception</dfn>, which
             is identified by one of the following names:
           </p>
           <ul>
@@ -4240,7 +4240,7 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
             ECMAScript specification.
           </p>
           <p>
-            The second kind of exception is a <dfn id='dfn-DOMException'>DOMException</dfn>,
+            The second kind of exception is a <dfn data-export data-dfn-type="interface" id='dfn-DOMException'>DOMException</dfn>,
             which is an exception that encapsulates a name and an optional integer code,
             for compatibility with historically defined exceptions in the DOM.
           </p>
@@ -4264,9 +4264,9 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
             to be of type <span class='idltype'>Error</span>.
           </p>
           <p>
-            Exceptions can be <dfn id='dfn-create-exception'>created</dfn> by providing its
+            Exceptions can be <dfn data-export data-dfn-for="exception" id='dfn-create-exception'>created</dfn> by providing its
             <a class='dfnref' href='#dfn-exception-error-name'>error name</a>.
-            Exceptions can also be <dfn id='dfn-throw'>thrown</dfn>, by providing the
+            Exceptions can also be <dfn data-export data-dfn-for="exception" data-lt="throw|thrown" id='dfn-throw'>thrown</dfn>, by providing the
             same details required to <a class='dfnref' href='#dfn-create-exception'>create</a> one.
           </p>
           <p>
@@ -4310,7 +4310,7 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
             <h4>Error names</h4>
 
             <p>
-              The <dfn id='dfn-error-names-table'>error names table</dfn> below lists all the allowed error names
+              The <dfn data-export id='dfn-error-names-table'>error names table</dfn> below lists all the allowed error names
               for <a class='dfnref' href='#dfn-DOMException'>DOMExceptions</a>, a description,
               and legacy code values.
             </p>
@@ -4325,175 +4325,175 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
               </thead>
               <tbody>
                 <tr>
-                  <td>"<dfn id="indexsizeerror"><code>IndexSizeError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="indexsizeerror"><code>IndexSizeError</code></dfn>"</td>
                   <td>The index is not in the allowed range.</td>
-                  <td><dfn id="dom-domexception-index_size_err" title="dom-DOMException-INDEX_SIZE_ERR"><code>INDEX_SIZE_ERR</code></dfn> (1)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-index_size_err" title="dom-DOMException-INDEX_SIZE_ERR"><code>INDEX_SIZE_ERR</code></dfn> (1)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn id="hierarchyrequesterror"><code>HierarchyRequestError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="hierarchyrequesterror"><code>HierarchyRequestError</code></dfn>"</td>
                   <td>The operation would yield an incorrect <a href="https://dom.spec.whatwg.org/#concept-node-tree" title="concept-node-tree">node tree</a>.</td>
-                  <td><dfn id="dom-domexception-hierarchy_request_err" title="dom-DOMException-HIERARCHY_REQUEST_ERR"><code>HIERARCHY_REQUEST_ERR</code></dfn> (3)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-hierarchy_request_err" title="dom-DOMException-HIERARCHY_REQUEST_ERR"><code>HIERARCHY_REQUEST_ERR</code></dfn> (3)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn id="wrongdocumenterror"><code>WrongDocumentError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="wrongdocumenterror"><code>WrongDocumentError</code></dfn>"</td>
                   <td>The object is in the wrong <a href="https://dom.spec.whatwg.org/#concept-document" title="concept-document">document</a>.</td>
-                  <td><dfn id="dom-domexception-wrong_document_err" title="dom-DOMException-WRONG_DOCUMENT_ERR"><code>WRONG_DOCUMENT_ERR</code></dfn> (4)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-wrong_document_err" title="dom-DOMException-WRONG_DOCUMENT_ERR"><code>WRONG_DOCUMENT_ERR</code></dfn> (4)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn id="invalidcharactererror"><code>InvalidCharacterError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="invalidcharactererror"><code>InvalidCharacterError</code></dfn>"</td>
                   <td>The string contains invalid characters.</td>
-                  <td><dfn id="dom-domexception-invalid_character_err" title="dom-DOMException-INVALID_CHARACTER_ERR"><code>INVALID_CHARACTER_ERR</code></dfn> (5)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-invalid_character_err" title="dom-DOMException-INVALID_CHARACTER_ERR"><code>INVALID_CHARACTER_ERR</code></dfn> (5)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn id="nomodificationallowederror"><code>NoModificationAllowedError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="nomodificationallowederror"><code>NoModificationAllowedError</code></dfn>"</td>
                   <td>The object can not be modified.</td>
-                  <td><dfn id="dom-domexception-no_modification_allowed_err" title="dom-DOMException-NO_MODIFICATION_ALLOWED_ERR"><code>NO_MODIFICATION_ALLOWED_ERR</code></dfn> (7)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-no_modification_allowed_err" title="dom-DOMException-NO_MODIFICATION_ALLOWED_ERR"><code>NO_MODIFICATION_ALLOWED_ERR</code></dfn> (7)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn id="notfounderror"><code>NotFoundError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="notfounderror"><code>NotFoundError</code></dfn>"</td>
                   <td>The object can not be found here.</td>
-                  <td><dfn id="dom-domexception-not_found_err" title="dom-DOMException-NOT_FOUND_ERR"><code>NOT_FOUND_ERR</code></dfn> (8)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-not_found_err" title="dom-DOMException-NOT_FOUND_ERR"><code>NOT_FOUND_ERR</code></dfn> (8)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn id="notsupportederror"><code>NotSupportedError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="notsupportederror"><code>NotSupportedError</code></dfn>"</td>
                   <td>The operation is not supported.</td>
-                  <td><dfn id="dom-domexception-not_supported_err" title="dom-DOMException-NOT_SUPPORTED_ERR"><code>NOT_SUPPORTED_ERR</code></dfn> (9)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-not_supported_err" title="dom-DOMException-NOT_SUPPORTED_ERR"><code>NOT_SUPPORTED_ERR</code></dfn> (9)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn id="inuseattributeerror"><code>InUseAttributeError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="inuseattributeerror"><code>InUseAttributeError</code></dfn>"</td>
                   <td>The attribute is in use.</td>
-                  <td><dfn id="dom-domexception-inuse_attribute_err" title="dom-DOMException-INUSE_ATTRIBUTE_ERR"><code>INUSE_ATTRIBUTE_ERR</code></dfn> (10)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-inuse_attribute_err" title="dom-DOMException-INUSE_ATTRIBUTE_ERR"><code>INUSE_ATTRIBUTE_ERR</code></dfn> (10)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn id="invalidstateerror"><code>InvalidStateError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="invalidstateerror"><code>InvalidStateError</code></dfn>"</td>
                   <td>The object is in an invalid state.</td>
-                  <td><dfn id="dom-domexception-invalid_state_err" title="dom-DOMException-INVALID_STATE_ERR"><code>INVALID_STATE_ERR</code></dfn> (11)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-invalid_state_err" title="dom-DOMException-INVALID_STATE_ERR"><code>INVALID_STATE_ERR</code></dfn> (11)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn id="syntaxerror"><code>SyntaxError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="syntaxerror"><code>SyntaxError</code></dfn>"</td>
                   <td>The string did not match the expected pattern.</td>
-                  <td><dfn id="dom-domexception-syntax_err" title="dom-DOMException-SYNTAX_ERR"><code>SYNTAX_ERR</code></dfn> (12)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-syntax_err" title="dom-DOMException-SYNTAX_ERR"><code>SYNTAX_ERR</code></dfn> (12)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn id="invalidmodificationerror"><code>InvalidModificationError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="invalidmodificationerror"><code>InvalidModificationError</code></dfn>"</td>
                   <td>The object can not be modified in this way.</td>
-                  <td><dfn id="dom-domexception-invalid_modification_err" title="dom-DOMException-INVALID_MODIFICATION_ERR"><code>INVALID_MODIFICATION_ERR</code></dfn> (13)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-invalid_modification_err" title="dom-DOMException-INVALID_MODIFICATION_ERR"><code>INVALID_MODIFICATION_ERR</code></dfn> (13)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn id="namespaceerror"><code>NamespaceError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="namespaceerror"><code>NamespaceError</code></dfn>"</td>
                   <td>The operation is not allowed by <cite>Namespaces in XML</cite>. <a href="#ref-XMLNS">[XMLNS]</a></td>
-                  <td><dfn id="dom-domexception-namespace_err" title="dom-DOMException-NAMESPACE_ERR"><code>NAMESPACE_ERR</code></dfn> (14)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-namespace_err" title="dom-DOMException-NAMESPACE_ERR"><code>NAMESPACE_ERR</code></dfn> (14)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn id="invalidaccesserror"><code>InvalidAccessError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="invalidaccesserror"><code>InvalidAccessError</code></dfn>"</td>
                   <td>The object does not support the operation or argument.</td>
-                  <td><dfn id="dom-domexception-invalid_access_err" title="dom-DOMException-INVALID_ACCESS_ERR"><code>INVALID_ACCESS_ERR</code></dfn> (15)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-invalid_access_err" title="dom-DOMException-INVALID_ACCESS_ERR"><code>INVALID_ACCESS_ERR</code></dfn> (15)</td>
                 </tr>
                 <tr>
                   <!-- XHR -->
-                  <td>"<dfn id="securityerror"><code>SecurityError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="securityerror"><code>SecurityError</code></dfn>"</td>
                   <td>The operation is insecure.</td>
-                  <td><dfn id="dom-domexception-security_err" title="dom-DOMException-SECURITY_ERR"><code>SECURITY_ERR</code></dfn> (18)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-security_err" title="dom-DOMException-SECURITY_ERR"><code>SECURITY_ERR</code></dfn> (18)</td>
                 </tr>
                 <tr>
                   <!-- XHR -->
-                  <td>"<dfn id="networkerror"><code>NetworkError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="networkerror"><code>NetworkError</code></dfn>"</td>
                   <td>A network error occurred.</td>
-                  <td><dfn id="dom-domexception-network_err" title="dom-DOMException-NETWORK_ERR"><code>NETWORK_ERR</code></dfn> (19)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-network_err" title="dom-DOMException-NETWORK_ERR"><code>NETWORK_ERR</code></dfn> (19)</td>
                 </tr>
                 <tr>
                   <!-- XHR -->
-                  <td>"<dfn id="aborterror"><code>AbortError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="aborterror"><code>AbortError</code></dfn>"</td>
                   <td>The operation was aborted.</td>
-                  <td><dfn id="dom-domexception-abort_err" title="dom-DOMException-ABORT_ERR"><code>ABORT_ERR</code></dfn> (20)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-abort_err" title="dom-DOMException-ABORT_ERR"><code>ABORT_ERR</code></dfn> (20)</td>
                 </tr>
                 <tr>
                   <!-- Workers -->
-                  <td>"<dfn id="urlmismatcherror"><code>URLMismatchError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="urlmismatcherror"><code>URLMismatchError</code></dfn>"</td>
                   <td>The given URL does not match another URL.</td>
-                  <td><dfn id="dom-domexception-url_mismatch_err" title="dom-DOMException-URL_MISMATCH_ERR"><code>URL_MISMATCH_ERR</code></dfn> (21)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-url_mismatch_err" title="dom-DOMException-URL_MISMATCH_ERR"><code>URL_MISMATCH_ERR</code></dfn> (21)</td>
                 </tr>
                 <tr>
                   <!-- HTML -->
-                  <td>"<dfn id="quotaexceedederror"><code>QuotaExceededError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="quotaexceedederror"><code>QuotaExceededError</code></dfn>"</td>
                   <td>The quota has been exceeded.</td>
-                  <td><dfn id="dom-domexception-quota_exceeded_err" title="dom-DOMException-QUOTA_EXCEEDED_ERR"><code>QUOTA_EXCEEDED_ERR</code></dfn> (22)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-quota_exceeded_err" title="dom-DOMException-QUOTA_EXCEEDED_ERR"><code>QUOTA_EXCEEDED_ERR</code></dfn> (22)</td>
                 </tr>
                 <tr>
                   <!-- XHR -->
-                  <td>"<dfn id="timeouterror"><code>TimeoutError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="timeouterror"><code>TimeoutError</code></dfn>"</td>
                   <td>The operation timed out.</td>
-                  <td><dfn id="dom-domexception-timeout_err" title="dom-DOMException-TIMEOUT_ERR"><code>TIMEOUT_ERR</code></dfn> (23)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-timeout_err" title="dom-DOMException-TIMEOUT_ERR"><code>TIMEOUT_ERR</code></dfn> (23)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn id="invalidnodetypeerror"><code>InvalidNodeTypeError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="invalidnodetypeerror"><code>InvalidNodeTypeError</code></dfn>"</td>
                   <td>The supplied node is incorrect or has an incorrect ancestor for this operation.</td>
-                  <td><dfn id="dom-domexception-invalid_node_type_err" title="dom-DOMException-INVALID_NODE_TYPE_ERR"><code>INVALID_NODE_TYPE_ERR</code></dfn> (24)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-invalid_node_type_err" title="dom-DOMException-INVALID_NODE_TYPE_ERR"><code>INVALID_NODE_TYPE_ERR</code></dfn> (24)</td>
                 </tr>
                 <tr>
                   <!-- HTML -->
-                  <td>"<dfn id="datacloneerror"><code>DataCloneError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="datacloneerror"><code>DataCloneError</code></dfn>"</td>
                   <td>The object can not be cloned.</td>
-                  <td><dfn id="dom-domexception-data_clone_err" title="dom-DOMException-DATA_CLONE_ERR"><code>DATA_CLONE_ERR</code></dfn> (25)</td>
+                  <td><dfn data-export data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-data_clone_err" title="dom-DOMException-DATA_CLONE_ERR"><code>DATA_CLONE_ERR</code></dfn> (25)</td>
                 </tr>
                 <tr>
                   <!-- Encoding -->
-                  <td>"<dfn id="encodingerror"><code>EncodingError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="encodingerror"><code>EncodingError</code></dfn>"</td>
                   <td>The encoding operation (either encoded or decoding) failed.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- File API -->
-                  <td>"<dfn id="notreadableerror"><code>NotReadableError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="notreadableerror"><code>NotReadableError</code></dfn>"</td>
                   <td>The I/O read operation failed.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Indexed DB / Web Crypto -->
-                  <td>"<dfn id="unknownerror"><code>UnknownError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="unknownerror"><code>UnknownError</code></dfn>"</td>
                   <td>The operation failed for an unknown transient reason (e.g. out of memory).</td>
                   <!-- The operation failed for reasons unrelated to the database itself and not covered by any other errors. -->
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Indexed DB -->
-                  <td>"<dfn id="constrainterror"><code>ConstraintError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="constrainterror"><code>ConstraintError</code></dfn>"</td>
                   <td>A mutation operation in a transaction failed because a constraint was not satisfied.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Indexed DB / Web Crypto -->
-                  <td>"<dfn id="dataerror"><code>DataError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="dataerror"><code>DataError</code></dfn>"</td>
                   <td>Provided data is inadequate.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Indexed DB -->
-                  <td>"<dfn id="transactioninactiveerror"><code>TransactionInactiveError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="transactioninactiveerror"><code>TransactionInactiveError</code></dfn>"</td>
                   <td>A request was placed against a transaction which is currently not active, or which is finished.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Indexed DB -->
-                  <td>"<dfn id="readonlyerror"><code>ReadOnlyError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="readonlyerror"><code>ReadOnlyError</code></dfn>"</td>
                   <td>The mutating operation was attempted in a "readonly" transaction.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Indexed DB -->
-                  <td>"<dfn id="versionerror"><code>VersionError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="versionerror"><code>VersionError</code></dfn>"</td>
                   <td>An attempt was made to open a database using a lower version than the existing version.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Web Crypto -->
-                  <td>"<dfn id="operationerror"><code>OperationError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="operationerror"><code>OperationError</code></dfn>"</td>
                   <td>The operation failed for an operation-specific reason.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- HTML -->
-                  <td>"<dfn id="notallowederror"><code>NotAllowedError</code></dfn>"</td>
+                  <td>"<dfn data-export data-dfn-type="interface" id="notallowederror"><code>NotAllowedError</code></dfn>"</td>
                   <td>The request is not allowed by the user agent or the platform in the current context.</td>
                   <td>—</td>
                 </tr>
@@ -4506,7 +4506,7 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
           <h3>Enumerations</h3>
 
           <p>
-            An <dfn id='dfn-enumeration'>enumeration</dfn> is a definition (matching
+            An <dfn data-export id='dfn-enumeration'>enumeration</dfn> is a definition (matching
             <a class='sym' href='#prod-Enum'>Enum</a>) used to declare a type
             whose valid values are a set of predefined strings.  Enumerations
             can be used to restrict the possible
@@ -4516,7 +4516,7 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
           </p>
           <pre class='syntax'>enum <i>identifier</i> { <i>enumeration-values…</i> };</pre>
           <p>
-            The <dfn id='dfn-enumeration-value'>enumeration values</dfn> are specified
+            The <dfn data-export data-lt="enumeration value" id='dfn-enumeration-value'>enumeration values</dfn> are specified
             as a comma-separated list of <a class='sym' href='#prod-string'>string</a> literals.
             The list of <a class='dfnref' href='#dfn-enumeration-value'>enumeration values</a>
             <span class='rfc2119'>MUST NOT</span> include duplicates.
@@ -4599,7 +4599,7 @@ meal.type == "noodles";              <span class='comment'>// Evaluates to true.
             just “functions” to make it clear that they can be used for both purposes?</p>
           </div>
           <p>
-            A <dfn id='dfn-callback-function'>callback function</dfn> is a definition (matching
+            A <dfn data-export id='dfn-callback-function'>callback function</dfn> is a definition (matching
             <span class='sym'>"callback"</span> <a class='sym' href='#prod-CallbackRest'>CallbackRest</a>) used to declare a function type.
           </p>
           <pre class='syntax'>callback <i>identifier</i> = <i>return-type</i> (<i>arguments…</i>);</pre>
@@ -4651,7 +4651,7 @@ ops.performOperation(function(status) {
           <h3>Typedefs</h3>
 
           <p>
-            A <dfn id='dfn-typedef'>typedef</dfn> is a definition (matching
+            A <dfn data-export id='dfn-typedef'>typedef</dfn> is a definition (matching
             <a class='sym' href='#prod-Typedef'>Typedef</a>)
             used to declare a new name for a type.  This new name is not exposed
             by language bindings; it is purely used as a shorthand for referencing
@@ -4701,7 +4701,7 @@ interface Widget {
           <h3>Implements statements</h3>
 
           <p>
-            An <dfn id='dfn-implements-statement'>implements statement</dfn> is a definition
+            An <dfn data-export id='dfn-implements-statement'>implements statement</dfn> is a definition
             (matching <a class='sym' href='#prod-ImplementsStatement'>ImplementsStatement</a>)
             used to declare that all objects implementing an interface <var>A</var>
             (identified by the first <a class='dfnref' href='#dfn-identifier'>identifier</a>)
@@ -4735,7 +4735,7 @@ interface Widget {
           </p>
           <p>
             Interfaces that a given object implements are partitioned into those that are considered
-            <dfn id='dfn-supplemental-interface'>supplemental interfaces</dfn> and those that are not.
+            <dfn data-export data-lt="supplemental interface" id='dfn-supplemental-interface'>supplemental interfaces</dfn> and those that are not.
             An interface <var>A</var> is considered to be a
             <a class='dfnref' href='#dfn-supplemental-interface'>supplemental interface</a> of an object
             <var>O</var> if:
@@ -4779,7 +4779,7 @@ Gizmo implements SomeFunctionality;
 Gizmo implements MoreFunctionality;</x:codeblock>
           </div>
           <p>
-            The <dfn id='dfn-consequential-interfaces'>consequential interfaces</dfn> of an interface
+            The <dfn data-export id='dfn-consequential-interfaces'>consequential interfaces</dfn> of an interface
             <var>A</var> are:
           </p>
           <ul>
@@ -4864,8 +4864,8 @@ EventTarget et = (EventTarget) n; <span class='comment'>// This should never thr
 
           <p>
             In a given implementation of a set of <a class='dfnref' href='#dfn-idl-fragment'>IDL fragments</a>,
-            an object can be described as being a <dfn id='dfn-platform-object'>platform object</dfn>, a
-            <dfn id='dfn-user-object'>user object</dfn>, or neither.  There are two kinds of
+            an object can be described as being a <dfn data-export id='dfn-platform-object'>platform object</dfn>, a
+            <dfn data-export id='dfn-user-object'>user object</dfn>, or neither.  There are two kinds of
             object that are considered to be platform objects:
           </p>
           <ul>
@@ -4986,7 +4986,7 @@ interface Person {
             of that type are represented.
           </p>
           <p>
-            The following types are known as <dfn id='dfn-integer-type'>integer types</dfn>:
+            The following types are known as <dfn data-export id='dfn-integer-type'>integer types</dfn>:
             <a class='idltype' href='#idl-byte'>byte</a>,
             <a class='idltype' href='#idl-octet'>octet</a>,
             <a class='idltype' href='#idl-short'>short</a>,
@@ -4997,7 +4997,7 @@ interface Person {
             <a class='idltype' href='#idl-unsigned-long-long'>unsigned long long</a>.
           </p>
           <p>
-            The following types are known as <dfn id='dfn-numeric-type'>numeric types</dfn>:
+            The following types are known as <dfn data-export id='dfn-numeric-type'>numeric types</dfn>:
             the <a class='dfnref' href='#dfn-integer-type'>integer types</a>,
             <a class='idltype' href='#idl-float'>float</a>,
             <a class='idltype' href='#idl-unrestricted-float'>unresticted float</a>,
@@ -5005,20 +5005,20 @@ interface Person {
             <a class='idltype' href='#idl-unrestricted-double'>unrestricted double</a>.
           </p>
           <p>
-            The <dfn id='dfn-primitive-type'>primitive types</dfn> are
+            The <dfn data-export id='dfn-primitive-type'>primitive types</dfn> are
             <span class='idltype'>boolean</span> and the <a class='dfnref' href='#dfn-numeric-type'>numeric types</a>.
           </p>
           <p>
-            The <dfn id='dfn-string-type'>string types</dfn> are
+            The <dfn data-export id='dfn-string-type'>string types</dfn> are
             <span class='idltype'>DOMString</span>, all <a href='#idl-enumeration'>enumeration types</a>,
             <span class='idltype'>ByteString</span> and <span class='idltype'>USVString</span>.
           </p>
           <p>
-            The <dfn id='dfn-exception-type'>exception types</dfn> are
+            The <dfn data-export id='dfn-exception-type'>exception types</dfn> are
             <span class='idltype'>Error</span> and <span class='idltype'>DOMException</span>.
           </p>
           <p>
-            The <dfn id='dfn-typed-array-type'>typed array types</dfn> are
+            The <dfn data-export id='dfn-typed-array-type'>typed array types</dfn> are
             <span class='idltype'>Int8Array</span>,
             <span class='idltype'>Int16Array</span>,
             <span class='idltype'>Int32Array</span>,
@@ -5030,7 +5030,7 @@ interface Person {
             <span class='idltype'>Float64Array</span>.
           </p>
           <p>
-            The <dfn id='dfn-buffer-source-type'>buffer source types</dfn>
+            The <dfn data-export id='dfn-buffer-source-type'>buffer source types</dfn>
             are <span class='idltype'>ArrayBuffer</span>,
             <span class='idltype'>DataView</span>,
             and the <a class='dfnref' href='#dfn-typed-array-type'>typed array types</a>.
@@ -5039,10 +5039,10 @@ interface Person {
             The <a class='idltype' href='#idl-object'>object</a> type,
             all <a class='dfnref' href='#idl-interface'>interface types</a>
             and the <a class='dfnref' href='#dfn-exception-type'>exception types</a>
-            are known as <dfn id='dfn-object-type'>object types</dfn>.
+            are known as <dfn data-export id='dfn-object-type'>object types</dfn>.
           </p>
           <p>
-            Every type has a <dfn id='dfn-type-name'>type name</dfn>, which
+            Every type has a <dfn data-export id='dfn-type-name'>type name</dfn>, which
             is a string, not necessarily unique, that identifies the type.
             Each sub-section below defines what the type name is for each
             type.
@@ -5065,7 +5065,7 @@ interface Person {
           <?productions grammar Type SingleType NonAnyType UnionType UnionMemberType UnionMemberTypes ConstType Null PrimitiveType FloatType UnrestrictedFloatType UnsignedIntegerType IntegerType OptionalLong PromiseType?>
 
           <div id='idl-any' class='section'>
-            <h4>any</h4>
+            <h4 data-dfn-type="interface" id="dom-any">any</h4>
 
             <p>
               The <a class='idltype' href='#idl-any'>any</a> type is the union of all other possible
@@ -5084,14 +5084,14 @@ interface Person {
             </p>
             <p>
               The particular type of an <a class='idltype' href='#idl-any'>any</a>
-              value is known as its <dfn id='dfn-specific-type'>specific type</dfn>.
+              value is known as its <dfn data-export id='dfn-specific-type'>specific type</dfn>.
               (Values of <a href='#idl-union'>union types</a> also have
               <a class='dfnref' href='#dfn-specific-type'>specific types</a>.)
             </p>
           </div>
 
           <div id='idl-boolean' class='section'>
-            <h4>boolean</h4>
+            <h4 data-dfn-type="interface" id="dom-boolean">boolean</h4>
 
             <p>
               The <a class='idltype' href='#idl-boolean'>boolean</a> type has two values:
@@ -5109,7 +5109,7 @@ interface Person {
           </div>
 
           <div id='idl-byte' class='section'>
-            <h4>byte</h4>
+            <h4 data-dfn-type="interface" id="dom-byte">byte</h4>
 
             <p>
               The <a class='idltype' href='#idl-byte'>byte</a> type is a signed integer
@@ -5127,7 +5127,7 @@ interface Person {
           </div>
 
           <div id='idl-octet' class='section'>
-            <h4>octet</h4>
+            <h4 data-dfn-type="interface" id="dom-octet">octet</h4>
 
             <p>
               The <a class='idltype' href='#idl-octet'>octet</a> type is an unsigned integer
@@ -5145,7 +5145,7 @@ interface Person {
           </div>
 
           <div id='idl-short' class='section'>
-            <h4>short</h4>
+            <h4 data-dfn-type="interface" id="dom-short">short</h4>
 
             <p>
               The <a class='idltype' href='#idl-short'>short</a> type is a signed integer
@@ -5163,7 +5163,7 @@ interface Person {
           </div>
 
           <div id='idl-unsigned-short' class='section'>
-            <h4>unsigned short</h4>
+            <h4 data-dfn-type="interface" id="dom-unsignedshort">unsigned short</h4>
 
             <p>
               The <a class='idltype' href='#idl-unsigned-short'>unsigned short</a> type is an unsigned integer
@@ -5181,7 +5181,7 @@ interface Person {
           </div>
 
           <div id='idl-long' class='section'>
-            <h4>long</h4>
+            <h4 data-dfn-type="interface" id="dom-long">long</h4>
 
             <p>
               The <a class='idltype' href='#idl-long'>long</a> type is a signed integer
@@ -5199,7 +5199,7 @@ interface Person {
           </div>
 
           <div id='idl-unsigned-long' class='section'>
-            <h4>unsigned long</h4>
+            <h4 data-dfn-type="interface" id="dom-unsignedlong">unsigned long</h4>
 
             <p>
               The <a class='idltype' href='#idl-unsigned-long'>unsigned long</a> type is an unsigned integer
@@ -5217,7 +5217,7 @@ interface Person {
           </div>
 
           <div id='idl-long-long' class='section'>
-            <h4>long long</h4>
+            <h4 data-dfn-type="interface" id="dom-longlong">long long</h4>
 
             <p>
               The <a class='idltype' href='#idl-long-long'>long long</a> type is a signed integer
@@ -5235,7 +5235,7 @@ interface Person {
           </div>
 
           <div id='idl-unsigned-long-long' class='section'>
-            <h4>unsigned long long</h4>
+            <h4 data-dfn-type="interface" id="dom-unsignedlonglong">unsigned long long</h4>
 
             <p>
               The <a class='idltype' href='#idl-unsigned-long-long'>unsigned long long</a> type is an unsigned integer
@@ -5253,7 +5253,7 @@ interface Person {
           </div>
 
           <div id='idl-float' class='section'>
-            <h4>float</h4>
+            <h4 data-dfn-type="interface" id="dom-float">float</h4>
 
             <p>
               The <a class='idltype' href='#idl-float'>float</a> type is a floating point numeric
@@ -5281,7 +5281,7 @@ interface Person {
           </div>
 
           <div id='idl-unrestricted-float' class='section'>
-            <h4>unrestricted float</h4>
+            <h4 data-dfn-type="interface" id="dom-unrestrictedfloat">unrestricted float</h4>
 
             <p>
               The <a class='idltype' href='#idl-unrestricted-float'>unrestricted float</a> type is a floating point numeric
@@ -5300,7 +5300,7 @@ interface Person {
           </div>
 
           <div id='idl-double' class='section'>
-            <h4>double</h4>
+            <h4 data-dfn-type="interface" id="dom-double">double</h4>
 
             <p>
               The <a class='idltype' href='#idl-double'>double</a> type is a floating point numeric
@@ -5319,7 +5319,7 @@ interface Person {
           </div>
 
           <div id='idl-unrestricted-double' class='section'>
-            <h4>unrestricted double</h4>
+            <h4 data-dfn-type="interface" id="dom-unrestricteddouble">unrestricted double</h4>
 
             <p>
               The <a class='idltype' href='#idl-unrestricted-double'>unrestricted double</a> type is a floating point numeric
@@ -5338,7 +5338,7 @@ interface Person {
           </div>
 
           <div id='idl-DOMString' class='section'>
-            <h4>DOMString</h4>
+            <h4 data-dfn-type="interface" id="dom-DOMString">DOMString</h4>
 
             <p>
               The <a class='idltype' href='#idl-DOMString'>DOMString</a> type
@@ -5370,7 +5370,7 @@ interface Person {
               <a>Unicode scalar values</a> given a particular sequence of
               <a class='dfnref' href='#dfn-code-unit'>code units</a>.
               The following algorithm defines a way to
-              <dfn id='dfn-obtain-unicode'>convert a DOMString to a sequence of Unicode scalar values</dfn>:
+              <dfn data-export data-lt="obtain Unicode|convert to a sequence of Unicode scalar values" id='dfn-obtain-unicode'>convert a DOMString to a sequence of Unicode scalar values</dfn>:
             </p>
             <ol class='algorithm'>
               <li>Let <var>S</var> be the <span class='idltype'>DOMString</span> value.</li>
@@ -5431,7 +5431,7 @@ interface Person {
           </div>
 
           <div id='idl-ByteString' class='section'>
-            <h4>ByteString</h4>
+            <h4 data-dfn-type="interface" id="dom-ByteString">ByteString</h4>
 
             <p>
               The <a class='idltype' href='#idl-ByteString'>ByteString</a> type
@@ -5466,7 +5466,7 @@ interface Person {
           </div>
 
           <div id='idl-USVString' class='section'>
-            <h4>USVString</h4>
+            <h4 data-dfn-type="interface" id="dom-USVString">USVString</h4>
 
             <p>
               The <a class='idltype' href='#idl-USVString'>USVString</a> type
@@ -5499,7 +5499,7 @@ interface Person {
           </div>
 
           <div id='idl-object' class='section'>
-            <h4>object</h4>
+            <h4 data-dfn-type="interface" id="dom-object">object</h4>
 
             <p>
               The <a class='idltype' href='#idl-object'>object</a> type corresponds to the set of
@@ -5532,7 +5532,7 @@ interface Person {
             <p>
               For non-callback interfaces, an IDL value of the interface type is represented just
               by an object reference.  For <a class='dfnref' href='#dfn-callback-interface'>callback interfaces</a>, an IDL value of the interface type
-              is represented by a tuple of an object reference and a <dfn id='dfn-callback-context'>callback context</dfn>.
+              is represented by a tuple of an object reference and a <dfn data-export id='dfn-callback-context'>callback context</dfn>.
               The <a class='dfnref' href='#dfn-callback-context'>callback context</a> is a language
               binding specific value, and is used to store information about the execution context at
               the time the language binding specific object reference is converted to an IDL value.
@@ -5635,8 +5635,8 @@ interface Person {
             <h4>Nullable types — <var>T</var>?</h4>
 
             <p>
-              A <dfn id='dfn-nullable-type'>nullable type</dfn> is an IDL type constructed
-              from an existing type (called the <dfn id='dfn-inner-type'>inner type</dfn>),
+              A <dfn data-export id='dfn-nullable-type'>nullable type</dfn> is an IDL type constructed
+              from an existing type (called the <dfn data-export id='dfn-inner-type'>inner type</dfn>),
               which just allows the additional value <span class='idlvalue'>null</span>
               to be a member of its set of values.  <a class='dfnref' href='#dfn-nullable-type'>Nullable types</a>
               are represented in IDL by placing a <span class='char'>U+003F QUESTION MARK ("?")</span>
@@ -5686,7 +5686,7 @@ interface Person {
           </div>
 
           <div id='idl-sequence' class='section'>
-            <h4>Sequences — sequence&lt;<var>T</var>></h4>
+            <h4 data-dfn-type="interface" id="dom-sequence" data-lt="sequence|sequence<T>">Sequences — sequence&lt;<var>T</var>></h4>
 
             <p>
               The <a class='idltype' href='#idl-sequence'>sequence&lt;<var>T</var>></a>
@@ -5727,10 +5727,10 @@ interface Person {
           </div>
 
           <div id='idl-promise' class='section'>
-            <h4>Promise types — Promise&lt;<var>T</var>&gt;</h4>
+            <h4 data-dfn-type="interface" id="dom-promise" data-lt="Promise">Promise types — Promise&lt;<var>T</var>&gt;</h4>
 
             <p>
-              A <dfn id='dfn-promise-type'>promise type</dfn> is a parameterized type
+              A <dfn data-export id='dfn-promise-type'>promise type</dfn> is a parameterized type
               whose values are references to objects that “is used as a place holder
               for the eventual results of a deferred (and possibly asynchronous) computation
               result of an asynchronous operation” <a href='#ref-ECMA-262'>[ECMA-262]</a>.
@@ -5751,13 +5751,13 @@ interface Person {
             <h4>Union types</h4>
 
             <p>
-              A <dfn id='dfn-union-type'>union type</dfn> is a type whose set of values
+              A <dfn data-export id='dfn-union-type'>union type</dfn> is a type whose set of values
               is the union of those in two or more other types.  Union types (matching
               <a class='sym' href='#prod-UnionType'>UnionType</a>)
               are written as a series of types separated by the <code>or</code> keyword
               with a set of surrounding parentheses.
               The types which comprise the union type are known as the
-              union’s <dfn id='dfn-union-member-type'>member types</dfn>.
+              union’s <dfn data-export data-dfn-for="union" id='dfn-union-member-type'>member types</dfn>.
             </p>
             <div class='note'>
               <p>
@@ -5783,7 +5783,7 @@ interface Person {
               that matches the value.
             </p>
             <p>
-              The <dfn id='dfn-flattened-union-member-types'>flattened member types</dfn>
+              The <dfn data-export data-dfn-for="union" id='dfn-flattened-union-member-types'>flattened member types</dfn>
               of a <a class='dfnref' href='#dfn-union-type'>union type</a> is a set of types
               determined as follows:
             </p>
@@ -5814,7 +5814,7 @@ interface Person {
               </p>
             </div>
             <p>
-              The <dfn id='dfn-number-of-nullable-member-types'>number of nullable member types</dfn>
+              The <dfn data-export id='dfn-number-of-nullable-member-types'>number of nullable member types</dfn>
               of a <a class='dfnref' href='#dfn-union-type'>union type</a> is an integer
               determined as follows:
             </p>
@@ -5851,7 +5851,7 @@ interface Person {
               <a class='dfnref' href='#dfn-flattened-union-member-types'>flattened member types</a>.
             </p>
             <p>
-              A type <dfn id='dfn-includes-a-nullable-type'>includes a nullable type</dfn> if:
+              A type <dfn data-export id='dfn-includes-a-nullable-type'>includes a nullable type</dfn> if:
             </p>
             <ul>
               <li>the type is a <a class='dfnref' href='#dfn-nullable-type'>nullable type</a>, or</li>
@@ -5878,7 +5878,7 @@ interface Person {
           </div>
 
           <div id='idl-RegExp' class='section'>
-            <h4>RegExp</h4>
+            <h4 data-dfn-type="interface" id="dom-RegExp">RegExp</h4>
 
             <p>
               The <a class='idltype' href='#idl-RegExp'>RegExp</a> type is a type
@@ -5897,7 +5897,7 @@ interface Person {
           </div>
 
           <div id='idl-Error' class='section'>
-            <h4>Error</h4>
+            <h4 data-dfn-type="interface" id="dom-Error">Error</h4>
 
             <p>The <a class='idltype' href='#idl-Error'>Error</a> type corresponds to the
               set of all possible non-null references to exception objects, including
@@ -5962,7 +5962,7 @@ interface Person {
               <p>These types all correspond to classes defined in ECMAScript.</p>
             </div>
             <p>
-              To <dfn id='dfn-detach'>detach</dfn> an <span class='idltype'>ArrayBuffer</span>
+              To <dfn data-export data-dfn-for="ArrayBuffer" id='dfn-detach'>detach</dfn> an <span class='idltype'>ArrayBuffer</span>
               is to set its buffer pointer to <span class='idlvalue'>null</span>.
             </p>
             <p>
@@ -5976,8 +5976,8 @@ interface Person {
               At the specification prose level, IDL <a class='dfnref' href='#dfn-buffer-source-type'>buffer source types</a>
               are simply references to objects.  To inspect or manipulate the bytes inside the buffer,
               specification prose <span class='rfc2119'>MUST</span> first either
-              <dfn id='dfn-get-buffer-source-reference'>get a reference to the bytes held by the buffer source</dfn>
-              or <dfn id='dfn-get-buffer-source-copy'>get a copy of the bytes held by the buffer source</dfn>.
+              <dfn data-export data-lt="get a reference to the buffer source" id='dfn-get-buffer-source-reference'>get a reference to the bytes held by the buffer source</dfn>
+              or <dfn data-export data-lt="get a copy of the buffer source" id='dfn-get-buffer-source-copy'>get a copy of the bytes held by the buffer source</dfn>.
               With a reference to the buffer source’s bytes, specification prose can get or set individual
               byte values using that reference.
             </p>
@@ -6023,10 +6023,10 @@ interface Person {
           </div>
 
           <div id='idl-frozen-array' class='section'>
-            <h4>Frozen arrays — FrozenArray&lt;<var>T</var>&gt;</h4>
+            <h4 data-dfn-type="interface" id="dom-FrozenArray" lt="FrozenArray|FrozenArray<T>">Frozen arrays — FrozenArray&lt;<var>T</var>&gt;</h4>
 
             <p>
-              A <dfn id='dfn-frozen-array-type'>frozen array type</dfn> is a parameterized
+              A <dfn data-export id='dfn-frozen-array-type'>frozen array type</dfn> is a parameterized
               type whose values are references to objects that hold a fixed length array
               of unmodifiable values.  The values in the array are of type <var>T</var>.
             </p>
@@ -6050,7 +6050,7 @@ interface Person {
           <h3>Extended attributes</h3>
 
           <p>
-            An <dfn id='dfn-extended-attribute'>extended attribute</dfn> is an annotation
+            An <dfn data-export id='dfn-extended-attribute'>extended attribute</dfn> is an annotation
             that can appear on
             <!--a class='dfnref' href='#dfn-definition'-->definitions<!--/a-->,
             <a class='dfnref' href='#dfn-interface-member'>interface members</a>,
@@ -6086,7 +6086,7 @@ interface Person {
                 <a class='sym' href='#prod-ExtendedAttributeNoArgs'>ExtendedAttributeNoArgs</a>
               </td>
               <td>
-                <dfn id='dfn-xattr-no-arguments'>takes no arguments</dfn>
+                <dfn data-export data-dfn-for="extended attribute" id='dfn-xattr-no-arguments'>takes no arguments</dfn>
               </td>
               <td>
                 <code>[Replaceable]</code>
@@ -6097,7 +6097,7 @@ interface Person {
                 <a class='sym' href='#prod-ExtendedAttributeArgList'>ExtendedAttributeArgList</a>
               </td>
               <td>
-                <dfn id='dfn-xattr-argument-list'>takes an argument list</dfn>
+                <dfn data-export data-dfn-for="extended attribute" id='dfn-xattr-argument-list'>takes an argument list</dfn>
               </td>
               <td>
                 <code>[Constructor(double x, double y)]</code>
@@ -6108,7 +6108,7 @@ interface Person {
                 <a class='sym' href='#prod-ExtendedAttributeNamedArgList'>ExtendedAttributeNamedArgList</a>
               </td>
               <td>
-                <dfn id='dfn-xattr-named-argument-list'>takes a named argument list</dfn>
+                <dfn data-export data-dfn-for="extended attribute" id='dfn-xattr-named-argument-list'>takes a named argument list</dfn>
               </td>
               <td>
                 <code>[NamedConstructor=Image(DOMString src)]</code>
@@ -6119,7 +6119,7 @@ interface Person {
                 <a class='sym' href='#prod-ExtendedAttributeIdent'>ExtendedAttributeIdent</a>
               </td>
               <td>
-                <dfn id='dfn-xattr-identifier'>takes an identifier</dfn>
+                <dfn data-export data-dfn-for="extended attribute" id='dfn-xattr-identifier'>takes an identifier</dfn>
               </td>
               <td>
                 <code>[PutForwards=name]</code>
@@ -6130,7 +6130,7 @@ interface Person {
                 <a class='sym' href='#prod-ExtendedAttributeIdentList'>ExtendedAttributeIdentList</a>
               </td>
               <td>
-                <dfn id='dfn-xattr-identifier-list'>takes an identifier list</dfn>
+                <dfn data-export data-dfn-for="extended attribute" id='dfn-xattr-identifier-list'>takes an identifier list</dfn>
               </td>
               <td>
                 <code>[Exposed=(Window,Worker)]</code>
@@ -6211,7 +6211,7 @@ interface Person {
           of objects defined in this section is the <span class='esvalue'>Object</span> prototype object.
         </p>
         <p>
-          Some objects described in this section are defined to have a <dfn id='dfn-class-string'>class string</dfn>,
+          Some objects described in this section are defined to have a <dfn data-export id='dfn-class-string'>class string</dfn>,
           which is the string to include in the string returned from Object.prototype.toString.
           If an object has a class string, then the object <span class='rfc2119'>MUST</span>,
           at the time it is created, have a property whose name is the <a>@@toStringTag</a> symbol
@@ -6223,7 +6223,7 @@ interface Person {
             and configurable.</p>
         </div>
         <p>
-          If an object is defined to be a <dfn id='dfn-function-object'>function object</dfn>, then
+          If an object is defined to be a <dfn data-export id='dfn-function-object'>function object</dfn>, then
           it has characteristics as follows:
         </p>
         <ul>
@@ -6289,7 +6289,7 @@ interface Person {
             <a class='dfnref' href='#dfn-idl-fragment'>IDL fragments</a>,
             there will exist a number of ECMAScript objects that correspond to
             definitions in those <a class='dfnref' href='#dfn-idl-fragment'>IDL fragments</a>.
-            These objects are termed the <dfn id='dfn-initial-object'>initial objects</dfn>,
+            These objects are termed the <dfn data-export id='dfn-initial-object'>initial objects</dfn>,
             and comprise the following:
           </p>
           <ul>
@@ -6343,7 +6343,7 @@ iframe.appendChild instanceof w.Function;  <span class='comment'>// Evaluates to
 &lt;/script></x:codeblock>
           </div>
           <p>
-            Unless otherwise specified, each ECMAScript global environment <dfn id='dfn-expose'>exposes</dfn>
+            Unless otherwise specified, each ECMAScript global environment <dfn data-export data-dfn-for="ECMAScript global environment" id='dfn-expose'>exposes</dfn>
             all <a class='dfnref' href='#dfn-interface'>interfaces</a>
             that the implementation supports.  If a given ECMAScript global environment does not
             expose an interface, then the requirements given in
@@ -6368,9 +6368,9 @@ iframe.appendChild instanceof w.Function;  <span class='comment'>// Evaluates to
           <p>
             Each sub-section below describes how values of a given IDL type are represented
             in ECMAScript.  For each IDL type, it is described how ECMAScript values are
-            <dfn id='dfn-convert-ecmascript-to-idl-value'>converted to an IDL value</dfn>
+            <dfn data-export data-lt="converted to an IDL value|converted to IDL values" id='dfn-convert-ecmascript-to-idl-value'>converted to an IDL value</dfn>
             when passed to a <a class='dfnref' href='#dfn-platform-object'>platform object</a> expecting that type, and how IDL values
-            of that type are <dfn id='dfn-convert-idl-to-ecmascript-value'>converted to ECMAScript values</dfn>
+            of that type are <dfn data-export data-lt="converted to an ECMAScript value|converted to ECMAScript values" id='dfn-convert-idl-to-ecmascript-value'>converted to ECMAScript values</dfn>
             when returned from a platform object.
           </p>
 
@@ -7759,7 +7759,7 @@ alert(b[4]);    <span class='comment'>// This would alert "50".</span></x:codebl
               IDL <a href='#idl-promise'>promise type</a> represents.
             </p>
             <p>
-              One can <dfn id='dfn-perform-steps-once-promise-is-settled'>perform some steps once a promise is settled</dfn>.
+              One can <dfn data-export data-lt="upon settling" id='dfn-perform-steps-once-promise-is-settled'>perform some steps once a promise is settled</dfn>.
               There can be one or two sets of steps to perform, covering when the promise is fulfilled, rejected, or both.
               When a specification says to perform some steps once a promise is settled, the following steps
               <span class='rfc2119'>MUST</span> be followed:
@@ -8232,7 +8232,7 @@ alert(b[4]);    <span class='comment'>// This would alert "50".</span></x:codebl
                 from <var>values</var>.</li>
             </ol>
             <p>
-              To <dfn id='dfn-create-frozen-array'>create a frozen array</dfn> from a sequence
+              To <dfn data-export id='dfn-create-frozen-array'>create a frozen array</dfn> from a sequence
               of values of type <var>T</var>, follow these steps:
             </p>
             <ol class='algorithm'>
@@ -8571,7 +8571,7 @@ context.setColorEnforcedRange(-1, 255, 256);</x:codeblock>
             <p>
               Every construct that the <a class='xattr' href='#Exposed'>[Exposed]</a>
               <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a>
-              can be specified on has an <dfn id="dfn-exposure-set">exposure set</dfn>,
+              can be specified on has an <dfn data-export id="dfn-exposure-set">exposure set</dfn>,
               which is a set of <a class='dfnref' href='#dfn-interface'>interfaces</a>
               defining which global environments the construct can be used in.
               The <a class='dfnref' href='#dfn-exposure-set'>exposure set</a>
@@ -8651,7 +8651,7 @@ context.setColorEnforcedRange(-1, 255, 256);</x:codeblock>
               An <a class='dfnref' href='#dfn-interface'>interface</a>,
               <a class='dfnref' href='#dfn-interface-member'>interface member</a> or
               <a class='dfnref' href='#dfn-dictionary'>dictionary</a>
-              is <dfn id='dfn-exposed'>exposed</dfn> in a given ECMAScript global environment if
+              is <dfn data-export id='dfn-exposed'>exposed</dfn> in a given ECMAScript global environment if
               the ECMAScript global object implements an interface that is in the
               interface, interface member or dictionary's
               <a class='dfnref' href='#dfn-exposure-set'>exposure set</a>.
@@ -8893,7 +8893,7 @@ var requestAnimationFrame = window.requestAnimationFrame ||
               <a class='xattr' href='#PrimaryGlobal'>[PrimaryGlobal]</a>
               <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a>
               is declared with an identifier list argument, then those identifiers are the interface’s
-              <dfn id='dfn-global-name'>global names</dfn>; otherwise, the interface has
+              <dfn data-export id='dfn-global-name'>global names</dfn>; otherwise, the interface has
               a single global name, which is the interface's identifier.
             </p>
             <div class='note'>
@@ -8909,7 +8909,7 @@ var requestAnimationFrame = window.requestAnimationFrame ||
               interface.  The <a class='xattr' href='#PrimaryGlobal'>[PrimaryGlobal]</a>
               extended attribute <span class='rfc2119'>MUST</span> be declared on
               at most one interface.  The interface <a class='xattr' href='#PrimaryGlobal'>[PrimaryGlobal]</a>
-              is declared on, if any, is known as the <dfn id='dfn-primary-global-interface'>primary global interface</dfn>.
+              is declared on, if any, is known as the <dfn data-export id='dfn-primary-global-interface'>primary global interface</dfn>.
             </p>
             <p>
               See <a href='#named-properties-object'>section <?sref named-properties-object?></a>,
@@ -9959,7 +9959,7 @@ d.isMemberOfBreed(null);  <span class='comment'>// This passes the string "" to 
               that implement the interface, rather than on the prototype.
             </p>
             <p>
-              An attribute or operation is said to be <dfn id='dfn-unforgeable-on-an-interface'>unforgeable</dfn>
+              An attribute or operation is said to be <dfn data-export id='dfn-unforgeable-on-an-interface'>unforgeable</dfn>
               on a given interface <var>A</var> if any of the following are true:
             </p>
             <ul>
@@ -10136,7 +10136,7 @@ with (thing) {
 
           <p>
             Certain algorithms in the sections below are defined to
-            <dfn id='dfn-perform-a-security-check'>perform a security check</dfn> on a given
+            <dfn data-export id='dfn-perform-a-security-check'>perform a security check</dfn> on a given
             object.  This check is used to determine whether a given
             <a class='dfnref' href='#dfn-operation'>operation</a> invocation or
             <a class='dfnref' href='#dfn-attribute'>attribute</a> access should be
@@ -10167,7 +10167,7 @@ with (thing) {
 
           <p>
             In order to define how overloaded function invocations are resolved, the
-            <dfn id='dfn-overload-resolution-algorithm'>overload resolution algorithm</dfn>
+            <dfn data-export id='dfn-overload-resolution-algorithm'>overload resolution algorithm</dfn>
             is defined.  Its input is an <a class='dfnref' href='#dfn-effective-overload-set'>effective overload set</a>,
             <var>S</var>, and a list of ECMAScript values, <var>arg</var><sub>0..<var>n</var>−1</sub>.
             Its output is a pair consisting of the <a class='dfnref' href='#dfn-operation'>operation</a> or
@@ -10609,7 +10609,7 @@ with (thing) {
             a corresponding property <span class='rfc2119'>MUST</span> exist on the
             ECMAScript environment's global object.
             The name of the property is the <a class='dfnref' href='#dfn-identifier'>identifier</a> of the interface,
-            and its value is an object called the <dfn id='dfn-interface-object'>interface object</dfn>.
+            and its value is an object called the <dfn data-export id='dfn-interface-object'>interface object</dfn>.
           </p>
           <p>
             The property has the attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>true</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>true</span> }</span>.
@@ -10623,7 +10623,7 @@ with (thing) {
             exist on the ECMAScript global object.  The name of the property is the
             <a class='sym' href='#prod-identifier'>identifier</a> that occurs directly after the
             “<span class='sym'>=</span>”, and its value is an object called a
-            <dfn id='dfn-named-constructor'>named constructor</dfn>, which allows
+            <dfn data-export id='dfn-named-constructor'>named constructor</dfn>, which allows
             construction of objects that implement the interface.  The property has the
             attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>true</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>true</span> }</span>.
             The characteristics of a named constructor are described in
@@ -10667,7 +10667,7 @@ with (thing) {
               class='rfc2119'>MUST</span> have a property named “prototype”
               with attributes
               <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>false</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>false</span> }</span>
-              whose value is an object called the <dfn id='dfn-interface-prototype-object'>interface prototype object</dfn>.  This object has properties
+              whose value is an object called the <dfn data-export id='dfn-interface-prototype-object'>interface prototype object</dfn>.  This object has properties
               that correspond to the <a class='dfnref' href='#dfn-regular-attribute'>regular attributes</a> and
               <a class='dfnref' href='#dfn-regular-operation'>regular operations</a> defined on the interface,
               and is described in more detail in
@@ -10929,7 +10929,7 @@ with (thing) {
               ECMAScript environment's global object.  The name of the property is the
               <a class='dfnref' href='#dfn-identifier'>identifier</a> of the dictionary,
               and its value is a <a class='dfnref' href='#dfn-function-object'>function object</a>
-              called the <dfn id='dfn-dictionary-constructor'>dictionary constructor</dfn>.
+              called the <dfn data-export id='dfn-dictionary-constructor'>dictionary constructor</dfn>.
             </p>
             <p>
               The property has the attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>true</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>true</span> }</span>.
@@ -11134,7 +11134,7 @@ partial interface Window {
               <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a>
               that <a class='dfnref' href='#dfn-support-named-properties'>supports named properties</a>,
               there <span class='rfc2119'>MUST</span> exist an object known as the
-              <dfn id='dfn-named-properties-object'>named properties object</dfn> for that
+              <dfn data-export id='dfn-named-properties-object'>named properties object</dfn> for that
               interface.
             </p>
             <p>
@@ -11378,7 +11378,7 @@ interface
                 </ul>
               </li>
               <li>
-                The <dfn id='dfn-attribute-getter'>attribute getter</dfn> is a <span class='estype'>Function</span>
+                The <dfn data-export id='dfn-attribute-getter'>attribute getter</dfn> is a <span class='estype'>Function</span>
                 object whose behavior when invoked is as follows:
                 <ol class='algorithm'>
                   <li>Let <var>idlValue</var> be an IDL value determined as follows.</li>
@@ -11438,7 +11438,7 @@ interface
                   concatenation of “get ” and the identifier of the attribute.</p>
               </li>
               <li>
-                The <dfn id='dfn-attribute-setter'>attribute setter</dfn> is <span class='esvalue'>undefined</span>
+                The <dfn data-export id='dfn-attribute-setter'>attribute setter</dfn> is <span class='esvalue'>undefined</span>
                 if the attribute is declared <code>readonly</code> and has neither a
                 <a class='xattr' href='#PutForwards'>[PutForwards]</a> nor a <a class='xattr' href='#Replaceable'>[Replaceable]</a>
                 <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a> declared on it.
@@ -11842,7 +11842,7 @@ interface
               <p>The value of the <span class='estype'>Function</span> object’s “name”
                 property is the <span class='estype'>String</span> value “toJSON”.</p>
               <p>
-                The following steps define how to <dfn id='dfn-convert-serialized-value-to-ecmascript-value'>convert a serialized value to an ECMAScript value</dfn>:
+                The following steps define how to <dfn data-export id='dfn-convert-serialized-value-to-ecmascript-value'>convert a serialized value to an ECMAScript value</dfn>:
               </p>
               <ol class='algorithm'>
                 <li>Let <var>S</var> be the <a class='dfnref' href='#dfn-serialized-value'>serialized value</a>.</li>
@@ -12009,10 +12009,10 @@ interface
               </p>
               <p>The value of the <a>@@iterator</a> <span class='estype'>Function</span> object’s “name”
               property is the <span class='estype'>String</span> value “entries” if the interface has a
-              <a class='dfnref' href='#dfn-pair-iterator'>pair iterator</a> or a 
+              <a class='dfnref' href='#dfn-pair-iterator'>pair iterator</a> or a
               <a class='dfnref' href='#dfn-maplike-declaration'>maplike
               declaration</a> and the <span class='estype'>String</span> “values”
-              if the interface has a 
+              if the interface has a
               <a class='dfnref' href='#dfn-setlike-declaration'>setlike declaration</a>.</p>
             </div>
 
@@ -12298,7 +12298,7 @@ interface
               <h5>Default iterator objects</h5>
 
               <p>
-                A <dfn id='dfn-default-iterator-object'>default iterator object</dfn> for a given
+                A <dfn data-export id='dfn-default-iterator-object'>default iterator object</dfn> for a given
                 <a class='dfnref' href='#dfn-interface'>interface</a>, target and iteration kind
                 is an object whose internal [[Prototype]] property is the
                 <a class='dfnref' href='#dfn-iterator-prototype-object'>iterator prototype object</a>
@@ -12340,7 +12340,7 @@ interface
               <h5>Iterator prototype object</h5>
 
               <p>
-                The <dfn id='dfn-iterator-prototype-object'>iterator prototype object</dfn>
+                The <dfn data-export id='dfn-iterator-prototype-object'>iterator prototype object</dfn>
                 for a given <a class='dfnref' href='#dfn-interface'>interface</a>
                 is an object that exists for every interface that has a
                 <a class='dfnref' href='#dfn-pair-iterator'>pair iterator</a>.  It serves as the
@@ -12449,7 +12449,7 @@ interface
 
             <p>
               Some of the properties below are defined to have a <a class='dfnref' href='#dfn-function-object'>function object</a> value
-              that <dfn id="dfn-forwards-to-the-internal-map-object">forwards to the internal map object</dfn>
+              that <dfn data-export id="dfn-forwards-to-the-internal-map-object">forwards to the internal map object</dfn>
               for a given function name.  Such functions behave as follows when invoked:
             </p>
             <ol class="algorithm">
@@ -12482,7 +12482,7 @@ interface
               </p>
               <ul>
                 <li>The property has attributes <span class='descriptor'>{ [[Get]]: <var>G</var>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>true</span> }</span>,
-                  where <var>G</var> is the interface’s <dfn id='dfn-map-size-getter'>map size getter</dfn>,
+                  where <var>G</var> is the interface’s <dfn data-export id='dfn-map-size-getter'>map size getter</dfn>,
                   defined below.</li>
                 <li><p>The <a class='dfnref' href='#dfn-map-size-getter'>map size getter</a> is
                   a <span class='estype'>Function</span> object whose
@@ -12707,7 +12707,7 @@ interface
 
             <p>
               Some of the properties below are defined to have a <a class='dfnref' href='#dfn-function-object'>function object</a> value
-              that <dfn id="dfn-forwards-to-the-internal-set-object">forwards to the internal set object</dfn>
+              that <dfn data-export id="dfn-forwards-to-the-internal-set-object">forwards to the internal set object</dfn>
               for a given function name.  Such functions behave as follows when invoked:
             </p>
             <ol class="algorithm">
@@ -12740,7 +12740,7 @@ interface
               </p>
               <ul>
                 <li>The property has attributes <span class='descriptor'>{ [[Get]]: <var>G</var>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>true</span> }</span>,
-                  where <var>G</var> is the interface’s <dfn id='dfn-set-size-getter'>set size getter</dfn>,
+                  where <var>G</var> is the interface’s <dfn data-export id='dfn-set-size-getter'>set size getter</dfn>,
                   defined below.</li>
                 <li><p>The <a class='dfnref' href='#dfn-set-size-getter'>set size getter</a> is
                   a <span class='estype'>Function</span> object whose
@@ -12925,7 +12925,7 @@ interface
             </p>
 
             <p>
-              To <dfn id='add-map-elements-from-iterable'>add map elements from an iterable</dfn> <var>iterable</var> to
+              To <dfn data-export id='add-map-elements-from-iterable'>add map elements from an iterable</dfn> <var>iterable</var> to
               an object <var>destination</var> with adder method name <var>adder</var>, perform the following steps:
             </p>
             <ol class='algorithm'>
@@ -13036,7 +13036,7 @@ C implements A;</x:codeblock>
             object is associated with.
           </p>
           <p>
-            The <dfn id='dfn-primary-interface'>primary interface</dfn> of a platform object
+            The <dfn data-export id='dfn-primary-interface'>primary interface</dfn> of a platform object
             that implements one or more interfaces is the most-derived <a class='dfnref' href='#dfn-supplemental-interface'>non-supplemental interface</a>
             that it implements.  The value of the internal <span class='prop'>[[Prototype]]</span>
             property of the platform object is the <a class='dfnref' href='#dfn-interface-prototype-object'>interface prototype object</a>
@@ -13045,7 +13045,7 @@ C implements A;</x:codeblock>
           </p>
           <p>
             The global environment that a given <a class='dfnref' href='#dfn-platform-object'>platform object</a>
-            is associated with can <dfn id="dfn-change-global-environment">change</dfn> after it has been created.  When
+            is associated with can <dfn data-export data-dfn-for="global environment" id="dfn-change-global-environment">change</dfn> after it has been created.  When
             the global environment associated with a platform object is changed, its internal
             <span class='prop'>[[Prototype]]</span> property <span class='rfc2119'>MUST</span> be immediately
             updated to be the <a class='dfnref' href='#dfn-interface-prototype-object'>interface prototype object</a>
@@ -13199,7 +13199,7 @@ C implements A;</x:codeblock>
                 <li>Return the <span class='esvalue'>this</span> value.</li>
               </ol>
               This <span class='estype'>Function</span> object is the
-              <dfn id='dfn-default-unforgeable-valueOf-function'>default unforgeable valueOf function</dfn>.
+              <dfn data-export id='dfn-default-unforgeable-valueOf-function'>default unforgeable valueOf function</dfn>.
             </li>
             <li>The value of the <span class='estype'>Function</span> object’s “length”
               property is the <span class='estype'>Number</span> value <span class='esvalue'>0</span>.</li>
@@ -13266,7 +13266,7 @@ C implements A;</x:codeblock>
 
             <p>
               The name of each property that appears to exist due to an object supporting indexed properties
-              is an <dfn id='dfn-array-index-property-name'>array index property name</dfn>, which is a property
+              is an <dfn data-export id='dfn-array-index-property-name'>array index property name</dfn>, which is a property
               name <var>P</var> such that <a>Type</a>(<var>P</var>) is String
               and for which the following algorithm returns <span class='esvalue'>true</span>:
             </p>
@@ -13293,7 +13293,7 @@ C implements A;</x:codeblock>
             </div>
             -->
             <p>
-              A property name is an <dfn id='dfn-unforgeable-property-name'>unforgeable property name</dfn> on a
+              A property name is an <dfn data-export id='dfn-unforgeable-property-name'>unforgeable property name</dfn> on a
               given platform object if the object implements an <a class='dfnref' href='#dfn-interface'>interface</a> that
               has an <a class='dfnref' href='#dfn-interface-member'>interface member</a> with that identifier
               and that interface member is <a class='dfnref' href='#dfn-unforgeable-on-an-interface'>unforgeable</a> on any of
@@ -13304,7 +13304,7 @@ C implements A;</x:codeblock>
               on that object.
             </p>
             <p>
-              The <dfn id='dfn-named-property-visibility'>named property visibility algorithm</dfn> is used to determine if
+              The <dfn data-export id='dfn-named-property-visibility'>named property visibility algorithm</dfn> is used to determine if
               a given named property is exposed on an object.  Some named properties are not exposed on an object
               depending on whether the <a class='xattr' href='#OverrideBuiltins'>[OverrideBuiltins]</a>
               <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a> was used.  The algorithm
@@ -13475,7 +13475,7 @@ C implements A;</x:codeblock>
           <div id='invoking-indexed-setter' class='section'>
             <h4>Invoking a platform object indexed property setter</h4>
             <p>
-              To <dfn id='invoke-indexed-setter'>invoke an indexed property
+              To <dfn data-export data-lt="invoke the indexed property setter" id='invoke-indexed-setter'>invoke an indexed property
               setter</dfn> with property name <var>P</var> and ECMAScript value
               <var>V</var>, the following steps <span
               class='rfc2119'>MUST</span> be performed:
@@ -13504,7 +13504,7 @@ C implements A;</x:codeblock>
           <div id='invoking-named-setter' class='section'>
             <h4>Invoking a platform object named property setter</h4>
             <p>
-              To <dfn id='invoke-named-setter'>invoke a named property
+              To <dfn data-export data-lt="invoke the named property setter" id='invoke-named-setter'>invoke a named property
               setter</dfn> with property name <var>P</var> and ECMAScript value
               <var>V</var>, the following steps <span
               class='rfc2119'>MUST</span> be performed:
@@ -13838,7 +13838,7 @@ C implements A;</x:codeblock>
             </li>
           </ul>
           <p>
-            A <dfn id='dfn-single-operation-callback-interface'>single operation callback interface</dfn> is
+            A <dfn data-export id='dfn-single-operation-callback-interface'>single operation callback interface</dfn> is
             a <a class='dfnref' href='#dfn-callback-interface'>callback interface</a> that:
           </p>
           <ul>
@@ -13851,7 +13851,7 @@ C implements A;</x:codeblock>
             A <a class='dfnref' href='#dfn-user-object'>user object</a>’s
             <a class='dfnref' href='#dfn-operation'>operation</a> is called
             with a list of IDL argument values <var>idlarg</var><sub>0..<var>n</var>−1</sub> by
-            following the algorithm below.  The <dfn id='dfn-callback-this-value'>callback this value</dfn>
+            following the algorithm below.  The <dfn data-export id='dfn-callback-this-value'>callback this value</dfn>
             is the value to use as the <span class='esvalue'>this</span> value
             when a <a>callable</a>
             object was supplied as the implementation of a
@@ -14063,7 +14063,7 @@ C implements A;</x:codeblock>
           <p>
             There <span class='rfc2119'>MUST</span> exist a property on the ECMAScript global object
             whose name is “DOMException” and value is an object called the
-            <dfn id='dfn-DOMException-constructor-object'>DOMException constructor object</dfn>,
+            <dfn data-export data-dfn-for="DOMException" id='dfn-DOMException-constructor-object'>DOMException constructor object</dfn>,
             which provides access to legacy DOMException code constants and allows construction of
             DOMException instances.
             The property has the attributes <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>true</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>true</span> }</span>.
@@ -14086,7 +14086,7 @@ C implements A;</x:codeblock>
               The DOMException constructor object <span class='rfc2119'>MUST</span> also have a property named
               “prototype” with attributes
               <span class='descriptor'>{ [[Writable]]: <span class='esvalue'>false</span>, [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span class='esvalue'>false</span> }</span>
-              whose value is an object called the <dfn id='dfn-DOMException-prototype-object'>DOMException prototype object</dfn>.
+              whose value is an object called the <dfn data-export data-dfn-for="DOMException" id='dfn-DOMException-prototype-object'>DOMException prototype object</dfn>.
               This object also provides access to the legacy code values.
             </p>
 
@@ -14191,7 +14191,7 @@ C implements A;</x:codeblock>
           <h3>Creating and throwing exceptions</h3>
 
           <p>
-            First, we define the <dfn id='dfn-current-global-environment'>current global environment</dfn>
+            First, we define the <dfn data-export id='dfn-current-global-environment'>current global environment</dfn>
             as the result of running the following algorithm:
           </p>
           <ol class='algorithm'>


### PR DESCRIPTION
Adds [appropriate markup](https://github.com/tabatkins/bikeshed/blob/master/docs/dfn-contract.md) to all of the `<dfn>` elements in WebIDL, so the spec can be added to Shepherd and linked properly by all Bikeshedded specs.  Nearly all of the definitions are reasonable to export and link to.

Also adds appropriate markup to the `<h4>`s for several IDL types that don't otherwise have a `<dfn>` element (because everything in the spec just links to the section instead).