### PR TITLE
Modernize invoking user code

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED" type="text/css" /></head>
 
   <body>
-    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL (Second Edition)</h1><h2>W3C Editor’s Draft <em>11 May 2016</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/">http://heycam.github.io/webidl/</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
+    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL (Second Edition)</h1><h2>W3C Editor’s Draft <em>19 May 2016</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/">http://heycam.github.io/webidl/</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
               Send feedback to <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a> or <a href="https://www.w3.org/Bugs/Public/enter_bug.cgi?product=WebAppsWG&amp;component=WebIDL">file a bug</a> (<a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=WebIDL&amp;resolution=---">open bugs</a>)
             </dd><dt>Editors:</dt><dd><a href="http://mcc.id.au/">Cameron McCormack</a>, Mozilla Corporation &lt;cam@mcc.id.au&gt;</dd><dd>Boris Zbarsky, Mozilla Corporation &lt;bzbarsky@mit.edu&gt;</dd></dl><p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &copy; 2016 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>&reg;</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p></div><hr /><script async="" src="file-bug.js"></script>
 
@@ -72,7 +72,7 @@
         report can be found in the <a href="http://www.w3.org/TR/">W3C technical
           reports index</a> at http://www.w3.org/TR/.
       </em></p><p>
-        This document is the 11 May 2016 <b>Editor’s Draft</b> of the
+        This document is the 19 May 2016 <b>Editor’s Draft</b> of the
         <cite>Web IDL (Second Edition)</cite> specification.
       
       Please send comments about this document to
@@ -176,6 +176,7 @@
             <li>Unicode characters: <span class="char">U+0030 DIGIT ZERO ("0")</span></li>
             <li>Extended attributes: <span class="xattr">[ExampleExtendedAttribute]</span></li>
             <li>Variable names in prose and algorithms: <var>exampleVariableName</var>.</li>
+            <li>Algorithms use <a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">the conventions of the ECMAScript specification</a>, including the ! and ? notation for unwrapping completion records.</li>
             <li>IDL informal syntax examples:
               <pre class="syntax">interface <i>identifier</i> {
   <em>interface-members…</em>
@@ -6513,6 +6514,17 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               for Web pages.
             </p>
           </div>
+
+          <p>
+            Although at the time of this writing the ECMAScript specification does not reflect this,
+            every ECMAScript object must have an <dfn data-export="" id="dfn-associated-realm">associated <a class="external external" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a></dfn>. The mechanisms
+            for associating objects with Realms are, for now, underspecified. However, we note that
+            in the case of <a class="dfnref" href="#dfn-platform-object">platform objects</a>, the
+            associated Realm is equal to the object's <a class="external external" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">relevant Realm</a>, and
+            for non-exotic function objects (i.e. not callable proxies, and not bound functions)
+            the associated Realm is equal to the value of the function object's [[Realm]] internal
+            slot.
+          </p>
         </div>
 
         <div id="es-type-mapping" class="section">
@@ -7889,12 +7901,12 @@ alert(b[4]);    <span class="comment">// This would alert "50".</span></code></p
               to an IDL <a class="idltype" href="#idl-promise">Promise&lt;<var>T</var>&gt;</a> value as follows:
             </p>
             <ol class="algorithm">
-              <li>Let <var>resolve</var> be the original value of <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Promise%</a>.resolve.
+              <li>Let <var>resolve</var> be the original value of <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.resolve.
                 <div class="ednote"><div class="ednoteHeader">Editorial note</div>
                   <p>ECMAScript should grow a %Promise_resolve% well-known intrinsic object that can be referenced here.</p>
                 </div>
               </li>
-              <li>Let <var>promise</var> be the result of calling <var>resolve</var> with <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Promise%</a>
+              <li>Let <var>promise</var> be the result of calling <var>resolve</var> with <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>
                 as the <span class="esvalue">this</span> value and <var>V</var> as the single argument value.</li>
               <li>Return the IDL <a href="#idl-promise">promise type</a> value that is a reference to the
                 same object as <var>promise</var>.</li>
@@ -11860,8 +11872,8 @@ interface
                       <li>If the operation has a <a class="dfnref" href="#dfn-return-type">return type</a>
                         that is a <a href="#idl-promise">promise type</a>, then:
                         <ol>
-                          <li>Let <var>reject</var> be the initial value of <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Promise%</a>.reject.</li>
-                          <li>Return the result of calling <var>reject</var> with <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Promise%</a> as the
+                          <li>Let <var>reject</var> be the initial value of <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.</li>
+                          <li>Return the result of calling <var>reject</var> with <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a> as the
                             <span class="esvalue">this</span> object and the exception as the single
                             argument value.</li>
                         </ol>
@@ -14007,6 +14019,15 @@ C implements A;</code></pre></div></div>
               property name that is that identifier.
             </li>
           </ul>
+
+          <p>
+            Note that ECMAScript objects need not have
+            properties corresponding to <a class="dfnref" href="#dfn-constant">constants</a>
+            on them to be considered as <a class="dfnref" href="#dfn-user-object">user objects</a>
+            implementing <a class="dfnref" href="#dfn-interface">interfaces</a> that happen
+            to have constants declared on them.
+          </p>
+
           <p>
             A <dfn data-export="" id="dfn-single-operation-callback-interface">single operation callback interface</dfn> is
             a <a class="dfnref" href="#dfn-callback-interface">callback interface</a> that:
@@ -14017,138 +14038,225 @@ C implements A;</code></pre></div></div>
             <li>has one or more <a class="dfnref" href="#dfn-regular-operation">regular operations</a> that all have the same <a class="dfnref" href="#dfn-identifier">identifier</a>,
               and no others.</li>
           </ul>
+
           <p>
-            A <a class="dfnref" href="#dfn-user-object">user object</a>’s
-            <a class="dfnref" href="#dfn-operation">operation</a> is called
-            with a list of IDL argument values <var>idlarg</var><sub>0..<var>n</var>−1</sub> by
-            following the algorithm below.  The <dfn data-export="" id="dfn-callback-this-value">callback this value</dfn>
-            is the value to use as the <span class="esvalue">this</span> value
-            when a <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">callable</a>
-            object was supplied as the implementation of a
-            <a class="dfnref" href="#dfn-single-operation-callback-interface">single operation callback interface</a>.
-            By default, <span class="esvalue">undefined</span> is used as the <a class="dfnref" href="#dfn-callback-this-value">callback this value</a>,
-            however this <span class="rfc2119">MAY</span> be overridden by other
-            specifications.
+            To <dfn>call a user object's operation</dfn>, given a <a class="dfnref" href="#idl-interface">callback interface type</a> value <var>value</var>,
+            sometimes-optional operation name <var>opName</var>, list of argument values
+            <var>arg</var><sub>0..<var>n</var>−1</sub> each of which is either an IDL value or the
+            special value “missing” (representing a missing optional argument), and optional <dfn data-export="" id="dfn-callback-this-value">callback this value</dfn>
+            <var>thisArg</var>, perform the following steps. These steps will either return an IDL
+            value or throw an exception.
           </p>
+
           <ol class="algorithm">
-            <li>Try running the following steps:
+            <li>Let <var>completion</var> be an uninitialized variable.</li>
+
+            <li>If <var>thisArg</var> was not given, let <var>thisArg</var> be <span class="esvalue">undefined</span>.</li>
+
+            <li>Let <var>O</var> be the ECMAScript object corresponding to <var>value</var>.</li>
+
+            <li>Let <var>realm</var> be <var>O</var>'s <a class="dfnref" href="#dfn-associated-realm">associated Realm</a>.</li>
+
+            <li>Let <var>settings</var> be <var>realm</var>'s <a class="dfnref external" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object">settings
+            object</a>.</li>
+
+            <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script">Prepare to run script</a> with <var>settings</var>.</li>
+
+            <li>
+              Determine the implementation of the operation, <var>X</var>:
+
               <ol>
-                <li>Let <var>V</var> be the IDL <a class="dfnref" href="#idl-interface">callback interface type</a> value
-                  that represents the <a class="dfnref" href="#dfn-user-object">user object</a> implementing the <a class="dfnref" href="#dfn-interface">interface</a>.</li>
-                <li>Let <var>O</var> be the ECMAScript object corresponding to <var>V</var>.</li>
-                <li>Let <var>X</var> be the implementation of the operation.  If the interface is a <a class="dfnref" href="#dfn-single-operation-callback-interface">single operation callback interface</a> and <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>O</var>) is true, then <var>X</var> is <var>O</var>.
-                  Otherwise, <var>X</var> is the result of calling
-                  the internal <span class="prop">[[Get]]</span> method of <var>O</var> with the identifier of the operation as the property name.</li>
-                <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>X</var>) is not Object, <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a> exception.</li>
-                <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>X</var>) is false, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a> exception.</li>
-                <li>Let <var>this</var> be <var>O</var> if the interface is not a <a class="dfnref" href="#dfn-single-operation-callback-interface">single operation callback interface</a>
-                  or if <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>O</var>) is false,
-                  and the <a class="dfnref" href="#dfn-callback-this-value">callback this value</a> otherwise.</li>
+                <li>If <var>value</var>'s interface is a <a class="dfnref" href="#dfn-single-operation-callback-interface">single operation callback
+                interface</a> and <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>O</var>) is true, then set
+                <var>X</var> to <var>O</var>.</li>
+
                 <li>
