### PR TITLE
Update links to ES2017.

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED" type="text/css" /></head>
 
   <body>
-    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL (Second Edition)</h1><h2>W3C Editor’s Draft <em>2 May 2016</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/">http://heycam.github.io/webidl/</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
+    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL (Second Edition)</h1><h2>W3C Editor’s Draft <em>4 May 2016</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/">http://heycam.github.io/webidl/</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
               Send feedback to <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a> or <a href="https://www.w3.org/Bugs/Public/enter_bug.cgi?product=WebAppsWG&amp;component=WebIDL">file a bug</a> (<a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=WebIDL&amp;resolution=---">open bugs</a>)
             </dd><dt>Editors:</dt><dd><a href="http://mcc.id.au/">Cameron McCormack</a>, Mozilla Corporation &lt;cam@mcc.id.au&gt;</dd><dd>Boris Zbarsky, Mozilla Corporation &lt;bzbarsky@mit.edu&gt;</dd></dl><p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &copy; 2016 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>&reg;</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p></div><hr /><script async="" src="file-bug.js"></script>
 
@@ -72,7 +72,7 @@
         report can be found in the <a href="http://www.w3.org/TR/">W3C technical
           reports index</a> at http://www.w3.org/TR/.
       </em></p><p>
-        This document is the 2 May 2016 <b>Editor’s Draft</b> of the
+        This document is the 4 May 2016 <b>Editor’s Draft</b> of the
         <cite>Web IDL (Second Edition)</cite> specification.
       
       Please send comments about this document to
@@ -1185,7 +1185,7 @@ node.appendChild(newNode);  <span class="comment">// This will throw a TypeError
             <ol class="algorithm">
               <li>Let <var>S</var> be the sequence of characters matched by the <a class="sym" href="#prod-float">float</a> token.</li>
               <li>Let <var>value</var> be the Mathematical Value that would be obtained if <var>S</var> were
-                parsed as an ECMAScript <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-numeric-literals"><em>NumericLiteral</em></a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 11.8.3).</li>
+                parsed as an ECMAScript <a class="external" href="https://tc39.github.io/ecma262/#sec-literals-numeric-literals"><em>NumericLiteral</em></a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 11.8.3).</li>
               <li>
                 If the <a class="sym" href="#prod-float">float</a> token is being
                 used as the value for a <a class="idltype" href="#idl-float">float</a> or
@@ -3613,7 +3613,7 @@ iterable&lt;<i>key-type</i>, <i>value-type</i>&gt;;</pre>
             </p>
             <div class="note"><div class="noteHeader">Note</div>
               <p>In the ECMAScript language binding, an interface that is iterable
-              will have “entries”, “forEach”, “keys”, “values” and <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@iterator</a>
+              will have “entries”, “forEach”, “keys”, “values” and <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a>
               properties on its <a class="dfnref" href="#dfn-interface-prototype-object">interface prototype object</a>.</p>
             </div>
             <p>
@@ -3670,10 +3670,10 @@ iterable&lt;<i>key-type</i>, <i>value-type</i>&gt;;</pre>
               </p>
             </div>
             <div class="note"><div class="noteHeader">Note</div>
-              <p>This is how <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array-iterator-objects">array iterator objects</a> work.
+              <p>This is how <a class="external" href="https://tc39.github.io/ecma262/#sec-array-iterator-objects">array iterator objects</a> work.
                 For interfaces that <a class="dfnref" href="#dfn-support-indexed-properties">support indexed properties</a>,
-                the iterator objects returned by “entries”, “keys”, “values” and <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@iterator</a> are
-                actual <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array-iterator-objects">array iterator objects</a>.</p>
+                the iterator objects returned by “entries”, “keys”, “values” and <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> are
+                actual <a class="external" href="https://tc39.github.io/ecma262/#sec-array-iterator-objects">array iterator objects</a>.</p>
             </div>
             <p>
               Interfaces with iterable declarations <span class="rfc2119">MUST NOT</span>
@@ -3716,7 +3716,7 @@ interface Session {
                 next value to be iterated over.  It has <code>values</code> and <code>entries</code>
                 methods that iterate over the indexes of the list of session objects
                 and [index, session object] pairs, respectively.  It also has
-                a <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@iterator</a> method that allows a <span class="idltype">SessionManager</span>
+                a <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> method that allows a <span class="idltype">SessionManager</span>
                 to be used in a <code>for..of</code> loop:
               </p>
               <div class="block"><div class="blockTitleDiv"><span class="blockTitle">ECMAScript</span></div><div class="blockContent"><pre class="code"><code class="es-code"><span class="comment">// Get an instance of SessionManager.
@@ -3812,7 +3812,7 @@ maplike&lt;<i>key-type</i>, <i>value-type</i>&gt;;</pre>
                 with the map entries is similar to that available on ECMAScript
                 <span class="estype">Map</span> objects.  If the <code>readonly</code>
                 keyword is used, this includes “entries”, “forEach”, “get”, “has”,
-                “keys”, “values”, <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@iterator</a> methods and a “size” getter.
+                “keys”, “values”, <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> methods and a “size” getter.
                 For read–write maplikes, it also includes “clear”, “delete” and
                 “set” methods.
               </p>
@@ -3896,7 +3896,7 @@ setlike&lt;<i>type</i>&gt;;</pre>
                 with the set entries is similar to that available on ECMAScript
                 <span class="estype">Set</span> objects.  If the <code>readonly</code>
                 keyword is used, this includes “entries”, “forEach”, “has”,
-                “keys”, “values”, <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@iterator</a> methods and a “size” getter.
+                “keys”, “values”, <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> methods and a “size” getter.
                 For read–write setlikes, it also includes “add”, “clear”, and “delete” methods.
               </p>
             </div>
@@ -4272,7 +4272,7 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
             <li><span class="idltype"><dfn data-export="" data-dfn-type="interface">URIError</dfn></span></li>
           </ul>
           <p>
-            These correspond to all of the <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-error-objects">ECMAScript error objects</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 19.5) (apart from
+            These correspond to all of the <a class="external" href="https://tc39.github.io/ecma262/#sec-error-objects">ECMAScript error objects</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 19.5) (apart from
             <span class="estype">SyntaxError</span>, which is deliberately omitted as
             it is for use only by the ECMAScript parser).
             The meaning of
