### PR TITLE
Bikeshed-link fixes

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -5076,7 +5076,7 @@ interface Person {
           <?productions grammar Type SingleType NonAnyType UnionType UnionMemberType UnionMemberTypes ConstType Null PrimitiveType FloatType UnrestrictedFloatType UnsignedIntegerType IntegerType OptionalLong PromiseType?>
 
           <div id='idl-any' class='section'>
-            <h4 data-dfn-type="interface" id="dom-any">any</h4>
+            <h4 data-dfn-type="interface" data-lt="any" id="dom-any">any</h4>
 
             <p>
               The <a class='idltype' href='#idl-any'>any</a> type is the union of all other possible
@@ -5102,7 +5102,7 @@ interface Person {
           </div>
 
           <div id='idl-boolean' class='section'>
-            <h4 data-dfn-type="interface" id="dom-boolean">boolean</h4>
+            <h4 data-dfn-type="interface" data-lt="boolean" id="dom-boolean">boolean</h4>
 
             <p>
               The <a class='idltype' href='#idl-boolean'>boolean</a> type has two values:
@@ -5120,7 +5120,7 @@ interface Person {
           </div>
 
           <div id='idl-byte' class='section'>
-            <h4 data-dfn-type="interface" id="dom-byte">byte</h4>
+            <h4 data-dfn-type="interface" data-lt="byte" id="dom-byte">byte</h4>
 
             <p>
               The <a class='idltype' href='#idl-byte'>byte</a> type is a signed integer
@@ -5138,7 +5138,7 @@ interface Person {
           </div>
 
           <div id='idl-octet' class='section'>
-            <h4 data-dfn-type="interface" id="dom-octet">octet</h4>
+            <h4 data-dfn-type="interface" data-lt="octet" id="dom-octet">octet</h4>
 
             <p>
               The <a class='idltype' href='#idl-octet'>octet</a> type is an unsigned integer
@@ -5156,7 +5156,7 @@ interface Person {
           </div>
 
           <div id='idl-short' class='section'>
-            <h4 data-dfn-type="interface" id="dom-short">short</h4>
+            <h4 data-dfn-type="interface" data-lt="short" id="dom-short">short</h4>
 
             <p>
               The <a class='idltype' href='#idl-short'>short</a> type is a signed integer
@@ -5174,7 +5174,7 @@ interface Person {
           </div>
 
           <div id='idl-unsigned-short' class='section'>
-            <h4 data-dfn-type="interface" id="dom-unsignedshort">unsigned short</h4>
+            <h4 data-dfn-type="interface" data-lt="unsigned short" id="dom-unsignedshort">unsigned short</h4>
 
             <p>
               The <a class='idltype' href='#idl-unsigned-short'>unsigned short</a> type is an unsigned integer
@@ -5192,7 +5192,7 @@ interface Person {
           </div>
 
           <div id='idl-long' class='section'>
-            <h4 data-dfn-type="interface" id="dom-long">long</h4>
+            <h4 data-dfn-type="interface" data-lt="long" id="dom-long">long</h4>
 
             <p>
               The <a class='idltype' href='#idl-long'>long</a> type is a signed integer
@@ -5210,7 +5210,7 @@ interface Person {
           </div>
 
           <div id='idl-unsigned-long' class='section'>
-            <h4 data-dfn-type="interface" id="dom-unsignedlong">unsigned long</h4>
+            <h4 data-dfn-type="interface" data-lt="unsigned long" id="dom-unsignedlong">unsigned long</h4>
 
             <p>
               The <a class='idltype' href='#idl-unsigned-long'>unsigned long</a> type is an unsigned integer
@@ -5228,7 +5228,7 @@ interface Person {
           </div>
 
           <div id='idl-long-long' class='section'>
-            <h4 data-dfn-type="interface" id="dom-longlong">long long</h4>
+            <h4 data-dfn-type="interface" data-lt="long long" id="dom-longlong">long long</h4>
 
             <p>
               The <a class='idltype' href='#idl-long-long'>long long</a> type is a signed integer
@@ -5246,7 +5246,7 @@ interface Person {
           </div>
 
           <div id='idl-unsigned-long-long' class='section'>
-            <h4 data-dfn-type="interface" id="dom-unsignedlonglong">unsigned long long</h4>
+            <h4 data-dfn-type="interface" data-lt="unsigned long long" id="dom-unsignedlonglong">unsigned long long</h4>
 
             <p>
               The <a class='idltype' href='#idl-unsigned-long-long'>unsigned long long</a> type is an unsigned integer
@@ -5264,7 +5264,7 @@ interface Person {
           </div>
 
           <div id='idl-float' class='section'>
-            <h4 data-dfn-type="interface" id="dom-float">float</h4>
+            <h4 data-dfn-type="interface" data-lt="float" id="dom-float">float</h4>
 
             <p>
               The <a class='idltype' href='#idl-float'>float</a> type is a floating point numeric
@@ -5292,7 +5292,7 @@ interface Person {
           </div>
 
           <div id='idl-unrestricted-float' class='section'>
-            <h4 data-dfn-type="interface" id="dom-unrestrictedfloat">unrestricted float</h4>
+            <h4 data-dfn-type="interface" data-lt="unrestricted float" id="dom-unrestrictedfloat">unrestricted float</h4>
 
             <p>
               The <a class='idltype' href='#idl-unrestricted-float'>unrestricted float</a> type is a floating point numeric
@@ -5311,7 +5311,7 @@ interface Person {
           </div>
 
           <div id='idl-double' class='section'>
-            <h4 data-dfn-type="interface" id="dom-double">double</h4>
+            <h4 data-dfn-type="interface" data-lt="double" id="dom-double">double</h4>
 
             <p>
               The <a class='idltype' href='#idl-double'>double</a> type is a floating point numeric
@@ -5330,7 +5330,7 @@ interface Person {
           </div>
 
           <div id='idl-unrestricted-double' class='section'>
-            <h4 data-dfn-type="interface" id="dom-unrestricteddouble">unrestricted double</h4>
+            <h4 data-dfn-type="interface" data-lt="unrestricted double" id="dom-unrestricteddouble">unrestricted double</h4>
 
             <p>
               The <a class='idltype' href='#idl-unrestricted-double'>unrestricted double</a> type is a floating point numeric
@@ -5349,7 +5349,7 @@ interface Person {
           </div>
 
           <div id='idl-DOMString' class='section'>
-            <h4 data-dfn-type="interface" id="dom-DOMString">DOMString</h4>
+            <h4 data-dfn-type="interface" data-lt="DOMString" id="dom-DOMString">DOMString</h4>
 
             <p>
               The <a class='idltype' href='#idl-DOMString'>DOMString</a> type
@@ -5442,7 +5442,7 @@ interface Person {
           </div>
 
           <div id='idl-ByteString' class='section'>
-            <h4 data-dfn-type="interface" id="dom-ByteString">ByteString</h4>
+            <h4 data-dfn-type="interface" data-lt="ByteString" id="dom-ByteString">ByteString</h4>
 
             <p>
               The <a class='idltype' href='#idl-ByteString'>ByteString</a> type
@@ -5477,7 +5477,7 @@ interface Person {
           </div>
 
           <div id='idl-USVString' class='section'>
-            <h4 data-dfn-type="interface" id="dom-USVString">USVString</h4>
+            <h4 data-dfn-type="interface" data-lt="USVString" id="dom-USVString">USVString</h4>
 
             <p>
               The <a class='idltype' href='#idl-USVString'>USVString</a> type
@@ -5510,7 +5510,7 @@ interface Person {
           </div>
 
           <div id='idl-object' class='section'>
-            <h4 data-dfn-type="interface" id="dom-object">object</h4>
+            <h4 data-dfn-type="interface" data-lt="object" id="dom-object">object</h4>
 
             <p>
               The <a class='idltype' href='#idl-object'>object</a> type corresponds to the set of
@@ -5889,7 +5889,7 @@ interface Person {
           </div>
 
           <div id='idl-RegExp' class='section'>
-            <h4 data-dfn-type="interface" id="dom-RegExp">RegExp</h4>
+            <h4 data-dfn-type="interface" data-lt="RegExp" id="dom-RegExp">RegExp</h4>
 
             <p>
               The <a class='idltype' href='#idl-RegExp'>RegExp</a> type is a type
@@ -5908,7 +5908,7 @@ interface Person {
           </div>
 
           <div id='idl-Error' class='section'>
-            <h4 data-dfn-type="interface" id="dom-Error">Error</h4>
+            <h4 data-dfn-type="interface" data-lt="Error" id="dom-Error">Error</h4>
 
             <p>The <a class='idltype' href='#idl-Error'>Error</a> type corresponds to the
               set of all possible non-null references to exception objects, including

--- a/index.xml
+++ b/index.xml
@@ -4234,12 +4234,12 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
             is identified by one of the following names:
           </p>
           <ul>
-            <li><span class='idltype'>Error</span></li>
-            <li><span class='idltype'>EvalError</span></li>
-            <li><span class='idltype'>RangeError</span></li>
-            <li><span class='idltype'>ReferenceError</span></li>
-            <li><span class='idltype'>TypeError</span></li>
-            <li><span class='idltype'>URIError</span></li>
+            <li><span class='idltype'><dfn data-export="" data-dfn-type="interface">Error</dfn></span></li>
+            <li><span class='idltype'><dfn data-export="" data-dfn-type="interface">EvalError</dfn></span></li>
+            <li><span class='idltype'><dfn data-export="" data-dfn-type="interface">RangeError</dfn></span></li>
+            <li><span class='idltype'><dfn data-export="" data-dfn-type="interface">ReferenceError</dfn></span></li>
+            <li><span class='idltype'><dfn data-export="" data-dfn-type="interface">TypeError</dfn></span></li>
+            <li><span class='idltype'><dfn data-export="" data-dfn-type="interface">URIError</dfn></span></li>
           </ul>
           <p>
             These correspond to all of the <a>ECMAScript error objects</a> (apart from
@@ -4336,175 +4336,175 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
               </thead>
               <tbody>
                 <tr>
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="indexsizeerror"><code>IndexSizeError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="indexsizeerror"><code>IndexSizeError</code></dfn>"</td>
                   <td>The index is not in the allowed range.</td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-index_size_err" title="dom-DOMException-INDEX_SIZE_ERR"><code>INDEX_SIZE_ERR</code></dfn> (1)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="hierarchyrequesterror"><code>HierarchyRequestError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="hierarchyrequesterror"><code>HierarchyRequestError</code></dfn>"</td>
                   <td>The operation would yield an incorrect <a href="https://dom.spec.whatwg.org/#concept-node-tree" title="concept-node-tree">node tree</a>.</td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-hierarchy_request_err" title="dom-DOMException-HIERARCHY_REQUEST_ERR"><code>HIERARCHY_REQUEST_ERR</code></dfn> (3)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="wrongdocumenterror"><code>WrongDocumentError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="wrongdocumenterror"><code>WrongDocumentError</code></dfn>"</td>
                   <td>The object is in the wrong <a href="https://dom.spec.whatwg.org/#concept-document" title="concept-document">document</a>.</td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-wrong_document_err" title="dom-DOMException-WRONG_DOCUMENT_ERR"><code>WRONG_DOCUMENT_ERR</code></dfn> (4)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="invalidcharactererror"><code>InvalidCharacterError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="invalidcharactererror"><code>InvalidCharacterError</code></dfn>"</td>
                   <td>The string contains invalid characters.</td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-invalid_character_err" title="dom-DOMException-INVALID_CHARACTER_ERR"><code>INVALID_CHARACTER_ERR</code></dfn> (5)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="nomodificationallowederror"><code>NoModificationAllowedError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="nomodificationallowederror"><code>NoModificationAllowedError</code></dfn>"</td>
                   <td>The object can not be modified.</td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-no_modification_allowed_err" title="dom-DOMException-NO_MODIFICATION_ALLOWED_ERR"><code>NO_MODIFICATION_ALLOWED_ERR</code></dfn> (7)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="notfounderror"><code>NotFoundError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="notfounderror"><code>NotFoundError</code></dfn>"</td>
                   <td>The object can not be found here.</td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-not_found_err" title="dom-DOMException-NOT_FOUND_ERR"><code>NOT_FOUND_ERR</code></dfn> (8)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="notsupportederror"><code>NotSupportedError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="notsupportederror"><code>NotSupportedError</code></dfn>"</td>
                   <td>The operation is not supported.</td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-not_supported_err" title="dom-DOMException-NOT_SUPPORTED_ERR"><code>NOT_SUPPORTED_ERR</code></dfn> (9)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="inuseattributeerror"><code>InUseAttributeError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="inuseattributeerror"><code>InUseAttributeError</code></dfn>"</td>
                   <td>The attribute is in use.</td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-inuse_attribute_err" title="dom-DOMException-INUSE_ATTRIBUTE_ERR"><code>INUSE_ATTRIBUTE_ERR</code></dfn> (10)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="invalidstateerror"><code>InvalidStateError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="invalidstateerror"><code>InvalidStateError</code></dfn>"</td>
                   <td>The object is in an invalid state.</td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-invalid_state_err" title="dom-DOMException-INVALID_STATE_ERR"><code>INVALID_STATE_ERR</code></dfn> (11)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="syntaxerror"><code>SyntaxError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="syntaxerror"><code>SyntaxError</code></dfn>"</td>
                   <td>The string did not match the expected pattern.</td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-syntax_err" title="dom-DOMException-SYNTAX_ERR"><code>SYNTAX_ERR</code></dfn> (12)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="invalidmodificationerror"><code>InvalidModificationError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="invalidmodificationerror"><code>InvalidModificationError</code></dfn>"</td>
                   <td>The object can not be modified in this way.</td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-invalid_modification_err" title="dom-DOMException-INVALID_MODIFICATION_ERR"><code>INVALID_MODIFICATION_ERR</code></dfn> (13)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="namespaceerror"><code>NamespaceError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="namespaceerror"><code>NamespaceError</code></dfn>"</td>
                   <td>The operation is not allowed by <cite>Namespaces in XML</cite>. <a href="#ref-XMLNS">[XMLNS]</a></td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-namespace_err" title="dom-DOMException-NAMESPACE_ERR"><code>NAMESPACE_ERR</code></dfn> (14)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="invalidaccesserror"><code>InvalidAccessError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="invalidaccesserror"><code>InvalidAccessError</code></dfn>"</td>
                   <td>The object does not support the operation or argument.</td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-invalid_access_err" title="dom-DOMException-INVALID_ACCESS_ERR"><code>INVALID_ACCESS_ERR</code></dfn> (15)</td>
                 </tr>
                 <tr>
                   <!-- XHR -->
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="securityerror"><code>SecurityError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="securityerror"><code>SecurityError</code></dfn>"</td>
                   <td>The operation is insecure.</td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-security_err" title="dom-DOMException-SECURITY_ERR"><code>SECURITY_ERR</code></dfn> (18)</td>
                 </tr>
                 <tr>
                   <!-- XHR -->
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="networkerror"><code>NetworkError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="networkerror"><code>NetworkError</code></dfn>"</td>
                   <td>A network error occurred.</td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-network_err" title="dom-DOMException-NETWORK_ERR"><code>NETWORK_ERR</code></dfn> (19)</td>
                 </tr>
                 <tr>
                   <!-- XHR -->
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="aborterror"><code>AbortError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="aborterror"><code>AbortError</code></dfn>"</td>
                   <td>The operation was aborted.</td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-abort_err" title="dom-DOMException-ABORT_ERR"><code>ABORT_ERR</code></dfn> (20)</td>
                 </tr>
                 <tr>
                   <!-- Workers -->
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="urlmismatcherror"><code>URLMismatchError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="urlmismatcherror"><code>URLMismatchError</code></dfn>"</td>
                   <td>The given URL does not match another URL.</td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-url_mismatch_err" title="dom-DOMException-URL_MISMATCH_ERR"><code>URL_MISMATCH_ERR</code></dfn> (21)</td>
                 </tr>
                 <tr>
                   <!-- HTML -->
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="quotaexceedederror"><code>QuotaExceededError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="quotaexceedederror"><code>QuotaExceededError</code></dfn>"</td>
                   <td>The quota has been exceeded.</td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-quota_exceeded_err" title="dom-DOMException-QUOTA_EXCEEDED_ERR"><code>QUOTA_EXCEEDED_ERR</code></dfn> (22)</td>
                 </tr>
                 <tr>
                   <!-- XHR -->
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="timeouterror"><code>TimeoutError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="timeouterror"><code>TimeoutError</code></dfn>"</td>
                   <td>The operation timed out.</td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-timeout_err" title="dom-DOMException-TIMEOUT_ERR"><code>TIMEOUT_ERR</code></dfn> (23)</td>
                 </tr>
                 <tr>
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="invalidnodetypeerror"><code>InvalidNodeTypeError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="invalidnodetypeerror"><code>InvalidNodeTypeError</code></dfn>"</td>
                   <td>The supplied node is incorrect or has an incorrect ancestor for this operation.</td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-invalid_node_type_err" title="dom-DOMException-INVALID_NODE_TYPE_ERR"><code>INVALID_NODE_TYPE_ERR</code></dfn> (24)</td>
                 </tr>
                 <tr>
                   <!-- HTML -->
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="datacloneerror"><code>DataCloneError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="datacloneerror"><code>DataCloneError</code></dfn>"</td>
                   <td>The object can not be cloned.</td>
                   <td><dfn data-export="" data-dfn-type="const" data-dfn-for="DOMException" id="dom-domexception-data_clone_err" title="dom-DOMException-DATA_CLONE_ERR"><code>DATA_CLONE_ERR</code></dfn> (25)</td>
                 </tr>
                 <tr>
                   <!-- Encoding -->
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="encodingerror"><code>EncodingError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="encodingerror"><code>EncodingError</code></dfn>"</td>
                   <td>The encoding operation (either encoded or decoding) failed.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- File API -->
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="notreadableerror"><code>NotReadableError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="notreadableerror"><code>NotReadableError</code></dfn>"</td>
                   <td>The I/O read operation failed.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Indexed DB / Web Crypto -->
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="unknownerror"><code>UnknownError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="unknownerror"><code>UnknownError</code></dfn>"</td>
                   <td>The operation failed for an unknown transient reason (e.g. out of memory).</td>
                   <!-- The operation failed for reasons unrelated to the database itself and not covered by any other errors. -->
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Indexed DB -->
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="constrainterror"><code>ConstraintError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="constrainterror"><code>ConstraintError</code></dfn>"</td>
                   <td>A mutation operation in a transaction failed because a constraint was not satisfied.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Indexed DB / Web Crypto -->
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="dataerror"><code>DataError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="dataerror"><code>DataError</code></dfn>"</td>
                   <td>Provided data is inadequate.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Indexed DB -->
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="transactioninactiveerror"><code>TransactionInactiveError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="transactioninactiveerror"><code>TransactionInactiveError</code></dfn>"</td>
                   <td>A request was placed against a transaction which is currently not active, or which is finished.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Indexed DB -->
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="readonlyerror"><code>ReadOnlyError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="readonlyerror"><code>ReadOnlyError</code></dfn>"</td>
                   <td>The mutating operation was attempted in a "readonly" transaction.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Indexed DB -->
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="versionerror"><code>VersionError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="versionerror"><code>VersionError</code></dfn>"</td>
                   <td>An attempt was made to open a database using a lower version than the existing version.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- Web Crypto -->
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="operationerror"><code>OperationError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="operationerror"><code>OperationError</code></dfn>"</td>
                   <td>The operation failed for an operation-specific reason.</td>
                   <td>—</td>
                 </tr>
                 <tr>
                   <!-- HTML -->
-                  <td>"<dfn data-export="" data-dfn-type="interface" id="notallowederror"><code>NotAllowedError</code></dfn>"</td>
+                  <td>"<dfn data-export="" data-dfn-type="exception" id="notallowederror"><code>NotAllowedError</code></dfn>"</td>
                   <td>The request is not allowed by the user agent or the platform in the current context.</td>
                   <td>—</td>
                 </tr>


### PR DESCRIPTION
* The heading-dfns need to have their linking text set explicitly; right now they're including the section number inserted by XSLT.
* The simple errors should be dfn'd, I think.  (Until ES is Bikeshed-friendly, at least.)
* The DOMException types should be "exception" type.  (I misunderstood what they were previously.)