-                  Let <var>arg</var><sub>0..<var>n</var>−1</sub> be a list of
-                  ECMAScript values, where <var>arg</var><sub><var>i</var></sub> is the result
-                  of <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a>
-                  <var>idlarg</var><sub><var>i</var></sub> to an ECMAScript value.
-                </li>
-                <li>Let <var>script</var> be the <a class="dfnref" href="#dfn-callback-context">callback context</a> associated with <var>V</var>.</li>
-                <li>Push <var>script</var> on to the <a class="dfnref external" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html">stack of incumbent scripts</a>. <a href="#ref-HTML">[HTML]</a></li>
-                <li>Let <var>R</var> be an uninitialized variable.</li>
-                <li>Try running the following step:
+                  Otherwise, <var>opName</var> must be supplied:
                   <ol>
-                    <li>Set <var>R</var> to the result of invoking the <span class="prop">[[Call]]</span> method of <var>X</var>, providing <var>this</var> as the <span class="esvalue">this</span> value and <var>arg</var><sub>0..<var>n</var>−1</sub> as the argument values.</li>
+                    <li>Let <var>getResult</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>O</var>,
+                    <var>opName</var>).</li>
+
+                    <li>If <var>getResult</var> is an abrupt completion, set <var>completion</var>
+                    to <var>getResult</var> and jump to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.</li>
+
+                    <li>Set <var>X</var> to <var>getResult</var>.[[Value]].</li>
                   </ol>
-                  And then, whether or not an exception was thrown:
-                  <ol>
-                    <li>Pop <var>script</var> off the <a class="dfnref external" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html">stack of incumbent scripts</a>.</li>
-                    <li>If an exception was thrown, end these steps, and allow it to propagate.</li>
-                  </ol>
-                </li>
-                <li>If the operation’s return type is <a class="idltype" href="#idl-void">void</a>, return.</li>
-                <li>
-                  Return the result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a>
-                  <var>R</var> to an IDL value of the same type as the operation’s return type.
                 </li>
               </ol>
-              And then, if an exception was thrown:
+            </li>
+
+
+            <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>X</var>) is <span class="esvalue">false</span>,
+            then set <var>completion</var> to a new <a class="external" href="https://tc39.github.io/ecma262/#sec-completion-record-specification-type">Completion</a>{[[Type]]: throw, [[Value]]: a
+            newly created <span class="estype">TypeError</span> object, [[Target]]: empty}, and jump
+            to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.</li>
+
+            <li>If <var>value</var>'s interface is not a <a class="dfnref" href="#dfn-single-operation-callback-interface">single operation callback interface</a>,
+            or if <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>O</var>) is <span class="esvalue">false</span>,
+            set <var>thisArg</var> to <var>O</var> (overriding the provided value).</li>
+
+            <li>Let <var>esArgs</var> be an empty List of ECMAScript values.</li>
+
+            <li>Let <var>i</var> be 0.</li>
+
+            <li>Let <var>count</var> be 0.</li>
+
+            <li>
+              While <var>i</var> &lt; <var>n</var>:
+
               <ol>
-                <li>If the operation has a <a class="dfnref" href="#dfn-return-type">return type</a> that is a <a href="#idl-promise">promise type</a>, then:
+                <li>If <var>arg</var><sub><var>i</var></sub> is the special value “missing”, then
+                append <span class="esvalue">undefined</span> to <var>esArgs</var>.</li>
+
+                <li>
+                  Otherwise, <var>arg</var><sub><var>i</var></sub> is an IDL value:
+
                   <ol>
-                    <li>Let <var>reject</var> be the initial value of <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Promise%</a>.reject.</li>
-                    <li>Return the result of calling <var>reject</var> with <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Promise%</a> as the <span class="esvalue">this</span> object and the exception as the single argument value.</li>
+                    <li>Let <var>convertResult</var> be the result of <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a>
+                    <var>arg</var><sub><var>i</var></sub> to an ECMAScript value.</li>
+
+                    <li>If <var>convertResult</var> is an abrupt completion, set <var>completion</var>
+                    to <var>convertResult</var> and jump to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.</li>
+
+                    <li>Append <var>convertResult</var>.[[Value]] to <var>esArgs</var>.</li>
+
+                    <li>Set <var>count</var> to <var>i</var> + 1.</li>
                   </ol>
                 </li>
-                <li>Otherwise, end these steps and allow the exception to propagate.</li>
+
+                <li>Set <var>i</var> to <var>i</var> + 1.</li>
+              </ol>
+            </li>
+
+            <li>Truncate <var>esArgs</var> to have length <var>count</var>.</li>
+
+            <li>Let <var>callResult</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-call">Call</a>(<var>X</var>, <var>thisArg</var>,
+            <var>esArgs</var>).</li>
+
+            <li>If <var>callResult</var> is an abrupt completion, set <var>completion</var> to
+            <var>callResult</var> and jump to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.</li>
+
+            <li>Set <var>completion</var> to the result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a>
+            <var>callResult</var>.[[Value]] to an IDL value of the same type as the operation’s
+            return type.</li>
+
+            <li>
+              <i id="call-user-object-operation-return">Return:</i> at this
+              point <var>completion</var> will be set to an ECMAScript completion value.
+
+              <ol>
+                <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script">Clean up after running script</a> with <var>settings</var>.</li>
+
+                <li>If <var>completion</var> is a normal completion, return
+                <var>completion</var>.</li>
+
+                <li>If <var>completion</var> is an abrupt completion and the operation has a <a class="dfnref" href="#dfn-return-type">return type</a> that is <em>not</em> a <a href="#idl-promise">promise type</a>, return <var>completion</var>.</li>
+
+                <li>Let <var>reject</var> be the initial value of <a class="external" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.</li>
+
+                <li>Let <var>rejectedPromise</var> be the result of calling <var>reject</var> with
+                <a class="external" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a> as the <span class="esvalue">this</span> value and
+                <var>completion</var>.[[Value]] as the single argument value.</li>
+
+                <li>Return the result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a>
+                <var>rejectedPromise</var> to the operation's return type.</li>
               </ol>
             </li>
           </ol>
+
           <p>
-            Note that ECMAScript objects need not have
-            properties corresponding to <a class="dfnref" href="#dfn-constant">constants</a>
-            on them to be considered as <a class="dfnref" href="#dfn-user-object">user objects</a>
-            implementing <a class="dfnref" href="#dfn-interface">interfaces</a> that happen
-            to have constants declared on them.
+            To <dfn data-export="">get a user object's attribute value</dfn>, given a <a class="dfnref" href="#idl-interface">callback interface type</a> value <var>object</var>
+            and attribute name <var>attributeName</var>, perform the following steps. These steps
+            will either return an IDL value or throw an exception.
           </p>
-          <p>
-            The value of a <a class="dfnref" href="#dfn-user-object">user object</a>’s
-            <a class="dfnref" href="#dfn-attribute">attribute</a> is retrieved using the
-            following algorithm:
-          </p>
+
           <ol class="algorithm">
-            <li>Try running the following steps:
+            <li>Let <var>completion</var> be an uninitialized variable.</li>
+
+            <li>Let <var>O</var> be the ECMAScript object corresponding to <var>object</var>.</li>
+
+            <li>Let <var>realm</var> be <var>O</var>'s <a class="dfnref" href="#dfn-associated-realm">associated Realm</a>.</li>
+
+            <li>Let <var>settings</var> be <var>realm</var>'s <a class="dfnref external" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object">settings
+            object</a>.</li>
+
+            <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script">Prepare to run script</a> with <var>settings</var>.</li>
+
+            <li>Let <var>getResult</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>O</var>, <var>attributeName</var>).</li>
+
+            <li>If <var>getResult</var> is an abrupt completion, set <var>completion</var> to
+            <var>getResult</var> and jump to the step labeled <a href="#get-user-object-attribute-return"><i>return</i></a>.</li>
+
+            <li>Set <var>completion</var> to the result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a>
+            <var>getResult</var>.[[Value]] to an IDL value of the same type as the attribute's
+            type.</li>
+
+            <li>
+              <i id="get-user-object-attribute-return">Return:</i> at this
+              point <var>completion</var> will be set to an ECMAScript completion value.
+
               <ol>