@@ -5806,7 +5806,7 @@ interface Person {
               whose values are references to objects that “is used as a place holder
               for the eventual results of a deferred (and possibly asynchronous) computation
               result of an asynchronous operation” <a href="#ref-ECMA-262">[ECMA-262]</a>.
-              See <a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects">section 25.4</a>
+              See <a href="https://tc39.github.io/ecma262/#sec-promise-objects">section 25.4</a>
               of the ECMAScript specification for details on the semantics of promise objects.
             </p>
             <p>
@@ -6334,8 +6334,8 @@ interface Person {
         </p>
         <p>
           Objects defined in this section have internal properties as described in
-          ECMA-262 <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ordinary-object-internal-methods-and-internal-slots">sections 9.1</a> and
-          <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-built-in-function-objects-call-thisargument-argumentslist">9.3.1</a> unless otherwise specified, in which case one or
+          ECMA-262 <a class="external" href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots">sections 9.1</a> and
+          <a class="external" href="https://tc39.github.io/ecma262/#sec-built-in-function-objects-call-thisargument-argumentslist">9.3.1</a> unless otherwise specified, in which case one or
           more of the following are redefined in accordance with the rules for exotic objects:
           <span class="prop">[[Call]]</span>,
           <span class="prop">[[Set]]</span>,
@@ -6371,12 +6371,12 @@ interface Person {
           Some objects described in this section are defined to have a <dfn data-export="" id="dfn-class-string">class string</dfn>,
           which is the string to include in the string returned from Object.prototype.toString.
           If an object has a class string, then the object <span class="rfc2119">MUST</span>,
-          at the time it is created, have a property whose name is the <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@toStringTag</a> symbol
+          at the time it is created, have a property whose name is the <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@toStringTag</a> symbol
           and whose value is the specified string.
         </p>
         <div class="ednote"><div class="ednoteHeader">Editorial note</div>
-          <p>Should define whether <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@toStringTag</a> is writable, enumerable and configurable.
-            All <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@toStringTag</a> properties in the ES6 spec are non-writable and non-enumerable,
+          <p>Should define whether <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@toStringTag</a> is writable, enumerable and configurable.
+            All <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@toStringTag</a> properties in the ES6 spec are non-writable and non-enumerable,
             and configurable.</p>
         </div>
         <p>
@@ -6385,28 +6385,28 @@ interface Person {
         </p>
         <ul>
           <li>Its <span class="prop">[[Prototype]]</span> internal property is
-          <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%FunctionPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4) unless otherwise specified.</li>
-          <li>Its <span class="prop">[[Get]]</span> internal property is set as described in <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver">ECMA-262 section 9.1.8</a>.</li>
-          <li>Its <span class="prop">[[Construct]]</span> internal property is set as described in <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-@@create">ECMA-262 section 19.2.2.3</a>.</li>
-          <li>Its <span class="prop">@@hasInstance</span> property is set as described in <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-function.prototype-@@hasinstance">ECMA-262 section 19.2.3.8</a>, unless otherwise specified.</li>
+          <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%FunctionPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4) unless otherwise specified.</li>
+          <li>Its <span class="prop">[[Get]]</span> internal property is set as described in <a class="external" href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver">ECMA-262 section 9.1.8</a>.</li>
+          <li>Its <span class="prop">[[Construct]]</span> internal property is set as described in <a class="external" href="https://tc39.github.io/ecma262/#sec-function-@@create">ECMA-262 section 19.2.2.3</a>.</li>
+          <li>Its <span class="prop">@@hasInstance</span> property is set as described in <a class="external" href="https://tc39.github.io/ecma262/#sec-function.prototype-@@hasinstance">ECMA-262 section 19.2.3.8</a>, unless otherwise specified.</li>
         </ul>
         <div class="ednote"><div class="ednoteHeader">Editorial note</div>
           <p>The list above needs updating for the latest ES6 draft.</p>
         </div>
         <p id="ecmascript-abstractop">
-          Algorithms in this section use the conventions described in <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">ECMA-262
+          Algorithms in this section use the conventions described in <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">ECMA-262
           section 5.2</a>, such as the use of steps and substeps, the use of mathematical
           operations, and so on.  The
-          <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toboolean">ToBoolean</a>,
-          <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tonumber">ToNumber</a>,
-          <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-touint16">ToUint16</a>,
-          <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toint32">ToInt32</a>,
-          <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-touint32">ToUint32</a>,
-          <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tostring">ToString</a>,
-          <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toobject">ToObject</a>,
-          <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-isaccessordescriptor">IsAccessorDescriptor</a> and
-          <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-isdatadescriptor">IsDataDescriptor</a> abstract operations and the
-          <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type(<var>x</var>)</a>
+          <a class="external" href="https://tc39.github.io/ecma262/#sec-toboolean">ToBoolean</a>,
+          <a class="external" href="https://tc39.github.io/ecma262/#sec-tonumber">ToNumber</a>,
+          <a class="external" href="https://tc39.github.io/ecma262/#sec-touint16">ToUint16</a>,
+          <a class="external" href="https://tc39.github.io/ecma262/#sec-toint32">ToInt32</a>,
+          <a class="external" href="https://tc39.github.io/ecma262/#sec-touint32">ToUint32</a>,
+          <a class="external" href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a>,
+          <a class="external" href="https://tc39.github.io/ecma262/#sec-toobject">ToObject</a>,
+          <a class="external" href="https://tc39.github.io/ecma262/#sec-isaccessordescriptor">IsAccessorDescriptor</a> and
+          <a class="external" href="https://tc39.github.io/ecma262/#sec-isdatadescriptor">IsDataDescriptor</a> abstract operations and the
+          <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type(<var>x</var>)</a>
           notation referenced in this section are defined in ECMA-262 sections 6 and 7.
         </p>
         <p id="ecmascript-throw">
@@ -6427,11 +6427,11 @@ interface Person {
           </p>
           <ol class="algorithm">
             <li>Let <var>x</var> be the ECMAScript value passed in to this algorithm.</li>
-            <li>Let <var>y</var> be the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tostring">ToString</a>(<var>x</var>).</li>
+            <li>Let <var>y</var> be the result of calling <a class="external" href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a>(<var>x</var>).</li>
             <li>Return <var>y</var>.</li>
           </ol>
           <p>
-            Since <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tostring">ToString</a> can throw an exception (for example if passed the object
+            Since <a class="external" href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a> can throw an exception (for example if passed the object
             <code>({ toString: function() { throw 1 } })</code>), and the exception is
             not handled in the above algorithm, if one is thrown then it causes this
             algorithm to end and for the exception to propagate out to its caller, if there
@@ -6468,7 +6468,7 @@ interface Person {
             <li><a class="dfnref" href="#dfn-named-properties-object">named properties objects</a></li>
           </ul>
           <p>
-            Each <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-code-realms">ECMAScript global environment</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 8.2)
+            Each <a class="external" href="https://tc39.github.io/ecma262/#sec-code-realms">ECMAScript global environment</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 8.2)
             <span class="rfc2119">MUST</span> have its own unique set of each of
             the <a class="dfnref" href="#dfn-initial-object">initial objects</a>, created
             before control enters any ECMAScript execution context associated with the
@@ -6627,7 +6627,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>Let <var>x</var> be the result of computing <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toboolean">ToBoolean</a>(<var>V</var>).</li>
+              <li>Let <var>x</var> be the result of computing <a class="external" href="https://tc39.github.io/ecma262/#sec-toboolean">ToBoolean</a>(<var>V</var>).</li>
               <li>Return the IDL <a class="idltype" href="#idl-boolean">boolean</a> value that is the one that represents the same truth value as the ECMAScript <span class="estype">Boolean</span> value <var>x</var>.</li>
             </ol>
             <p id="boolean-to-es">
@@ -6649,7 +6649,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>Initialize <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
+              <li>Initialize <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
               <li>If the conversion to an IDL value is being performed due to any of the following:
                 <ul>
                   <li><var>V</var> is being assigned to an <a class="dfnref" href="#dfn-attribute">attribute</a> annotated with the <a class="xattr" href="#EnforceRange">[EnforceRange]</a> <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>,</li>
@@ -6659,7 +6659,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 then:
                 <ol>
                   <li>If <var>x</var> is <span class="esvalue">NaN</span>, +∞, or −∞, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
-                  <li>Set <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">floor</a>(<a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
+                  <li>Set <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">floor</a>(<a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
                   <li>If <var>x</var> &lt; −2<sup>7</sup> or <var>x</var> &gt; 2<sup>7</sup> − 1, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
                   <li>Return the IDL <a class="idltype" href="#idl-byte">byte</a> value that represents the same numeric value as <var>x</var>.</li>
                 </ol>
@@ -6678,8 +6678,8 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 </ol>
               </li>
               <li>If <var>x</var> is <span class="esvalue">NaN</span>, +0, −0, +∞, or −∞, then return the IDL <a class="idltype" href="#idl-byte">byte</a> value that represents 0.</li>
-              <li>Set <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">floor</a>(<a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
-              <li>Set <var>x</var> to <var>x</var> <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">modulo</a> 2<sup>8</sup>.</li>
+              <li>Set <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">floor</a>(<a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
+              <li>Set <var>x</var> to <var>x</var> <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">modulo</a> 2<sup>8</sup>.</li>
               <li>If <var>x</var> ≥ 2<sup>7</sup>, return the IDL <a class="idltype" href="#idl-byte">byte</a> value that represents the same numeric value as <var>x</var> − 2<sup>8</sup>.
                 Otherwise, return the IDL <a class="idltype" href="#idl-byte">byte</a> value that represents the same numeric value as <var>x</var>.</li>
             </ol>
@@ -6702,7 +6702,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>Initialize <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
+              <li>Initialize <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
               <li>If the conversion to an IDL value is being performed due to any of the following:
                 <ul>
                   <li><var>V</var> is being assigned to an <a class="dfnref" href="#dfn-attribute">attribute</a> annotated with the <a class="xattr" href="#EnforceRange">[EnforceRange]</a> <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>,</li>
@@ -6712,7 +6712,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 then:
                 <ol>
                   <li>If <var>x</var> is <span class="esvalue">NaN</span>, +∞, or −∞, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
-                  <li>Set <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">floor</a>(<a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
+                  <li>Set <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">floor</a>(<a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
                   <li>If <var>x</var> &lt; 0 or <var>x</var> &gt; 2<sup>8</sup> − 1, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
                   <li>Return the IDL <a class="idltype" href="#idl-octet">octet</a> value that represents the same numeric value as <var>x</var>.</li>
                 </ol>
@@ -6731,8 +6731,8 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 </ol>
               </li>
               <li>If <var>x</var> is <span class="esvalue">NaN</span>, +0, −0, +∞, or −∞, then return the IDL <a class="idltype" href="#idl-octet">octet</a> value that represents 0.</li>
-              <li>Set <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">floor</a>(<a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
-              <li>Set <var>x</var> to <var>x</var> <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">modulo</a> 2<sup>8</sup>.</li>
+              <li>Set <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">floor</a>(<a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
+              <li>Set <var>x</var> to <var>x</var> <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">modulo</a> 2<sup>8</sup>.</li>
               <li>Return the IDL <a class="idltype" href="#idl-octet">octet</a> value that represents the same numeric value as <var>x</var>.</li>
             </ol>
             <p id="octet-to-es">
@@ -6755,7 +6755,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>Initialize <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
+              <li>Initialize <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
               <li>If the conversion to an IDL value is being performed due to any of the following:
                 <ul>
                   <li><var>V</var> is being assigned to an <a class="dfnref" href="#dfn-attribute">attribute</a> annotated with the <a class="xattr" href="#EnforceRange">[EnforceRange]</a> <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>,</li>
@@ -6765,7 +6765,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 then:
                 <ol>
                   <li>If <var>x</var> is <span class="esvalue">NaN</span>, +∞, or −∞, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
-                  <li>Set <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">floor</a>(<a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
+                  <li>Set <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">floor</a>(<a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
                   <li>If <var>x</var> &lt; −2<sup>15</sup> or <var>x</var> &gt; 2<sup>15</sup> − 1, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
                   <li>Return the IDL <a class="idltype" href="#idl-short">short</a> value that represents the same numeric value as <var>x</var>.</li>
                 </ol>
@@ -6784,8 +6784,8 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 </ol>
               </li>
               <li>If <var>x</var> is <span class="esvalue">NaN</span>, +0, −0, +∞, or −∞, then return the IDL <a class="idltype" href="#idl-short">short</a> value that represents 0.</li>
-              <li>Set <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">floor</a>(<a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
-              <li>Set <var>x</var> to <var>x</var> <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">modulo</a> 2<sup>16</sup>.</li>
+              <li>Set <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">floor</a>(<a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
+              <li>Set <var>x</var> to <var>x</var> <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">modulo</a> 2<sup>16</sup>.</li>
               <li>If <var>x</var> ≥ 2<sup>15</sup>, return the IDL <a class="idltype" href="#idl-short">short</a> value that represents the same numeric value as <var>x</var> − 2<sup>16</sup>.
                 Otherwise, return the IDL <a class="idltype" href="#idl-short">short</a> value that represents the same numeric value as <var>x</var>.</li>
             </ol>
@@ -6809,7 +6809,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>Initialize <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
+              <li>Initialize <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
               <li>If the conversion to an IDL value is being performed due to any of the following:
                 <ul>
                   <li><var>V</var> is being assigned to an <a class="dfnref" href="#dfn-attribute">attribute</a> annotated with the <a class="xattr" href="#EnforceRange">[EnforceRange]</a> <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>,</li>
@@ -6819,7 +6819,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 then:
                 <ol>
                   <li>If <var>x</var> is <span class="esvalue">NaN</span>, +∞, or −∞, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
-                  <li>Set <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">floor</a>(<a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
+                  <li>Set <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">floor</a>(<a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
                   <li>If <var>x</var> &lt; 0 or <var>x</var> &gt; 2<sup>16</sup> − 1, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
                   <li>Return the IDL <a class="idltype" href="#idl-unsigned-short">unsigned short</a> value that represents the same numeric value as <var>x</var>.</li>
                 </ol>
@@ -6837,7 +6837,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                   <li>Return the IDL <a class="idltype" href="#idl-unsigned-short">unsigned short</a> value that represents the same numeric value as <var>x</var>.</li>
                 </ol>
               </li>
-              <li>Set <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-touint16">ToUint16</a>(<var>x</var>).</li>
+              <li>Set <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-touint16">ToUint16</a>(<var>x</var>).</li>
               <li>Return the IDL <a class="idltype" href="#idl-unsigned-short">unsigned short</a> value that represents the same numeric value as <var>x</var>.</li>
             </ol>
             <p id="unsigned-short-to-es">
@@ -6860,7 +6860,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>Initialize <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
+              <li>Initialize <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
               <li>If the conversion to an IDL value is being performed due to any of the following:
                 <ul>
                   <li><var>V</var> is being assigned to an <a class="dfnref" href="#dfn-attribute">attribute</a> annotated with the <a class="xattr" href="#EnforceRange">[EnforceRange]</a> <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>,</li>
@@ -6870,7 +6870,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 then:
                 <ol>
                   <li>If <var>x</var> is <span class="esvalue">NaN</span>, +∞, or −∞, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
-                  <li>Set <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">floor</a>(<a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
+                  <li>Set <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">floor</a>(<a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
                   <li>If <var>x</var> &lt; −2<sup>31</sup> or <var>x</var> &gt; 2<sup>31</sup> − 1, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
                   <li>Return the IDL <a class="idltype" href="#idl-long">long</a> value that represents the same numeric value as <var>x</var>.</li>
                 </ol>
@@ -6888,7 +6888,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                   <li>Return the IDL <a class="idltype" href="#idl-long">long</a> value that represents the same numeric value as <var>x</var>.</li>
                 </ol>
               </li>
-              <li>Set <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toint32">ToInt32</a>(<var>x</var>).</li>
+              <li>Set <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-toint32">ToInt32</a>(<var>x</var>).</li>
               <li>Return the IDL <a class="idltype" href="#idl-long">long</a> value that represents the same numeric value as <var>x</var>.</li>
             </ol>
             <p id="long-to-es">
@@ -6911,7 +6911,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>Initialize <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
+              <li>Initialize <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
               <li>If the conversion to an IDL value is being performed due to any of the following:
                 <ul>
                   <li><var>V</var> is being assigned to an <a class="dfnref" href="#dfn-attribute">attribute</a> annotated with the <a class="xattr" href="#EnforceRange">[EnforceRange]</a> <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>,</li>
@@ -6921,7 +6921,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 then:
                 <ol>
                   <li>If <var>x</var> is <span class="esvalue">NaN</span>, +∞, or −∞, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
-                  <li>Set <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">floor</a>(<a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
+                  <li>Set <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">floor</a>(<a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
                   <li>If <var>x</var> &lt; 0 or <var>x</var> &gt; 2<sup>32</sup> − 1, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
                   <li>Return the IDL <a class="idltype" href="#idl-unsigned-long">unsigned long</a> value that represents the same numeric value as <var>x</var>.</li>
                 </ol>
@@ -6939,7 +6939,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                   <li>Return the IDL <a class="idltype" href="#idl-unsigned-long">unsigned long</a> value that represents the same numeric value as <var>x</var>.</li>
                 </ol>
               </li>
-              <li>Set <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-touint32">ToUint32</a>(<var>x</var>).</li>
+              <li>Set <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-touint32">ToUint32</a>(<var>x</var>).</li>
               <li>Return the IDL <a class="idltype" href="#idl-unsigned-long">unsigned long</a> value that represents the same numeric value as <var>x</var>.</li>
             </ol>
             <p id="unsigned-long-to-es">
@@ -6962,7 +6962,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>Initialize <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
+              <li>Initialize <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
               <li>If the conversion to an IDL value is being performed due to any of the following:
                 <ul>
                   <li><var>V</var> is being assigned to an <a class="dfnref" href="#dfn-attribute">attribute</a> annotated with the <a class="xattr" href="#EnforceRange">[EnforceRange]</a> <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>,</li>
@@ -6972,7 +6972,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 then:
                 <ol>
                   <li>If <var>x</var> is <span class="esvalue">NaN</span>, +∞, or −∞, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
-                  <li>Set <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">floor</a>(<a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
+                  <li>Set <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">floor</a>(<a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
                   <li>If <var>x</var> &lt; −2<sup>53</sup> + 1 or <var>x</var> &gt; 2<sup>53</sup> − 1, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
                   <li>Return the IDL <a class="idltype" href="#idl-long-long">long long</a> value that represents the same numeric value as <var>x</var>.</li>
                 </ol>
@@ -6991,8 +6991,8 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 </ol>
               </li>
               <li>If <var>x</var> is <span class="esvalue">NaN</span>, +0, −0, +∞, or −∞, then return the IDL <a class="idltype" href="#idl-long-long">long long</a> value that represents 0.</li>
-              <li>Set <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">floor</a>(<a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
-              <li>Set <var>x</var> to <var>x</var> <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">modulo</a> 2<sup>64</sup>.</li>
+              <li>Set <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">floor</a>(<a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
+              <li>Set <var>x</var> to <var>x</var> <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">modulo</a> 2<sup>64</sup>.</li>
               <li>If <var>x</var> is greater than or equal to 2<sup>63</sup>, then set <var>x</var> to <var>x</var> − 2<sup>64</sup>.</li>
               <li>Return the IDL <a class="idltype" href="#idl-long-long">long long</a> value that represents the same numeric value as <var>x</var>.</li>
             </ol>
@@ -7002,7 +7002,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               value is a <span class="estype">Number</span> value that
               represents the closest numeric value to the <a class="idltype" href="#idl-long-long">long long</a>,
               choosing the numeric value with an <em>even significand</em> if there are
-              two <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-language-types-number-type">equally close values</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.6).
+              two <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">equally close values</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.6).
               If the <a class="idltype" href="#idl-long-long">long long</a> is in the range
               [−2<sup>53</sup> + 1, 2<sup>53</sup> − 1], then the <span class="estype">Number</span>
               will be able to represent exactly the same value as the
@@ -7020,7 +7020,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>Initialize <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
+              <li>Initialize <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
               <li>If the conversion to an IDL value is being performed due to any of the following:
                 <ul>
                   <li><var>V</var> is being assigned to an <a class="dfnref" href="#dfn-attribute">attribute</a> annotated with the <a class="xattr" href="#EnforceRange">[EnforceRange]</a> <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>,</li>
@@ -7030,7 +7030,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 then:
                 <ol>
                   <li>If <var>x</var> is <span class="esvalue">NaN</span>, +∞, or −∞, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
-                  <li>Set <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">floor</a>(<a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
+                  <li>Set <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">floor</a>(<a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
                   <li>If <var>x</var> &lt; 0 or <var>x</var> &gt; 2<sup>53</sup> − 1, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
                   <li>Return the IDL <a class="idltype" href="#idl-unsigned-long-long">unsigned long long</a> value that represents the same numeric value as <var>x</var>.</li>
                 </ol>
@@ -7049,8 +7049,8 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 </ol>
               </li>
               <li>If <var>x</var> is <span class="esvalue">NaN</span>, +0, −0, +∞, or −∞, then return the IDL <a class="idltype" href="#idl-unsigned-long-long">unsigned long long</a> value that represents 0.</li>
-              <li>Set <var>x</var> to <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">floor</a>(<a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
-              <li>Set <var>x</var> to <var>x</var> <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">modulo</a> 2<sup>64</sup>.</li>
+              <li>Set <var>x</var> to <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">sign</a>(<var>x</var>) * <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">floor</a>(<a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">abs</a>(<var>x</var>)).</li>
+              <li>Set <var>x</var> to <var>x</var> <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">modulo</a> 2<sup>64</sup>.</li>
               <li>Return the IDL <a class="idltype" href="#idl-unsigned-long-long">unsigned long long</a> value that represents the same numeric value as <var>x</var>.</li>
             </ol>
             <p id="unsigned-long-long-to-es">
@@ -7059,7 +7059,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               value is a <span class="estype">Number</span> value that
               represents the closest numeric value to the <a class="idltype" href="#idl-unsigned-long-long">unsigned long long</a>,
               choosing the numeric value with an <em>even significand</em> if there are
-              two <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-language-types-number-type">equally close values</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.6).
+              two <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">equally close values</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.6).
               If the <a class="idltype" href="#idl-unsigned-long-long">unsigned long long</a> is less than or equal to 2<sup>53</sup> − 1,
               then the <span class="estype">Number</span> will be able to
               represent exactly the same value as the
@@ -7077,7 +7077,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>Let <var>x</var> be <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
+              <li>Let <var>x</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
               <li>If <var>x</var> is <span class="esvalue">NaN</span>, <span class="esvalue">+Infinity</span> or
                 <span class="esvalue">−Infinity</span>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
               <li>
@@ -7088,7 +7088,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               <li>
                 Let <var>y</var> be the number in <var>S</var> that is closest
                 to <var>x</var>, selecting the number with an
-                <em>even significand</em> if there are two <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-language-types-number-type">equally close values</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.6).
+                <em>even significand</em> if there are two <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">equally close values</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.6).
                 (The two special values 2<sup>128</sup> and −2<sup>128</sup>
                 are considered to have even significands for this purpose.)
               </li>
@@ -7120,7 +7120,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>Let <var>x</var> be <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
+              <li>Let <var>x</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
               <li>If <var>x</var> is <span class="esvalue">NaN</span>, then return the IDL <a class="idltype" href="#idl-unrestricted-float">unrestricted float</a> value that represents the IEEE 754 NaN value with the bit pattern 0x7fc00000 <a href="#ref-IEEE-754">[IEEE-754]</a>.</li>
               <li>
                 Let <var>S</var> be the set of finite IEEE 754 single-precision floating
@@ -7130,7 +7130,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               <li>
                 Let <var>y</var> be the number in <var>S</var> that is closest
                 to <var>x</var>, selecting the number with an
-                <em>even significand</em> if there are two <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-language-types-number-type">equally close values</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.6).
+                <em>even significand</em> if there are two <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">equally close values</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.6).
                 (The two special values 2<sup>128</sup> and −2<sup>128</sup>
                 are considered to have even significands for this purpose.)
               </li>
@@ -7183,7 +7183,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>Let <var>x</var> be <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
+              <li>Let <var>x</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
               <li>If <var>x</var> is <span class="esvalue">NaN</span>, <span class="esvalue">+Infinity</span> or
                 <span class="esvalue">−Infinity</span>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
               <li>
@@ -7209,7 +7209,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>Let <var>x</var> be <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
+              <li>Let <var>x</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-tonumber">ToNumber</a>(<var>V</var>).</li>
               <li>If <var>x</var> is <span class="esvalue">NaN</span>, then return the IDL <a class="idltype" href="#idl-unrestricted-double">unrestricted double</a> value that represents the IEEE 754 NaN value with the bit pattern 0x7ff8000000000000 <a href="#ref-IEEE-754">[IEEE-754]</a>.</li>
               <li>
                 Return the IDL <a class="idltype" href="#idl-unrestricted-double">unrestricted double</a> value
@@ -7276,7 +7276,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 then return the <a class="idltype" href="#idl-DOMString">DOMString</a>
                 value that represents the empty string.
               </li>
-              <li>Let <var>x</var> be <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tostring">ToString</a>(<var>V</var>).</li>
+              <li>Let <var>x</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a>(<var>V</var>).</li>
               <li>Return the IDL <a class="idltype" href="#idl-DOMString">DOMString</a> value that represents the same sequence of code units as the one the ECMAScript <span class="estype">String</span> value <var>x</var> represents.</li>
             </ol>
             <p id="DOMString-to-es">
@@ -7298,8 +7298,8 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>Let <var>x</var> be <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tostring">ToString</a>(<var>V</var>).</li>
-              <li>If the value of any <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-language-types-string-type">element</a>
+              <li>Let <var>x</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a>(<var>V</var>).</li>
+              <li>If the value of any <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type">element</a>
                 of <var>x</var> is greater than 255, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
               <li>Return an IDL <a class="idltype" href="#idl-ByteString">ByteString</a> value
                 whose length is the length of <var>x</var>, and where the value of each element is
@@ -7356,7 +7356,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
+              <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
               <li>Return the IDL <a class="idltype" href="#idl-object">object</a> value that is a reference to the same object as <var>V</var>.</li>
             </ol>
             <p id="object-to-es">
@@ -7382,7 +7382,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               by running the following algorithm (where <var>I</var> is the <a class="dfnref" href="#dfn-interface">interface</a>):
             </p>
             <ol class="algorithm">
-              <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
+              <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
               <li>If <var>V</var> is a <a class="dfnref" href="#dfn-platform-object">platform object</a> that implements <var>I</var>, then return the IDL <a href="#idl-interface">interface type</a> value that represents a reference to that platform object.</li>
               <li>If <var>V</var> is a <a class="dfnref" href="#dfn-user-object">user object</a>
                 that is considered to implement <var>I</var> according to the rules in
@@ -7416,7 +7416,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               by running the following algorithm (where <var>D</var> is the <a class="dfnref" href="#dfn-dictionary">dictionary</a>):
             </p>
             <ol class="algorithm">
-              <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Undefined, Null or Object, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
+              <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Undefined, Null or Object, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
               <li>If <var>V</var> is a native <span class="estype">RegExp</span> object, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
               <li>Let <var>dict</var> be an empty dictionary value of type <var>D</var>;
               every <a class="dfnref" href="#dfn-dictionary-member">dictionary member</a>
@@ -7428,7 +7428,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                   <li>For each dictionary member <var>member</var> declared on <var>dictionary</var>, in lexicographical order:
                     <ol>
                       <li>Let <var>key</var> be the <a class="dfnref" href="#dfn-identifier">identifier</a> of <var>member</var>.</li>
-                      <li>Let <var>value</var> be an ECMAScript value, depending on <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>):
+                      <li>Let <var>value</var> be an ECMAScript value, depending on <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>):
                         <dl class="switch">
                           <dt>Undefined</dt>
                           <dt>Null</dt>
@@ -7515,7 +7515,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               value as follows (where <var>E</var> is the <a class="dfnref" href="#dfn-enumeration">enumeration</a>):
             </p>
             <ol class="algorithm">
-              <li>Let <var>S</var> be the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tostring">ToString</a>(<var>V</var>).</li>
+              <li>Let <var>S</var> be the result of calling <a class="external" href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a>(<var>V</var>).</li>
               <li>If <var>S</var> is not one of <var>E</var>’s <a class="dfnref" href="#dfn-enumeration-value">enumeration values</a>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
               <li>Return the enumeration value of type <var>E</var> that is equal to <var>S</var>.</li>
             </ol>
@@ -7543,7 +7543,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>If the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">IsCallable</a>(<var>V</var>) is <span class="esvalue">false</span> and the conversion to an IDL value
+              <li>If the result of calling <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>V</var>) is <span class="esvalue">false</span> and the conversion to an IDL value
               is not being performed due
                 to <var>V</var> being assigned to an <a class="dfnref" href="#dfn-attribute">attribute</a>
                 whose type is a <a class="dfnref" href="#dfn-nullable-type">nullable</a>
@@ -7580,7 +7580,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
             </p>
             <ol class="algorithm">
               <li>
-                If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object, and
+                If <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object, and
                 the conversion to an IDL value is being performed due
                 to <var>V</var> being assigned to an <a class="dfnref" href="#dfn-attribute">attribute</a>
                 whose type is a <a class="dfnref" href="#dfn-nullable-type">nullable</a>
@@ -7644,10 +7644,10 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               </li>
               <li>
                 Let <var>method</var> be the result of
-                <a class="external" href="http://www.ecma-international.org/ecma-262/6.0/#sec-getmethod">GetMethod</a>(<var>V</var>, <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@iterator</a>).
+                <a class="external" href="http://www.ecma-international.org/ecma-262/6.0/#sec-getmethod">GetMethod</a>(<var>V</var>, <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a>).
               </li>
               <li>
-                <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>method</var>).
+                <a class="external" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>method</var>).
               </li>
               <li>
                 If <var>method</var> is <span class="esvalue">undefined</span>,
