### PR TITLE
Document that NotAllowedError should be used for denied permissions.

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -4506,7 +4506,7 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
                 <tr>
                   <!-- HTML -->
                   <td>"<dfn data-export="" data-dfn-type="exception" id="notallowederror"><code>NotAllowedError</code></dfn>"</td>
-                  <td>The request is not allowed by the user agent or the platform in the current context.</td>
+                  <td>The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.</td>
                   <td>—</td>
                 </tr>
               </tbody>


### PR DESCRIPTION
FYI @mvano @foolip re https://github.com/w3c/push-api/issues/186.

This fixes #95.