-                <li>Let <var>V</var> be the IDL <a class="dfnref" href="#idl-interface">callback interface type</a> value
-                  that represents the <a class="dfnref" href="#dfn-user-object">user object</a> implementing the <a class="dfnref" href="#dfn-interface">interface</a>.</li>
-                <li>Let <var>O</var> be the ECMAScript object corresponding to <var>V</var>.</li>
-                <li>Let <var>P</var> be the <a class="dfnref" href="#dfn-identifier">identifier</a> of the attribute.</li>
-                <li>Let <var>script</var> be the <a class="dfnref" href="#dfn-callback-context">callback context</a> associated with <var>V</var>.</li>
-                <li>Push <var>script</var> on to the <a class="dfnref external" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html">stack of incumbent scripts</a>. <a href="#ref-HTML">[HTML]</a></li>
-                <li>Let <var>R</var> be an uninitialized variable.</li>
-                <li>Try running the following step:
-                  <ol>
-                    <li>Set <var>R</var> to the result of invoking the <span class="prop">[[Get]]</span> method of <var>O</var> with property name <var>P</var>.</li>
-                  </ol>
-                  And then, whether or not an exception was thrown:
-                  <ol>
-                    <li>Pop <var>script</var> off the <a class="dfnref external" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html">stack of incumbent scripts</a>.</li>
-                    <li>If an exception was thrown, end these steps, and allow it to propagate.</li>
-                  </ol>
-                </li>
-                <li>Return the result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a> <var>R</var> to an IDL value of the same type as the attribute’s type.</li>
-              </ol>
-              And then, if an exception was thrown:
-              <ol>
-                <li>If the attribute has a <a class="dfnref" href="#dfn-return-type">return type</a> that is a <a href="#idl-promise">promise type</a>, then:
-                  <ol>
-                    <li>Let <var>reject</var> be the initial value of <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Promise%</a>.reject.</li>
-                    <li>Return the result of calling <var>reject</var> with <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Promise%</a> as the <span class="esvalue">this</span> object and the exception as the single argument value.</li>
-                  </ol>
-                </li>
-                <li>Otherwise, end these steps and allow the exception to propagate.</li>
+                <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script">Clean up after running script</a> with <var>settings</var>.</li>
+
+                <li>If <var>completion</var> is a normal completion, return
+                <var>completion</var>.</li>
+
+                <li>If <var>completion</var> is an abrupt completion and the attribute's type is
+                <em>not</em> a <a href="#idl-promise">promise type</a>, return
+                <var>completion</var>.</li>
+
+                <li>Let <var>reject</var> be the initial value of <a class="external" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.</li>
+
+                <li>Let <var>rejectedPromise</var> be the result of calling <var>reject</var> with
+                <a class="external" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a> as the <span class="esvalue">this</span> value and
+                <var>completion</var>.[[Value]] as the single argument value.</li>
+
+                <li>Return the result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a>
+                <var>rejectedPromise</var> to the attribute's type.</li>
               </ol>
             </li>
           </ol>
+
           <p>
-            The value of a <a class="dfnref" href="#dfn-user-object">user object</a>’s
-            <a class="dfnref" href="#dfn-attribute">attribute</a> is set using the
-            following algorithm:
+            To <dfn data-export="">set a user object's attribute value</dfn>, given a <a class="dfnref" href="#idl-interface">callback interface type</a> value
+            <var>object</var>, attribute name <var>attributeName</var>, and IDL value
+            <var>value</var>, perform the following steps. These steps will not return anything, but
+            could throw an exception.
           </p>
+
           <ol class="algorithm">
-            <li>Let <var>V</var> be the IDL <a class="dfnref" href="#idl-interface">callback interface type</a> value
-              that represents the <a class="dfnref" href="#dfn-user-object">user object</a> implementing the <a class="dfnref" href="#dfn-interface">interface</a>.</li>
-            <li>Let <var>O</var> be the ECMAScript object corresponding to <var>V</var>.</li>
-            <li>Let <var>P</var> be the <a class="dfnref" href="#dfn-identifier">identifier</a> of the attribute.</li>
-            <li>Let <var>V</var> be the IDL value to be assigned to the attribute.</li>
-            <li>Let <var>W</var> be the result of <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a> <var>V</var> to an ECMAScript value.</li>
-            <li>Let <var>script</var> be the <a class="dfnref" href="#dfn-callback-context">callback context</a> associated with <var>V</var>.</li>
-            <li>Push <var>script</var> on to the <a class="dfnref external" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html">stack of incumbent scripts</a>. <a href="#ref-HTML">[HTML]</a></li>
-            <li>Try running the following step:
+            <li>Let <var>completion</var> be an uninitialized variable.</li>
+
+            <li>Let <var>O</var> be the ECMAScript object corresponding to <var>object</var>.</li>
+
+            <li>Let <var>realm</var> be <var>O</var>'s <a class="dfnref" href="#dfn-associated-realm">associated Realm</a>.</li>
+
+            <li>Let <var>settings</var> be <var>realm</var>'s <a class="dfnref external" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object">settings
+            object</a>.</li>
+
+            <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script">Prepare to run script</a> with <var>settings</var>.</li>
+
+            <li>Let <var>convertResult</var> be the result of <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a> <var>value</var> to an
+            ECMAScript value.</li>
+
+            <li>If <var>convertResult</var> is an abrupt completion, set <var>completion</var> to
+            <var>convertResult</var> and jump to the step labeled <a href="#set-user-object-attribute-return"><i>return</i></a>.</li>
+
+            <li>Set <var>completion</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-set-o-p-v-throw">Set</a>(<var>O</var>, <var>attributeName</var>,
+            <var>convertResult</var>.[[Value]], <span class="esvalue">true</span>).</li>
+
+            <li>
+              <i id="set-user-object-attribute-return">Return:</i> at this
+              point <var>completion</var> will be set to an ECMAScript completion value, which is
+              either an abrupt completion or a normal completion for the value <span class="esvalue">true</span> (as returned by <a class="external" href="https://tc39.github.io/ecma262/#sec-set-o-p-v-throw">Set</a>).
+
               <ol>
-                <li>Invoke the <span class="prop">[[Put]]</span> method of <var>O</var> with property name <var>P</var> and value <var>W</var>.</li>
-              </ol>
-              And then, whether or not an exception was thrown:
-              <ol>
-                <li>Pop <var>script</var> off the <a class="dfnref external" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html">stack of incumbent scripts</a>.</li>
-                <li>If an exception was thrown, end these steps, and allow it to propagate.</li>
+                <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script">Clean up after running script</a> with <var>settings</var>.</li>
+
+                <li>If <var>completion</var> is an abrupt completion, return
+                <var>completion</var>.</li>
+
+                <li>Return <a class="external" href="https://tc39.github.io/ecma262/#sec-normalcompletion">NormalCompletion</a>(<a class="idltype" href="#idl-void">void</a>).</li>
               </ol>
             </li>
           </ol>
@@ -14162,66 +14270,116 @@ C implements A;</code></pre></div></div>
             used as a <a class="dfnref" href="#dfn-callback-function">callback function</a> value is
             called in a manner similar to how <a class="dfnref" href="#dfn-operation">operations</a>
             on <a class="dfnref" href="#dfn-user-object">user objects</a> are called (as
-            described in the previous section).  The <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">callable</a> object
-            is called with a list of values
-            <var>arg</var><sub>0..<var>n</var>−1</sub>,
-            each of which is either an IDL value of the special value “missing” (representing
-            a missing optional argument), by
-            following the algorithm below.  By default, the <a class="dfnref" href="#dfn-callback-this-value">callback this value</a>
-            when invoking a <a class="dfnref" href="#dfn-callback-function">callback function</a>
-            is <span class="esvalue">undefined</span>, unless overridden by other specifications.
+            described in the previous section).
           </p>
+
+          <p>
+            To <dfn data-export="">invoke</dfn> a <a class="dfnref" href="#idl-callback-function">callback function type</a> value <var>callable</var> with
+            a list of arguments <var>arg</var><sub>0..<var>n</var>−1</sub>, each of which is either
+            an IDL value or the special value “missing” (representing a missing optional argument),
+            and with optional <a class="dfnref" href="#dfn-callback-this-value">callback this
+            value</a> <var>thisArg</var>, perform the following steps. These steps will either
+            return an IDL value or throw an exception.
+          </p>
+
           <ol class="algorithm">
-            <li>Try running the following steps:
+            <li>Let <var>completion</var> be an uninitialized variable.</li>
+
+            <li>If <var>thisArg</var> was not given, let <var>thisArg</var> be <span class="esvalue">undefined</span>.</li>
+
+            <li>Let <var>F</var> be the ECMAScript object corresponding to <var>value</var>.</li>
+
+            <li>
+              If <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>F</var>) is <span class="esvalue">false</span>:
+
               <ol>