@@ -7677,7 +7677,7 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                   <li>Let <var>V</var> be the value in <var>S</var> at index <var>i</var>.</li>
                   <li>Let <var>E</var> be the result of <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a>
                     <var>V</var> to an ECMAScript value.</li>
-                  <li>Let <var>P</var> be the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tostring">ToString</a>(<var>i</var>).</li>
+                  <li>Let <var>P</var> be the result of calling <a class="external" href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a>(<var>i</var>).</li>
                   <li>Call the <span class="prop">[[DefineOwnProperty]]</span> internal method on <var>A</var> with property name <var>P</var>,
                     Property Descriptor <span class="descriptor">{ [[Writable]]: <span class="esvalue">true</span>, [[Enumerable]]: <span class="esvalue">true</span>, [[Configurable]]: <span class="esvalue">true</span>, [[Value]]: <var>E</var> }</span>
                     and Boolean flag <span class="esvalue">false</span>.</li>
@@ -7697,18 +7697,18 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               <ol class="algorithm">
                 <li>
                   Let <var>iter</var> be
-                  <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-getiterator">GetIterator</a>(<var>iterable</var>, <var>method</var>).
+                  <a class="external" href="https://tc39.github.io/ecma262/#sec-getiterator">GetIterator</a>(<var>iterable</var>, <var>method</var>).
                 </li>
                 <li>
-                  <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>iter</var>).
+                  <a class="external" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>iter</var>).
                 </li>
                 <li>Initialize <var>i</var> to be 0.</li>
                 <li>Repeat
                 <ol>
                   <li>
-                    Let <var>next</var> be <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iteratorstep">IteratorStep</a>(<var>iter</var>).
+                    Let <var>next</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-iteratorstep">IteratorStep</a>(<var>iter</var>).
                   </li>
-                  <li><a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>next</var>).</li>
+                  <li><a class="external" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>next</var>).</li>
                   <li>
                     If <var>next</var> is <span class="esvalue">false</span>,
                     then return an IDL sequence value of type
@@ -7719,9 +7719,9 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                   </li>
                   <li>
                     Let <var>nextItem</var> be
-                    <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iteratorvalue">IteratorValue</a>(<var>next</var>).
+                    <a class="external" href="https://tc39.github.io/ecma262/#sec-iteratorvalue">IteratorValue</a>(<var>next</var>).
                   </li>
-                  <li><a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>nextItem</var>).</li>
+                  <li><a class="external" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>nextItem</var>).</li>
                   <li>
                     Initialize <var>S</var><sub><var>i</var></sub> to the result of
                     <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a>
@@ -7893,12 +7893,12 @@ alert(b[4]);    <span class="comment">// This would alert "50".</span></code></p
               to an IDL <a class="idltype" href="#idl-promise">Promise&lt;<var>T</var>&gt;</a> value as follows:
             </p>
             <ol class="algorithm">
-              <li>Let <var>resolve</var> be the original value of <a class="nocite external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%Promise%</a>.resolve.
+              <li>Let <var>resolve</var> be the original value of <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Promise%</a>.resolve.
                 <div class="ednote"><div class="ednoteHeader">Editorial note</div>
                   <p>ECMAScript should grow a %Promise_resolve% well-known intrinsic object that can be referenced here.</p>
                 </div>
               </li>
-              <li>Let <var>promise</var> be the result of calling <var>resolve</var> with <a class="nocite external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%Promise%</a>
+              <li>Let <var>promise</var> be the result of calling <var>resolve</var> with <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Promise%</a>
                 as the <span class="esvalue">this</span> value and <var>V</var> as the single argument value.</li>
               <li>Return the IDL <a href="#idl-promise">promise type</a> value that is a reference to the
                 same object as <var>promise</var>.</li>
@@ -7950,7 +7950,7 @@ alert(b[4]);    <span class="comment">// This would alert "50".</span></code></p
                 </ol>
               </li>
               <li>Let <var>then</var> be the result of calling the internal <span class="prop">[[Get]]</span> method of <var>promise</var> with property name “then”.</li>
-              <li>If <var>then</var> is not <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">callable</a>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
+              <li>If <var>then</var> is not <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">callable</a>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
               <li>Return the result of calling <var>then</var> with <var>promise</var> as the <span class="esvalue">this</span> value and <var>onFulfilled</var> and <var>onRejected</var>
                 as its two arguments.</li>
             </ol>
@@ -8011,7 +8011,7 @@ alert(b[4]);    <span class="comment">// This would alert "50".</span></code></p
                 </ol>
               </li>
               <li>