-                <li>Let <var>V</var> be the IDL <a class="dfnref" href="#idl-callback-function">callback function type</a> value.</li>
-                <li>Let <var>F</var> be the ECMAScript object corresponding to <var>V</var>.</li>
-                <li>Let <var>R</var> be an uninitialized variable.</li>
-                <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>F</var>) is false, then set <var>R</var> to the value <span class="estype">undefined</span>.</li>
-                <li>Otherwise,
-                <ol>
-                <li>Initialize <var>values</var> to be an empty list of ECMAScript values.</li>
-                <li>Initialize <var>count</var> to 0.</li>
-                <li>Initialize <var>i</var> to 0.</li>
-                <li>While <var>i</var> &lt; <var>n</var>:
-                  <ol>
-                    <li>If <var>arg</var><sub><var>i</var></sub> is the special value “missing”, then append to <var>values</var> the ECMAScript <span class="estype">undefined</span> value.</li>
-                    <li>Otherwise, <var>arg</var><sub><var>i</var></sub> is an IDL value.  Append to <var>values</var> the result of
-                      <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a> <var>arg</var><sub><var>i</var></sub> to an ECMAScript value,
-                      and set <var>count</var> to <var>i</var> + 1.</li>
-                    <li>Set <var>i</var> to <var>i</var> + 1.</li>
-                  </ol>
-                </li>
-                <li>Truncate <var>values</var> to have length <var>count</var>.</li>
-                <li>Let <var>script</var> be the <a class="dfnref" href="#dfn-callback-context">callback context</a> associated with <var>V</var>.</li>
-                <li>Push <var>script</var> on to the <a class="dfnref external" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html">stack of incumbent scripts</a>. <a href="#ref-HTML">[HTML]</a></li>
-                <li>Try running the following step:
-                  <ol>
-                    <li>Set <var>R</var> to the result of invoking the <span class="prop">[[Call]]</span> method of <var>F</var>, providing the <a class="dfnref" href="#dfn-callback-this-value">callback this value</a> as the <span class="esvalue">this</span> value and <var>values</var> as the argument values.</li>
-                  </ol>
-                  And then, whether or not an exception was thrown:
-                  <ol>
-                    <li>Pop <var>script</var> off the <a class="dfnref external" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html">stack of incumbent scripts</a>.</li>
-                    <li>If an exception was thrown, end these steps, and allow it to propagate.</li>
-                  </ol>
-                </li>
-                </ol>
-                </li>
-                <li>If the callback function’s return type is <a class="idltype" href="#idl-void">void</a>, return.</li>
                 <li>
-                  Return the result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a>
-                  <var>R</var> to an IDL value of the same type as the callback function’s return type.
+                  <p>If the callback function's return type is <a class="idltype" href="#idl-void">void</a>,
+                  return.</p>
+
+                  <div class="note"><div class="noteHeader">Note</div>
+                    <p>This is only possible when the callback function came from an attribute
+                    marked with <a class="xattr" href="#TreatNonObjectAsNull">[TreatNonObjectAsNull]</a>.</p>
+                  </div>
                 </li>
+
+                <li>Return the result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a> <span class="esvalue">undefined</span> to the callback function's return type.</li>
               </ol>
-              And then, if an exception was thrown:
+            </li>
+
+            <li>Let <var>realm</var> be <var>F</var>'s <a class="dfnref" href="#dfn-associated-realm">associated Realm</a>.</li>
+
+            <li>Let <var>settings</var> be <var>realm</var>'s <a class="dfnref external" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object">settings
+            object</a>.</li>
+
+            <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script">Prepare to run script</a> with <var>settings</var>.</li>
+
+            <li>Let <var>esArgs</var> be an empty List of ECMAScript values.</li>
+
+            <li>Let <var>i</var> be 0.</li>
+
+            <li>Let <var>count</var> be 0.</li>
+
+            <li>
+              While <var>i</var> &lt; <var>n</var>:
+
               <ol>
-                <li>If the callback function has a <a class="dfnref" href="#dfn-return-type">return type</a> that is a <a href="#idl-promise">promise type</a>, then:
+                <li>If <var>arg</var><sub><var>i</var></sub> is the special value “missing”, then
+                append <span class="esvalue">undefined</span> to <var>esArgs</var>.</li>
+
+                <li>
+                  Otherwise, <var>arg</var><sub><var>i</var></sub> is an IDL value:
+
                   <ol>
-                    <li>Let <var>reject</var> be the initial value of <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Promise%</a>.reject.</li>
-                    <li>Return the result of calling <var>reject</var> with <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Promise%</a> as the <span class="esvalue">this</span> object and the exception as the single argument value.</li>
+                    <li>Let <var>convertResult</var> be the result of <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a>
+                    <var>arg</var><sub><var>i</var></sub> to an ECMAScript value.</li>
+
+                    <li>If <var>convertResult</var> is an abrupt completion, set <var>completion</var>
+                    to <var>convertResult</var> and jump to the step labeled <a href="#invoke-return"><i>return</i></a>.</li>
+
+                    <li>Append <var>convertResult</var>.[[Value]] to <var>esArgs</var>.</li>
+
+                    <li>Set <var>count</var> to <var>i</var> + 1.</li>
                   </ol>
                 </li>
-                <li>Otherwise, end these steps and allow the exception to propagate.</li>
+
+                <li>Set <var>i</var> to <var>i</var> + 1.</li>
+              </ol>
+            </li>
+
+            <li>Truncate <var>esArgs</var> to have length <var>count</var>.</li>
+
+            <li>Let <var>callResult</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-call">Call</a>(<var>X</var>, <var>thisArg</var>,
+            <var>esArgs</var>).</li>
+
+            <li>If <var>callResult</var> is an abrupt completion, set <var>completion</var> to
+            <var>callResult</var> and jump to the step labeled <a href="#invoke-return"><i>return</i></a>.</li>
+
+            <li>Set <var>completion</var> to the result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a>
+            <var>callResult</var>.[[Value]] to an IDL value of the same type as the operation’s
+            return type.</li>
+
+            <li>
+              <i id="invoke-return">Return:</i> at this
+              point <var>completion</var> will be set to an ECMAScript completion value.
+
+              <ol>
+                <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script">Clean up after running script</a> with <var>settings</var>.</li>
+
+                <li>If <var>completion</var> is a normal completion, return
+                <var>completion</var>.</li>
+
+                <li>If <var>completion</var> is an abrupt completion and the callback function has a
+                <a class="dfnref" href="#dfn-return-type">return type</a> that is <em>not</em> a <a href="#idl-promise">promise type</a>, return <var>completion</var>.</li>
+
+                <li>Let <var>reject</var> be the initial value of <a class="external" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.</li>
+
+                <li>Let <var>rejectedPromise</var> be the result of calling <var>reject</var> with
+                <a class="external" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a> as the <span class="esvalue">this</span> value and
+                <var>completion</var>.[[Value]] as the single argument value.</li>
+
+                <li>Return the result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a>
+                <var>rejectedPromise</var> to the callback function's return type.</li>
               </ol>
             </li>
           </ol>

--- a/index.xml
+++ b/index.xml
@@ -82,7 +82,7 @@
         <term name='%ErrorPrototype%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
         <term name='%FunctionPrototype%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
         <term name='%ObjProto_toString%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
-        <term name='%Promise%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
+        <term name='%Promise%' class='external' href='https://tc39.github.io/ecma262/#sec-promise-constructor'/>
         <term name='%IteratorPrototype%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
         <term name='Property Descriptor' class='external' href='https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type' ref='ECMA-262' section='6.2.4'/>
         <term name='array index' class='external' href='https://tc39.github.io/ecma262/#sec-array-exotic-objects' ref='ECMA-262' section='9.4.2'/>
@@ -91,6 +91,8 @@
         <term name='default [[Set]] internal method' class='external' href='https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver' ref='ECMA-262' section='9.1.9'/>
         <term name='equally close values' class='external' href='https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type' ref='ECMA-262' section='6.1.6'/>
         <term name='internal slot' class='external' href='https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots'/>
+        <term name='JavaScript execution context stack' class='external' href='https://tc39.github.io/ecma262/#execution-context-stack'/>
+        <term name='running JavaScript execution context' class='external' href='https://tc39.github.io/ecma262/#running-execution-context'/>
         <term name="ReturnIfAbrupt" class='external'
               href='https://tc39.github.io/ecma262/#sec-returnifabrupt'/>
         <term name='GetMethod' class='external'
@@ -131,18 +133,36 @@
               href='https://tc39.github.io/ecma262/#sec-array-iterator-objects'/>
         <term name='array iterator objects' class='external'
               href='https://tc39.github.io/ecma262/#sec-array-iterator-objects'/>
+        <term name='Call' class='external'
+              href='https://tc39.github.io/ecma262/#sec-call'/>
         <term name='Get' class='external'
               href='https://tc39.github.io/ecma262/#sec-get-o-p'/>
+        <term name='Set' class='external'
+              href='https://tc39.github.io/ecma262/#sec-set-o-p-v-throw'/>
         <term name='IsConstructor' class='external'
               href='https://tc39.github.io/ecma262/#sec-isconstructor'/>
         <term name='Construct' class='external'
               href='https://tc39.github.io/ecma262/#sec-construct'/>
         <term name='DefinePropertyOrThrow' class='external'
               href='https://tc39.github.io/ecma262/#sec-definepropertyorthrow'/>
+        <term name='Realm' class='external'
+              href='https://tc39.github.io/ecma262/#sec-code-realms'/>
+        <term name='Completion' class='external'
+              href='https://tc39.github.io/ecma262/#sec-completion-record-specification-type'/>
+        <term name='!' class='external'
+              href='https://tc39.github.io/ecma262/#sec-algorithm-conventions'/>
+        <term name='?' class='external'
+              href='https://tc39.github.io/ecma262/#sec-algorithm-conventions'/>
         <term name='relevant settings object' class='external'
               href='https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object'/>
+        <term name='relevant Realm' class='external'
+              href='https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm'/>
         <term name='secure context' class='external'
               href='https://w3c.github.io/webappsec-secure-contexts/#secure-context'/>
+        <term name='Prepare to run script' class='external'
+              href='https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script'/>
+        <term name='Clean up after running script' class='external'
+              href='https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script'/>
       </links>
     </options>
   </head>
@@ -272,6 +292,7 @@
             <li>Unicode characters: <span class='char'>U+0030 DIGIT ZERO ("0")</span></li>
             <li>Extended attributes: <span class='xattr'>[ExampleExtendedAttribute]</span></li>
             <li>Variable names in prose and algorithms: <var>exampleVariableName</var>.</li>