-                If <var>V</var> is a native <span class="estype">Error</span> object (that is, it has an [[ErrorData]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>), then:
+                If <var>V</var> is a native <span class="estype">Error</span> object (that is, it has an [[ErrorData]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>), then:
                 <ol>
                   <li>If <var>types</var> includes <a class="idltype" href="#idl-Error">Error</a>, then return the
                     result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a>
@@ -8021,7 +8021,7 @@ alert(b[4]);    <span class="comment">// This would alert "50".</span></code></p
                 </ol>
               </li>
               <li>
-                If <var>V</var> is an object with an [[ArrayBufferData]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>, then:
+                If <var>V</var> is an object with an [[ArrayBufferData]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, then:
                 <ol>
                   <li>If <var>types</var> includes <a class="idltype" href="#idl-ArrayBuffer">ArrayBuffer</a>, then return the
                     result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a>
@@ -8031,7 +8031,7 @@ alert(b[4]);    <span class="comment">// This would alert "50".</span></code></p
                 </ol>
               </li>
               <li>
-                If <var>V</var> is an object with a [[DataView]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>, then:
+                If <var>V</var> is an object with a [[DataView]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, then:
                 <ol>
                   <li>If <var>types</var> includes <a class="idltype" href="#idl-DataView">DataView</a>, then return the
                     result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a>
@@ -8041,10 +8041,10 @@ alert(b[4]);    <span class="comment">// This would alert "50".</span></code></p
                 </ol>
               </li>
               <li>
-                If <var>V</var> is an object with a [[TypedArrayName]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>, then:
+                If <var>V</var> is an object with a [[TypedArrayName]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, then:
                 <ol>
                   <li>If <var>types</var> includes a <a class="dfnref" href="#dfn-typed-array-type">typed array type</a>
-                    whose name is the value of <var>V</var>’s [[TypedArrayName]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>, then return the
+                    whose name is the value of <var>V</var>’s [[TypedArrayName]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, then return the
                     result of <a class="dfnref" href="#dfn-convert-ecmascript-to-idl-value">converting</a>
                     <var>V</var> to that type.</li>
                   <li>If <var>types</var> includes <a class="idltype" href="#idl-object">object</a>, then return the IDL value
@@ -8052,7 +8052,7 @@ alert(b[4]);    <span class="comment">// This would alert "50".</span></code></p
                 </ol>
               </li>
               <li>
-                If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">IsCallable</a>(<var>V</var>) is true, then:
+                If <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>V</var>) is true, then:
                 <ol>
                   <li>If <var>types</var> includes a <a class="dfnref" href="#dfn-callback-function">callback function</a>
                     type, then return the result of
@@ -8080,10 +8080,10 @@ alert(b[4]);    <span class="comment">// This would alert "50".</span></code></p
                     <ol>
                       <li>
                         Let <var>method</var> be the result of
-                        <a class="external" href="http://www.ecma-international.org/ecma-262/6.0/#sec-getmethod">GetMethod</a>(<var>V</var>, <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@iterator</a>).
+                        <a class="external" href="http://www.ecma-international.org/ecma-262/6.0/#sec-getmethod">GetMethod</a>(<var>V</var>, <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a>).
                       </li>
                       <li>
-                        <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>method</var>).
+                        <a class="external" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>method</var>).
                       </li>
                       <li>
                         If <var>method</var> is not
@@ -8100,10 +8100,10 @@ alert(b[4]);    <span class="comment">// This would alert "50".</span></code></p
                     <ol>
                       <li>
                         Let <var>method</var> be the result of
-                        <a class="external" href="http://www.ecma-international.org/ecma-262/6.0/#sec-getmethod">GetMethod</a>(<var>V</var>, <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@iterator</a>).
+                        <a class="external" href="http://www.ecma-international.org/ecma-262/6.0/#sec-getmethod">GetMethod</a>(<var>V</var>, <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a>).
                       </li>
                       <li>
-                        <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>method</var>).
+                        <a class="external" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>method</var>).
                       </li>
                       <li>
                         If <var>method</var> is not
@@ -8189,7 +8189,7 @@ alert(b[4]);    <span class="comment">// This would alert "50".</span></code></p
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
+              <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
                 or <var>V</var> is not a native <span class="estype">RegExp</span> object,
                 then set <var>V</var> to be a newly created <span class="estype">RegExp</span> object created as if by the
                 expression <code>new RegExp(<var>V</var>)</code>, where <code>RegExp</code> is the standard built-in constructor with that name
@@ -8224,8 +8224,8 @@ alert(b[4]);    <span class="comment">// This would alert "50".</span></code></p
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
-                or <var>V</var> does not have an [[ErrorData]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
+              <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
+                or <var>V</var> does not have an [[ErrorData]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
               <li>Return the IDL <a class="idltype" href="#idl-Error">Error</a> value that is a reference to the same object as <var>V</var>.</li>
             </ol>
             <p id="Error-to-es">
@@ -8250,7 +8250,7 @@ alert(b[4]);    <span class="comment">// This would alert "50".</span></code></p
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
+              <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
                 or <var>V</var> is not a platform object that represents a <a class="dfnref" href="#dfn-DOMException">DOMException</a>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
               <li>Return the IDL <a class="idltype" href="#idl-DOMException">DOMException</a> value that is a reference to the same object as <var>V</var>.</li>
             </ol>
@@ -8276,9 +8276,9 @@ alert(b[4]);    <span class="comment">// This would alert "50".</span></code></p
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
-                or <var>V</var> does not have an [[ArrayBufferData]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>,
-                or <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-isdetachedbuffer">IsDetachedBuffer</a>(<var>V</var>) is true,
+              <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
+                or <var>V</var> does not have an [[ArrayBufferData]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>,
+                or <a class="external" href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer">IsDetachedBuffer</a>(<var>V</var>) is true,
                 then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.
               </li>
               <li>Return the IDL <a class="idltype" href="#idl-ArrayBuffer">ArrayBuffer</a> value that is a reference to the same object as <var>V</var>.</li>
@@ -8290,8 +8290,8 @@ alert(b[4]);    <span class="comment">// This would alert "50".</span></code></p
               by running the following algorithm:
             </p>
             <ol class="algorithm">
-              <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
-                or <var>V</var> does not have a [[DataView]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>,
+              <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
+                or <var>V</var> does not have a [[DataView]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>,
                 then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
               <li>Return the IDL <a class="idltype" href="#idl-DataView">DataView</a> value that is a reference to the same object as <var>V</var>.</li>
             </ol>
@@ -8311,8 +8311,8 @@ alert(b[4]);    <span class="comment">// This would alert "50".</span></code></p
             </p>
             <ol class="algorithm">
               <li>Let <var>T</var> be the IDL type <var>V</var> is being converted to.</li>
-              <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
-                or <var>V</var> does not have a [[TypedArrayName]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>
+              <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
+                or <var>V</var> does not have a [[TypedArrayName]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>
                 with a value equal to the name of <var>T</var>,
                 then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
               <li>Return the IDL value of type <var>T</var> that is a reference to the same object as <var>V</var>.</li>
@@ -8334,19 +8334,19 @@ alert(b[4]);    <span class="comment">// This would alert "50".</span></code></p
               <li>Initialize <var>arrayBuffer</var> to <var>O</var>.</li>
               <li>Initialize <var>offset</var> to 0.</li>
               <li>Initialize <var>length</var> to 0.</li>
-              <li>If <var>O</var> has a [[ViewedArrayBuffer]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>, then:
+              <li>If <var>O</var> has a [[ViewedArrayBuffer]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, then:
                 <ol>
-                  <li>Set <var>arrayBuffer</var> to the value of <var>O</var>’s [[ViewedArrayBuffer]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
+                  <li>Set <var>arrayBuffer</var> to the value of <var>O</var>’s [[ViewedArrayBuffer]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
                   <li>If <var>arrayBuffer</var> is <span class="esvalue">undefined</span>, then
                     <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
-                  <li>Set <var>offset</var> to the value of <var>O</var>’s [[ByteOffset]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
-                  <li>Set <var>length</var> to the value of <var>O</var>’s [[ByteLength]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
+                  <li>Set <var>offset</var> to the value of <var>O</var>’s [[ByteOffset]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
+                  <li>Set <var>length</var> to the value of <var>O</var>’s [[ByteLength]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
                 </ol>
               </li>
-              <li>Otherwise, set <var>length</var> to the value of <var>O</var>’s [[ArrayBufferByteLength]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
-              <li>If <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-isdetachedbuffer">IsDetachedBuffer</a>(<var>O</var>), then
+              <li>Otherwise, set <var>length</var> to the value of <var>O</var>’s [[ArrayBufferByteLength]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
+              <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer">IsDetachedBuffer</a>(<var>O</var>), then
                 <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
-              <li>Let <var>data</var> be the value of <var>O</var>’s [[ArrayBufferData]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
+              <li>Let <var>data</var> be the value of <var>O</var>’s [[ArrayBufferData]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
               <li>Return a reference to or copy of (as required) the <var>length</var> bytes in <var>data</var>
                 starting at byte offset <var>offset</var>.</li>
             </ol>
@@ -8356,7 +8356,7 @@ alert(b[4]);    <span class="comment">// This would alert "50".</span></code></p
             </p>
             <ol class="algorithm">
               <li>Let <var>O</var> be the ECMAScript object that is the <a class="idltype" href="#idl-ArrayBuffer">ArrayBuffer</a>.</li>
-              <li><a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-detacharraybuffer">DetachArrayBuffer</a>(<var>O</var>).</li>
+              <li><a class="external" href="https://tc39.github.io/ecma262/#sec-detacharraybuffer">DetachArrayBuffer</a>(<var>O</var>).</li>
             </ol>
           </div>
 
@@ -8389,7 +8389,7 @@ alert(b[4]);    <span class="comment">// This would alert "50".</span></code></p
               <li>Let <var>array</var> be the result of
                 <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a>
                 the sequence of values to an ECMAScript value.</li>
-              <li>Perform <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-setintegritylevel">SetIntegrityLevel</a>(<var>array</var>, <code>"frozen"</code>).</li>
+              <li>Perform <a class="external" href="https://tc39.github.io/ecma262/#sec-setintegritylevel">SetIntegrityLevel</a>(<var>array</var>, <code>"frozen"</code>).</li>
               <li>Return <var>array</var>.</li>
             </ol>
             <p>
@@ -8440,7 +8440,7 @@ alert(b[4]);    <span class="comment">// This would alert "50".</span></code></p
               it indicates that when an ECMAScript <span class="estype">Number</span> is
               converted to the IDL type, out of range values will be clamped to the range
               of valid values, rather than using the operators that use a modulo operation
-              (<a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toint32">ToInt32</a>, <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-touint32">ToUint32</a>, etc.).
+              (<a class="external" href="https://tc39.github.io/ecma262/#sec-toint32">ToInt32</a>, <a class="external" href="https://tc39.github.io/ecma262/#sec-touint32">ToUint32</a>, etc.).
             </p>
             <p>
               The <a class="xattr" href="#Clamp">[Clamp]</a>
@@ -8592,7 +8592,7 @@ var z = new NodeList();    <span class="comment">// This would throw a TypeError
               it indicates that when an ECMAScript <span class="estype">Number</span> is
               converted to the IDL type, out of range values will cause an exception to
               be thrown, rather than converted to being a valid value using the operators that use a modulo operation
-              (<a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toint32">ToInt32</a>, <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-touint32">ToUint32</a>, etc.).  The <span class="estype">Number</span>
+              (<a class="external" href="https://tc39.github.io/ecma262/#sec-toint32">ToInt32</a>, <a class="external" href="https://tc39.github.io/ecma262/#sec-touint32">ToUint32</a>, etc.).  The <span class="estype">Number</span>
               will be rounded towards zero before being checked against its range.
             </p>
             <p>
@@ -9156,7 +9156,7 @@ list.unshift({ });         <span class="comment">// Insert an item at index 0.</
                 and no indexed property <a class="dfnref" href="#dfn-indexed-property-setter">setter</a>.  The
                 mutating <span class="estype">Array</span> methods will generally not
                 succeed on objects implementing <span class="idltype">ImmutableItemList</span>.
-                The exact behavior depends on the definition of <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-array-prototype-object">the <span class="estype">Array</span> methods
+                The exact behavior depends on the definition of <a class="external" href="https://tc39.github.io/ecma262/#sec-properties-of-the-array-prototype-object">the <span class="estype">Array</span> methods
                   themselves</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 22.1.3).
               </p>
             </div>
@@ -10578,7 +10578,7 @@ with (thing) {
                 </li>
 
                 <li>
-                  Otherwise: if <var>V</var> is an <span class="estype">Error</span> object (that is, it has an [[ErrorData]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>) and
+                  Otherwise: if <var>V</var> is an <span class="estype">Error</span> object (that is, it has an [[ErrorData]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>) and
                   there is an entry in <var>S</var> that has one of the following types at position <var>i</var> of its type list,
                   <ul>
                     <li><a class="idltype" href="#idl-Error">Error</a></li>
@@ -10591,7 +10591,7 @@ with (thing) {
                 </li>
 
                 <li>
-                  Otherwise: if <var>V</var> is an object with an [[ArrayBufferData]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a> and
+                  Otherwise: if <var>V</var> is an object with an [[ArrayBufferData]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a> and
                   there is an entry in <var>S</var> that has one of the following types at position <var>i</var> of its type list,
                   <ul>
                     <li><a class="idltype" href="#idl-ArrayBuffer">ArrayBuffer</a></li>
@@ -10604,7 +10604,7 @@ with (thing) {
                 </li>
 
                 <li>
-                  Otherwise: if <var>V</var> is an object with a [[DataView]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a> and
+                  Otherwise: if <var>V</var> is an object with a [[DataView]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a> and
                   there is an entry in <var>S</var> that has one of the following types at position <var>i</var> of its type list,
                   <ul>
                     <li><a class="idltype" href="#idl-DataView">DataView</a></li>
@@ -10617,11 +10617,11 @@ with (thing) {
                 </li>
 
                 <li>
-                  Otherwise: if <var>V</var> is an object with a [[TypedArrayName]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a> and
+                  Otherwise: if <var>V</var> is an object with a [[TypedArrayName]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a> and
                   there is an entry in <var>S</var> that has one of the following types at position <var>i</var> of its type list,
                   <ul>
                     <li>a <a class="dfnref" href="#dfn-typed-array-type">typed array type</a> whose name
-                      is equal to the value of <var>V</var>’s [[TypedArrayName]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a></li>
+                      is equal to the value of <var>V</var>’s [[TypedArrayName]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a></li>
                     <li><a class="idltype" href="#idl-object">object</a></li>
                     <li>a <a class="dfnref" href="#dfn-nullable-type">nullable</a> version of either of the above types</li>
                     <li>a <a class="dfnref" href="#dfn-union-type">union type</a> or <a class="dfnref" href="#dfn-nullable-type">nullable</a> union type
@@ -10631,7 +10631,7 @@ with (thing) {
                 </li>
 
                 <li>
-                  Otherwise: if <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">IsCallable</a>(<var>V</var>) is true,
+                  Otherwise: if <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>V</var>) is true,
                   and there is an entry in <var>S</var> that has one of the following types at position <var>i</var> of its type list,
                   <ul>
                     <li>a <a class="dfnref" href="#dfn-callback-function">callback function</a> type</li>
@@ -10660,10 +10660,10 @@ with (thing) {
                   <ol>
                     <li>
                       Let <var>method</var> be the result of
-                      <a class="external" href="http://www.ecma-international.org/ecma-262/6.0/#sec-getmethod">GetMethod</a>(<var>V</var>, <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@iterator</a>).
+                      <a class="external" href="http://www.ecma-international.org/ecma-262/6.0/#sec-getmethod">GetMethod</a>(<var>V</var>, <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a>).
                     </li>
                     <li>
-                      <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>method</var>).
+                      <a class="external" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>method</var>).
                     </li>
                   </ol>
                   <var>method</var> is not <span class="esvalue">undefined</span>, then remove from <var>S</var> all
@@ -10941,7 +10941,7 @@ with (thing) {
               <li>
                 If the interface doesn't inherit from any other interface,
                 the value of <span class="prop">[[Prototype]]</span> is
-                <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%FunctionPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
+                <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%FunctionPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
               </li>
             </ol>
             <p>
@@ -11249,8 +11249,8 @@ with (thing) {
               <a class="dfnref" href="#dfn-interface-prototype-object">interface prototype object</a>
               for the inherited interface.</li>
               <li>Otherwise, if <var>A</var> is declared with the <a class="xattr" href="#LegacyArrayClass">[LegacyArrayClass]</a>
-              extended attribute, then return <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%ArrayPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).</li>
-              <li>Otherwise, return <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%ObjectPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
+              extended attribute, then return <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ArrayPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).</li>
+              <li>Otherwise, return <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ObjectPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
               (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 15.2.4).</li>
             </ol>
             <div class="note"><div class="noteHeader">Note</div>
@@ -11344,8 +11344,8 @@ partial interface Window {
               <a class="dfnref" href="#dfn-interface-prototype-object">interface prototype object</a>
               for the inherited interface.</li>
               <li>Otherwise, if <var>A</var> is declared with the <a class="xattr" href="#LegacyArrayClass">[LegacyArrayClass]</a>
-              extended attribute, then return <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%ArrayPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).</li>
-              <li>Otherwise, return <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%ObjectPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).</li>
+              extended attribute, then return <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ArrayPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).</li>
+              <li>Otherwise, return <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ObjectPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).</li>
             </ol>
             <p>
               The <a class="dfnref" href="#dfn-class-string">class string</a> of a
@@ -11388,7 +11388,7 @@ partial interface Window {
                     <li>Otherwise, <var>operation</var> was defined with an identifier.  Set <var>value</var> to the result
                       of performing the steps listed in the description of <var>operation</var> with <var>P</var> as the only argument value.</li>
 
-                    <li>Let <var>desc</var> be a newly created <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-property-descriptor-specification-type">Property Descriptor</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.2.4) with no fields.</li>
+                    <li>Let <var>desc</var> be a newly created <a class="external" href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">Property Descriptor</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.2.4) with no fields.</li>
                     <li>Set <var>desc</var>.<span class="prop">[[Value]]</span> to the result of <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a>
                       <var>value</var> to an ECMAScript value.</li>
                     <li>If <var>A</var> implements an interface with the
@@ -11402,7 +11402,7 @@ partial interface Window {
                   </ol>
                 </li>
 
-                <li>Return the result of calling the <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p">default <span class="prop">[[GetOwnProperty]]</span> internal method</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 9.1.5) on <var>O</var> passing <var>P</var> as the argument.</li>
+                <li>Return the result of calling the <a class="external" href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p">default <span class="prop">[[GetOwnProperty]]</span> internal method</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 9.1.5) on <var>O</var> passing <var>P</var> as the argument.</li>
               </ol>
             </div>
 
@@ -11699,7 +11699,7 @@ interface
                     <ul>
                       <li>If the type of the attribute is an <a class="dfnref" href="#dfn-enumeration">enumeration</a>, then:
                         <ol>
-                          <li>Let <var>S</var> be the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tostring">ToString</a>(<var>V</var>).</li>
+                          <li>Let <var>S</var> be the result of calling <a class="external" href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a>(<var>V</var>).</li>
                           <li>If <var>S</var> is not one of the <a class="dfnref" href="#dfn-enumeration-value">enumeration’s values</a>, then return <span class="esvalue">undefined</span>.</li>
                           <li>The value of <var>idlValue</var> is the enumeration value equal to <var>S</var>.</li>
                         </ol>
@@ -11872,8 +11872,8 @@ interface
                       <li>If the operation has a <a class="dfnref" href="#dfn-return-type">return type</a>
                         that is a <a href="#idl-promise">promise type</a>, then:
                         <ol>
-                          <li>Let <var>reject</var> be the initial value of <a class="nocite external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%Promise%</a>.reject.</li>
-                          <li>Return the result of calling <var>reject</var> with <a class="nocite external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%Promise%</a> as the
+                          <li>Let <var>reject</var> be the initial value of <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Promise%</a>.reject.</li>
+                          <li>Return the result of calling <var>reject</var> with <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Promise%</a> as the
                             <span class="esvalue">this</span> object and the exception as the single
                             argument value.</li>
                         </ol>
@@ -11932,7 +11932,7 @@ interface
                 <li>
                   <p>The value of the property is a <span class="estype">Function</span> object, which behaves as follows:</p>
                   <ol class="algorithm">
-                    <li>Let <var>O</var> be the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toobject">ToObject</a> on the <span class="esvalue">this</span> value.</li>
+                    <li>Let <var>O</var> be the result of calling <a class="external" href="https://tc39.github.io/ecma262/#sec-toobject">ToObject</a> on the <span class="esvalue">this</span> value.</li>
                     <li>If <var>O</var> is a <a class="dfnref" href="#dfn-platform-object">platform object</a>,
                       then <a class="dfnref" href="#dfn-perform-a-security-check">perform a security check</a>, passing:
                       <ul>
@@ -12003,7 +12003,7 @@ interface
                 <span class="rfc2119">MUST</span> behave as follows:
               </p>
               <ol class="algorithm">
-                <li>Let <var>O</var> be the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toobject">ToObject</a> on the <span class="esvalue">this</span> value.</li>
+                <li>Let <var>O</var> be the result of calling <a class="external" href="https://tc39.github.io/ecma262/#sec-toobject">ToObject</a> on the <span class="esvalue">this</span> value.</li>
                 <li>If <var>O</var> is a <a class="dfnref" href="#dfn-platform-object">platform object</a>,
                   then <a class="dfnref" href="#dfn-perform-a-security-check">perform a security check</a>, passing:
                   <ul>
@@ -12077,7 +12077,7 @@ interface
                           <ol>
                             <li>Let <var>V</var> be the result of <a class="dfnref" href="#dfn-convert-serialized-value-to-ecmascript-value">converting</a>
                             the value of the element in <var>S</var> at index <var>index</var> to an ECMAScript value.</li>
-                            <li>Let <var>P</var> be <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tostring">ToString</a>(<var>index</var>).</li>
+                            <li>Let <var>P</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a>(<var>index</var>).</li>
                             <li>Call the <span class="prop">[[DefineOwnProperty]]</span> internal method of <var>O</var> passing
                             property name <var>P</var>, Property Descriptor <span class="descriptor">{ [[Value]]: <var>V</var>,
                             [[Writable]]: <span class="esvalue">true</span>, [[Enumerable]]: <span class="esvalue">true</span>,
@@ -12123,7 +12123,7 @@ interface
               </ul>
               <p>
                 then a property <span class="rfc2119">MUST</span> exist
-                whose name is the <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@iterator</a> symbol,
+                whose name is the <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> symbol,
                 with attributes <span class="descriptor">{ [[Writable]]: <span class="esvalue">true</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">true</span> }</span>
                 and whose value is a <a class="dfnref" href="#dfn-function-object">function object</a>.
               </p>
@@ -12142,7 +12142,7 @@ interface
               </ul>
               <p>
                 If the interface defines an <a class="dfnref" href="#dfn-indexed-property-getter">indexed property getter</a>,
-                then the <span class="estype">Function</span> object is <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%ArrayProto_values%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
+                then the <span class="estype">Function</span> object is <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ArrayProto_values%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
               </p>
               <p>
                 If the interface has a <a class="dfnref" href="#dfn-pair-iterator">pair iterator</a>,
@@ -12150,7 +12150,7 @@ interface
                 <span class="rfc2119">MUST</span> behave as follows:
               </p>
               <ol class="algorithm">
-                <li>Let <var>object</var> be the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toobject">ToObject</a> on the <span class="esvalue">this</span> value.</li>
+                <li>Let <var>object</var> be the result of calling <a class="external" href="https://tc39.github.io/ecma262/#sec-toobject">ToObject</a> on the <span class="esvalue">this</span> value.</li>
                 <li>If <var>object</var> is a <a class="dfnref" href="#dfn-platform-object">platform object</a>,
                   then <a class="dfnref" href="#dfn-perform-a-security-check">perform a security check</a>, passing:
                   <ul>
@@ -12172,11 +12172,11 @@ interface
               <p>
                 If the interface has a <a class="dfnref" href="#dfn-maplike-declaration">maplike declaration</a>
                 or <a class="dfnref" href="#dfn-setlike-declaration">setlike declaration</a>,
-                then the <span class="estype">Function</span> object that is the value of the <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@iterator</a> property,
+                then the <span class="estype">Function</span> object that is the value of the <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> property,
                 when invoked, <span class="rfc2119">MUST</span> behave as follows:
               </p>
               <ol class="algorithm">
-                <li>Let <var>object</var> be the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toobject">ToObject</a> on the <span class="esvalue">this</span> value.</li>
+                <li>Let <var>object</var> be the result of calling <a class="external" href="https://tc39.github.io/ecma262/#sec-toobject">ToObject</a> on the <span class="esvalue">this</span> value.</li>
                 <li>If <var>object</var> is a <a class="dfnref" href="#dfn-platform-object">platform object</a>,
                   then <a class="dfnref" href="#dfn-perform-a-security-check">perform a security check</a>, passing:
                   <ul>
@@ -12193,22 +12193,22 @@ interface
                   then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
                 <li>If the interface has a <a class="dfnref" href="#dfn-maplike-declaration">maplike declaration</a>, then:
                   <ol>
-                    <li>Let <var>backing</var> be the value of the [[BackingMap]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a> of <var>object</var>.</li>
-                    <li>Return <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-createmapiterator">CreateMapIterator</a>(<var>backing</var>, <code>"key+value"</code>).</li>
+                    <li>Let <var>backing</var> be the value of the [[BackingMap]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a> of <var>object</var>.</li>
+                    <li>Return <a class="external" href="https://tc39.github.io/ecma262/#sec-createmapiterator">CreateMapIterator</a>(<var>backing</var>, <code>"key+value"</code>).</li>
                   </ol>
                 </li>
                 <li>Otherwise:
                   <ol>
-                    <li>Let <var>backing</var> be the value of the [[BackingSet]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a> of <var>object</var>.</li>
-                    <li>Return <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-createsetiterator">CreateSetIterator</a>(<var>backing</var>, <code>"value"</code>).</li>
+                    <li>Let <var>backing</var> be the value of the [[BackingSet]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a> of <var>object</var>.</li>
+                    <li>Return <a class="external" href="https://tc39.github.io/ecma262/#sec-createsetiterator">CreateSetIterator</a>(<var>backing</var>, <code>"value"</code>).</li>
                   </ol>
                 </li>
               </ol>
               <p>
-                The value of the <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@iterator</a> <span class="estype">Function</span> object’s “length”
+                The value of the <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> <span class="estype">Function</span> object’s “length”
                 property is the <span class="estype">Number</span> value <span class="esvalue">0</span>.
               </p>
-              <p>The value of the <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@iterator</a> <span class="estype">Function</span> object’s “name”
+              <p>The value of the <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> <span class="estype">Function</span> object’s “name”
               property is the <span class="estype">String</span> value “entries” if the interface has a
               <a class="dfnref" href="#dfn-pair-iterator">pair iterator</a> or a
               <a class="dfnref" href="#dfn-maplike-declaration">maplike
@@ -12250,7 +12250,7 @@ interface
               <p>
                 If the interface defines an <a class="dfnref" href="#dfn-indexed-property-getter">indexed property getter</a>,
                 then the <span class="estype">Function</span> object is
-                the initial value of the “forEach” data property of <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%ArrayPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
+                the initial value of the “forEach” data property of <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ArrayPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
               </p>
               <p>
                 If the interface has a <a class="dfnref" href="#dfn-pair-iterator">pair iterator</a>,
@@ -12288,7 +12288,7 @@ interface
                 <span class="rfc2119">MUST</span> behave as follows:
               </p>
               <ol class="algorithm">
-                <li>Let <var>object</var> be the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toobject">ToObject</a> on the <span class="esvalue">this</span> value.</li>
+                <li>Let <var>object</var> be the result of calling <a class="external" href="https://tc39.github.io/ecma262/#sec-toobject">ToObject</a> on the <span class="esvalue">this</span> value.</li>
                 <li>If <var>object</var> is a <a class="dfnref" href="#dfn-platform-object">platform object</a>,
                   then <a class="dfnref" href="#dfn-perform-a-security-check">perform a security check</a>, passing:
                   <ul>
@@ -12305,11 +12305,11 @@ interface
                   that implements <var>interface</var>,
                   then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
                 <li>Let <var>callbackFn</var> be the value of the first argument passed to the function, or <span class="esvalue">undefined</span> if the argument was not supplied.</li>
-                <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">IsCallable</a>(<var>callbackFn</var>) is <span class="esvalue">false</span>, <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
+                <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>callbackFn</var>) is <span class="esvalue">false</span>, <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
                 <li>Let <var>thisArg</var> be the value of the second argument passed to the function, or <span class="esvalue">undefined</span> if the argument was not supplied.</li>
-                <li>Let <var>backing</var> be the value of the [[BackingMap]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a> of <var>object</var>,
+                <li>Let <var>backing</var> be the value of the [[BackingMap]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a> of <var>object</var>,
                   if the interface has a <a class="dfnref" href="#dfn-maplike-declaration">maplike declaration</a>,
-                  or the [[BackingSet]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a> of <var>object</var> otherwise.</li>
+                  or the [[BackingSet]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a> of <var>object</var> otherwise.</li>
                 <li>Let <var>callbackWrapper</var> be a <span class="estype">Function</span> that, when invoked, behaves as follows:
                   <ol>
                     <li>Let <var>v</var> and <var>k</var> be the first two arguments passed to the function.</li>
@@ -12329,7 +12329,7 @@ interface
                 </li>
                 <li>Let <var>forEach</var> be the result of calling the [[Get]] internal method of
                   <var>backing</var> with “forEach” and <var>backing</var> as arguments.</li>
-                <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">IsCallable</a>(<var>forEach</var>) is <span class="esvalue">false</span>, <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
+                <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>forEach</var>) is <span class="esvalue">false</span>, <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
                 <li>Call the [[Call]] internal method of <var>forEach</var> with <var>backing</var> as <var>thisArgument</var>
                   and <var>callbackWrapper</var> and <var>thisArg</var> as <var>argumentsList</var>.</li>
                 <li>Return <span class="esvalue">undefined</span>.</li>
@@ -12372,12 +12372,12 @@ interface
               <p>
                 If the interface has a <a class="dfnref" href="#dfn-value-iterator">value iterator</a>,
                 then the <span class="estype">Function</span> object is
-                the initial value of the “entries” data property of <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%ArrayPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
+                the initial value of the “entries” data property of <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ArrayPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
               </p>
               <p>
                 If the interface has a <a class="dfnref" href="#dfn-pair-iterator">pair iterator</a>,
                 then the <span class="estype">Function</span> object is
-                the value of the <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@iterator</a> property.
+                the value of the <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> property.
               </p>
             </div>
 
@@ -12407,14 +12407,14 @@ interface
               <p>
                 If the interface has a <a class="dfnref" href="#dfn-value-iterator">value iterator</a>,
                 then the <span class="estype">Function</span> object is
-                the initial value of the “keys” data property of <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%ArrayPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
+                the initial value of the “keys” data property of <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ArrayPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
               </p>
               <p>
                 If the interface has a <a class="dfnref" href="#dfn-pair-iterator">pair iterator</a>,
                 then the <span class="estype">Function</span>, when invoked, <span class="rfc2119">MUST</span> behave as follows:
               </p>
               <ol class="algorithm">
-                <li>Let <var>object</var> be the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toobject">ToObject</a> on the <span class="esvalue">this</span> value.</li>
+                <li>Let <var>object</var> be the result of calling <a class="external" href="https://tc39.github.io/ecma262/#sec-toobject">ToObject</a> on the <span class="esvalue">this</span> value.</li>
                 <li>If <var>object</var> is a <a class="dfnref" href="#dfn-platform-object">platform object</a>,
                   then <a class="dfnref" href="#dfn-perform-a-security-check">perform a security check</a>, passing:
                   <ul>
@@ -12464,7 +12464,7 @@ interface
               <p>
                 If the interface has a <a class="dfnref" href="#dfn-value-iterator">value iterator</a>,
                 then the <span class="estype">Function</span> object is
-                the value of the <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@iterator</a> property.
+                the value of the <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> property.
               </p>
 
               <p>
@@ -12472,7 +12472,7 @@ interface
                 then the <span class="estype">Function</span>, when invoked, <span class="rfc2119">MUST</span> behave as follows:
               </p>
               <ol class="algorithm">
-                <li>Let <var>object</var> be the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toobject">ToObject</a> on the <span class="esvalue">this</span> value.</li>
+                <li>Let <var>object</var> be the result of calling <a class="external" href="https://tc39.github.io/ecma262/#sec-toobject">ToObject</a> on the <span class="esvalue">this</span> value.</li>
                 <li>If <var>object</var> is a <a class="dfnref" href="#dfn-platform-object">platform object</a>,
                   then <a class="dfnref" href="#dfn-perform-a-security-check">perform a security check</a>, passing:
                   <ul>
@@ -12550,7 +12550,7 @@ interface
               </p>
               <p>
                 The internal [[Prototype]] property of an <a class="dfnref" href="#dfn-iterator-prototype-object">iterator prototype object</a>
-                <span class="rfc2119">MUST</span> be <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%IteratorPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
+                <span class="rfc2119">MUST</span> be <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%IteratorPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
               </p>
               <p>
                 An <a class="dfnref" href="#dfn-iterator-prototype-object">iterator prototype object</a>
@@ -12562,7 +12562,7 @@ interface
               <ol class="algorithm">
                 <li>Let <var>interface</var> be the <a class="dfnref" href="#dfn-interface">interface</a> for which the
                   <a class="dfnref" href="#dfn-iterator-prototype-object">iterator prototype object</a> exists.</li>
-                <li>Let <var>object</var> be the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toobject">ToObject</a> on the <span class="esvalue">this</span> value.</li>
+                <li>Let <var>object</var> be the result of calling <a class="external" href="https://tc39.github.io/ecma262/#sec-toobject">ToObject</a> on the <span class="esvalue">this</span> value.</li>
                 <li>If <var>object</var> is a <a class="dfnref" href="#dfn-platform-object">platform object</a>,
                   then <a class="dfnref" href="#dfn-perform-a-security-check">perform a security check</a>, passing:
                   <ul>
@@ -12580,7 +12580,7 @@ interface
                 <li>Let <var>values</var> be the list of <a class="dfnref" href="#dfn-value-pairs-to-iterate-over">value pairs to iterate over</a>.</li>
                 <li>Let <var>len</var> be the length of <var>values</var>.</li>
                 <li>If <var>object</var>’s index is greater than or equal to <var>len</var>, then
-                  return <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-createiterresultobject">CreateIterResultObject</a>(<span class="esvalue">undefined</span>, <span class="esvalue">true</span>).</li>
+                  return <a class="external" href="https://tc39.github.io/ecma262/#sec-createiterresultobject">CreateIterResultObject</a>(<span class="esvalue">undefined</span>, <span class="esvalue">true</span>).</li>
                 <li>Let <var>pair</var> be the entry in <var>values</var> at index <var>index</var>.</li>
                 <li>Let <var>result</var> be a value determined by the value of <var>kind</var>:
                   <dl class="switch">
@@ -12607,15 +12607,15 @@ interface
                         <li>Let <var>idlValue</var> be <var>pair</var>’s value.</li>
                         <li>Let <var>key</var> be the result of <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a> <var>idlKey</var> to an ECMAScript value.</li>
                         <li>Let <var>value</var> be the result of <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a> <var>idlValue</var> to an ECMAScript value.</li>
-                        <li>Let <var>array</var> be the result of performing <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arraycreate">ArrayCreate</a>(2).</li>
-                        <li>Call <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-createdataproperty">CreateDataProperty</a>(<var>array</var>, "0", <var>key</var>).</li>
-                        <li>Call <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-createdataproperty">CreateDataProperty</a>(<var>array</var>, "1", <var>value</var>).</li>
+                        <li>Let <var>array</var> be the result of performing <a class="external" href="https://tc39.github.io/ecma262/#sec-arraycreate">ArrayCreate</a>(2).</li>
+                        <li>Call <a class="external" href="https://tc39.github.io/ecma262/#sec-createdataproperty">CreateDataProperty</a>(<var>array</var>, "0", <var>key</var>).</li>
+                        <li>Call <a class="external" href="https://tc39.github.io/ecma262/#sec-createdataproperty">CreateDataProperty</a>(<var>array</var>, "1", <var>value</var>).</li>
                         <li><var>result</var> is <var>array</var>.</li>
                       </ol>
                     </dd>
                   </dl>
                 </li>
-                <li>Return <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-createiterresultobject">CreateIterResultObject</a>(<var>result</var>, <span class="esvalue">false</span>).</li>
+                <li>Return <a class="external" href="https://tc39.github.io/ecma262/#sec-createiterresultobject">CreateIterResultObject</a>(<var>result</var>, <span class="esvalue">false</span>).</li>
               </ol>
               <p>
                 The <a class="dfnref" href="#dfn-class-string">class string</a> of an
@@ -12634,7 +12634,7 @@ interface
             <p>
               Any object that implements an <a class="dfnref" href="#dfn-interface">interface</a>
               that has a <a class="dfnref" href="#dfn-maplike-declaration">maplike declaration</a>
-              <span class="rfc2119">MUST</span> have a [[BackingMap]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
+              <span class="rfc2119">MUST</span> have a [[BackingMap]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
               initially set to a newly created <span class="estype">Map</span> object.
               This <span class="estype">Map</span> object’s [[MapData]] internal slot is
               the object’s <a class="dfnref" href="#dfn-map-entries">map entries</a>.
@@ -12667,9 +12667,9 @@ interface
                 </ul>
               </li>
               <li>If <var>O</var> is not an object that implements <var>A</var>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
-              <li>Let <var>map</var> be the <span class="estype">Map</span> object that is the value of <var>O</var>’s [[BackingMap]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
+              <li>Let <var>map</var> be the <span class="estype">Map</span> object that is the value of <var>O</var>’s [[BackingMap]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
               <li>Let <var>function</var> be the result of calling the [[Get]] internal method of <var>map</var> passing <var>name</var> and <var>map</var> as arguments.</li>
-              <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">IsCallable</a>(<var>function</var>) is <span class="esvalue">false</span>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
+              <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>function</var>) is <span class="esvalue">false</span>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
               <li>Return the result of calling the [[Call]] internal method of <var>function</var> with <var>map</var> as <var>thisArg</var> and <var>arguments</var> as <var>argumentsList</var>.</li>
             </ol>
 
@@ -12700,7 +12700,7 @@ interface
                       </ul>
                     </li>
                     <li>If <var>O</var> is not an object that implements <var>A</var>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
-                    <li>Let <var>map</var> be the <span class="estype">Map</span> object that is the value of <var>O</var>’s [[BackingMap]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
+                    <li>Let <var>map</var> be the <span class="estype">Map</span> object that is the value of <var>O</var>’s [[BackingMap]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
                     <li>Return the result of calling the [[Get]] internal method of <var>map</var> passing “size” and <var>map</var> as arguments.</li>
                   </ol>
                   <p>The value of the <span class="estype">Function</span> object’s “length” property is the <span class="estype">Number</span> value <span class="esvalue">0</span>.</p>
@@ -12717,7 +12717,7 @@ interface
                 <var>A</var>’s <a class="dfnref" href="#dfn-interface-prototype-object">interface prototype object</a>
                 with attributes <span class="descriptor">{ [[Writable]]: <span class="esvalue">true</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">true</span> }</span>
                 and whose value is the <a class="dfnref" href="#dfn-function-object">function object</a> that is the value of
-                the <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@iterator</a> property.
+                the <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> property.
               </p>
             </div>
 
@@ -12761,7 +12761,7 @@ interface
                       </ul>
                     </li>
                     <li>If <var>O</var> is not an object that implements <var>A</var>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
-                    <li>Let <var>map</var> be the <span class="estype">Map</span> object that is the value of <var>O</var>’s [[BackingMap]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
+                    <li>Let <var>map</var> be the <span class="estype">Map</span> object that is the value of <var>O</var>’s [[BackingMap]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
                     <li>Let <var>keyType</var> be the key type specified in the <a class="dfnref" href="#dfn-maplike-declaration">maplike declaration</a>.</li>
                     <li>Let <var>function</var> be the result of calling the [[Get]] internal method of <var>map</var> passing <var>name</var> and <var>map</var> as arguments.</li>
                     <li>Let <var>keyArg</var> be the first argument passed to this function, or <span class="esvalue">undefined</span> if not supplied.</li>
@@ -12824,7 +12824,7 @@ interface
                       </ul>
                     </li>
                     <li>If <var>O</var> is not an object that implements <var>A</var>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
-                    <li>Let <var>map</var> be the <span class="estype">Map</span> object that is the value of <var>O</var>’s [[BackingMap]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
+                    <li>Let <var>map</var> be the <span class="estype">Map</span> object that is the value of <var>O</var>’s [[BackingMap]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
                     <li>Let <var>keyType</var> be the key type specified in the <a class="dfnref" href="#dfn-maplike-declaration">maplike declaration</a>.</li>
                     <li>Let <var>function</var> be the result of calling the [[Get]] internal method of <var>map</var> passing “delete” and <var>map</var> as arguments.</li>
                     <li>Let <var>keyArg</var> be the first argument passed to this function, or <span class="esvalue">undefined</span> if not supplied.</li>
@@ -12866,7 +12866,7 @@ interface
                       </ul>
                     </li>
                     <li>If <var>O</var> is not an object that implements <var>A</var>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
-                    <li>Let <var>map</var> be the <span class="estype">Map</span> object that is the value of <var>O</var>’s [[BackingMap]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
+                    <li>Let <var>map</var> be the <span class="estype">Map</span> object that is the value of <var>O</var>’s [[BackingMap]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
                     <li>Let <var>keyType</var> and <var>valueType</var> be the key and value types specified in the <a class="dfnref" href="#dfn-maplike-declaration">maplike declaration</a>.</li>
                     <li>Let <var>function</var> be the result of calling the [[Get]] internal method of <var>map</var> passing “set” and <var>map</var> as arguments.</li>
                     <li>Let <var>keyArg</var> be the first argument passed to this function, or <span class="esvalue">undefined</span> if not supplied.</li>
@@ -12892,7 +12892,7 @@ interface
             <p>
               Any object that implements an <a class="dfnref" href="#dfn-interface">interface</a>
               that has a <a class="dfnref" href="#dfn-setlike-declaration">setlike declaration</a>
-              <span class="rfc2119">MUST</span> have a [[BackingSet]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
+              <span class="rfc2119">MUST</span> have a [[BackingSet]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
               initially set to a newly created <span class="estype">Set</span> object.
               This <span class="estype">Set</span> object’s [[SetData]] internal slot is
               the object’s <a class="dfnref" href="#dfn-set-entries">set entries</a>.
@@ -12925,9 +12925,9 @@ interface
                 </ul>
               </li>
               <li>If <var>O</var> is not an object that implements <var>A</var>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
-              <li>Let <var>set</var> be the <span class="estype">Set</span> object that is the value of <var>O</var>’s [[BackingSet]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
+              <li>Let <var>set</var> be the <span class="estype">Set</span> object that is the value of <var>O</var>’s [[BackingSet]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
               <li>Let <var>function</var> be the result of calling the [[Get]] internal method of <var>set</var> passing <var>name</var> and <var>set</var> as arguments.</li>
-              <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">IsCallable</a>(<var>function</var>) is <span class="esvalue">false</span>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
+              <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>function</var>) is <span class="esvalue">false</span>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
               <li>Return the result of calling the [[Call]] internal method of <var>function</var> with <var>set</var> as <var>thisArg</var> and <var>arguments</var> as <var>argumentsList</var>.</li>
             </ol>
 
@@ -12958,7 +12958,7 @@ interface
                       </ul>
                     </li>
                     <li>If <var>O</var> is not an object that implements <var>A</var>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
-                    <li>Let <var>set</var> be the <span class="estype">Set</span> object that is the value of <var>O</var>’s [[BackingSet]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
+                    <li>Let <var>set</var> be the <span class="estype">Set</span> object that is the value of <var>O</var>’s [[BackingSet]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
                     <li>Return the result of calling the [[Get]] internal method of <var>set</var> passing “size” and <var>set</var> as arguments.</li>
                   </ol>
                   <p>The value of the <span class="estype">Function</span> object’s “length” property is the <span class="estype">Number</span> value <span class="esvalue">0</span>.</p>
@@ -12975,7 +12975,7 @@ interface
                 <var>A</var>’s <a class="dfnref" href="#dfn-interface-prototype-object">interface prototype object</a>
                 with attributes <span class="descriptor">{ [[Writable]]: <span class="esvalue">true</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">true</span> }</span>
                 and whose value is the <a class="dfnref" href="#dfn-function-object">function object</a> that is the value of
-                the <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">@@iterator</a> property.
+                the <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> property.
               </p>
             </div>
 
@@ -13018,7 +13018,7 @@ interface
                       </ul>
                     </li>
                     <li>If <var>O</var> is not an object that implements <var>A</var>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
-                    <li>Let <var>set</var> be the <span class="estype">Set</span> object that is the value of <var>O</var>’s [[BackingSet]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
+                    <li>Let <var>set</var> be the <span class="estype">Set</span> object that is the value of <var>O</var>’s [[BackingSet]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
                     <li>Let <var>type</var> be the value type specified in the <a class="dfnref" href="#dfn-setlike-declaration">setlike declaration</a>.</li>
                     <li>Let <var>function</var> be the result of calling the [[Get]] internal method of <var>set</var> passing “has” and <var>set</var> as arguments.</li>
                     <li>Let <var>arg</var> be the first argument passed to this function, or <span class="esvalue">undefined</span> if not supplied.</li>
@@ -13066,7 +13066,7 @@ interface
                       </ul>
                     </li>
                     <li>If <var>O</var> is not an object that implements <var>A</var>, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
-                    <li>Let <var>set</var> be the <span class="estype">Set</span> object that is the value of <var>O</var>’s [[BackingSet]] <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
+                    <li>Let <var>set</var> be the <span class="estype">Set</span> object that is the value of <var>O</var>’s [[BackingSet]] <a class="external" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</li>
                     <li>Let <var>type</var> be the value type specified in the <a class="dfnref" href="#dfn-setlike-declaration">setlike declaration</a>.</li>
                     <li>Let <var>function</var> be the result of calling the [[Get]] internal method of <var>set</var> passing <var>name</var> and <var>set</var> as arguments.</li>
                     <li>Let <var>arg</var> be the first argument passed to this function, or <span class="esvalue">undefined</span> if not supplied.</li>
@@ -13130,34 +13130,34 @@ interface
               an object <var>destination</var> with adder method name <var>adder</var>, perform the following steps:
             </p>
             <ol class="algorithm">
-              <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type</a>(<var>destination</var>) is not Object, then, <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span> exception</a>.</li>
+              <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>destination</var>) is not Object, then, <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span> exception</a>.</li>
               <li>If <var>iterable</var> is not present, let <var>iterable</var> be <span class="esvalue">undefined</span>.</li>
               <li>If <var>iterable</var> is either <span class="esvalue">undefined</span> or <span class="esvalue">null</span>, then let <var>iter</var> be <span class="esvalue">undefined</span>.</li>
               <li>Else,
                 <ol>
-                  <li>Let <var>adder</var> be the result of <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-o-p">Get</a>(<var>destination</var>, <var>adder</var>).</li>
-                  <li><a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>adder</var>).</li>
-                  <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">IsCallable</a>(<var>adder</var>) is <span class="esvalue">false</span>, <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span> exception</a>.</li>
-                  <li>Let <var>iter</var> be the result of <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-getiterator">GetIterator</a>(<var>iterable</var>).</li>
-                  <li><a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>iter</var>).</li>
+                  <li>Let <var>adder</var> be the result of <a class="external" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>destination</var>, <var>adder</var>).</li>
+                  <li><a class="external" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>adder</var>).</li>
+                  <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>adder</var>) is <span class="esvalue">false</span>, <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span> exception</a>.</li>
+                  <li>Let <var>iter</var> be the result of <a class="external" href="https://tc39.github.io/ecma262/#sec-getiterator">GetIterator</a>(<var>iterable</var>).</li>
+                  <li><a class="external" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>iter</var>).</li>
                 </ol>
               </li>
               <li>If <var>iter</var> is <span class="esvalue">undefined</span>, then return.</li>
               <li>Repeat
                 <ol>
-                  <li>Let <var>next</var> be the result of <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iteratorstep">IteratorStep</a>(<var>iter</var>).</li>
-                  <li><a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>next</var>).</li>
-                  <li>If <var>next</var> is <span class="esvalue">false</span>, then return <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-normalcompletion">NormalCompletion</a>(<var>destination</var>).</li>
-                  <li>Let <var>nextItem</var> be <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iteratorvalue">IteratorValue</a>(<var>next</var>).</li>
-                  <li><a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>nextItem</var>).</li>
-                  <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type</a>(<var>nextItem</var>) is not Object, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span> exception</a>.</li>
-                  <li>Let <var>k</var> be the result of <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-o-p">Get</a>(<var>nextItem</var>, <code>'0'</code>).</li>
-                  <li><a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>k</var>).</li>
-                  <li>Let <var>v</var> be the result of <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-o-p">Get</a>(<var>nextItem</var>, <code>'1'</code>).</li>
-                  <li><a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>v</var>).</li>
+                  <li>Let <var>next</var> be the result of <a class="external" href="https://tc39.github.io/ecma262/#sec-iteratorstep">IteratorStep</a>(<var>iter</var>).</li>
+                  <li><a class="external" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>next</var>).</li>
+                  <li>If <var>next</var> is <span class="esvalue">false</span>, then return <a class="external" href="https://tc39.github.io/ecma262/#sec-normalcompletion">NormalCompletion</a>(<var>destination</var>).</li>
+                  <li>Let <var>nextItem</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-iteratorvalue">IteratorValue</a>(<var>next</var>).</li>
+                  <li><a class="external" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>nextItem</var>).</li>
+                  <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>nextItem</var>) is not Object, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span> exception</a>.</li>
+                  <li>Let <var>k</var> be the result of <a class="external" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>nextItem</var>, <code>'0'</code>).</li>
+                  <li><a class="external" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>k</var>).</li>
+                  <li>Let <var>v</var> be the result of <a class="external" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>nextItem</var>, <code>'1'</code>).</li>
+                  <li><a class="external" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>v</var>).</li>
                   <li>Let <var>status</var> be the result of calling the [[Call]] internal method of <var>adder</var> with <var>destination</var> as
                       <var>thisArgument</var> and (<var>k</var>, <var>v</var>) as <var>argumentsList</var>.</li>
-                  <li><a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>status</var>).</li>
+                  <li><a class="external" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>status</var>).</li>
                 </ol>
               </li>
             </ol>
@@ -13369,7 +13369,7 @@ C implements A;</code></pre></div></div>
           <ul>
             <li>The name of the property is “toString”.</li>
             <li>The property has attributes <span class="descriptor">{ [[Writable]]: <span class="esvalue">false</span>, [[Enumerable]]: <span class="esvalue">true</span>, [[Configurable]]: <span class="esvalue">false</span> }</span>.</li>
-            <li>The value of the property is <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%ObjProto_toString%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4), the initial value of Object.prototype.toString.</li>
+            <li>The value of the property is <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ObjProto_toString%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4), the initial value of Object.prototype.toString.</li>
           </ul>
 
           <p>
@@ -13468,12 +13468,12 @@ C implements A;</code></pre></div></div>
             <p>
               The name of each property that appears to exist due to an object supporting indexed properties
               is an <dfn data-export="" id="dfn-array-index-property-name">array index property name</dfn>, which is a property
-              name <var>P</var> such that <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type</a>(<var>P</var>) is String
+              name <var>P</var> such that <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>P</var>) is String
               and for which the following algorithm returns <span class="esvalue">true</span>:
             </p>
             <ol class="algorithm">
-              <li>Let <var>i</var> be <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-touint32">ToUint32</a>(<var>P</var>).</li>
-              <li>Let <var>s</var> be <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tostring">ToString</a>(<var>i</var>).</li>
+              <li>Let <var>i</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-touint32">ToUint32</a>(<var>P</var>).</li>
+              <li>Let <var>s</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a>(<var>i</var>).</li>
               <li>If <var>s</var> ≠ <var>P</var> or <var>i</var> = 2<sup>32</sup> − 1, then return <span class="esvalue">false</span>.</li>
               <li>Return <span class="esvalue">true</span>.</li>
             </ol>
@@ -13586,7 +13586,7 @@ C implements A;</code></pre></div></div>
                 If <var>O</var> <a class="dfnref" href="#dfn-support-indexed-properties">supports indexed properties</a>
                 and <var>P</var> is an <a class="dfnref" href="#dfn-array-index-property-name">array index property name</a>, then:
                 <ol>
-                  <li>Let <var>index</var> be the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-touint32">ToUint32</a>(<var>P</var>).</li>
+                  <li>Let <var>index</var> be the result of calling <a class="external" href="https://tc39.github.io/ecma262/#sec-touint32">ToUint32</a>(<var>P</var>).</li>
                   <li>If <var>index</var> is a <a class="dfnref" href="#dfn-supported-property-indices">supported property index</a>, then:
                     <ol>
                       <li>Let <var>operation</var> be the operation used to declare the indexed property getter.</li>
@@ -13599,7 +13599,7 @@ C implements A;</code></pre></div></div>
                       <li>Otherwise, <var>operation</var> was defined with an identifier.  Set <var>value</var> to the result
                         of performing the steps listed in the description of <var>operation</var> with <var>index</var> as the only argument value.</li>
 
-                      <li>Let <var>desc</var> be a newly created <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-property-descriptor-specification-type">Property Descriptor</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.2.4) with no fields.</li>
+                      <li>Let <var>desc</var> be a newly created <a class="external" href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">Property Descriptor</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.2.4) with no fields.</li>
                       <li>Set <var>desc</var>.<span class="prop">[[Value]]</span> to the result of <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a>
                         <var>value</var> to an ECMAScript value.</li>
                       <li>If <var>O</var> implements an interface with an <a class="dfnref" href="#dfn-indexed-property-setter">indexed property setter</a>, then set
@@ -13628,7 +13628,7 @@ C implements A;</code></pre></div></div>
                   <li>Otherwise, <var>operation</var> was defined with an identifier.  Set <var>value</var> to the result
                     of performing the steps listed in the description of <var>operation</var> with <var>P</var> as the only argument value.</li>
 
-                  <li>Let <var>desc</var> be a newly created <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-property-descriptor-specification-type">Property Descriptor</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.2.4) with no fields.</li>
+                  <li>Let <var>desc</var> be a newly created <a class="external" href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">Property Descriptor</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.2.4) with no fields.</li>
                   <li>Set <var>desc</var>.<span class="prop">[[Value]]</span> to the result of <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a>
                     <var>value</var> to an ECMAScript value.</li>
                   <li>If <var>O</var> implements an interface with a <a class="dfnref" href="#dfn-named-property-setter">named property setter</a><!-- and
@@ -13646,7 +13646,7 @@ C implements A;</code></pre></div></div>
                 </ol>
               </li>
 
-              <li>Return the result of calling the <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p">default <span class="prop">[[GetOwnProperty]]</span> internal method</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 9.1.5) on <var>O</var> passing <var>P</var> as the argument.</li>
+              <li>Return the result of calling the <a class="external" href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p">default <span class="prop">[[GetOwnProperty]]</span> internal method</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 9.1.5) on <var>O</var> passing <var>P</var> as the argument.</li>
             </ol>
           </div>
 
@@ -13679,7 +13679,7 @@ C implements A;</code></pre></div></div>
               <var>V</var>, the following steps <span class="rfc2119">MUST</span> be performed:
             </p>
             <ol class="algorithm">
-              <li>Let <var>index</var> be the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-touint32">ToUint32</a>(<var>P</var>).</li>
+              <li>Let <var>index</var> be the result of calling <a class="external" href="https://tc39.github.io/ecma262/#sec-touint32">ToUint32</a>(<var>P</var>).</li>
               <li>Let <var>creating</var> be true if <var>index</var> is not a <a class="dfnref" href="#dfn-supported-property-indices">supported property index</a>, and false otherwise.</li>
               <li>Let <var>operation</var> be the operation used to declare the indexed property setter.</li>
               <li>Let <var>T</var> be the type of the second argument of <var>operation</var>.</li>
@@ -13759,7 +13759,7 @@ C implements A;</code></pre></div></div>
 
                 <li>
                   If <var>O</var> <a class="dfnref" href="#dfn-support-named-properties">supports named
-                  properties</a>, <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type</a>(<var>P</var>) is String,
+                  properties</a>, <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>P</var>) is String,
                   <var>P</var> is not an <a class="dfnref" href="#dfn-array-index-property-name">array index property
                   name</a>, and <var>O</var> implements an interface with a <a class="dfnref" href="#dfn-named-property-setter">named
                   property setter</a>, then:
@@ -13780,7 +13780,7 @@ C implements A;</code></pre></div></div>
                 arguments.
               </li>
               <li>
-                Perform steps 3-11 of the <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver">default [[Set]] internal method</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 9.1.9).
+                Perform steps 3-11 of the <a class="external" href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver">default [[Set]] internal method</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 9.1.9).
               </li>
             </ol>
           </div>
@@ -13802,7 +13802,7 @@ C implements A;</code></pre></div></div>
                 If <var>O</var> <a class="dfnref" href="#dfn-support-indexed-properties">supports indexed properties</a> and
                 <var>P</var> is an <a class="dfnref" href="#dfn-array-index-property-name">array index property name</a>, then:
                 <ol>
-                  <li>If the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-isdatadescriptor">IsDataDescriptor</a>(<var>Desc</var>) is <span class="esvalue">false</span>, then <a href="#Reject">Reject</a>.</li>
+                  <li>If the result of calling <a class="external" href="https://tc39.github.io/ecma262/#sec-isdatadescriptor">IsDataDescriptor</a>(<var>Desc</var>) is <span class="esvalue">false</span>, then <a href="#Reject">Reject</a>.</li>
                   <li>If <var>O</var> does not implement an interface with an <a class="dfnref" href="#dfn-indexed-property-setter">indexed property setter</a>, then <a href="#Reject">Reject</a>.</li>
                   <li><a href="#invoking-indexed-setter">Invoke the indexed
                   property setter</a> with <var>P</var> and <var>Desc</var>.<span class="prop">[[Value]]</span>.</li>
@@ -13849,7 +13849,7 @@ C implements A;</code></pre></div></div>
                       <li>If <var>creating</var> is false and <var>O</var> does not implement an interface with a <a class="dfnref" href="#dfn-named-property-setter">named property setter</a>, then <a href="#Reject">Reject</a>.</li>
                       <li>If <var>O</var> implements an interface with a <a class="dfnref" href="#dfn-named-property-setter">named property setter</a>, then:
                         <ol>
-                          <li>If the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-isdatadescriptor">IsDataDescriptor</a>(<var>Desc</var>) is <span class="esvalue">false</span>, then <a href="#Reject">Reject</a>.</li>
+                          <li>If the result of calling <a class="external" href="https://tc39.github.io/ecma262/#sec-isdatadescriptor">IsDataDescriptor</a>(<var>Desc</var>) is <span class="esvalue">false</span>, then <a href="#Reject">Reject</a>.</li>
                           <li>
                             <a href="#invoking-named-setter">Invoke the named
                           property setter</a> with <var>P</var> and
@@ -13866,7 +13866,7 @@ C implements A;</code></pre></div></div>
               <li>If <var>O</var> does not implement an <a class="dfnref" href="#dfn-interface">interface</a> with the
                 <a class="xattr" href="#Global">[Global]</a> or <a class="xattr" href="#PrimaryGlobal">[PrimaryGlobal]</a> <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>,
                 then set <var>Desc</var>.<span class="prop">[[Configurable]]</span> to <span class="esvalue">true</span>.</li>
-              <li>Call the <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc">default <span class="prop">[[DefineOwnProperty]]</span> internal method</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 9.1.6) on <var>O</var> passing <var>P</var>, <var>Desc</var>, and <var>Throw</var> as arguments.</li>
+              <li>Call the <a class="external" href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc">default <span class="prop">[[DefineOwnProperty]]</span> internal method</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 9.1.6) on <var>O</var> passing <var>P</var>, <var>Desc</var>, and <var>Throw</var> as arguments.</li>
             </ol>
           </div>
 
@@ -13886,7 +13886,7 @@ C implements A;</code></pre></div></div>
                 If <var>O</var> <a class="dfnref" href="#dfn-support-indexed-properties">supports indexed properties</a> and
                 <var>P</var> is an <a class="dfnref" href="#dfn-array-index-property-name">array index property name</a>, then:
                 <ol>
-                  <li>Let <var>index</var> be the result of calling <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-touint32">ToUint32</a>(<var>P</var>).</li>
+                  <li>Let <var>index</var> be the result of calling <a class="external" href="https://tc39.github.io/ecma262/#sec-touint32">ToUint32</a>(<var>P</var>).</li>
                   <li>If <var>index</var> is not a <a class="dfnref" href="#dfn-supported-property-indices">supported property index</a>, then return <span class="esvalue">true</span>.</li>
                   <li>Return <span class="esvalue">false</span>.</li>
                 </ol>
@@ -14008,10 +14008,10 @@ C implements A;</code></pre></div></div>
               The implementation of the operation (or set of overloaded operations) is
               as follows:
               <ul>
-                <li>If the object is <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">callable</a>,
+                <li>If the object is <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">callable</a>,
                 then the implementation of the operation (or set of overloaded operations) is
                 the callable object itself.</li>
-                <li>Otherwise, the object is not <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">callable</a>.
+                <li>Otherwise, the object is not <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">callable</a>.
                 The implementation of the operation (or set of overloaded operations) is
                 the result of invoking the internal <span class="prop">[[Get]]</span> method
                 on the object with a property name that is the <a class="dfnref" href="#dfn-identifier">identifier</a>
@@ -14043,7 +14043,7 @@ C implements A;</code></pre></div></div>
             with a list of IDL argument values <var>idlarg</var><sub>0..<var>n</var>−1</sub> by
             following the algorithm below.  The <dfn data-export="" id="dfn-callback-this-value">callback this value</dfn>
             is the value to use as the <span class="esvalue">this</span> value
-            when a <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">callable</a>
+            when a <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">callable</a>
             object was supplied as the implementation of a
             <a class="dfnref" href="#dfn-single-operation-callback-interface">single operation callback interface</a>.
             By default, <span class="esvalue">undefined</span> is used as the <a class="dfnref" href="#dfn-callback-this-value">callback this value</a>,
@@ -14056,13 +14056,13 @@ C implements A;</code></pre></div></div>
                 <li>Let <var>V</var> be the IDL <a class="dfnref" href="#idl-interface">callback interface type</a> value
                   that represents the <a class="dfnref" href="#dfn-user-object">user object</a> implementing the <a class="dfnref" href="#dfn-interface">interface</a>.</li>
                 <li>Let <var>O</var> be the ECMAScript object corresponding to <var>V</var>.</li>
-                <li>Let <var>X</var> be the implementation of the operation.  If the interface is a <a class="dfnref" href="#dfn-single-operation-callback-interface">single operation callback interface</a> and <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">IsCallable</a>(<var>O</var>) is true, then <var>X</var> is <var>O</var>.
+                <li>Let <var>X</var> be the implementation of the operation.  If the interface is a <a class="dfnref" href="#dfn-single-operation-callback-interface">single operation callback interface</a> and <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>O</var>) is true, then <var>X</var> is <var>O</var>.
                   Otherwise, <var>X</var> is the result of calling
                   the internal <span class="prop">[[Get]]</span> method of <var>O</var> with the identifier of the operation as the property name.</li>
-                <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type</a>(<var>X</var>) is not Object, <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a> exception.</li>
-                <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">IsCallable</a>(<var>X</var>) is false, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a> exception.</li>
+                <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>X</var>) is not Object, <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a> exception.</li>
+                <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>X</var>) is false, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a> exception.</li>
                 <li>Let <var>this</var> be <var>O</var> if the interface is not a <a class="dfnref" href="#dfn-single-operation-callback-interface">single operation callback interface</a>
-                  or if <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">IsCallable</a>(<var>O</var>) is false,
+                  or if <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>O</var>) is false,
                   and the <a class="dfnref" href="#dfn-callback-this-value">callback this value</a> otherwise.</li>
                 <li>
                   Let <var>arg</var><sub>0..<var>n</var>−1</sub> be a list of
@@ -14093,8 +14093,8 @@ C implements A;</code></pre></div></div>
               <ol>
                 <li>If the operation has a <a class="dfnref" href="#dfn-return-type">return type</a> that is a <a href="#idl-promise">promise type</a>, then:
                   <ol>
-                    <li>Let <var>reject</var> be the initial value of <a class="nocite external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%Promise%</a>.reject.</li>
-                    <li>Return the result of calling <var>reject</var> with <a class="nocite external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%Promise%</a> as the <span class="esvalue">this</span> object and the exception as the single argument value.</li>
+                    <li>Let <var>reject</var> be the initial value of <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Promise%</a>.reject.</li>
+                    <li>Return the result of calling <var>reject</var> with <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Promise%</a> as the <span class="esvalue">this</span> object and the exception as the single argument value.</li>
                   </ol>
                 </li>
                 <li>Otherwise, end these steps and allow the exception to propagate.</li>
@@ -14139,8 +14139,8 @@ C implements A;</code></pre></div></div>
               <ol>
                 <li>If the attribute has a <a class="dfnref" href="#dfn-return-type">return type</a> that is a <a href="#idl-promise">promise type</a>, then:
                   <ol>
-                    <li>Let <var>reject</var> be the initial value of <a class="nocite external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%Promise%</a>.reject.</li>
-                    <li>Return the result of calling <var>reject</var> with <a class="nocite external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%Promise%</a> as the <span class="esvalue">this</span> object and the exception as the single argument value.</li>
+                    <li>Let <var>reject</var> be the initial value of <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Promise%</a>.reject.</li>
+                    <li>Return the result of calling <var>reject</var> with <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Promise%</a> as the <span class="esvalue">this</span> object and the exception as the single argument value.</li>
                   </ol>
                 </li>
                 <li>Otherwise, end these steps and allow the exception to propagate.</li>
@@ -14178,11 +14178,11 @@ C implements A;</code></pre></div></div>
           <h3>4.10. Invoking callback functions</h3>
 
           <p>
-            An ECMAScript <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">callable</a> object that is being
+            An ECMAScript <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">callable</a> object that is being
             used as a <a class="dfnref" href="#dfn-callback-function">callback function</a> value is
             called in a manner similar to how <a class="dfnref" href="#dfn-operation">operations</a>
             on <a class="dfnref" href="#dfn-user-object">user objects</a> are called (as
-            described in the previous section).  The <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">callable</a> object
+            described in the previous section).  The <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">callable</a> object
             is called with a list of values
             <var>arg</var><sub>0..<var>n</var>−1</sub>,
             each of which is either an IDL value of the special value “missing” (representing
@@ -14197,7 +14197,7 @@ C implements A;</code></pre></div></div>
                 <li>Let <var>V</var> be the IDL <a class="dfnref" href="#idl-callback-function">callback function type</a> value.</li>
                 <li>Let <var>F</var> be the ECMAScript object corresponding to <var>V</var>.</li>
                 <li>Let <var>R</var> be an uninitialized variable.</li>
-                <li>If <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable">IsCallable</a>(<var>F</var>) is false, then set <var>R</var> to the value <span class="estype">undefined</span>.</li>
+                <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>F</var>) is false, then set <var>R</var> to the value <span class="estype">undefined</span>.</li>
                 <li>Otherwise,
                 <ol>
                 <li>Initialize <var>values</var> to be an empty list of ECMAScript values.</li>
@@ -14237,8 +14237,8 @@ C implements A;</code></pre></div></div>
               <ol>
                 <li>If the callback function has a <a class="dfnref" href="#dfn-return-type">return type</a> that is a <a href="#idl-promise">promise type</a>, then:
                   <ol>
-                    <li>Let <var>reject</var> be the initial value of <a class="nocite external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%Promise%</a>.reject.</li>
-                    <li>Return the result of calling <var>reject</var> with <a class="nocite external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%Promise%</a> as the <span class="esvalue">this</span> object and the exception as the single argument value.</li>
+                    <li>Let <var>reject</var> be the initial value of <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Promise%</a>.reject.</li>
+                    <li>Return the result of calling <var>reject</var> with <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Promise%</a> as the <span class="esvalue">this</span> object and the exception as the single argument value.</li>
                   </ol>
                 </li>
                 <li>Otherwise, end these steps and allow the exception to propagate.</li>
@@ -14264,7 +14264,7 @@ C implements A;</code></pre></div></div>
 
             <p>
               The DOMException constructor object <span class="rfc2119">MUST</span> be a <a class="dfnref" href="#dfn-function-object">function object</a>
-              but with a <span class="prop">[[Prototype]]</span> value of <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%Error%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
+              but with a <span class="prop">[[Prototype]]</span> value of <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Error%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
             </p>
             <p>
               For every legacy code listed in the <a href="#dfn-error-names-table">error names table</a>,
@@ -14289,17 +14289,17 @@ C implements A;</code></pre></div></div>
                 <li>Let <var>F</var> be the active function object.</li>
                 <li>If NewTarget is <span class="esvalue">undefined</span>, let <var>newTarget</var> be <var>F</var>, else let <var>newTarget</var> be NewTarget.</li>
                 <li>Let <var>super</var> be <var>F</var>.[[GetPrototypeOf]]().</li>
-                <li><a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>super</var>).</li>
-                <li>If <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-isconstructor">IsConstructor</a>(<var>super</var>) is <span class="esvalue">false</span>, throw a <span class="esvalue">TypeError</span> exception.</li>
-                <li>Let <var>O</var> be <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-construct">Construct</a>(<var>super</var>, «<var>message</var>», <var>newTarget</var>).</li>
+                <li><a class="external" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>super</var>).</li>
+                <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-isconstructor">IsConstructor</a>(<var>super</var>) is <span class="esvalue">false</span>, throw a <span class="esvalue">TypeError</span> exception.</li>
+                <li>Let <var>O</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-construct">Construct</a>(<var>super</var>, «<var>message</var>», <var>newTarget</var>).</li>
                 <li>If <var>name</var> is not <span class="esvalue">undefined</span>, then
                   <ol>
-                    <li>Let <var>name</var> be <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tostring">ToString</a>(<var>name</var>).</li>
-                    <li>Let <var>status</var> be <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-definepropertyorthrow">DefinePropertyOrThrow</a>(<var>O</var>, <code>"name"</code>, PropertyDescriptor<span class="descriptor">{[[Value]]: <var>name</var>, [[Writable]]: <span class="esvalue">true</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">true</span>}</span>).</li>
-                    <li><a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>status</var>).</li>
+                    <li>Let <var>name</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a>(<var>name</var>).</li>
+                    <li>Let <var>status</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow">DefinePropertyOrThrow</a>(<var>O</var>, <code>"name"</code>, PropertyDescriptor<span class="descriptor">{[[Value]]: <var>name</var>, [[Writable]]: <span class="esvalue">true</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">true</span>}</span>).</li>
+                    <li><a class="external" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>status</var>).</li>
                     <li>Let <var>code</var> be the legacy code indicated in the <a class="dfnref" href="#dfn-error-names-table">error names table</a> for error name <var>name</var>, or <span class="esvalue">0</span> if there is none.</li>
-                    <li>Let <var>status</var> be <a class="external" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-definepropertyorthrow">DefinePropertyOrThrow</a>(<var>O</var>, <code>"code"</code>, PropertyDescriptor<span class="descriptor">{[[Value]]: <var>code</var>, [[Writable]]: <span class="esvalue">true</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">true</span>}</span>).</li>
-                    <li><a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>status</var>).</li>
+                    <li>Let <var>status</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow">DefinePropertyOrThrow</a>(<var>O</var>, <code>"code"</code>, PropertyDescriptor<span class="descriptor">{[[Value]]: <var>code</var>, [[Writable]]: <span class="esvalue">true</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">true</span>}</span>).</li>
+                    <li><a class="external" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>status</var>).</li>
                   </ol>
                 </li>
                 <li>Return <var>O</var>.</li>
@@ -14312,7 +14312,7 @@ C implements A;</code></pre></div></div>
 
             <p>
               The DOMException prototype object <span class="rfc2119">MUST</span>
-              have an internal <span class="prop">[[Prototype]]</span> property whose value is <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects">%ErrorPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
+              have an internal <span class="prop">[[Prototype]]</span> property whose value is <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ErrorPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
             </p>
             <p>
               The <a class="dfnref" href="#dfn-class-string">class string</a> of the
@@ -15122,10 +15122,9 @@ d.type = et;
           <dl>
             <dt id="ref-ECMA-262">[ECMA-262]</dt>
             <dd>
-              <cite><a href="http://wiki.ecmascript.org/doku.php?id=harmony:specification_drafts">ECMAScript Language Specification, 6th Edition</a></cite>,
-              A. Wirfs-Brock, Editor. Ecma International, 8 November 2013 (Working Draft).
-              <span class="print"><br />Available at http://wiki.ecmascript.org/doku.php?id=harmony:specification_drafts</span>
-              <br />Unofficial HTML version available at <a href="http://people.mozilla.org/~jorendorff/es6-draft.html">http://people.mozilla.org/~jorendorff/es6-draft.html</a>.
+              <cite><a href="https://tc39.github.io/ecma262/">ECMAScript Language Specification</a></cite>.
+              Ecma International.
+              <span class="print"><br />Available at https://tc39.github.io/ecma262/.</span>
             </dd>
             <dt id="ref-IEEE-754">[IEEE-754]</dt>
             <dd>

--- a/index.xml
+++ b/index.xml
@@ -54,91 +54,91 @@
       <links>
         <term name='Unicode scalar value' class='external' href='http://www.unicode.org/glossary/#unicode_scalar_value'/>
         <term name='Unicode scalar values' class='external' href='http://www.unicode.org/glossary/#unicode_scalar_value'/>
-        <term name='NumericLiteral' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-numeric-literals' ref='ECMA-262' section='11.8.3'/>
-        <term name='ECMAScript error objects' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-error-objects' ref='ECMA-262' section='19.5'/>
-        <term name='ToBoolean' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toboolean'/>
-        <term name='ToNumber' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tonumber'/>
-        <term name='ToUint16' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-touint16'/>
-        <term name='ToInt32' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toint32'/>
-        <term name='ToUint32' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-touint32'/>
-        <term name='ToString' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tostring'/>
-        <term name='ToObject' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-toobject'/>
-        <term name='IsAccessorDescriptor' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-isaccessordescriptor'/>
-        <term name='IsDataDescriptor' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-isdatadescriptor'/>
-        <term name='Type' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values'/>
-        <term name='sign' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions'/>
-        <term name='floor' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions'/>
-        <term name='abs' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions'/>
-        <term name='modulo' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions'/>
-        <term name='element' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-language-types-string-type'/>
-        <term name='IsCallable' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable'/>
-        <term name='callable' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable'/>
-        <term name='%ArrayPrototype%' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
-        <term name='%ArrayProto_values%' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
-        <term name='%MapPrototype%' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
-        <term name='%ObjectPrototype%' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
-        <term name='%SetPrototype%' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
-        <term name='%Error%' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
-        <term name='%ErrorPrototype%' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
-        <term name='%FunctionPrototype%' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
-        <term name='%ObjProto_toString%' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
-        <term name='%Promise%' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
-        <term name='%IteratorPrototype%' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
-        <term name='Property Descriptor' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-property-descriptor-specification-type' ref='ECMA-262' section='6.2.4'/>
-        <term name='array index' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-array-exotic-objects' ref='ECMA-262' section='9.4.2'/>
-        <term name='default [[GetOwnProperty]] internal method' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p' ref='ECMA-262' section='9.1.5'/>
-        <term name='default [[DefineOwnProperty]] internal method' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc' ref='ECMA-262' section='9.1.6'/>
-        <term name='default [[Set]] internal method' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver' ref='ECMA-262' section='9.1.9'/>
-        <term name='equally close values' class='external' href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-language-types-number-type' ref='ECMA-262' section='6.1.6'/>
-        <term name='internal slot' class='external' href='https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-internal-methods-and-internal-slots'/>
+        <term name='NumericLiteral' class='external' href='https://tc39.github.io/ecma262/#sec-literals-numeric-literals' ref='ECMA-262' section='11.8.3'/>
+        <term name='ECMAScript error objects' class='external' href='https://tc39.github.io/ecma262/#sec-error-objects' ref='ECMA-262' section='19.5'/>
+        <term name='ToBoolean' class='external' href='https://tc39.github.io/ecma262/#sec-toboolean'/>
+        <term name='ToNumber' class='external' href='https://tc39.github.io/ecma262/#sec-tonumber'/>
+        <term name='ToUint16' class='external' href='https://tc39.github.io/ecma262/#sec-touint16'/>
+        <term name='ToInt32' class='external' href='https://tc39.github.io/ecma262/#sec-toint32'/>
+        <term name='ToUint32' class='external' href='https://tc39.github.io/ecma262/#sec-touint32'/>
+        <term name='ToString' class='external' href='https://tc39.github.io/ecma262/#sec-tostring'/>
+        <term name='ToObject' class='external' href='https://tc39.github.io/ecma262/#sec-toobject'/>
+        <term name='IsAccessorDescriptor' class='external' href='https://tc39.github.io/ecma262/#sec-isaccessordescriptor'/>
+        <term name='IsDataDescriptor' class='external' href='https://tc39.github.io/ecma262/#sec-isdatadescriptor'/>
+        <term name='Type' class='external' href='https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values'/>
+        <term name='sign' class='external' href='https://tc39.github.io/ecma262/#sec-algorithm-conventions'/>
+        <term name='floor' class='external' href='https://tc39.github.io/ecma262/#sec-algorithm-conventions'/>
+        <term name='abs' class='external' href='https://tc39.github.io/ecma262/#sec-algorithm-conventions'/>
+        <term name='modulo' class='external' href='https://tc39.github.io/ecma262/#sec-algorithm-conventions'/>
+        <term name='element' class='external' href='https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type'/>
+        <term name='IsCallable' class='external' href='https://tc39.github.io/ecma262/#sec-iscallable'/>
+        <term name='callable' class='external' href='https://tc39.github.io/ecma262/#sec-iscallable'/>
+        <term name='%ArrayPrototype%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
+        <term name='%ArrayProto_values%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
+        <term name='%MapPrototype%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
+        <term name='%ObjectPrototype%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
+        <term name='%SetPrototype%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
+        <term name='%Error%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
+        <term name='%ErrorPrototype%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
+        <term name='%FunctionPrototype%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
+        <term name='%ObjProto_toString%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
+        <term name='%Promise%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
+        <term name='%IteratorPrototype%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
+        <term name='Property Descriptor' class='external' href='https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type' ref='ECMA-262' section='6.2.4'/>
+        <term name='array index' class='external' href='https://tc39.github.io/ecma262/#sec-array-exotic-objects' ref='ECMA-262' section='9.4.2'/>
+        <term name='default [[GetOwnProperty]] internal method' class='external' href='https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p' ref='ECMA-262' section='9.1.5'/>
+        <term name='default [[DefineOwnProperty]] internal method' class='external' href='https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc' ref='ECMA-262' section='9.1.6'/>
+        <term name='default [[Set]] internal method' class='external' href='https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver' ref='ECMA-262' section='9.1.9'/>
+        <term name='equally close values' class='external' href='https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type' ref='ECMA-262' section='6.1.6'/>
+        <term name='internal slot' class='external' href='https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots'/>
         <term name="ReturnIfAbrupt" class='external'
-              href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-returnifabrupt'/>
+              href='https://tc39.github.io/ecma262/#sec-returnifabrupt'/>
         <term name='GetMethod' class='external'
               href='http://www.ecma-international.org/ecma-262/6.0/#sec-getmethod'/>
         <term name='GetIterator' class='external'
-              href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-getiterator'/>
+              href='https://tc39.github.io/ecma262/#sec-getiterator'/>
         <term name='IteratorStep' class='external'
-              href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iteratorstep'/>
+              href='https://tc39.github.io/ecma262/#sec-iteratorstep'/>
         <term name='NormalCompletion' class='external'
-              href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-normalcompletion'/>
+              href='https://tc39.github.io/ecma262/#sec-normalcompletion'/>
         <term name='IteratorValue' class='external'
-              href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-iteratorvalue'/>
+              href='https://tc39.github.io/ecma262/#sec-iteratorvalue'/>
         <term name='@@iterator' class='external'
-              href='https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols'/>
+              href='https://tc39.github.io/ecma262/#sec-well-known-symbols'/>
         <term name='@@toStringTag' class='external'
-              href='https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols'/>
+              href='https://tc39.github.io/ecma262/#sec-well-known-symbols'/>
         <term name='@@unscopables' class='external'
               href='http://www.ecma-international.org/ecma-262/6.0/#sec-well-known-symbols'/>
         <term name='CreateArrayIterator' class='external'
-              href='https://people.mozilla.org/~jorendorff/es6-draft.html#sec-createarrayiterator'/>
+              href='https://tc39.github.io/ecma262/#sec-createarrayiterator'/>
         <term name='CreateIterResultObject' class='external'
-              href='https://people.mozilla.org/~jorendorff/es6-draft.html#sec-createiterresultobject'/>
+              href='https://tc39.github.io/ecma262/#sec-createiterresultobject'/>
         <term name='CreateMapIterator' class='external'
-              href='https://people.mozilla.org/~jorendorff/es6-draft.html#sec-createmapiterator'/>
+              href='https://tc39.github.io/ecma262/#sec-createmapiterator'/>
         <term name='CreateSetIterator' class='external'
-              href='https://people.mozilla.org/~jorendorff/es6-draft.html#sec-createsetiterator'/>
+              href='https://tc39.github.io/ecma262/#sec-createsetiterator'/>
         <term name='ArrayCreate' class='external'
-              href='https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arraycreate'/>
+              href='https://tc39.github.io/ecma262/#sec-arraycreate'/>
         <term name='CreateDataProperty' class='external'
-              href='https://people.mozilla.org/~jorendorff/es6-draft.html#sec-createdataproperty'/>
+              href='https://tc39.github.io/ecma262/#sec-createdataproperty'/>
         <term name='DetachArrayBuffer' class='external'
-              href='https://people.mozilla.org/~jorendorff/es6-draft.html#sec-detacharraybuffer'/>
+              href='https://tc39.github.io/ecma262/#sec-detacharraybuffer'/>
         <term name='IsDetachedBuffer' class='external'
-              href='https://people.mozilla.org/~jorendorff/es6-draft.html#sec-isdetachedbuffer'/>
+              href='https://tc39.github.io/ecma262/#sec-isdetachedbuffer'/>
         <term name='SetIntegrityLevel' class='external'
-              href='https://people.mozilla.org/~jorendorff/es6-draft.html#sec-setintegritylevel'/>
+              href='https://tc39.github.io/ecma262/#sec-setintegritylevel'/>
         <term name='array iterator object' class='external'
-              href='https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array-iterator-objects'/>
+              href='https://tc39.github.io/ecma262/#sec-array-iterator-objects'/>
         <term name='array iterator objects' class='external'
-              href='https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array-iterator-objects'/>
+              href='https://tc39.github.io/ecma262/#sec-array-iterator-objects'/>
         <term name='Get' class='external'
-              href='http://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-o-p'/>
+              href='https://tc39.github.io/ecma262/#sec-get-o-p'/>
         <term name='IsConstructor' class='external'
-              href='https://people.mozilla.org/~jorendorff/es6-draft.html#sec-isconstructor'/>
+              href='https://tc39.github.io/ecma262/#sec-isconstructor'/>
         <term name='Construct' class='external'
-              href='https://people.mozilla.org/~jorendorff/es6-draft.html#sec-construct'/>
+              href='https://tc39.github.io/ecma262/#sec-construct'/>
         <term name='DefinePropertyOrThrow' class='external'
-              href='https://people.mozilla.org/~jorendorff/es6-draft.html#sec-definepropertyorthrow'/>
+              href='https://tc39.github.io/ecma262/#sec-definepropertyorthrow'/>
         <term name='relevant settings object' class='external'
               href='https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object'/>
         <term name='secure context' class='external'
@@ -5746,7 +5746,7 @@ interface Person {
               whose values are references to objects that “is used as a place holder
               for the eventual results of a deferred (and possibly asynchronous) computation
               result of an asynchronous operation” <a href='#ref-ECMA-262'>[ECMA-262]</a>.
-              See <a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects">section 25.4</a>
+              See <a href="https://tc39.github.io/ecma262/#sec-promise-objects">section 25.4</a>
               of the ECMAScript specification for details on the semantics of promise objects.
             </p>
             <p>
@@ -6189,8 +6189,8 @@ interface Person {
         </p>
         <p>
           Objects defined in this section have internal properties as described in
-          ECMA-262 <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ordinary-object-internal-methods-and-internal-slots">sections 9.1</a> and
-          <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-built-in-function-objects-call-thisargument-argumentslist">9.3.1</a> unless otherwise specified, in which case one or
+          ECMA-262 <a class="external" href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots">sections 9.1</a> and
+          <a class="external" href="https://tc39.github.io/ecma262/#sec-built-in-function-objects-call-thisargument-argumentslist">9.3.1</a> unless otherwise specified, in which case one or
           more of the following are redefined in accordance with the rules for exotic objects:
           <span class="prop">[[Call]]</span>,
           <span class="prop">[[Set]]</span>,
@@ -6241,15 +6241,15 @@ interface Person {
         <ul>
           <li>Its <span class='prop'>[[Prototype]]</span> internal property is
           <a>%FunctionPrototype%</a> unless otherwise specified.</li>
-          <li>Its <span class='prop'>[[Get]]</span> internal property is set as described in <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver">ECMA-262 section 9.1.8</a>.</li>
-          <li>Its <span class='prop'>[[Construct]]</span> internal property is set as described in <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-@@create">ECMA-262 section 19.2.2.3</a>.</li>
-          <li>Its <span class='prop'>@@hasInstance</span> property is set as described in <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-function.prototype-@@hasinstance">ECMA-262 section 19.2.3.8</a>, unless otherwise specified.</li>
+          <li>Its <span class='prop'>[[Get]]</span> internal property is set as described in <a class="external" href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver">ECMA-262 section 9.1.8</a>.</li>
+          <li>Its <span class='prop'>[[Construct]]</span> internal property is set as described in <a class="external" href="https://tc39.github.io/ecma262/#sec-function-@@create">ECMA-262 section 19.2.2.3</a>.</li>
+          <li>Its <span class='prop'>@@hasInstance</span> property is set as described in <a class="external" href="https://tc39.github.io/ecma262/#sec-function.prototype-@@hasinstance">ECMA-262 section 19.2.3.8</a>, unless otherwise specified.</li>
         </ul>
         <div class='ednote'>
           <p>The list above needs updating for the latest ES6 draft.</p>
         </div>
         <p id='ecmascript-abstractop'>
-          Algorithms in this section use the conventions described in <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-algorithm-conventions">ECMA-262
+          Algorithms in this section use the conventions described in <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">ECMA-262
           section 5.2</a>, such as the use of steps and substeps, the use of mathematical
           operations, and so on.  The
           <a>ToBoolean</a>,
@@ -6261,7 +6261,7 @@ interface Person {
           <a>ToObject</a>,
           <a>IsAccessorDescriptor</a> and
           <a>IsDataDescriptor</a> abstract operations and the
-          <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-data-types-and-values">Type(<var>x</var>)</a>
+          <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type(<var>x</var>)</a>
           notation referenced in this section are defined in ECMA-262 sections 6 and 7.
         </p>
         <p id='ecmascript-throw'>
@@ -6323,7 +6323,7 @@ interface Person {
             <li><a class='dfnref' href='#dfn-named-properties-object'>named properties objects</a></li>
           </ul>
           <p>
-            Each <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-code-realms">ECMAScript global environment</a> (<a href='#ref-ECMA-262'>[ECMA-262]</a>, section 8.2)
+            Each <a class="external" href="https://tc39.github.io/ecma262/#sec-code-realms">ECMAScript global environment</a> (<a href='#ref-ECMA-262'>[ECMA-262]</a>, section 8.2)
             <span class='rfc2119'>MUST</span> have its own unique set of each of
             the <a class='dfnref' href='#dfn-initial-object'>initial objects</a>, created
             before control enters any ECMAScript execution context associated with the
@@ -9019,7 +9019,7 @@ list.unshift({ });         <span class='comment'>// Insert an item at index 0.</
                 and no indexed property <a class='dfnref' href='#dfn-indexed-property-setter'>setter</a>.  The
                 mutating <span class='estype'>Array</span> methods will generally not
                 succeed on objects implementing <span class='idltype'>ImmutableItemList</span>.
-                The exact behavior depends on the definition of <a class="external" href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-array-prototype-object">the <span class='estype'>Array</span> methods
+                The exact behavior depends on the definition of <a class="external" href="https://tc39.github.io/ecma262/#sec-properties-of-the-array-prototype-object">the <span class='estype'>Array</span> methods
                   themselves</a> (<a href='#ref-ECMA-262'>[ECMA-262]</a>, section 22.1.3).
               </p>
             </div>
@@ -14990,10 +14990,9 @@ d.type = et;
           <dl>
             <dt id='ref-ECMA-262'>[ECMA-262]</dt>
             <dd>
-              <cite><a href="http://wiki.ecmascript.org/doku.php?id=harmony:specification_drafts">ECMAScript Language Specification, 6th Edition</a></cite>,
-              A. Wirfs-Brock, Editor. Ecma International, 8 November 2013 (Working Draft).
-              <span class="print"><br/>Available at http://wiki.ecmascript.org/doku.php?id=harmony:specification_drafts</span>
-              <br/>Unofficial HTML version available at <a href="http://people.mozilla.org/~jorendorff/es6-draft.html">http://people.mozilla.org/~jorendorff/es6-draft.html</a>.
+              <cite><a href="https://tc39.github.io/ecma262/">ECMAScript Language Specification</a></cite>.
+              Ecma International.
+              <span class="print"><br/>Available at https://tc39.github.io/ecma262/.</span>
             </dd>
             <dt id='ref-IEEE-754'>[IEEE-754]</dt>
             <dd>


### PR DESCRIPTION
jorendorff's unofficial HTML version already redirects there, so there's no
point in linking to that URL.

This commit only updates the links; more work is needed to ensure all
references are still correct in ES2017.