+            <li>Algorithms use <a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">the conventions of the ECMAScript specification</a>, including the ! and ? notation for unwrapping completion records.</li>
             <li>IDL informal syntax examples:
               <pre class='syntax'>interface <i>identifier</i> {
   <em>interface-members…</em>
@@ -6368,6 +6389,18 @@ iframe.appendChild instanceof w.Function;  <span class='comment'>// Evaluates to
               for Web pages.
             </p>
           </div>
+
+          <p>
+            Although at the time of this writing the ECMAScript specification does not reflect this,
+            every ECMAScript object must have an <dfn data-export=''
+            id='dfn-associated-realm'>associated <a class='external'>Realm</a></dfn>. The mechanisms
+            for associating objects with Realms are, for now, underspecified. However, we note that
+            in the case of <a class='dfnref' href='#dfn-platform-object'>platform objects</a>, the
+            associated Realm is equal to the object's <a class='external'>relevant Realm</a>, and
+            for non-exotic function objects (i.e. not callable proxies, and not bound functions)
+            the associated Realm is equal to the value of the function object's [[Realm]] internal
+            slot.
+          </p>
         </div>
 
         <div id='es-type-mapping' class='section'>
@@ -13889,6 +13922,15 @@ C implements A;</x:codeblock>
               property name that is that identifier.
             </li>
           </ul>
+
+          <p>
+            Note that ECMAScript objects need not have
+            properties corresponding to <a class='dfnref' href='#dfn-constant'>constants</a>
+            on them to be considered as <a class='dfnref' href='#dfn-user-object'>user objects</a>
+            implementing <a class='dfnref' href='#dfn-interface'>interfaces</a> that happen
+            to have constants declared on them.
+          </p>
+
           <p>
             A <dfn data-export="" id='dfn-single-operation-callback-interface'>single operation callback interface</dfn> is
             a <a class='dfnref' href='#dfn-callback-interface'>callback interface</a> that:
@@ -13899,138 +13941,252 @@ C implements A;</x:codeblock>
             <li>has one or more <a class='dfnref' href='#dfn-regular-operation'>regular operations</a> that all have the same <a class='dfnref' href='#dfn-identifier'>identifier</a>,
               and no others.</li>
           </ul>
+
           <p>
-            A <a class='dfnref' href='#dfn-user-object'>user object</a>’s
-            <a class='dfnref' href='#dfn-operation'>operation</a> is called
-            with a list of IDL argument values <var>idlarg</var><sub>0..<var>n</var>−1</sub> by
-            following the algorithm below.  The <dfn data-export="" id='dfn-callback-this-value'>callback this value</dfn>
-            is the value to use as the <span class='esvalue'>this</span> value
-            when a <a>callable</a>
-            object was supplied as the implementation of a
-            <a class='dfnref' href='#dfn-single-operation-callback-interface'>single operation callback interface</a>.
-            By default, <span class='esvalue'>undefined</span> is used as the <a class='dfnref' href='#dfn-callback-this-value'>callback this value</a>,
-            however this <span class='rfc2119'>MAY</span> be overridden by other
-            specifications.
+            To <dfn>call a user object's operation</dfn>, given a <a class='dfnref'
+            href='#idl-interface'>callback interface type</a> value <var>value</var>,
+            sometimes-optional operation name <var>opName</var>, list of argument values
+            <var>arg</var><sub>0..<var>n</var>−1</sub> each of which is either an IDL value or the
+            special value “missing” (representing a missing optional argument), and optional <dfn
+            data-export='' id='dfn-callback-this-value'>callback this value</dfn>
+            <var>thisArg</var>, perform the following steps. These steps will either return an IDL
+            value or throw an exception.
           </p>
+
           <ol class='algorithm'>
-            <li>Try running the following steps:
+            <li>Let <var>completion</var> be an uninitialized variable.</li>
+
+            <li>If <var>thisArg</var> was not given, let <var>thisArg</var> be <span
+            class='esvalue'>undefined</span>.</li>
+
+            <li>Let <var>O</var> be the ECMAScript object corresponding to <var>value</var>.</li>
+
+            <li>Let <var>realm</var> be <var>O</var>'s <a class='dfnref'
+            href='#dfn-associated-realm'>associated Realm</a>.</li>
+
+            <li>Let <var>settings</var> be <var>realm</var>'s <a class='dfnref external'
+            href='https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object'>settings
+            object</a>.</li>
+
+            <li><a>Prepare to run script</a> with <var>settings</var>.</li>
+
+            <li>
+              Determine the implementation of the operation, <var>X</var>:
+
               <ol>
-                <li>Let <var>V</var> be the IDL <a class='dfnref' href='#idl-interface'>callback interface type</a> value
-                  that represents the <a class='dfnref' href='#dfn-user-object'>user object</a> implementing the <a class='dfnref' href='#dfn-interface'>interface</a>.</li>
-                <li>Let <var>O</var> be the ECMAScript object corresponding to <var>V</var>.</li>
-                <li>Let <var>X</var> be the implementation of the operation.  If the interface is a <a class='dfnref' href='#dfn-single-operation-callback-interface'>single operation callback interface</a> and <a>IsCallable</a>(<var>O</var>) is true, then <var>X</var> is <var>O</var>.
-                  Otherwise, <var>X</var> is the result of calling
-                  the internal <span class='prop'>[[Get]]</span> method of <var>O</var> with the identifier of the operation as the property name.</li>
-                <li>If <a>Type</a>(<var>X</var>) is not Object, <a href='#ecmascript-throw' class='dfnref external'>throw a <span class='estype'>TypeError</span></a> exception.</li>
-                <li>If <a>IsCallable</a>(<var>X</var>) is false, then <a href='#ecmascript-throw' class='dfnref external'>throw a <span class='estype'>TypeError</span></a> exception.</li>
-                <li>Let <var>this</var> be <var>O</var> if the interface is not a <a class='dfnref' href='#dfn-single-operation-callback-interface'>single operation callback interface</a>
-                  or if <a>IsCallable</a>(<var>O</var>) is false,
-                  and the <a class='dfnref' href='#dfn-callback-this-value'>callback this value</a> otherwise.</li>
+                <li>If <var>value</var>'s interface is a <a class='dfnref'
+                href='#dfn-single-operation-callback-interface'>single operation callback
+                interface</a> and <a>!</a> <a>IsCallable</a>(<var>O</var>) is true, then set
+                <var>X</var> to <var>O</var>.</li>
+
                 <li>
-                  Let <var>arg</var><sub>0..<var>n</var>−1</sub> be a list of
-                  ECMAScript values, where <var>arg</var><sub><var>i</var></sub> is the result
-                  of <a class='dfnref' href='#dfn-convert-idl-to-ecmascript-value'>converting</a>
-                  <var>idlarg</var><sub><var>i</var></sub> to an ECMAScript value.
-                </li>
-                <li>Let <var>script</var> be the <a class='dfnref' href='#dfn-callback-context'>callback context</a> associated with <var>V</var>.</li>
-                <li>Push <var>script</var> on to the <a class='dfnref external' href='http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html'>stack of incumbent scripts</a>. <a href='#ref-HTML'>[HTML]</a></li>
-                <li>Let <var>R</var> be an uninitialized variable.</li>
-                <li>Try running the following step:
+                  Otherwise, <var>opName</var> must be supplied:
                   <ol>
-                    <li>Set <var>R</var> to the result of invoking the <span class='prop'>[[Call]]</span> method of <var>X</var>, providing <var>this</var> as the <span class='esvalue'>this</span> value and <var>arg</var><sub>0..<var>n</var>−1</sub> as the argument values.</li>
+                    <li>Let <var>getResult</var> be <a>Get</a>(<var>O</var>,
+                    <var>opName</var>).</li>
+
+                    <li>If <var>getResult</var> is an abrupt completion, set <var>completion</var>
+                    to <var>getResult</var> and jump to the step labeled <a
+                    href='#call-user-object-operation-return'><i>return</i></a>.</li>
+
+                    <li>Set <var>X</var> to <var>getResult</var>.[[Value]].</li>
                   </ol>
-                  And then, whether or not an exception was thrown:
-                  <ol>
-                    <li>Pop <var>script</var> off the <a class='dfnref external' href='http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html'>stack of incumbent scripts</a>.</li>
-                    <li>If an exception was thrown, end these steps, and allow it to propagate.</li>
-                  </ol>
-                </li>
-                <li>If the operation’s return type is <span class='idltype'>void</span>, return.</li>
-                <li>
-                  Return the result of <a class='dfnref' href='#dfn-convert-ecmascript-to-idl-value'>converting</a>
-                  <var>R</var> to an IDL value of the same type as the operation’s return type.
                 </li>
               </ol>
-              And then, if an exception was thrown:
+            </li>
+
+
+            <li>If <a>!</a> <a>IsCallable</a>(<var>X</var>) is <span class='esvalue'>false</span>,
+            then set <var>completion</var> to a new <a>Completion</a>{[[Type]]: throw, [[Value]]: a
+            newly created <span class='estype'>TypeError</span> object, [[Target]]: empty}, and jump
+            to the step labeled <a href='#call-user-object-operation-return'><i>return</i></a>.</li>
+
+            <li>If <var>value</var>'s interface is not a <a class='dfnref'
+            href='#dfn-single-operation-callback-interface'>single operation callback interface</a>,
+            or if <a>!</a> <a>IsCallable</a>(<var>O</var>) is <span class='esvalue'>false</span>,
+            set <var>thisArg</var> to <var>O</var> (overriding the provided value).</li>
+
+            <li>Let <var>esArgs</var> be an empty List of ECMAScript values.</li>
+
+            <li>Let <var>i</var> be 0.</li>
+
+            <li>Let <var>count</var> be 0.</li>
+
+            <li>
+              While <var>i</var> &lt; <var>n</var>:
+
               <ol>
-                <li>If the operation has a <a class='dfnref' href='#dfn-return-type'>return type</a> that is a <a href='#idl-promise'>promise type</a>, then:
+                <li>If <var>arg</var><sub><var>i</var></sub> is the special value “missing”, then
+                append <span class='esvalue'>undefined</span> to <var>esArgs</var>.</li>
+
+                <li>
+                  Otherwise, <var>arg</var><sub><var>i</var></sub> is an IDL value:
+
                   <ol>
-                    <li>Let <var>reject</var> be the initial value of <a class='nocite'>%Promise%</a>.reject.</li>
-                    <li>Return the result of calling <var>reject</var> with <a class='nocite'>%Promise%</a> as the <span class='esvalue'>this</span> object and the exception as the single argument value.</li>
+                    <li>Let <var>convertResult</var> be the result of <a class='dfnref'
+                    href='#dfn-convert-idl-to-ecmascript-value'>converting</a>
+                    <var>arg</var><sub><var>i</var></sub> to an ECMAScript value.</li>
+
+                    <li>If <var>convertResult</var> is an abrupt completion, set <var>completion</var>
+                    to <var>convertResult</var> and jump to the step labeled <a
+                    href='#call-user-object-operation-return'><i>return</i></a>.</li>
+
+                    <li>Append <var>convertResult</var>.[[Value]] to <var>esArgs</var>.</li>
+
+                    <li>Set <var>count</var> to <var>i</var> + 1.</li>
                   </ol>
                 </li>
-                <li>Otherwise, end these steps and allow the exception to propagate.</li>
+
+                <li>Set <var>i</var> to <var>i</var> + 1.</li>
+              </ol>
+            </li>
+
+            <li>Truncate <var>esArgs</var> to have length <var>count</var>.</li>
+
+            <li>Let <var>callResult</var> be <a>Call</a>(<var>X</var>, <var>thisArg</var>,
+            <var>esArgs</var>).</li>
+
+            <li>If <var>callResult</var> is an abrupt completion, set <var>completion</var> to
+            <var>callResult</var> and jump to the step labeled <a
+            href='#call-user-object-operation-return'><i>return</i></a>.</li>
+
+            <li>Set <var>completion</var> to the result of <a class='dfnref'
+            href='#dfn-convert-ecmascript-to-idl-value'>converting</a>
+            <var>callResult</var>.[[Value]] to an IDL value of the same type as the operation’s
+            return type.</li>
+
+            <li>
+              <i id='call-user-object-operation-return'>Return:</i> at this
+              point <var>completion</var> will be set to an ECMAScript completion value.
+
+              <ol>
+                <li><a>Clean up after running script</a> with <var>settings</var>.</li>
+
+                <li>If <var>completion</var> is a normal completion, return
+                <var>completion</var>.</li>
+
+                <li>If <var>completion</var> is an abrupt completion and the operation has a <a
+                class='dfnref' href='#dfn-return-type'>return type</a> that is <em>not</em> a <a
+                href='#idl-promise'>promise type</a>, return <var>completion</var>.</li>
+
+                <li>Let <var>reject</var> be the initial value of <a>%Promise%</a>.reject.</li>
+
+                <li>Let <var>rejectedPromise</var> be the result of calling <var>reject</var> with
+                <a>%Promise%</a> as the <span class='esvalue'>this</span> value and
+                <var>completion</var>.[[Value]] as the single argument value.</li>
+
+                <li>Return the result of <a class='dfnref'
+                href='#dfn-convert-ecmascript-to-idl-value'>converting</a>
+                <var>rejectedPromise</var> to the operation's return type.</li>
               </ol>
             </li>
           </ol>
+
           <p>
-            Note that ECMAScript objects need not have
-            properties corresponding to <a class='dfnref' href='#dfn-constant'>constants</a>
-            on them to be considered as <a class='dfnref' href='#dfn-user-object'>user objects</a>
-            implementing <a class='dfnref' href='#dfn-interface'>interfaces</a> that happen
-            to have constants declared on them.
+            To <dfn data-export="">get a user object's attribute value</dfn>, given a <a
+            class='dfnref' href='#idl-interface'>callback interface type</a> value <var>object</var>
+            and attribute name <var>attributeName</var>, perform the following steps. These steps
+            will either return an IDL value or throw an exception.
           </p>
-          <p>
-            The value of a <a class='dfnref' href='#dfn-user-object'>user object</a>’s
-            <a class='dfnref' href='#dfn-attribute'>attribute</a> is retrieved using the
-            following algorithm:
-          </p>
+
           <ol class='algorithm'>
-            <li>Try running the following steps:
+            <li>Let <var>completion</var> be an uninitialized variable.</li>
+
+            <li>Let <var>O</var> be the ECMAScript object corresponding to <var>object</var>.</li>
+
+            <li>Let <var>realm</var> be <var>O</var>'s <a class='dfnref'
+            href='#dfn-associated-realm'>associated Realm</a>.</li>
+
+            <li>Let <var>settings</var> be <var>realm</var>'s <a class='dfnref external'
+            href='https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object'>settings
+            object</a>.</li>
+
+            <li><a>Prepare to run script</a> with <var>settings</var>.</li>
+
+            <li>Let <var>getResult</var> be <a>Get</a>(<var>O</var>, <var>attributeName</var>).</li>
+
+            <li>If <var>getResult</var> is an abrupt completion, set <var>completion</var> to
+            <var>getResult</var> and jump to the step labeled <a
+            href='#get-user-object-attribute-return'><i>return</i></a>.</li>
+
+            <li>Set <var>completion</var> to the result of <a class='dfnref'
+            href='#dfn-convert-ecmascript-to-idl-value'>converting</a>
+            <var>getResult</var>.[[Value]] to an IDL value of the same type as the attribute's
+            type.</li>
+
+            <li>
+              <i id='get-user-object-attribute-return'>Return:</i> at this
+              point <var>completion</var> will be set to an ECMAScript completion value.
+
               <ol>
-                <li>Let <var>V</var> be the IDL <a class='dfnref' href='#idl-interface'>callback interface type</a> value
-                  that represents the <a class='dfnref' href='#dfn-user-object'>user object</a> implementing the <a class='dfnref' href='#dfn-interface'>interface</a>.</li>
-                <li>Let <var>O</var> be the ECMAScript object corresponding to <var>V</var>.</li>
-                <li>Let <var>P</var> be the <a class='dfnref' href='#dfn-identifier'>identifier</a> of the attribute.</li>
-                <li>Let <var>script</var> be the <a class='dfnref' href='#dfn-callback-context'>callback context</a> associated with <var>V</var>.</li>
-                <li>Push <var>script</var> on to the <a class='dfnref external' href='http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html'>stack of incumbent scripts</a>. <a href='#ref-HTML'>[HTML]</a></li>
-                <li>Let <var>R</var> be an uninitialized variable.</li>
-                <li>Try running the following step:
-                  <ol>
-                    <li>Set <var>R</var> to the result of invoking the <span class='prop'>[[Get]]</span> method of <var>O</var> with property name <var>P</var>.</li>
-                  </ol>
-                  And then, whether or not an exception was thrown:
-                  <ol>
-                    <li>Pop <var>script</var> off the <a class='dfnref external' href='http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html'>stack of incumbent scripts</a>.</li>
-                    <li>If an exception was thrown, end these steps, and allow it to propagate.</li>
-                  </ol>
-                </li>
-                <li>Return the result of <a class='dfnref' href='#dfn-convert-ecmascript-to-idl-value'>converting</a> <var>R</var> to an IDL value of the same type as the attribute’s type.</li>
-              </ol>
-              And then, if an exception was thrown:
-              <ol>
-                <li>If the attribute has a <a class='dfnref' href='#dfn-return-type'>return type</a> that is a <a href='#idl-promise'>promise type</a>, then:
-                  <ol>
-                    <li>Let <var>reject</var> be the initial value of <a class='nocite'>%Promise%</a>.reject.</li>
-                    <li>Return the result of calling <var>reject</var> with <a class='nocite'>%Promise%</a> as the <span class='esvalue'>this</span> object and the exception as the single argument value.</li>
-                  </ol>
-                </li>
-                <li>Otherwise, end these steps and allow the exception to propagate.</li>
+                <li><a>Clean up after running script</a> with <var>settings</var>.</li>
+
+                <li>If <var>completion</var> is a normal completion, return
+                <var>completion</var>.</li>
+
+                <li>If <var>completion</var> is an abrupt completion and the attribute's type is
+                <em>not</em> a <a href='#idl-promise'>promise type</a>, return
+                <var>completion</var>.</li>
+
+                <li>Let <var>reject</var> be the initial value of <a>%Promise%</a>.reject.</li>
+
+                <li>Let <var>rejectedPromise</var> be the result of calling <var>reject</var> with
+                <a>%Promise%</a> as the <span class='esvalue'>this</span> value and
+                <var>completion</var>.[[Value]] as the single argument value.</li>
+
+                <li>Return the result of <a class='dfnref'
+                href='#dfn-convert-ecmascript-to-idl-value'>converting</a>
+                <var>rejectedPromise</var> to the attribute's type.</li>
               </ol>
             </li>
           </ol>
+
           <p>
-            The value of a <a class='dfnref' href='#dfn-user-object'>user object</a>’s
-            <a class='dfnref' href='#dfn-attribute'>attribute</a> is set using the
-            following algorithm:
+            To <dfn data-export=''>set a user object's attribute value</dfn>, given a <a
+            class='dfnref' href='#idl-interface'>callback interface type</a> value
+            <var>object</var>, attribute name <var>attributeName</var>, and IDL value
+            <var>value</var>, perform the following steps. These steps will not return anything, but
+            could throw an exception.
           </p>
+
           <ol class='algorithm'>
-            <li>Let <var>V</var> be the IDL <a class='dfnref' href='#idl-interface'>callback interface type</a> value
-              that represents the <a class='dfnref' href='#dfn-user-object'>user object</a> implementing the <a class='dfnref' href='#dfn-interface'>interface</a>.</li>
-            <li>Let <var>O</var> be the ECMAScript object corresponding to <var>V</var>.</li>
-            <li>Let <var>P</var> be the <a class='dfnref' href='#dfn-identifier'>identifier</a> of the attribute.</li>
-            <li>Let <var>V</var> be the IDL value to be assigned to the attribute.</li>
-            <li>Let <var>W</var> be the result of <a class='dfnref' href='#dfn-convert-idl-to-ecmascript-value'>converting</a> <var>V</var> to an ECMAScript value.</li>
-            <li>Let <var>script</var> be the <a class='dfnref' href='#dfn-callback-context'>callback context</a> associated with <var>V</var>.</li>
-            <li>Push <var>script</var> on to the <a class='dfnref external' href='http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html'>stack of incumbent scripts</a>. <a href='#ref-HTML'>[HTML]</a></li>
-            <li>Try running the following step:
+            <li>Let <var>completion</var> be an uninitialized variable.</li>
+
+            <li>Let <var>O</var> be the ECMAScript object corresponding to <var>object</var>.</li>
+
+            <li>Let <var>realm</var> be <var>O</var>'s <a class='dfnref'
+            href='#dfn-associated-realm'>associated Realm</a>.</li>
+
+            <li>Let <var>settings</var> be <var>realm</var>'s <a class='dfnref external'
+            href='https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object'>settings
+            object</a>.</li>
+
+            <li><a>Prepare to run script</a> with <var>settings</var>.</li>
+
+            <li>Let <var>convertResult</var> be the result of <a class='dfnref'
+            href='#dfn-convert-idl-to-ecmascript-value'>converting</a> <var>value</var> to an
+            ECMAScript value.</li>
+
+            <li>If <var>convertResult</var> is an abrupt completion, set <var>completion</var> to
+            <var>convertResult</var> and jump to the step labeled <a
+            href='#set-user-object-attribute-return'><i>return</i></a>.</li>
+
+            <li>Set <var>completion</var> to <a>Set</a>(<var>O</var>, <var>attributeName</var>,
+            <var>convertResult</var>.[[Value]], <span class='esvalue'>true</span>).</li>
+
+            <li>
+              <i id='set-user-object-attribute-return'>Return:</i> at this
+              point <var>completion</var> will be set to an ECMAScript completion value, which is
+              either an abrupt completion or a normal completion for the value <span
+              class='esvalue'>true</span> (as returned by <a>Set</a>).
+
               <ol>
-                <li>Invoke the <span class='prop'>[[Put]]</span> method of <var>O</var> with property name <var>P</var> and value <var>W</var>.</li>
-              </ol>
-              And then, whether or not an exception was thrown:
-              <ol>
-                <li>Pop <var>script</var> off the <a class='dfnref external' href='http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html'>stack of incumbent scripts</a>.</li>
-                <li>If an exception was thrown, end these steps, and allow it to propagate.</li>
+                <li><a>Clean up after running script</a> with <var>settings</var>.</li>
+
+                <li>If <var>completion</var> is an abrupt completion, return
+                <var>completion</var>.</li>
+
+                <li>Return <a>NormalCompletion</a>(<span class='idltype'>void</span>).</li>
               </ol>
             </li>
           </ol>
@@ -14044,66 +14200,129 @@ C implements A;</x:codeblock>
             used as a <a class='dfnref' href='#dfn-callback-function'>callback function</a> value is
             called in a manner similar to how <a class='dfnref' href='#dfn-operation'>operations</a>
             on <a class='dfnref' href='#dfn-user-object'>user objects</a> are called (as
-            described in the previous section).  The <a>callable</a> object
-            is called with a list of values
-            <var>arg</var><sub>0..<var>n</var>−1</sub>,
-            each of which is either an IDL value of the special value “missing” (representing
-            a missing optional argument), by
-            following the algorithm below.  By default, the <a class='dfnref' href='#dfn-callback-this-value'>callback this value</a>
-            when invoking a <a class='dfnref' href='#dfn-callback-function'>callback function</a>
-            is <span class='esvalue'>undefined</span>, unless overridden by other specifications.
+            described in the previous section).
           </p>
+
+          <p>
+            To <dfn data-export=''>invoke</dfn> a <a class='dfnref'
+            href='#idl-callback-function'>callback function type</a> value <var>callable</var> with
+            a list of arguments <var>arg</var><sub>0..<var>n</var>−1</sub>, each of which is either
+            an IDL value or the special value “missing” (representing a missing optional argument),
+            and with optional <a class='dfnref' href='#dfn-callback-this-value'>callback this
+            value</a> <var>thisArg</var>, perform the following steps. These steps will either
+            return an IDL value or throw an exception.
+          </p>
+
           <ol class='algorithm'>
-            <li>Try running the following steps:
+            <li>Let <var>completion</var> be an uninitialized variable.</li>
+
+            <li>If <var>thisArg</var> was not given, let <var>thisArg</var> be <span
+            class='esvalue'>undefined</span>.</li>
+
+            <li>Let <var>F</var> be the ECMAScript object corresponding to <var>value</var>.</li>
+
+            <li>
+              If <a>!</a> <a>IsCallable</a>(<var>F</var>) is <span class='esvalue'>false</span>:
+
               <ol>
-                <li>Let <var>V</var> be the IDL <a class='dfnref' href='#idl-callback-function'>callback function type</a> value.</li>
-                <li>Let <var>F</var> be the ECMAScript object corresponding to <var>V</var>.</li>
-                <li>Let <var>R</var> be an uninitialized variable.</li>
-                <li>If <a>IsCallable</a>(<var>F</var>) is false, then set <var>R</var> to the value <span class='estype'>undefined</span>.</li>
-                <li>Otherwise,
-                <ol>
-                <li>Initialize <var>values</var> to be an empty list of ECMAScript values.</li>
-                <li>Initialize <var>count</var> to 0.</li>
-                <li>Initialize <var>i</var> to 0.</li>
-                <li>While <var>i</var> &lt; <var>n</var>:
-                  <ol>
-                    <li>If <var>arg</var><sub><var>i</var></sub> is the special value “missing”, then append to <var>values</var> the ECMAScript <span class='estype'>undefined</span> value.</li>
-                    <li>Otherwise, <var>arg</var><sub><var>i</var></sub> is an IDL value.  Append to <var>values</var> the result of
-                      <a class='dfnref' href='#dfn-convert-idl-to-ecmascript-value'>converting</a> <var>arg</var><sub><var>i</var></sub> to an ECMAScript value,
-                      and set <var>count</var> to <var>i</var> + 1.</li>
-                    <li>Set <var>i</var> to <var>i</var> + 1.</li>
-                  </ol>
-                </li>
-                <li>Truncate <var>values</var> to have length <var>count</var>.</li>
-                <li>Let <var>script</var> be the <a class='dfnref' href='#dfn-callback-context'>callback context</a> associated with <var>V</var>.</li>
-                <li>Push <var>script</var> on to the <a class='dfnref external' href='http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html'>stack of incumbent scripts</a>. <a href='#ref-HTML'>[HTML]</a></li>
-                <li>Try running the following step:
-                  <ol>
-                    <li>Set <var>R</var> to the result of invoking the <span class='prop'>[[Call]]</span> method of <var>F</var>, providing the <a class='dfnref' href='#dfn-callback-this-value'>callback this value</a> as the <span class='esvalue'>this</span> value and <var>values</var> as the argument values.</li>
-                  </ol>
-                  And then, whether or not an exception was thrown:
-                  <ol>
-                    <li>Pop <var>script</var> off the <a class='dfnref external' href='http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html'>stack of incumbent scripts</a>.</li>
-                    <li>If an exception was thrown, end these steps, and allow it to propagate.</li>
-                  </ol>
-                </li>
-                </ol>
-                </li>
-                <li>If the callback function’s return type is <span class='idltype'>void</span>, return.</li>
                 <li>
-                  Return the result of <a class='dfnref' href='#dfn-convert-ecmascript-to-idl-value'>converting</a>
-                  <var>R</var> to an IDL value of the same type as the callback function’s return type.
+                  <p>If the callback function's return type is <span class='idltype'>void</span>,
+                  return.</p>
+
+                  <div class='note'>
+                    <p>This is only possible when the callback function came from an attribute
+                    marked with <a class='xattr'
+                    href='#TreatNonObjectAsNull'>[TreatNonObjectAsNull]</a>.</p>
+                  </div>
                 </li>
+
+                <li>Return the result of <a class='dfnref'
+                href='#dfn-convert-ecmascript-to-idl-value'>converting</a> <span
+                class='esvalue'>undefined</span> to the callback function's return type.</li>
               </ol>
-              And then, if an exception was thrown:
+            </li>
+
+            <li>Let <var>realm</var> be <var>F</var>'s <a class='dfnref'
+            href='#dfn-associated-realm'>associated Realm</a>.</li>
+
+            <li>Let <var>settings</var> be <var>realm</var>'s <a class='dfnref external'
+            href='https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object'>settings
+            object</a>.</li>
+
+            <li><a>Prepare to run script</a> with <var>settings</var>.</li>
+
+            <li>Let <var>esArgs</var> be an empty List of ECMAScript values.</li>
+
+            <li>Let <var>i</var> be 0.</li>
+
+            <li>Let <var>count</var> be 0.</li>
+
+            <li>
+              While <var>i</var> &lt; <var>n</var>:
+
               <ol>
-                <li>If the callback function has a <a class='dfnref' href='#dfn-return-type'>return type</a> that is a <a href='#idl-promise'>promise type</a>, then:
+                <li>If <var>arg</var><sub><var>i</var></sub> is the special value “missing”, then
+                append <span class='esvalue'>undefined</span> to <var>esArgs</var>.</li>
+
+                <li>
+                  Otherwise, <var>arg</var><sub><var>i</var></sub> is an IDL value:
+
                   <ol>
-                    <li>Let <var>reject</var> be the initial value of <a class='nocite'>%Promise%</a>.reject.</li>
-                    <li>Return the result of calling <var>reject</var> with <a class='nocite'>%Promise%</a> as the <span class='esvalue'>this</span> object and the exception as the single argument value.</li>
+                    <li>Let <var>convertResult</var> be the result of <a class='dfnref'
+                    href='#dfn-convert-idl-to-ecmascript-value'>converting</a>
+                    <var>arg</var><sub><var>i</var></sub> to an ECMAScript value.</li>
+
+                    <li>If <var>convertResult</var> is an abrupt completion, set <var>completion</var>
+                    to <var>convertResult</var> and jump to the step labeled <a
+                    href='#invoke-return'><i>return</i></a>.</li>
+
+                    <li>Append <var>convertResult</var>.[[Value]] to <var>esArgs</var>.</li>
+
+                    <li>Set <var>count</var> to <var>i</var> + 1.</li>
                   </ol>
                 </li>
-                <li>Otherwise, end these steps and allow the exception to propagate.</li>
+
+                <li>Set <var>i</var> to <var>i</var> + 1.</li>
+              </ol>
+            </li>
+
+            <li>Truncate <var>esArgs</var> to have length <var>count</var>.</li>
+
+            <li>Let <var>callResult</var> be <a>Call</a>(<var>X</var>, <var>thisArg</var>,
+            <var>esArgs</var>).</li>
+
+            <li>If <var>callResult</var> is an abrupt completion, set <var>completion</var> to
+            <var>callResult</var> and jump to the step labeled <a
+            href='#invoke-return'><i>return</i></a>.</li>
+
+            <li>Set <var>completion</var> to the result of <a class='dfnref'
+            href='#dfn-convert-ecmascript-to-idl-value'>converting</a>
+            <var>callResult</var>.[[Value]] to an IDL value of the same type as the operation’s
+            return type.</li>
+
+            <li>
+              <i id='invoke-return'>Return:</i> at this
+              point <var>completion</var> will be set to an ECMAScript completion value.
+
+              <ol>
+                <li><a>Clean up after running script</a> with <var>settings</var>.</li>
+
+                <li>If <var>completion</var> is a normal completion, return
+                <var>completion</var>.</li>
+
+                <li>If <var>completion</var> is an abrupt completion and the callback function has a
+                <a class='dfnref' href='#dfn-return-type'>return type</a> that is <em>not</em> a <a
+                href='#idl-promise'>promise type</a>, return <var>completion</var>.</li>
+
+                <li>Let <var>reject</var> be the initial value of <a>%Promise%</a>.reject.</li>
+
+                <li>Let <var>rejectedPromise</var> be the result of calling <var>reject</var> with
+                <a>%Promise%</a> as the <span class='esvalue'>this</span> value and
+                <var>completion</var>.[[Value]] as the single argument value.</li>
+
+                <li>Return the result of <a class='dfnref'
+                href='#dfn-convert-ecmascript-to-idl-value'>converting</a>
+                <var>rejectedPromise</var> to the callback function's return type.</li>
               </ol>
             </li>
           </ol>


### PR DESCRIPTION
This updates the four algorithms that invoke user code in the following ways:

- Updates them to use HTML's latest framework for managing script settings objects. The previous version referred to concepts, such as the "stack of incumbent scripts", which have not been defined for a long time (i.e. since before whatwg/html#401). Updates in whatwg/html#401 and whatwg/html#1091 have changed the setup here. There is still some ongoing discussion in whatwg/html#473 about whether the current HTML setup is correct for managing _incumbent_ settings objects, but this at least updates the algorithms to correctly manage _entry_ settings objects. The plan implemented here is roughly that discussed in https://github.com/whatwg/html/issues/473#issuecomment-212164549.
- Gives them explicit `<dfn>`s with explicit arguments to be passed.
- Updates them to use some slightly-more-modern ES technology such as Call(), Get(), and Set().

This also updates all ECMAScript references to point to the latest spec.

--

Review appreciated @bzbarsky. As I say above, incumbent might be a bit messed up at the moment, but I am pretty sure this is a strict improvement. I wanted to finish off fixing "entry"; now I need to go off an take care of incumbent.