### PR TITLE
Add namespaces

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED" type="text/css" /></head>
 
   <body>
-    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL (Second Edition)</h1><h2>W3C Editor’s Draft <em>15 July 2016</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/">http://heycam.github.io/webidl/</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
+    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL (Second Edition)</h1><h2>W3C Editor’s Draft <em>25 August 2016</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/">http://heycam.github.io/webidl/</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
               Send feedback to <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a> or <a href="https://www.w3.org/Bugs/Public/enter_bug.cgi?product=WebAppsWG&amp;component=WebIDL">file a bug</a> (<a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=WebIDL&amp;resolution=---">open bugs</a>)
             </dd><dt>Editors:</dt><dd><a href="http://mcc.id.au/">Cameron McCormack</a>, Mozilla Corporation &lt;cam@mcc.id.au&gt;</dd><dd>Boris Zbarsky, Mozilla Corporation &lt;bzbarsky@mit.edu&gt;</dd></dl><p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &copy; 2016 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>&reg;</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p></div><hr /><script async="" src="file-bug.js"></script>
 
@@ -72,7 +72,7 @@
         report can be found in the <a href="http://www.w3.org/TR/">W3C technical
           reports index</a> at http://www.w3.org/TR/.
       </em></p><p>
-        This document is the 15 July 2016 <b>Editor’s Draft</b> of the
+        This document is the 25 August 2016 <b>Editor’s Draft</b> of the
         <cite>Web IDL (Second Edition)</cite> specification.
       
       Please send comments about this document to
@@ -673,7 +673,7 @@ interface TextField {
   <i>interface-members…</i>
 };</pre>
           <p>
-            The order that members appear has significance both for <a href="#idl-overloading">overloading</a> and for property enumeration in the <a href="#es-interfaces">ECMAScript binding</a>.
+            The order that members appear in has significance for property enumeration in the <a href="#es-interfaces">ECMAScript binding</a>.
           </p>
           <p>
             Interfaces may specify an interface member that has the same name as
@@ -3191,11 +3191,6 @@ partial interface A {
                   <li>Add to <var>S</var> the tuple &lt;<var>X</var>, <var>t</var><sub>0..<var>n</var>−1</sub>, <var>o</var><sub>0..<var>n</var>−1</sub>&gt;.</li>
                   <li>If <var>X</var> is declared to be <a class="dfnref" href="#dfn-variadic">variadic</a>, then:
                     <ol>
-                      <li>Add to <var>S</var> the tuple &lt;<var>X</var>, <var>t</var><sub>0..<var>n</var>−2</sub>, <var>o</var><sub>0..<var>n</var>−2</sub>&gt;.
-                        <div class="note"><div class="noteHeader">Note</div>
-                          <p>This leaves off the final, variadic argument.</p>
-                        </div>
-                      </li>
                       <li>For every integer <var>i</var>, such that <var>n</var> ≤ <var>i</var> ≤ <var>m</var>−1:
                         <ol>
                           <li>Let <var>u</var><sub>0..<var>i</var></sub> be a list of types, where <var>u</var><sub>j</sub> = <var>t</var><sub>j</sub> (for <var>j</var> &lt; <var>n</var>) and <var>u</var><sub>j</sub> = <var>t</var><sub><var>n</var>−1</sub> (for <var>j</var> ≥ <var>n</var>).</li>
@@ -3208,12 +3203,14 @@ partial interface A {
                   <li>Initialize <var>i</var> to <var>n</var>−1.</li>
                   <li>While <var>i</var> ≥ 0:
                     <ol>
-                      <li>If argument <var>i</var> of <var>X</var> is not <a class="dfnref" href="#dfn-optional-argument">optional</a>, then break this loop.</li>
+                      <li>If argument <var>i</var> of <var>X</var> is not
+                        <a class="dfnref" href="#dfn-optional-argument">optional</a>
+                        (i.e., it is not marked as <code>optional</code> and is not
+                        a final, variadic argument), then break this loop.</li>
                       <li>Otherwise, add to <var>S</var> the tuple &lt;<var>X</var>, <var>t</var><sub>0..<var>i</var>−1</sub>, <var>o</var><sub>0..<var>i</var>−1</sub>&gt;.</li>
                       <li>Set <var>i</var> to <var>i</var>−1.</li>
                     </ol>
                   </li>
-                  <li>If <var>n</var> &gt; 0 and all arguments of <var>X</var> are optional, then add to <var>S</var> the tuple &lt;<var>X</var>, (), ()&gt; (where “()” represents the empty list).</li>
                 </ol>
               </li>
               <li>
@@ -3991,14 +3988,14 @@ partial namespace <em>SomeNamespace</em> {
           <div class="note"><div class="noteHeader">Note</div>
             <p>
               As with partial interface definitions, partial namespace definitions are intended for
-              use as a specification editorial aide, allowing the definition of an interface to be
+              use as a specification editorial aide, allowing the definition of a namespace to be
               separated over more than one section of the document, and sometimes multiple
               documents.
             </p>
           </div>
 
           <p>
-            The order that members appear has significance both for <a href="#idl-overloading">overloading</a> and for property enumeration in the <a href="#es-namespaces">ECMAScript binding</a>.
+            The order that members appear in has significance for property enumeration in the <a href="#es-namespaces">ECMAScript binding</a>.
           </p>
 
           <p>
@@ -4006,11 +4003,8 @@ partial namespace <em>SomeNamespace</em> {
           </p>
 
           <p>
-            Only the <a class="xattr" href="#Exposed">[Exposed]</a> and <a class="xattr" href="#SecureContext">[SecureContext]</a> extended attributes are applicable to
-            namespaces. When declaring a <a class="dfnref" href="#dfn-partial-namespace">partial
-            namespace</a>, the partial namespace must have the same extended attributes (and
-            extended attribute argument values, if any) specified as the original namespace
-            definition with the same identifier.
+            Of the extended attributes defined in this specification, only the <a class="xattr" href="#Exposed">[Exposed]</a> and <a class="xattr" href="#SecureContext">[SecureContext]</a> extended attributes are applicable to
+            namespaces.
           </p>
 
           <table class="grammar"><tr><td><span class="prod-number">[6]</span></td><td><a class="sym" href="#prod-Partial">Partial</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"partial" <a class="sym" href="#prod-PartialDefinition">PartialDefinition</a></span></td></tr><tr><td><span class="prod-number">[7]</span></td><td><a class="sym" href="#prod-PartialDefinition">PartialDefinition</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-PartialInterface">PartialInterface</a> <br /> |
@@ -4668,7 +4662,7 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
               separated at all, unless there is a specific reason to use another
               value naming scheme.  For example, an enumeration value that
               indicates an object should be created could be named
-              <code>"createobject"</code> or <code>'create-object"</code>.
+              <code>"createobject"</code> or <code>"create-object"</code>.
               Consider related uses of enumeration values when deciding whether
               to dash-separate or not separate enumeration value words so that
               similar APIs are consistent.
@@ -5612,7 +5606,9 @@ interface Person {
             </p>
             <p>
               There is no way to represent a constant <a class="idltype" href="#idl-ByteString">ByteString</a>
-              value in IDL.
+              value in IDL, although <a class="idltype" href="#idl-ByteString">ByteString</a> <a class="dfnref" href="#dfn-dictionary-member">dictionary member</a>
+              and <a class="dfnref" href="#dfn-optional-argument">operation optional argument</a> default values
+              can be specified using a <a class="sym" href="#prod-string">string</a> literal.
             </p>
             <p>
               The <a class="dfnref" href="#dfn-type-name">type name</a> of the
@@ -8758,7 +8754,8 @@ context.setColorEnforcedRange(-1, 255, 256);</code></pre></div></div>
               <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>
               appears on an <a class="dfnref" href="#dfn-interface">interface</a>,
               <a class="dfnref" href="#dfn-partial-interface">partial interface</a>,
-              <a class="dfnref" href="#dfn-namespace">namespace</a>, or
+              <a class="dfnref" href="#dfn-namespace">namespace</a>,
+              <a class="dfnref" href="#dfn-partial-namespace">partial namespace</a>, or
               an individual <a class="dfnref" href="#dfn-interface-member">interface member</a> or
               <a class="dfnref" href="#dfn-namespace-member">namespace member</a>,
               it indicates that the construct is exposed
@@ -8800,13 +8797,14 @@ context.setColorEnforcedRange(-1, 255, 256);</code></pre></div></div>
                 <dl class="switch">
                   <dt>interface</dt>
                   <dt>namespace</dt>
-                  <dd>The <a class="dfnref" href="#dfn-exposure-set">exposure set</a> of the interface
-                  only contains the
+                  <dd>The <a class="dfnref" href="#dfn-exposure-set">exposure set</a> of the
+                  interface or namespace only contains the
                   <a class="dfnref" href="#dfn-primary-global-interface">primary global interface</a>.</dd>
                   <dt>partial interface</dt>
+                  <dt>partial namespace</dt>
                   <dd>The <a class="dfnref" href="#dfn-exposure-set">exposure set</a> of the partial
-                  interface is the <a class="dfnref" href="#dfn-exposure-set">exposure set</a> of the original
-                  interface definition.</dd>
+                  interface or namespace is the <a class="dfnref" href="#dfn-exposure-set">exposure
+                  set</a> of the original interface or namespace definition.</dd>
                   <dt>interface member</dt>
                   <dd>The <a class="dfnref" href="#dfn-exposure-set">exposure set</a> of the interface member
                   is the <a class="dfnref" href="#dfn-exposure-set">exposure set</a> of the interface or
@@ -8814,7 +8812,7 @@ context.setColorEnforcedRange(-1, 255, 256);</code></pre></div></div>
                   <dt>namespace member</dt>
                   <dd>The <a class="dfnref" href="#dfn-exposure-set">exposure set</a> of the
                   namespace member is the <a class="dfnref" href="#dfn-exposure-set">exposure
-                  set</a> of the namespace the member is declared on.</dd>
+                  set</a> of the namespace or partial namespace the member is declared on.</dd>
                 </dl>
               </li>
             </ul>
@@ -8827,18 +8825,18 @@ context.setColorEnforcedRange(-1, 255, 256);</code></pre></div></div>
               The <a class="xattr" href="#Exposed">[Exposed]</a> extended attribute
               <span class="rfc2119">MUST NOT</span> be specified on both an interface
               member and a partial interface definition the interface member is declared on.
+              Similarly, the <a class="xattr" href="#Exposed">[Exposed]</a> extended attribute
+              <span class="rfc2119">MUST NOT</span> be specified on both a namespace
+              member and a partial namespace definition the namespace member is declared on.
             </p>
             <p>
-              If <a class="xattr" href="#Exposed">[Exposed]</a> appears on both an interface
-              and one of its interface members, then the interface member's
-              <a class="dfnref" href="#dfn-exposure-set">exposure set</a>
-              <span class="rfc2119">MUST</span> be a subset of the interface's
-              <a class="dfnref" href="#dfn-exposure-set">exposure set</a>.
-              Similarly, if <a class="xattr" href="#Exposed">[Exposed]</a> appears on both a
-              namespace and one of its namespace members, then the namespace member's
-              <a class="dfnref" href="#dfn-exposure-set">exposure set</a>
-              <span class="rfc2119">MUST</span> be a subset of the namespace's
-              <a class="dfnref" href="#dfn-exposure-set">exposure set</a>.
+              If <a class="xattr" href="#Exposed">[Exposed]</a> appears an interface member, then
+              the interface member's <a class="dfnref" href="#dfn-exposure-set">exposure set</a>
+              <span class="rfc2119">MUST</span> be a subset of the <a class="dfnref" href="#dfn-exposure-set">exposure set</a> of the interface or partial interface it's a
+              member of. Similarly, if <a class="xattr" href="#Exposed">[Exposed]</a> appears on a
+              namespace member, then the namespace member's <a class="dfnref" href="#dfn-exposure-set">exposure set</a> <span class="rfc2119">MUST</span> be a
+              subset of the <a class="dfnref" href="#dfn-exposure-set">exposure set</a> of the
+              namespace or partial namespace it's a member of.
             </p>
             <p>
               An interface's <a class="dfnref" href="#dfn-exposure-set">exposure set</a>
@@ -10093,6 +10091,8 @@ counter.value;                                           <span class="comment">/
               <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>
               appears on an <a class="dfnref" href="#dfn-interface">interface</a>,
               <a class="dfnref" href="#dfn-partial-interface">partial interface</a>,
+              <a class="dfnref" href="#dfn-namespace">namespace</a>,
+              <a class="dfnref" href="#dfn-partial-namespace">partial namespace</a>,
               <a class="dfnref" href="#dfn-interface-member">interface member</a>, or
               <a class="dfnref" href="#dfn-namespace-member">namespace member</a>,
               it indicates that the construct is exposed
@@ -10111,6 +10111,8 @@ counter.value;                                           <span class="comment">/
               be used on anything other than an
               <a class="dfnref" href="#dfn-interface">interface</a>,
               <a class="dfnref" href="#dfn-partial-interface">partial interface</a>,
+              <a class="dfnref" href="#dfn-namespace">namespace</a>,
+              <a class="dfnref" href="#dfn-partial-namespace">partial namespace</a>,
               <a class="dfnref" href="#dfn-interface-member">interface member</a>, or
               <a class="dfnref" href="#dfn-namespace-member">namespace member</a>.
             </p>
@@ -10135,17 +10137,23 @@ counter.value;                                           <span class="comment">/
                 depends on the type of construct:</p>
                 <dl class="switch">
                   <dt>interface</dt>
-                  <dd>The interface or dictionary is not
+                  <dt>namespace</dt>
+                  <dd>The interface or namespace is not
                   <a class="dfnre" href="#dfn-available-only-in-secure-contexts">available only in secure contexts</a>.</dd>
+
                   <dt>partial interface</dt>
-                  <dd>The partial interface is <a class="dfnre" href="#dfn-available-only-in-secure-contexts">available only in secure contexts</a>
-                  if and only if the original interface definition is.</dd>
+                  <dt>partial namespace</dt>
+                  <dd>The partial interface or partial namespace is <a class="dfnre" href="#dfn-available-only-in-secure-contexts">available only in secure
+                  contexts</a> if and only if the original interface or namespace definition
+                  is.</dd>
+
                   <dt>interface member</dt>
                   <dd>The interface member is <a class="dfnre" href="#dfn-available-only-in-secure-contexts">available only in secure contexts</a>
                   if and only if the interface or partial interface the member is declared on is.</dd>
+
                   <dt>namespace member</dt>
                   <dd>The namespace member is <a class="dfnre" href="#dfn-available-only-in-secure-contexts">available only in secure contexts</a>
-                  if and only if the namspace the member is declared on is.</dd>
+                  if and only if the namspace or partial namespace the member is declared on is.</dd>
                 </dl>
               </li>
             </ul>
@@ -10164,10 +10172,10 @@ counter.value;                                           <span class="comment">/
             </p>
             <p>
               The <a class="xattr" href="#SecureContext">[SecureContext]</a> extended attribute
-              <span class="rfc2119">MUST NOT</span> be specified on both an interface
-              member and the interface or partial interface definition the
-              interface member is declared within, or on both a namespace member and the namespace
-              definition the namespace member is declared within.
+              <span class="rfc2119">MUST NOT</span> be specified on both an interface member and the
+              interface or partial interface definition the interface member is declared within, or
+              on both a namespace member and the namespace or partial namespace definition the
+              namespace member is declared within.
             </p>
             <p>
               An interface without the <a class="xattr" href="#SecureContext">[SecureContext]</a> extended attribute
@@ -10666,19 +10674,6 @@ with (thing) {
                     <li><a class="idltype" href="#idl-object">object</a></li>
                     <li>a <a class="dfnref" href="#dfn-nullable-type">nullable</a> version of any of the above types</li>
                     <li>a <a class="dfnref" href="#dfn-union-type">union type</a> or a <a class="dfnref" href="#dfn-nullable-type">nullable</a> union type
-                       that has one of the above types in its <a class="dfnref" href="#dfn-flattened-union-member-types">flattened member types</a></li>
-                  </ul>
-                  then remove from <var>S</var> all other entries.
-                </li>
-
-                <li>
-                  Otherwise: if <var>V</var> is a <span class="estype">RegExp</span> object and
-                  there is an entry in <var>S</var> that has one of the following types at position <var>i</var> of its type list,
-                  <ul>
-                    <li><a class="idltype" href="#idl-RegExp">RegExp</a></li>
-                    <li><a class="idltype" href="#idl-object">object</a></li>
-                    <li>a <a class="dfnref" href="#dfn-nullable-type">nullable</a> version of either of the above types</li>
-                    <li>a <a class="dfnref" href="#dfn-union-type">union type</a> or <a class="dfnref" href="#dfn-nullable-type">nullable</a> union type
                        that has one of the above types in its <a class="dfnref" href="#dfn-flattened-union-member-types">flattened member types</a></li>
                   </ul>
                   then remove from <var>S</var> all other entries.
@@ -11531,7 +11526,7 @@ partial interface Window {
                   </ol>
                 </li>
 
-                <li>Return the result of calling the <a class="external" href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p">default <span class="prop">[[GetOwnProperty]]</span> internal method</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 9.1.5) on <var>O</var> passing <var>P</var> as the argument.</li>
+                <li>Return <a class="external" href="https://tc39.github.io/ecma262/#sec-ordinarygetownproperty">OrdinaryGetOwnProperty</a>(<var>O</var>, <var>P</var>).</li>
               </ol>
             </div>
 
@@ -13762,7 +13757,7 @@ C implements A;</code></pre></div></div>
                 </ol>
               </li>
 
-              <li>Return the result of calling the <a class="external" href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p">default <span class="prop">[[GetOwnProperty]]</span> internal method</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 9.1.5) on <var>O</var> passing <var>P</var> as the argument.</li>
+              <li>Return <a class="external" href="https://tc39.github.io/ecma262/#sec-ordinarygetownproperty">OrdinaryGetOwnProperty</a>(<var>O</var>, <var>P</var>).</li>
             </ol>
           </div>
 
@@ -14027,21 +14022,21 @@ C implements A;</code></pre></div></div>
                 and the result of calling the <a class="dfnref" href="#dfn-named-property-visibility">named property visibility algorithm</a>
                 with property name <var>P</var> and object <var>O</var> is true, then:
                 <ol>
-                  <li>If <var>O</var> does not implement an interface with a <a class="dfnref" href="#dfn-named-property-deleter">named property deleter</a>, then <span class="esvalue">false</span>.</li>
+                  <li>If <var>O</var> does not implement an interface with a <a class="dfnref" href="#dfn-named-property-deleter">named property deleter</a>, then return <span class="esvalue">false</span>.</li>
                   <li>Let <var>operation</var> be the operation used to declare the named property deleter.</li>
                   <li>If <var>operation</var> was defined without an <a class="dfnref" href="#dfn-identifier">identifier</a>, then:
                     <ol>
                       <li>Perform the steps listed in the interface description to
                         <a class="dfnref" href="#dfn-delete-an-existing-named-property">delete an existing named property</a>
                         with <var>P</var> as the name.</li>
-                      <li>If the steps indicated that the deletion failed, then <span class="esvalue">false</span>.</li>
+                      <li>If the steps indicated that the deletion failed, then return <span class="esvalue">false</span>.</li>
                     </ol>
                   </li>
                   <li>Otherwise, <var>operation</var> was defined with an identifier:
                     <ol>
                       <li>Perform the steps listed in the description of <var>operation</var> with <var>P</var> as the only argument value.</li>
                       <li>If <var>operation</var> was declared with a <a class="dfnref" href="#dfn-return-type">return type</a> of <a class="idltype" href="#idl-boolean">boolean</a>
-                        and the steps returned <span class="idlvalue">false</span>, then <span class="esvalue">false</span>.</li>
+                        and the steps returned <span class="idlvalue">false</span>, then return <span class="esvalue">false</span>.</li>
                     </ol>
                   </li>
                   <li>Return <span class="esvalue">true</span>.</li>
@@ -14050,7 +14045,7 @@ C implements A;</code></pre></div></div>
 
               <li>If <var>O</var> has an own property with name <var>P</var>, then:
                 <ol>
-                  <li>If the property is not configurable, then <span class="esvalue">false</span>.</li>
+                  <li>If the property is not configurable, then return <span class="esvalue">false</span>.</li>
                   <li>Otherwise, remove the property from <var>O</var>.</li>
                 </ol>
               </li>
@@ -15155,6 +15150,7 @@ d.type = et;
           Marcos Cáceres,
           Giovanni Campagna,
           Domenic Denicola,
+          Chris Dumez,
           Michael Dyck,
           Brendan Eich,
           João Eiras,

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED" type="text/css" /></head>
 
   <body>
-    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL (Second Edition)</h1><h2>W3C Editor’s Draft <em>23 August 2016</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/">http://heycam.github.io/webidl/</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
+    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL (Second Edition)</h1><h2>W3C Editor’s Draft <em>15 July 2016</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/">http://heycam.github.io/webidl/</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
               Send feedback to <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a> or <a href="https://www.w3.org/Bugs/Public/enter_bug.cgi?product=WebAppsWG&amp;component=WebIDL">file a bug</a> (<a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=WebIDL&amp;resolution=---">open bugs</a>)
             </dd><dt>Editors:</dt><dd><a href="http://mcc.id.au/">Cameron McCormack</a>, Mozilla Corporation &lt;cam@mcc.id.au&gt;</dd><dd>Boris Zbarsky, Mozilla Corporation &lt;bzbarsky@mit.edu&gt;</dd></dl><p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &copy; 2016 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>&reg;</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p></div><hr /><script async="" src="file-bug.js"></script>
 
@@ -72,7 +72,7 @@
         report can be found in the <a href="http://www.w3.org/TR/">W3C technical
           reports index</a> at http://www.w3.org/TR/.
       </em></p><p>
-        This document is the 23 August 2016 <b>Editor’s Draft</b> of the
+        This document is the 15 July 2016 <b>Editor’s Draft</b> of the
         <cite>Web IDL (Second Edition)</cite> specification.
       
       Please send comments about this document to
@@ -123,7 +123,7 @@
 
     <div id="toc">
       <h2>Table of Contents</h2>
-      <div class="toc"><ul><li><a href="#introduction">1. Introduction</a><ul><li><a href="#conventions">1.1. Typographic conventions</a></li></ul></li><li><a href="#conformance">2. Conformance</a></li><li><a href="#idl">3. Interface definition language</a><ul><li><a href="#idl-names">3.1. Names</a></li><li><a href="#idl-interfaces">3.2. Interfaces</a><ul><li><a href="#idl-constants">3.2.1. Constants</a></li><li><a href="#idl-attributes">3.2.2. Attributes</a></li><li><a href="#idl-operations">3.2.3. Operations</a></li><li><a href="#idl-special-operations">3.2.4. Special operations</a><ul><li><a href="#idl-legacy-callers">3.2.4.1. Legacy callers</a></li><li><a href="#idl-stringifiers">3.2.4.2. Stringifiers</a></li><li><a href="#idl-serializers">3.2.4.3. Serializers</a></li><li><a href="#idl-indexed-properties">3.2.4.4. Indexed properties</a></li><li><a href="#idl-named-properties">3.2.4.5. Named properties</a></li></ul></li><li><a href="#idl-static-attributes-and-operations">3.2.5. Static attributes and operations</a></li><li><a href="#idl-overloading">3.2.6. Overloading</a></li><li><a href="#idl-iterable">3.2.7. Iterable declarations</a></li><li><a href="#idl-maplike">3.2.8. Maplike declarations</a></li><li><a href="#idl-setlike">3.2.9. Setlike declarations</a></li></ul></li><li><a href="#idl-dictionaries">3.3. Dictionaries</a></li><li><a href="#idl-exceptions">3.4. Exceptions</a><ul><li><a href="#idl-DOMException-error-names">3.4.1. Error names</a></li></ul></li><li><a href="#idl-enums">3.5. Enumerations</a></li><li><a href="#idl-callback-functions">3.6. Callback functions</a></li><li><a href="#idl-typedefs">3.7. Typedefs</a></li><li><a href="#idl-implements-statements">3.8. Implements statements</a></li><li><a href="#idl-objects">3.9. Objects implementing interfaces</a></li><li><a href="#idl-types">3.10. Types</a><ul><li><a href="#idl-any">3.10.1. any</a></li><li><a href="#idl-boolean">3.10.2. boolean</a></li><li><a href="#idl-byte">3.10.3. byte</a></li><li><a href="#idl-octet">3.10.4. octet</a></li><li><a href="#idl-short">3.10.5. short</a></li><li><a href="#idl-unsigned-short">3.10.6. unsigned short</a></li><li><a href="#idl-long">3.10.7. long</a></li><li><a href="#idl-unsigned-long">3.10.8. unsigned long</a></li><li><a href="#idl-long-long">3.10.9. long long</a></li><li><a href="#idl-unsigned-long-long">3.10.10. unsigned long long</a></li><li><a href="#idl-float">3.10.11. float</a></li><li><a href="#idl-unrestricted-float">3.10.12. unrestricted float</a></li><li><a href="#idl-double">3.10.13. double</a></li><li><a href="#idl-unrestricted-double">3.10.14. unrestricted double</a></li><li><a href="#idl-DOMString">3.10.15. DOMString</a></li><li><a href="#idl-ByteString">3.10.16. ByteString</a></li><li><a href="#idl-USVString">3.10.17. USVString</a></li><li><a href="#idl-object">3.10.18. object</a></li><li><a href="#idl-interface">3.10.19. Interface types</a></li><li><a href="#idl-dictionary">3.10.20. Dictionary types</a></li><li><a href="#idl-enumeration">3.10.21. Enumeration types</a></li><li><a href="#idl-callback-function">3.10.22. Callback function types</a></li><li><a href="#idl-nullable-type">3.10.23. Nullable types — <var>T</var>?</a></li><li><a href="#idl-sequence">3.10.24. Sequences — sequence&lt;<var>T</var>&gt;</a></li><li><a href="#idl-promise">3.10.25. Promise types — Promise&lt;<var>T</var>&gt;</a></li><li><a href="#idl-union">3.10.26. Union types</a></li><li><a href="#idl-RegExp">3.10.27. RegExp</a></li><li><a href="#idl-Error">3.10.28. Error</a></li><li><a href="#idl-DOMException">3.10.29. DOMException</a></li><li><a href="#idl-buffer-source-types">3.10.30. Buffer source types</a></li><li><a href="#idl-frozen-array">3.10.31. Frozen arrays — FrozenArray&lt;<var>T</var>&gt;</a></li></ul></li><li><a href="#idl-extended-attributes">3.11. Extended attributes</a></li></ul></li><li><a href="#ecmascript-binding">4. ECMAScript binding</a><ul><li><a href="#es-environment">4.1. ECMAScript environment</a></li><li><a href="#es-type-mapping">4.2. ECMAScript type mapping</a><ul><li><a href="#es-any">4.2.1. any</a></li><li><a href="#es-void">4.2.2. void</a></li><li><a href="#es-boolean">4.2.3. boolean</a></li><li><a href="#es-byte">4.2.4. byte</a></li><li><a href="#es-octet">4.2.5. octet</a></li><li><a href="#es-short">4.2.6. short</a></li><li><a href="#es-unsigned-short">4.2.7. unsigned short</a></li><li><a href="#es-long">4.2.8. long</a></li><li><a href="#es-unsigned-long">4.2.9. unsigned long</a></li><li><a href="#es-long-long">4.2.10. long long</a></li><li><a href="#es-unsigned-long-long">4.2.11. unsigned long long</a></li><li><a href="#es-float">4.2.12. float</a></li><li><a href="#es-unrestricted-float">4.2.13. unrestricted float</a></li><li><a href="#es-double">4.2.14. double</a></li><li><a href="#es-unrestricted-double">4.2.15. unrestricted double</a></li><li><a href="#es-DOMString">4.2.16. DOMString</a></li><li><a href="#es-ByteString">4.2.17. ByteString</a></li><li><a href="#es-USVString">4.2.18. USVString</a></li><li><a href="#es-object">4.2.19. object</a></li><li><a href="#es-interface">4.2.20. Interface types</a></li><li><a href="#es-dictionary">4.2.21. Dictionary types</a></li><li><a href="#es-enumeration">4.2.22. Enumeration types</a></li><li><a href="#es-callback-function">4.2.23. Callback function types</a></li><li><a href="#es-nullable-type">4.2.24. Nullable types — <var>T</var>?</a></li><li><a href="#es-sequence">4.2.25. Sequences — sequence&lt;<var>T</var>&gt;</a><ul><li><a href="#create-sequence-from-iterable">4.2.25.1. Creating a sequence from an iterable</a></li></ul></li><li><a href="#es-promise">4.2.26. Promise types — Promise&lt;<var>T</var>&gt;</a></li><li><a href="#es-union">4.2.27. Union types</a></li><li><a href="#es-RegExp">4.2.28. RegExp</a></li><li><a href="#es-Error">4.2.29. Error</a></li><li><a href="#es-DOMException">4.2.30. DOMException</a></li><li><a href="#es-buffer-source-types">4.2.31. Buffer source types</a></li><li><a href="#es-frozen-array">4.2.32. Frozen arrays — FrozenArray&lt;<var>T</var>&gt;</a><ul><li><a href="#create-frozen-array-from-iterable">4.2.32.1. Creating a frozen array from an iterable</a></li></ul></li></ul></li><li><a href="#es-extended-attributes">4.3. ECMAScript-specific extended attributes</a><ul><li><a href="#Clamp">4.3.1. [Clamp]</a></li><li><a href="#Constructor">4.3.2. [Constructor]</a></li><li><a href="#EnforceRange">4.3.3. [EnforceRange]</a></li><li><a href="#Exposed">4.3.4. [Exposed]</a></li><li><a href="#ImplicitThis">4.3.5. [ImplicitThis]</a></li><li><a href="#Global">4.3.6. [Global] and [PrimaryGlobal]</a></li><li><a href="#LegacyArrayClass">4.3.7. [LegacyArrayClass]</a></li><li><a href="#LegacyUnenumerableNamedProperties">4.3.8. [LegacyUnenumerableNamedProperties]</a></li><li><a href="#LenientSetter">4.3.9. [LenientSetter]</a></li><li><a href="#LenientThis">4.3.10. [LenientThis]</a></li><li><a href="#NamedConstructor">4.3.11. [NamedConstructor]</a></li><li><a href="#NewObject">4.3.12. [NewObject]</a></li><li><a href="#NoInterfaceObject">4.3.13. [NoInterfaceObject]</a></li><li><a href="#OverrideBuiltins">4.3.14. [OverrideBuiltins]</a></li><li><a href="#PutForwards">4.3.15. [PutForwards]</a></li><li><a href="#Replaceable">4.3.16. [Replaceable]</a></li><li><a href="#SameObject">4.3.17. [SameObject]</a></li><li><a href="#SecureContext">4.3.18. [SecureContext]</a></li><li><a href="#TreatNonObjectAsNull">4.3.19. [TreatNonObjectAsNull]</a></li><li><a href="#TreatNullAs">4.3.20. [TreatNullAs]</a></li><li><a href="#Unforgeable">4.3.21. [Unforgeable]</a></li><li><a href="#Unscopable">4.3.22. [Unscopable]</a></li></ul></li><li><a href="#es-security">4.4. Security</a></li><li><a href="#es-overloads">4.5. Overload resolution algorithm</a></li><li><a href="#es-interfaces">4.6. Interfaces</a><ul><li><a href="#interface-object">4.6.1. Interface object</a><ul><li><a href="#es-interface-call">4.6.1.1. Interface object [[Call]] method</a></li><li><a href="#es-interface-hasinstance">4.6.1.2. Interface object [[HasInstance]] method</a></li></ul></li><li><a href="#named-constructors">4.6.2. Named constructors</a></li><li><a href="#interface-prototype-object">4.6.3. Interface prototype object</a></li><li><a href="#named-properties-object">4.6.4. Named properties object</a><ul><li><a href="#named-properties-object-getownproperty">4.6.4.1. Named properties object [[GetOwnProperty]] method</a></li><li><a href="#named-properties-object-defineownproperty">4.6.4.2. Named properties object [[DefineOwnProperty]] method</a></li><li><a href="#named-properties-object-delete">4.6.4.3. Named properties object [[Delete]] method</a></li></ul></li><li><a href="#es-constants">4.6.5. Constants</a></li><li><a href="#es-attributes">4.6.6. Attributes</a></li><li><a href="#es-operations">4.6.7. Operations</a><ul><li><a href="#es-stringifier">4.6.7.1. Stringifiers</a></li><li><a href="#es-serializer">4.6.7.2. Serializers</a></li></ul></li><li><a href="#es-iterators">4.6.8. Common iterator behavior</a><ul><li><a href="#es-iterator">4.6.8.1. @@iterator</a></li><li><a href="#es-forEach">4.6.8.2. forEach</a></li></ul></li><li><a href="#es-iterable">4.6.9. Iterable declarations</a><ul><li><a href="#es-iterable-entries">4.6.9.1. entries</a></li><li><a href="#es-iterable-keys">4.6.9.2. keys</a></li><li><a href="#es-iterable-values">4.6.9.3. values</a></li><li><a href="#es-default-iterator-object">4.6.9.4. Default iterator objects</a></li><li><a href="#es-iterator-prototype-object">4.6.9.5. Iterator prototype object</a></li></ul></li><li><a href="#es-maplike">4.6.10. Maplike declarations</a><ul><li><a href="#es-map-size">4.6.10.1. size</a></li><li><a href="#es-map-entries">4.6.10.2. entries</a></li><li><a href="#es-map-keys-values">4.6.10.3. keys and values</a></li><li><a href="#es-map-get-has">4.6.10.4. get and has</a></li><li><a href="#es-map-clear">4.6.10.5. clear</a></li><li><a href="#es-map-delete">4.6.10.6. delete</a></li><li><a href="#es-map-set">4.6.10.7. set</a></li></ul></li><li><a href="#es-setlike">4.6.11. Setlike declarations</a><ul><li><a href="#es-set-size">4.6.11.1. size</a></li><li><a href="#es-set-values">4.6.11.2. values</a></li><li><a href="#es-set-entries-keys">4.6.11.3. entries and keys</a></li><li><a href="#es-set-has">4.6.11.4. has</a></li><li><a href="#es-add-delete">4.6.11.5. add and delete</a></li><li><a href="#es-set-clear">4.6.11.6. clear</a></li></ul></li><li><a href="#initializing-objects-from-iterables">4.6.12. Initializing objects from iterables</a></li></ul></li><li><a href="#es-implements-statements">4.7. Implements statements</a></li><li><a href="#es-platform-objects">4.8. Platform objects implementing interfaces</a><ul><li><a href="#indexed-and-named-properties">4.8.1. Indexed and named properties</a></li><li><a href="#getownproperty-guts">4.8.2. The PlatformObjectGetOwnProperty abstract operation</a></li><li><a href="#getownproperty">4.8.3. Platform object [[GetOwnProperty]] method</a></li><li><a href="#invoking-indexed-setter">4.8.4. Invoking a platform object indexed property setter</a></li><li><a href="#invoking-named-setter">4.8.5. Invoking a platform object named property setter</a></li><li><a href="#platformobjectset">4.8.6. Platform object [[Set]] method</a></li><li><a href="#defineownproperty">4.8.7. Platform object [[DefineOwnProperty]] method</a></li><li><a href="#delete">4.8.8. Platform object [[Delete]] method</a></li><li><a href="#call">4.8.9. Platform object [[Call]] method</a></li><li><a href="#property-enumeration">4.8.10. Property enumeration</a></li></ul></li><li><a href="#es-user-objects">4.9. User objects implementing callback interfaces</a></li><li><a href="#es-invoking-callback-functions">4.10. Invoking callback functions</a></li><li><a href="#es-exceptions">4.11. Exceptions</a><ul><li><a href="#es-DOMException-constructor-object">4.11.1. DOMException constructor object</a><ul><li><a href="#es-DOMException-call">4.11.1.1. DOMException(message, name)</a></li></ul></li><li><a href="#es-DOMException-prototype-object">4.11.2. DOMException prototype object</a></li></ul></li><li><a href="#es-exception-objects">4.12. Exception objects</a></li><li><a href="#es-creating-throwing-exceptions">4.13. Creating and throwing exceptions</a></li><li><a href="#es-handling-exceptions">4.14. Handling exceptions</a></li></ul></li><li><a href="#common">5. Common definitions</a><ul><li><a href="#common-ArrayBufferView">5.1. ArrayBufferView</a></li><li><a href="#common-BufferSource">5.2. BufferSource</a></li><li><a href="#common-DOMTimeStamp">5.3. DOMTimeStamp</a></li><li><a href="#common-Function">5.4. Function</a></li><li><a href="#common-Function">5.5. VoidFunction</a></li></ul></li><li><a href="#extensibility">6. Extensibility</a></li><li><a href="#referencing">7. Referencing this specification</a></li><li><a href="#acknowledgements">8. Acknowledgements</a></li></ul><ul><li><a href="#idl-grammar">A. IDL grammar</a></li><li><a href="#references">B. References</a><ul><li><a href="#normative-references">B.1. Normative references</a></li><li><a href="#informative-references">B.2. Informative references</a></li></ul></li><li><a href="#changes">C. Changes</a></li></ul></div>
+      <div class="toc"><ul><li><a href="#introduction">1. Introduction</a><ul><li><a href="#conventions">1.1. Typographic conventions</a></li></ul></li><li><a href="#conformance">2. Conformance</a></li><li><a href="#idl">3. Interface definition language</a><ul><li><a href="#idl-names">3.1. Names</a></li><li><a href="#idl-interfaces">3.2. Interfaces</a><ul><li><a href="#idl-constants">3.2.1. Constants</a></li><li><a href="#idl-attributes">3.2.2. Attributes</a></li><li><a href="#idl-operations">3.2.3. Operations</a></li><li><a href="#idl-special-operations">3.2.4. Special operations</a><ul><li><a href="#idl-legacy-callers">3.2.4.1. Legacy callers</a></li><li><a href="#idl-stringifiers">3.2.4.2. Stringifiers</a></li><li><a href="#idl-serializers">3.2.4.3. Serializers</a></li><li><a href="#idl-indexed-properties">3.2.4.4. Indexed properties</a></li><li><a href="#idl-named-properties">3.2.4.5. Named properties</a></li></ul></li><li><a href="#idl-static-attributes-and-operations">3.2.5. Static attributes and operations</a></li><li><a href="#idl-overloading">3.2.6. Overloading</a></li><li><a href="#idl-iterable">3.2.7. Iterable declarations</a></li><li><a href="#idl-maplike">3.2.8. Maplike declarations</a></li><li><a href="#idl-setlike">3.2.9. Setlike declarations</a></li></ul></li><li><a href="#idl-namespaces">3.3. Namespaces</a></li><li><a href="#idl-dictionaries">3.4. Dictionaries</a></li><li><a href="#idl-exceptions">3.5. Exceptions</a><ul><li><a href="#idl-DOMException-error-names">3.5.1. Error names</a></li></ul></li><li><a href="#idl-enums">3.6. Enumerations</a></li><li><a href="#idl-callback-functions">3.7. Callback functions</a></li><li><a href="#idl-typedefs">3.8. Typedefs</a></li><li><a href="#idl-implements-statements">3.9. Implements statements</a></li><li><a href="#idl-objects">3.10. Objects implementing interfaces</a></li><li><a href="#idl-types">3.11. Types</a><ul><li><a href="#idl-any">3.11.1. any</a></li><li><a href="#idl-boolean">3.11.2. boolean</a></li><li><a href="#idl-byte">3.11.3. byte</a></li><li><a href="#idl-octet">3.11.4. octet</a></li><li><a href="#idl-short">3.11.5. short</a></li><li><a href="#idl-unsigned-short">3.11.6. unsigned short</a></li><li><a href="#idl-long">3.11.7. long</a></li><li><a href="#idl-unsigned-long">3.11.8. unsigned long</a></li><li><a href="#idl-long-long">3.11.9. long long</a></li><li><a href="#idl-unsigned-long-long">3.11.10. unsigned long long</a></li><li><a href="#idl-float">3.11.11. float</a></li><li><a href="#idl-unrestricted-float">3.11.12. unrestricted float</a></li><li><a href="#idl-double">3.11.13. double</a></li><li><a href="#idl-unrestricted-double">3.11.14. unrestricted double</a></li><li><a href="#idl-DOMString">3.11.15. DOMString</a></li><li><a href="#idl-ByteString">3.11.16. ByteString</a></li><li><a href="#idl-USVString">3.11.17. USVString</a></li><li><a href="#idl-object">3.11.18. object</a></li><li><a href="#idl-interface">3.11.19. Interface types</a></li><li><a href="#idl-dictionary">3.11.20. Dictionary types</a></li><li><a href="#idl-enumeration">3.11.21. Enumeration types</a></li><li><a href="#idl-callback-function">3.11.22. Callback function types</a></li><li><a href="#idl-nullable-type">3.11.23. Nullable types — <var>T</var>?</a></li><li><a href="#idl-sequence">3.11.24. Sequences — sequence&lt;<var>T</var>&gt;</a></li><li><a href="#idl-promise">3.11.25. Promise types — Promise&lt;<var>T</var>&gt;</a></li><li><a href="#idl-union">3.11.26. Union types</a></li><li><a href="#idl-RegExp">3.11.27. RegExp</a></li><li><a href="#idl-Error">3.11.28. Error</a></li><li><a href="#idl-DOMException">3.11.29. DOMException</a></li><li><a href="#idl-buffer-source-types">3.11.30. Buffer source types</a></li><li><a href="#idl-frozen-array">3.11.31. Frozen arrays — FrozenArray&lt;<var>T</var>&gt;</a></li></ul></li><li><a href="#idl-extended-attributes">3.12. Extended attributes</a></li></ul></li><li><a href="#ecmascript-binding">4. ECMAScript binding</a><ul><li><a href="#es-environment">4.1. ECMAScript environment</a></li><li><a href="#es-type-mapping">4.2. ECMAScript type mapping</a><ul><li><a href="#es-any">4.2.1. any</a></li><li><a href="#es-void">4.2.2. void</a></li><li><a href="#es-boolean">4.2.3. boolean</a></li><li><a href="#es-byte">4.2.4. byte</a></li><li><a href="#es-octet">4.2.5. octet</a></li><li><a href="#es-short">4.2.6. short</a></li><li><a href="#es-unsigned-short">4.2.7. unsigned short</a></li><li><a href="#es-long">4.2.8. long</a></li><li><a href="#es-unsigned-long">4.2.9. unsigned long</a></li><li><a href="#es-long-long">4.2.10. long long</a></li><li><a href="#es-unsigned-long-long">4.2.11. unsigned long long</a></li><li><a href="#es-float">4.2.12. float</a></li><li><a href="#es-unrestricted-float">4.2.13. unrestricted float</a></li><li><a href="#es-double">4.2.14. double</a></li><li><a href="#es-unrestricted-double">4.2.15. unrestricted double</a></li><li><a href="#es-DOMString">4.2.16. DOMString</a></li><li><a href="#es-ByteString">4.2.17. ByteString</a></li><li><a href="#es-USVString">4.2.18. USVString</a></li><li><a href="#es-object">4.2.19. object</a></li><li><a href="#es-interface">4.2.20. Interface types</a></li><li><a href="#es-dictionary">4.2.21. Dictionary types</a></li><li><a href="#es-enumeration">4.2.22. Enumeration types</a></li><li><a href="#es-callback-function">4.2.23. Callback function types</a></li><li><a href="#es-nullable-type">4.2.24. Nullable types — <var>T</var>?</a></li><li><a href="#es-sequence">4.2.25. Sequences — sequence&lt;<var>T</var>&gt;</a><ul><li><a href="#create-sequence-from-iterable">4.2.25.1. Creating a sequence from an iterable</a></li></ul></li><li><a href="#es-promise">4.2.26. Promise types — Promise&lt;<var>T</var>&gt;</a></li><li><a href="#es-union">4.2.27. Union types</a></li><li><a href="#es-RegExp">4.2.28. RegExp</a></li><li><a href="#es-Error">4.2.29. Error</a></li><li><a href="#es-DOMException">4.2.30. DOMException</a></li><li><a href="#es-buffer-source-types">4.2.31. Buffer source types</a></li><li><a href="#es-frozen-array">4.2.32. Frozen arrays — FrozenArray&lt;<var>T</var>&gt;</a><ul><li><a href="#create-frozen-array-from-iterable">4.2.32.1. Creating a frozen array from an iterable</a></li></ul></li></ul></li><li><a href="#es-extended-attributes">4.3. ECMAScript-specific extended attributes</a><ul><li><a href="#Clamp">4.3.1. [Clamp]</a></li><li><a href="#Constructor">4.3.2. [Constructor]</a></li><li><a href="#EnforceRange">4.3.3. [EnforceRange]</a></li><li><a href="#Exposed">4.3.4. [Exposed]</a></li><li><a href="#ImplicitThis">4.3.5. [ImplicitThis]</a></li><li><a href="#Global">4.3.6. [Global] and [PrimaryGlobal]</a></li><li><a href="#LegacyArrayClass">4.3.7. [LegacyArrayClass]</a></li><li><a href="#LegacyUnenumerableNamedProperties">4.3.8. [LegacyUnenumerableNamedProperties]</a></li><li><a href="#LenientSetter">4.3.9. [LenientSetter]</a></li><li><a href="#LenientThis">4.3.10. [LenientThis]</a></li><li><a href="#NamedConstructor">4.3.11. [NamedConstructor]</a></li><li><a href="#NewObject">4.3.12. [NewObject]</a></li><li><a href="#NoInterfaceObject">4.3.13. [NoInterfaceObject]</a></li><li><a href="#OverrideBuiltins">4.3.14. [OverrideBuiltins]</a></li><li><a href="#PutForwards">4.3.15. [PutForwards]</a></li><li><a href="#Replaceable">4.3.16. [Replaceable]</a></li><li><a href="#SameObject">4.3.17. [SameObject]</a></li><li><a href="#SecureContext">4.3.18. [SecureContext]</a></li><li><a href="#TreatNonObjectAsNull">4.3.19. [TreatNonObjectAsNull]</a></li><li><a href="#TreatNullAs">4.3.20. [TreatNullAs]</a></li><li><a href="#Unforgeable">4.3.21. [Unforgeable]</a></li><li><a href="#Unscopable">4.3.22. [Unscopable]</a></li></ul></li><li><a href="#es-security">4.4. Security</a></li><li><a href="#es-overloads">4.5. Overload resolution algorithm</a></li><li><a href="#es-interfaces">4.6. Interfaces</a><ul><li><a href="#interface-object">4.6.1. Interface object</a><ul><li><a href="#es-interface-call">4.6.1.1. Interface object [[Call]] method</a></li><li><a href="#es-interface-hasinstance">4.6.1.2. Interface object [[HasInstance]] method</a></li></ul></li><li><a href="#named-constructors">4.6.2. Named constructors</a></li><li><a href="#interface-prototype-object">4.6.3. Interface prototype object</a></li><li><a href="#named-properties-object">4.6.4. Named properties object</a><ul><li><a href="#named-properties-object-getownproperty">4.6.4.1. Named properties object [[GetOwnProperty]] method</a></li><li><a href="#named-properties-object-defineownproperty">4.6.4.2. Named properties object [[DefineOwnProperty]] method</a></li><li><a href="#named-properties-object-delete">4.6.4.3. Named properties object [[Delete]] method</a></li></ul></li><li><a href="#es-constants">4.6.5. Constants</a></li><li><a href="#es-attributes">4.6.6. Attributes</a></li><li><a href="#es-operations">4.6.7. Operations</a><ul><li><a href="#es-stringifier">4.6.7.1. Stringifiers</a></li><li><a href="#es-serializer">4.6.7.2. Serializers</a></li></ul></li><li><a href="#es-iterators">4.6.8. Common iterator behavior</a><ul><li><a href="#es-iterator">4.6.8.1. @@iterator</a></li><li><a href="#es-forEach">4.6.8.2. forEach</a></li></ul></li><li><a href="#es-iterable">4.6.9. Iterable declarations</a><ul><li><a href="#es-iterable-entries">4.6.9.1. entries</a></li><li><a href="#es-iterable-keys">4.6.9.2. keys</a></li><li><a href="#es-iterable-values">4.6.9.3. values</a></li><li><a href="#es-default-iterator-object">4.6.9.4. Default iterator objects</a></li><li><a href="#es-iterator-prototype-object">4.6.9.5. Iterator prototype object</a></li></ul></li><li><a href="#es-maplike">4.6.10. Maplike declarations</a><ul><li><a href="#es-map-size">4.6.10.1. size</a></li><li><a href="#es-map-entries">4.6.10.2. entries</a></li><li><a href="#es-map-keys-values">4.6.10.3. keys and values</a></li><li><a href="#es-map-get-has">4.6.10.4. get and has</a></li><li><a href="#es-map-clear">4.6.10.5. clear</a></li><li><a href="#es-map-delete">4.6.10.6. delete</a></li><li><a href="#es-map-set">4.6.10.7. set</a></li></ul></li><li><a href="#es-setlike">4.6.11. Setlike declarations</a><ul><li><a href="#es-set-size">4.6.11.1. size</a></li><li><a href="#es-set-values">4.6.11.2. values</a></li><li><a href="#es-set-entries-keys">4.6.11.3. entries and keys</a></li><li><a href="#es-set-has">4.6.11.4. has</a></li><li><a href="#es-add-delete">4.6.11.5. add and delete</a></li><li><a href="#es-set-clear">4.6.11.6. clear</a></li></ul></li><li><a href="#initializing-objects-from-iterables">4.6.12. Initializing objects from iterables</a></li></ul></li><li><a href="#es-implements-statements">4.7. Implements statements</a></li><li><a href="#es-platform-objects">4.8. Platform objects implementing interfaces</a><ul><li><a href="#indexed-and-named-properties">4.8.1. Indexed and named properties</a></li><li><a href="#getownproperty-guts">4.8.2. The PlatformObjectGetOwnProperty abstract operation</a></li><li><a href="#getownproperty">4.8.3. Platform object [[GetOwnProperty]] method</a></li><li><a href="#invoking-indexed-setter">4.8.4. Invoking a platform object indexed property setter</a></li><li><a href="#invoking-named-setter">4.8.5. Invoking a platform object named property setter</a></li><li><a href="#platformobjectset">4.8.6. Platform object [[Set]] method</a></li><li><a href="#defineownproperty">4.8.7. Platform object [[DefineOwnProperty]] method</a></li><li><a href="#delete">4.8.8. Platform object [[Delete]] method</a></li><li><a href="#call">4.8.9. Platform object [[Call]] method</a></li><li><a href="#property-enumeration">4.8.10. Property enumeration</a></li></ul></li><li><a href="#es-user-objects">4.9. User objects implementing callback interfaces</a></li><li><a href="#es-invoking-callback-functions">4.10. Invoking callback functions</a></li><li><a href="#es-namespaces">4.11. Namespaces</a><ul><li><a href="#namespace-object">4.11.1. Namespace object</a></li></ul></li><li><a href="#es-exceptions">4.12. Exceptions</a><ul><li><a href="#es-DOMException-constructor-object">4.12.1. DOMException constructor object</a><ul><li><a href="#es-DOMException-call">4.12.1.1. DOMException(message, name)</a></li></ul></li><li><a href="#es-DOMException-prototype-object">4.12.2. DOMException prototype object</a></li></ul></li><li><a href="#es-exception-objects">4.13. Exception objects</a></li><li><a href="#es-creating-throwing-exceptions">4.14. Creating and throwing exceptions</a></li><li><a href="#es-handling-exceptions">4.15. Handling exceptions</a></li></ul></li><li><a href="#common">5. Common definitions</a><ul><li><a href="#common-ArrayBufferView">5.1. ArrayBufferView</a></li><li><a href="#common-BufferSource">5.2. BufferSource</a></li><li><a href="#common-DOMTimeStamp">5.3. DOMTimeStamp</a></li><li><a href="#common-Function">5.4. Function</a></li><li><a href="#common-Function">5.5. VoidFunction</a></li></ul></li><li><a href="#extensibility">6. Extensibility</a></li><li><a href="#referencing">7. Referencing this specification</a></li><li><a href="#acknowledgements">8. Acknowledgements</a></li></ul><ul><li><a href="#idl-grammar">A. IDL grammar</a></li><li><a href="#references">B. References</a><ul><li><a href="#normative-references">B.1. Normative references</a></li><li><a href="#informative-references">B.2. Informative references</a></li></ul></li><li><a href="#changes">C. Changes</a></li></ul></div>
     </div>
 
     <div id="sections">
@@ -286,6 +286,8 @@ window.onload = function() { window.alert("loaded"); };</code></pre></div></div>
           <a class="dfnref" href="#dfn-idl-fragment">IDL fragment</a> are:
           <a class="dfnref" href="#dfn-interface">interfaces</a>,
           <a class="dfnref" href="#dfn-partial-interface">partial interface definitions</a>,
+          <a class="dfnref" href="#dfn-namespace">namespaces</a>,
+          <a class="dfnref" href="#dfn-partial-namespace">partial namespace definitions</a>,
           <a class="dfnref" href="#dfn-dictionary">dictionaries</a>,
           <a class="dfnref" href="#dfn-partial-dictionary">partial dictionary definitions</a>,
           <a class="dfnref" href="#dfn-typedef">typedefs</a> and
@@ -300,7 +302,7 @@ window.onload = function() { window.alert("loaded"); };</code></pre></div></div>
           <a class="sym" href="#prod-ExtendedAttributeList">ExtendedAttributeList</a>),
           which can control how the definition will be handled in language bindings.
           The extended attributes defined by this specification that are language binding
-          agnostic are discussed in <a href="#idl-extended-attributes">section 3.11</a>,
+          agnostic are discussed in <a href="#idl-extended-attributes">section 3.12</a>,
           while those specific to the ECMAScript language binding are discussed
           in <a href="#es-extended-attributes">section 4.3</a>.
         </p>
@@ -312,6 +314,7 @@ interface <i>identifier</i> {
 
         <table class="grammar"><tr id="proddef-Definitions"><td><span class="prod-number">[1]</span></td><td><a class="sym" href="#prod-Definitions">Definitions</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-ExtendedAttributeList">ExtendedAttributeList</a> <a class="sym" href="#prod-Definition">Definition</a> <a class="sym" href="#prod-Definitions">Definitions</a> <br /> |
              ε</span></td></tr><tr id="proddef-Definition"><td><span class="prod-number">[2]</span></td><td><a class="sym" href="#prod-Definition">Definition</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-CallbackOrInterface">CallbackOrInterface</a> <br /> |
+             <a class="sym" href="#prod-Namespace">Namespace</a> <br /> |
              <a class="sym" href="#prod-Partial">Partial</a> <br /> |
              <a class="sym" href="#prod-Dictionary">Dictionary</a> <br /> |
              <a class="sym" href="#prod-Enum">Enum</a> <br /> |
@@ -391,6 +394,8 @@ interface GraphicalWindow {
           <p>
             Every <a class="dfnref" href="#dfn-interface">interface</a>,
             <a class="dfnref" href="#dfn-partial-interface">partial interface definition</a>,
+            <a class="dfnref" href="#dfn-namespace">namespace</a>,
+            <a class="dfnref" href="#dfn-partial-namespace">partial namespace definition</a>,
             <a class="dfnref" href="#dfn-dictionary">dictionary</a>,
             <a class="dfnref" href="#dfn-partial-dictionary">partial dictionary definition</a>,
             <a class="dfnref" href="#dfn-enumeration">enumeration</a>,
@@ -409,12 +414,14 @@ interface GraphicalWindow {
             <li>
               For <a class="dfnref" href="#dfn-named-definition">named definitions</a>,
               the <a class="sym" href="#prod-identifier">identifier</a> token that appears
-              directly after the <code>interface</code>,
+              directly after the <code>interface</code>, <code>namespace</code>,
               <code>dictionary</code>, <code>enum</code>
               or <code>callback</code> keyword
               determines the identifier of that definition.
               <pre class="syntax">interface <em>interface-identifier</em> { <i>interface-members…</i> };
 partial interface <em>interface-identifier</em> { <i>interface-members…</i> };
+namespace <em>namespace-identifier</em> { <i>namespace-members…</i> };
+partial namespace <em>namespace-identifier</em> { <i>namespace-members…</i> };
 dictionary <em>dictionary-identifier</em> { <i>dictionary-members…</i> };
 partial dictionary <em>dictionary-identifier</em> { <i>dictionary-members…</i> };
 enum <em>enumeration-identifier</em> { <i>enumeration-values…</i> };
@@ -533,6 +540,7 @@ dictionary <i>identifier</i> {
             that a given implementation supports,
             the <a class="dfnref" href="#dfn-identifier">identifier</a> of every
             <a class="dfnref" href="#dfn-interface">interface</a>,
+            <a class="dfnref" href="#dfn-namespace">namespace</a>,
             <a class="dfnref" href="#dfn-dictionary">dictionary</a>,
             <a class="dfnref" href="#dfn-enumeration">enumeration</a>,
             <a class="dfnref" href="#dfn-callback-function">callback function</a> and
@@ -540,6 +548,7 @@ dictionary <i>identifier</i> {
             <span class="rfc2119">MUST NOT</span>
             be the same as the identifier of any other
             <a class="dfnref" href="#dfn-interface">interface</a>,
+            <a class="dfnref" href="#dfn-namespace">namespace</a>,
             <a class="dfnref" href="#dfn-dictionary">dictionary</a>,
             <a class="dfnref" href="#dfn-enumeration">enumeration</a>,
             <a class="dfnref" href="#dfn-callback-function">callback function</a> or
@@ -664,8 +673,7 @@ interface TextField {
   <i>interface-members…</i>
 };</pre>
           <p>
-            The order that members appear in has no significance except in the
-            case of <a href="#idl-overloading">overloading</a>.
+            The order that members appear has significance both for <a href="#idl-overloading">overloading</a> and for property enumeration in the <a href="#es-interfaces">ECMAScript binding</a>.
           </p>
           <p>
             Interfaces may specify an interface member that has the same name as
@@ -783,7 +791,7 @@ public interface B extends A {
             its definition.  Callback interfaces are ones that can be
             implemented by <a class="dfnref" href="#dfn-user-object">user objects</a>
             and not by <a class="dfnref" href="#dfn-platform-object">platform objects</a>,
-            as described in <a href="#idl-objects">section 3.9</a>
+            as described in <a href="#idl-objects">section 3.10</a>
             below.
           </p>
           <pre class="syntax">callback interface <i>identifier</i> {
@@ -985,7 +993,8 @@ partial interface <em>SomeInterface</em> {
           <table class="grammar"><tr><td><span class="prod-number">[3]</span></td><td><a class="sym" href="#prod-CallbackOrInterface">CallbackOrInterface</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"callback" <a class="sym" href="#prod-CallbackRestOrInterface">CallbackRestOrInterface</a> <br /> |
              <a class="sym" href="#prod-Interface">Interface</a></span></td></tr><tr id="proddef-CallbackRestOrInterface"><td><span class="prod-number">[4]</span></td><td><a class="sym" href="#prod-CallbackRestOrInterface">CallbackRestOrInterface</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-CallbackRest">CallbackRest</a> <br /> |
              <a class="sym" href="#prod-Interface">Interface</a></span></td></tr><tr id="proddef-Interface"><td><span class="prod-number">[5]</span></td><td><a class="sym" href="#prod-Interface">Interface</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"interface" <a class="sym" href="#prod-identifier">identifier</a> <a class="sym" href="#prod-Inheritance">Inheritance</a> "{" <a class="sym" href="#prod-InterfaceMembers">InterfaceMembers</a> "}" ";"</span></td></tr><tr id="proddef-Partial"><td><span class="prod-number">[6]</span></td><td><a class="sym" href="#prod-Partial">Partial</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"partial" <a class="sym" href="#prod-PartialDefinition">PartialDefinition</a></span></td></tr><tr id="proddef-PartialDefinition"><td><span class="prod-number">[7]</span></td><td><a class="sym" href="#prod-PartialDefinition">PartialDefinition</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-PartialInterface">PartialInterface</a> <br /> |
-             <a class="sym" href="#prod-PartialDictionary">PartialDictionary</a></span></td></tr><tr id="proddef-PartialInterface"><td><span class="prod-number">[8]</span></td><td><a class="sym" href="#prod-PartialInterface">PartialInterface</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"interface" <a class="sym" href="#prod-identifier">identifier</a> "{" <a class="sym" href="#prod-InterfaceMembers">InterfaceMembers</a> "}" ";"</span></td></tr><tr id="proddef-InterfaceMembers"><td><span class="prod-number">[9]</span></td><td><a class="sym" href="#prod-InterfaceMembers">InterfaceMembers</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-ExtendedAttributeList">ExtendedAttributeList</a> <a class="sym" href="#prod-InterfaceMember">InterfaceMember</a> <a class="sym" href="#prod-InterfaceMembers">InterfaceMembers</a> <br /> |
+             <a class="sym" href="#prod-PartialDictionary">PartialDictionary</a> <br /> |
+             <a class="sym" href="#prod-Namespace">Namespace</a></span></td></tr><tr id="proddef-PartialInterface"><td><span class="prod-number">[8]</span></td><td><a class="sym" href="#prod-PartialInterface">PartialInterface</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"interface" <a class="sym" href="#prod-identifier">identifier</a> "{" <a class="sym" href="#prod-InterfaceMembers">InterfaceMembers</a> "}" ";"</span></td></tr><tr id="proddef-InterfaceMembers"><td><span class="prod-number">[9]</span></td><td><a class="sym" href="#prod-InterfaceMembers">InterfaceMembers</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-ExtendedAttributeList">ExtendedAttributeList</a> <a class="sym" href="#prod-InterfaceMember">InterfaceMember</a> <a class="sym" href="#prod-InterfaceMembers">InterfaceMembers</a> <br /> |
              ε</span></td></tr><tr id="proddef-InterfaceMember"><td><span class="prod-number">[10]</span></td><td><a class="sym" href="#prod-InterfaceMember">InterfaceMember</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-Const">Const</a> <br /> |
              <a class="sym" href="#prod-Operation">Operation</a> <br /> |
              <a class="sym" href="#prod-Serializer">Serializer</a> <br /> |
@@ -1175,7 +1184,7 @@ node.appendChild(newNode);  <span class="comment">// This will throw a TypeError
               as the type of the constant, dictionary member or optional argument it is being used as the value of.
               The value of the <a class="sym" href="#prod-integer">integer</a> token <span class="rfc2119">MUST NOT</span>
               lie outside the valid range of values for its type, as given in
-              <a href="#idl-types">section 3.10</a> below.
+              <a href="#idl-types">section 3.11</a> below.
             </p>
             <p id="float-token-value">
               The value of a <a class="sym" href="#prod-float">float</a> token is
@@ -1229,7 +1238,7 @@ node.appendChild(newNode);  <span class="comment">// This will throw a TypeError
               as the type of the constant, dictionary member or optional argument it is being used as the value of.  The value of the
               <a class="sym" href="#prod-float">float</a> token <span class="rfc2119">MUST NOT</span>
               lie outside the valid range of values for its type, as given in
-              <a href="#idl-types">section 3.10</a> below.
+              <a href="#idl-types">section 3.11</a> below.
               Also, <code>Infinity</code>, <code>-Infinity</code> and <code>NaN</code> <span class="rfc2119">MUST NOT</span>
               be used as the value of a <a class="idltype" href="#idl-float">float</a>
               or <a class="idltype" href="#idl-double">double</a>.
@@ -1533,7 +1542,7 @@ interface Person : Animal {
               then it declares a special operation.  A single operation can declare
               both a regular operation and a special operation; see
               <a href="#idl-special-operations">section 3.2.4</a> below
-              for details on special operations.
+              for details on special operations. Note that in addition to being <a class="dfnref" href="#dfn-interface-member">interface members</a>, regular operations can also be <a class="dfnref" href="#dfn-namespace-member">namespace members</a>.
             </p>
             <p>
               If an operation has no identifier,
@@ -3182,6 +3191,11 @@ partial interface A {
                   <li>Add to <var>S</var> the tuple &lt;<var>X</var>, <var>t</var><sub>0..<var>n</var>−1</sub>, <var>o</var><sub>0..<var>n</var>−1</sub>&gt;.</li>
                   <li>If <var>X</var> is declared to be <a class="dfnref" href="#dfn-variadic">variadic</a>, then:
                     <ol>
+                      <li>Add to <var>S</var> the tuple &lt;<var>X</var>, <var>t</var><sub>0..<var>n</var>−2</sub>, <var>o</var><sub>0..<var>n</var>−2</sub>&gt;.
+                        <div class="note"><div class="noteHeader">Note</div>
+                          <p>This leaves off the final, variadic argument.</p>
+                        </div>
+                      </li>
                       <li>For every integer <var>i</var>, such that <var>n</var> ≤ <var>i</var> ≤ <var>m</var>−1:
                         <ol>
                           <li>Let <var>u</var><sub>0..<var>i</var></sub> be a list of types, where <var>u</var><sub>j</sub> = <var>t</var><sub>j</sub> (for <var>j</var> &lt; <var>n</var>) and <var>u</var><sub>j</sub> = <var>t</var><sub><var>n</var>−1</sub> (for <var>j</var> ≥ <var>n</var>).</li>
@@ -3194,14 +3208,12 @@ partial interface A {
                   <li>Initialize <var>i</var> to <var>n</var>−1.</li>
                   <li>While <var>i</var> ≥ 0:
                     <ol>
-                      <li>If argument <var>i</var> of <var>X</var> is not
-                        <a class="dfnref" href="#dfn-optional-argument">optional</a>
-                        (i.e., it is not marked as <code>optional</code> and is not
-                        a final, variadic argument), then break this loop.</li>
+                      <li>If argument <var>i</var> of <var>X</var> is not <a class="dfnref" href="#dfn-optional-argument">optional</a>, then break this loop.</li>
                       <li>Otherwise, add to <var>S</var> the tuple &lt;<var>X</var>, <var>t</var><sub>0..<var>i</var>−1</sub>, <var>o</var><sub>0..<var>i</var>−1</sub>&gt;.</li>
                       <li>Set <var>i</var> to <var>i</var>−1.</li>
                     </ol>
                   </li>
+                  <li>If <var>n</var> &gt; 0 and all arguments of <var>X</var> are optional, then add to <var>S</var> the tuple &lt;<var>X</var>, (), ()&gt; (where “()” represents the empty list).</li>
                 </ol>
               </li>
               <li>
@@ -3942,8 +3954,96 @@ setlike&lt;<i>type</i>&gt;;</pre>
           </div>
         </div>
 
+        <div id="idl-namespaces" class="section">
+          <h3>3.3. Namespaces</h3>
+
+          <p>
+            A <dfn data-export="" id="dfn-namespace">namespace</dfn> is a definition (matching <a class="sym" href="#prod-Namespace">Namespace</a>) that declares a global singleton with
+            associated behaviors.
+          </p>
+
+          <pre class="syntax">namespace <i>identifier</i> {
+  <i>namespace-members…</i>
+};</pre>
+
+          <p>
+            A namespace is a specification of a set of <dfn data-export="" data-lt="namespace             member" id="dfn-namespace-member">namespace members</dfn> (matching <a class="sym" href="#prod-NamespaceMembers">NamespaceMembers</a>), which are the <a class="dfnref" href="#dfn-regular-operation">regular operations</a> that appear between the braces in
+            the namespace declaration. These operations describe the behaviors packaged into the
+            namespace.
+          </p>
+
+          <p>
+            As with interfaces, the IDL for namespaces can be split into multiple parts by using
+            <dfn data-export="" id="dfn-partial-namespace">partial namespace</dfn> definitions
+            (matching <span class="sym">"partial"</span> <a class="sym" href="#prod-Namespace">Namespace</a>). The <a class="dfnref" href="#dfn-identifier">identifier</a> of a partial namespace definition <span class="rfc2119">MUST</span> be the same as the identifier of a namespace definition.
+            All of the members that appear on each of the partial namespace definitions are
+            considered to be members of the namespace itself.
+          </p>
+
+          <pre class="syntax">namespace <em>SomeNamespace</em> {
+  <i>namespace-members…</i>
+};
+
+partial namespace <em>SomeNamespace</em> {
+  <i>namespace-members…</i>
+};</pre>
+
+          <div class="note"><div class="noteHeader">Note</div>
+            <p>
+              As with partial interface definitions, partial namespace definitions are intended for
+              use as a specification editorial aide, allowing the definition of an interface to be
+              separated over more than one section of the document, and sometimes multiple
+              documents.
+            </p>
+          </div>
+
+          <p>
+            The order that members appear has significance both for <a href="#idl-overloading">overloading</a> and for property enumeration in the <a href="#es-namespaces">ECMAScript binding</a>.
+          </p>
+
+          <p>
+            Note that unlike interfaces or dictionaries, namespaces do not create types.
+          </p>
+
+          <p>
+            Only the <a class="xattr" href="#Exposed">[Exposed]</a> and <a class="xattr" href="#SecureContext">[SecureContext]</a> extended attributes are applicable to
+            namespaces. When declaring a <a class="dfnref" href="#dfn-partial-namespace">partial
+            namespace</a>, the partial namespace must have the same extended attributes (and
+            extended attribute argument values, if any) specified as the original namespace
+            definition with the same identifier.
+          </p>
+
+          <table class="grammar"><tr><td><span class="prod-number">[6]</span></td><td><a class="sym" href="#prod-Partial">Partial</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"partial" <a class="sym" href="#prod-PartialDefinition">PartialDefinition</a></span></td></tr><tr><td><span class="prod-number">[7]</span></td><td><a class="sym" href="#prod-PartialDefinition">PartialDefinition</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-PartialInterface">PartialInterface</a> <br /> |
+             <a class="sym" href="#prod-PartialDictionary">PartialDictionary</a> <br /> |
+             <a class="sym" href="#prod-Namespace">Namespace</a></span></td></tr><tr id="proddef-Namespace"><td><span class="prod-number">[97]</span></td><td><a class="sym" href="#prod-Namespace">Namespace</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"namespace" <a class="sym" href="#prod-identifier">identifier</a> "{" <a class="sym" href="#prod-NamespaceMembers">NamespaceMembers</a> "}" ";"</span></td></tr><tr id="proddef-NamespaceMembers"><td><span class="prod-number">[98]</span></td><td><a class="sym" href="#prod-NamespaceMembers">NamespaceMembers</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-ExtendedAttributeList">ExtendedAttributeList</a> <a class="sym" href="#prod-NamespaceMember">NamespaceMember</a> <a class="sym" href="#prod-NamespaceMembers">NamespaceMembers</a> <br /> |
+             ε</span></td></tr><tr id="proddef-NamespaceMember"><td><span class="prod-number">[99]</span></td><td><a class="sym" href="#prod-NamespaceMember">NamespaceMember</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-ReturnType">ReturnType</a> <a class="sym" href="#prod-OperationRest">OperationRest</a></span></td></tr></table>
+
+
+          <div class="example"><div class="exampleHeader">Example</div>
+            <p>
+              The following <a class="dfnref" href="#dfn-idl-fragment">IDL fragment</a> defines an
+              <a class="dfnref" href="#dfn-namespace">namespace</a>.
+            </p>
+            <div class="block"><div class="blockTitleDiv"><span class="blockTitle">IDL</span></div><div class="blockContent"><pre class="code"><code class="idl-code">namespace VectorUtils {
+  double dotProduct(Vector x, Vector y);
+  Vector crossProduct(Vector x, Vector y);
+};</code></pre></div></div>
+
+            <p>
+              An ECMAScript implementation would then expose a global property named
+              <code>VectorUtils</code> which was a simple object (with prototype
+              <a class="external" href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a>) with enumerable data properties for each declared operation:
+            </p>
+
+            <div class="block"><div class="blockTitleDiv"><span class="blockTitle">ECMAScript</span></div><div class="blockContent"><pre class="code"><code class="es-code">Object.getPrototypeOf(VectorUtils);                         <span class="comment">// Evaluates to Object.prototype.</span>
+Object.keys(VectorUtils);                                   <span class="comment">// Evaluates to ["dotProduct", "crossProduct"].</span>
+Object.getOwnPropertyDescriptor(VectorUtils, "dotProduct"); <span class="comment">// Evaluates to { value: &lt;a function&gt;, enumerable: true, configurable: true, writable: true }.</span></code></pre></div></div>
+          </div>
+
+        </div>
+
         <div id="idl-dictionaries" class="section">
-          <h3>3.3. Dictionaries</h3>
+          <h3>3.4. Dictionaries</h3>
 
           <p>
             A <dfn data-export="" id="dfn-dictionary">dictionary</dfn> is a definition (matching
@@ -4194,7 +4294,8 @@ something.f(dict);</code></pre></div></div>
             <a class="xattr" href="#EnforceRange">[EnforceRange]</a>.
           </p>
           <table class="grammar"><tr><td><span class="prod-number">[6]</span></td><td><a class="sym" href="#prod-Partial">Partial</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"partial" <a class="sym" href="#prod-PartialDefinition">PartialDefinition</a></span></td></tr><tr><td><span class="prod-number">[7]</span></td><td><a class="sym" href="#prod-PartialDefinition">PartialDefinition</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-PartialInterface">PartialInterface</a> <br /> |
-             <a class="sym" href="#prod-PartialDictionary">PartialDictionary</a></span></td></tr><tr id="proddef-Dictionary"><td><span class="prod-number">[11]</span></td><td><a class="sym" href="#prod-Dictionary">Dictionary</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"dictionary" <a class="sym" href="#prod-identifier">identifier</a> <a class="sym" href="#prod-Inheritance">Inheritance</a> "{" <a class="sym" href="#prod-DictionaryMembers">DictionaryMembers</a> "}" ";"</span></td></tr><tr id="proddef-DictionaryMembers"><td><span class="prod-number">[12]</span></td><td><a class="sym" href="#prod-DictionaryMembers">DictionaryMembers</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-ExtendedAttributeList">ExtendedAttributeList</a> <a class="sym" href="#prod-DictionaryMember">DictionaryMember</a> <a class="sym" href="#prod-DictionaryMembers">DictionaryMembers</a> <br /> |
+             <a class="sym" href="#prod-PartialDictionary">PartialDictionary</a> <br /> |
+             <a class="sym" href="#prod-Namespace">Namespace</a></span></td></tr><tr id="proddef-Dictionary"><td><span class="prod-number">[11]</span></td><td><a class="sym" href="#prod-Dictionary">Dictionary</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"dictionary" <a class="sym" href="#prod-identifier">identifier</a> <a class="sym" href="#prod-Inheritance">Inheritance</a> "{" <a class="sym" href="#prod-DictionaryMembers">DictionaryMembers</a> "}" ";"</span></td></tr><tr id="proddef-DictionaryMembers"><td><span class="prod-number">[12]</span></td><td><a class="sym" href="#prod-DictionaryMembers">DictionaryMembers</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-ExtendedAttributeList">ExtendedAttributeList</a> <a class="sym" href="#prod-DictionaryMember">DictionaryMember</a> <a class="sym" href="#prod-DictionaryMembers">DictionaryMembers</a> <br /> |
              ε</span></td></tr><tr id="proddef-DictionaryMember"><td><span class="prod-number">[13]</span></td><td><a class="sym" href="#prod-DictionaryMember">DictionaryMember</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-Required">Required</a> <a class="sym" href="#prod-Type">Type</a> <a class="sym" href="#prod-identifier">identifier</a> <a class="sym" href="#prod-Default">Default</a> ";"</span></td></tr><tr id="proddef-PartialDictionary"><td><span class="prod-number">[15]</span></td><td><a class="sym" href="#prod-PartialDictionary">PartialDictionary</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"dictionary" <a class="sym" href="#prod-identifier">identifier</a> "{" <a class="sym" href="#prod-DictionaryMembers">DictionaryMembers</a> "}" ";"</span></td></tr><tr id="proddef-Default"><td><span class="prod-number">[16]</span></td><td><a class="sym" href="#prod-Default">Default</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"=" <a class="sym" href="#prod-DefaultValue">DefaultValue</a> <br /> |
              ε</span></td></tr><tr><td><span class="prod-number">[17]</span></td><td><a class="sym" href="#prod-DefaultValue">DefaultValue</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-ConstValue">ConstValue</a> <br /> |
              <a class="sym" href="#prod-string">string</a> <br /> |
@@ -4241,7 +4342,7 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
         </div>
 
         <div id="idl-exceptions" class="section">
-          <h3>3.4. Exceptions</h3>
+          <h3>3.5. Exceptions</h3>
 
           <p>
             An <dfn data-export="" id="dfn-exception">exception</dfn> is a type of object that
@@ -4313,7 +4414,7 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
           </p>
           <div class="note"><div class="noteHeader">Note</div>
             <p>
-              See <a href="#es-creating-throwing-exceptions">section 4.13</a>
+              See <a href="#es-creating-throwing-exceptions">section 4.14</a>
               below for details on what creating and throwing an exception
               entails in the ECMAScript language binding.
             </p>
@@ -4346,7 +4447,7 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
           </div>
 
           <div id="idl-DOMException-error-names" class="section">
-            <h4>3.4.1. Error names</h4>
+            <h4>3.5.1. Error names</h4>
 
             <p>
               The <dfn data-export="" id="dfn-error-names-table">error names table</dfn> below lists all the allowed error names
@@ -4542,7 +4643,7 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
         </div>
 
         <div id="idl-enums" class="section">
-          <h3>3.5. Enumerations</h3>
+          <h3>3.6. Enumerations</h3>
 
           <p>
             An <dfn data-export="" id="dfn-enumeration">enumeration</dfn> is a definition (matching
@@ -4567,7 +4668,7 @@ ctx.drawRectangle(300, 200, { fillPattern: "red", position: new Point(10, 10) })
               separated at all, unless there is a specific reason to use another
               value naming scheme.  For example, an enumeration value that
               indicates an object should be created could be named
-              <code>"createobject"</code> or <code>"create-object"</code>.
+              <code>"createobject"</code> or <code>'create-object"</code>.
               Consider related uses of enumeration values when deciding whether
               to dash-separate or not separate enumeration value words so that
               similar APIs are consistent.
@@ -4632,7 +4733,7 @@ meal.type == "noodles";              <span class="comment">// Evaluates to true.
         </div>
 
         <div id="idl-callback-functions" class="section">
-          <h3>3.6. Callback functions</h3>
+          <h3>3.7. Callback functions</h3>
 
           <div class="ednote"><div class="ednoteHeader">Editorial note</div>
             <p>The “Custom DOM Elements” spec wants to use callback function types for
@@ -4691,7 +4792,7 @@ ops.performOperation(function(status) {
         </div>
 
         <div id="idl-typedefs" class="section">
-          <h3>3.7. Typedefs</h3>
+          <h3>3.8. Typedefs</h3>
 
           <p>
             A <dfn data-export="" id="dfn-typedef">typedef</dfn> is a definition (matching
@@ -4741,7 +4842,7 @@ interface Widget {
         </div>
 
         <div id="idl-implements-statements" class="section">
-          <h3>3.8. Implements statements</h3>
+          <h3>3.9. Implements statements</h3>
 
           <p>
             An <dfn data-export="" id="dfn-implements-statement">implements statement</dfn> is a definition
@@ -4903,7 +5004,7 @@ EventTarget et = (EventTarget) n; <span class='comment'>// This should never thr
         </div>
 
         <div id="idl-objects" class="section">
-          <h3>3.9. Objects implementing interfaces</h3>
+          <h3>3.10. Objects implementing interfaces</h3>
 
           <p>
             In a given implementation of a set of <a class="dfnref" href="#dfn-idl-fragment">IDL fragments</a>,
@@ -5021,7 +5122,7 @@ interface Person {
         -->
 
         <div id="idl-types" class="section">
-          <h3>3.10. Types</h3>
+          <h3>3.11. Types</h3>
 
           <p>
             This section lists the types supported by Web IDL, the set of values
@@ -5135,7 +5236,7 @@ interface Person {
              ε</span></td></tr></table>
 
           <div id="idl-any" class="section">
-            <h4 data-dfn-type="interface" data-lt="any" id="dom-any">3.10.1. any</h4>
+            <h4 data-dfn-type="interface" data-lt="any" id="dom-any">3.11.1. any</h4>
 
             <p>
               The <a class="idltype" href="#idl-any">any</a> type is the union of all other possible
@@ -5161,7 +5262,7 @@ interface Person {
           </div>
 
           <div id="idl-boolean" class="section">
-            <h4 data-dfn-type="interface" data-lt="boolean" id="dom-boolean">3.10.2. boolean</h4>
+            <h4 data-dfn-type="interface" data-lt="boolean" id="dom-boolean">3.11.2. boolean</h4>
 
             <p>
               The <a class="idltype" href="#idl-boolean">boolean</a> type has two values:
@@ -5179,7 +5280,7 @@ interface Person {
           </div>
 
           <div id="idl-byte" class="section">
-            <h4 data-dfn-type="interface" data-lt="byte" id="dom-byte">3.10.3. byte</h4>
+            <h4 data-dfn-type="interface" data-lt="byte" id="dom-byte">3.11.3. byte</h4>
 
             <p>
               The <a class="idltype" href="#idl-byte">byte</a> type is a signed integer
@@ -5197,7 +5298,7 @@ interface Person {
           </div>
 
           <div id="idl-octet" class="section">
-            <h4 data-dfn-type="interface" data-lt="octet" id="dom-octet">3.10.4. octet</h4>
+            <h4 data-dfn-type="interface" data-lt="octet" id="dom-octet">3.11.4. octet</h4>
 
             <p>
               The <a class="idltype" href="#idl-octet">octet</a> type is an unsigned integer
@@ -5215,7 +5316,7 @@ interface Person {
           </div>
 
           <div id="idl-short" class="section">
-            <h4 data-dfn-type="interface" data-lt="short" id="dom-short">3.10.5. short</h4>
+            <h4 data-dfn-type="interface" data-lt="short" id="dom-short">3.11.5. short</h4>
 
             <p>
               The <a class="idltype" href="#idl-short">short</a> type is a signed integer
@@ -5233,7 +5334,7 @@ interface Person {
           </div>
 
           <div id="idl-unsigned-short" class="section">
-            <h4 data-dfn-type="interface" data-lt="unsigned short" id="dom-unsignedshort">3.10.6. unsigned short</h4>
+            <h4 data-dfn-type="interface" data-lt="unsigned short" id="dom-unsignedshort">3.11.6. unsigned short</h4>
 
             <p>
               The <a class="idltype" href="#idl-unsigned-short">unsigned short</a> type is an unsigned integer
@@ -5251,7 +5352,7 @@ interface Person {
           </div>
 
           <div id="idl-long" class="section">
-            <h4 data-dfn-type="interface" data-lt="long" id="dom-long">3.10.7. long</h4>
+            <h4 data-dfn-type="interface" data-lt="long" id="dom-long">3.11.7. long</h4>
 
             <p>
               The <a class="idltype" href="#idl-long">long</a> type is a signed integer
@@ -5269,7 +5370,7 @@ interface Person {
           </div>
 
           <div id="idl-unsigned-long" class="section">
-            <h4 data-dfn-type="interface" data-lt="unsigned long" id="dom-unsignedlong">3.10.8. unsigned long</h4>
+            <h4 data-dfn-type="interface" data-lt="unsigned long" id="dom-unsignedlong">3.11.8. unsigned long</h4>
 
             <p>
               The <a class="idltype" href="#idl-unsigned-long">unsigned long</a> type is an unsigned integer
@@ -5287,7 +5388,7 @@ interface Person {
           </div>
 
           <div id="idl-long-long" class="section">
-            <h4 data-dfn-type="interface" data-lt="long long" id="dom-longlong">3.10.9. long long</h4>
+            <h4 data-dfn-type="interface" data-lt="long long" id="dom-longlong">3.11.9. long long</h4>
 
             <p>
               The <a class="idltype" href="#idl-long-long">long long</a> type is a signed integer
@@ -5305,7 +5406,7 @@ interface Person {
           </div>
 
           <div id="idl-unsigned-long-long" class="section">
-            <h4 data-dfn-type="interface" data-lt="unsigned long long" id="dom-unsignedlonglong">3.10.10. unsigned long long</h4>
+            <h4 data-dfn-type="interface" data-lt="unsigned long long" id="dom-unsignedlonglong">3.11.10. unsigned long long</h4>
 
             <p>
               The <a class="idltype" href="#idl-unsigned-long-long">unsigned long long</a> type is an unsigned integer
@@ -5323,7 +5424,7 @@ interface Person {
           </div>
 
           <div id="idl-float" class="section">
-            <h4 data-dfn-type="interface" data-lt="float" id="dom-float">3.10.11. float</h4>
+            <h4 data-dfn-type="interface" data-lt="float" id="dom-float">3.11.11. float</h4>
 
             <p>
               The <a class="idltype" href="#idl-float">float</a> type is a floating point numeric
@@ -5351,7 +5452,7 @@ interface Person {
           </div>
 
           <div id="idl-unrestricted-float" class="section">
-            <h4 data-dfn-type="interface" data-lt="unrestricted float" id="dom-unrestrictedfloat">3.10.12. unrestricted float</h4>
+            <h4 data-dfn-type="interface" data-lt="unrestricted float" id="dom-unrestrictedfloat">3.11.12. unrestricted float</h4>
 
             <p>
               The <a class="idltype" href="#idl-unrestricted-float">unrestricted float</a> type is a floating point numeric
@@ -5370,7 +5471,7 @@ interface Person {
           </div>
 
           <div id="idl-double" class="section">
-            <h4 data-dfn-type="interface" data-lt="double" id="dom-double">3.10.13. double</h4>
+            <h4 data-dfn-type="interface" data-lt="double" id="dom-double">3.11.13. double</h4>
 
             <p>
               The <a class="idltype" href="#idl-double">double</a> type is a floating point numeric
@@ -5389,7 +5490,7 @@ interface Person {
           </div>
 
           <div id="idl-unrestricted-double" class="section">
-            <h4 data-dfn-type="interface" data-lt="unrestricted double" id="dom-unrestricteddouble">3.10.14. unrestricted double</h4>
+            <h4 data-dfn-type="interface" data-lt="unrestricted double" id="dom-unrestricteddouble">3.11.14. unrestricted double</h4>
 
             <p>
               The <a class="idltype" href="#idl-unrestricted-double">unrestricted double</a> type is a floating point numeric
@@ -5408,7 +5509,7 @@ interface Person {
           </div>
 
           <div id="idl-DOMString" class="section">
-            <h4 data-dfn-type="interface" data-lt="DOMString" id="dom-DOMString">3.10.15. DOMString</h4>
+            <h4 data-dfn-type="interface" data-lt="DOMString" id="dom-DOMString">3.11.15. DOMString</h4>
 
             <p>
               The <a class="idltype" href="#idl-DOMString">DOMString</a> type
@@ -5501,7 +5602,7 @@ interface Person {
           </div>
 
           <div id="idl-ByteString" class="section">
-            <h4 data-dfn-type="interface" data-lt="ByteString" id="dom-ByteString">3.10.16. ByteString</h4>
+            <h4 data-dfn-type="interface" data-lt="ByteString" id="dom-ByteString">3.11.16. ByteString</h4>
 
             <p>
               The <a class="idltype" href="#idl-ByteString">ByteString</a> type
@@ -5511,9 +5612,7 @@ interface Person {
             </p>
             <p>
               There is no way to represent a constant <a class="idltype" href="#idl-ByteString">ByteString</a>
-              value in IDL, although <a class="idltype" href="#idl-ByteString">ByteString</a> <a class="dfnref" href="#dfn-dictionary-member">dictionary member</a>
-              and <a class="dfnref" href="#dfn-optional-argument">operation optional argument</a> default values
-              can be specified using a <a class="sym" href="#prod-string">string</a> literal.
+              value in IDL.
             </p>
             <p>
               The <a class="dfnref" href="#dfn-type-name">type name</a> of the
@@ -5538,7 +5637,7 @@ interface Person {
           </div>
 
           <div id="idl-USVString" class="section">
-            <h4 data-dfn-type="interface" data-lt="USVString" id="dom-USVString">3.10.17. USVString</h4>
+            <h4 data-dfn-type="interface" data-lt="USVString" id="dom-USVString">3.11.17. USVString</h4>
 
             <p>
               The <a class="idltype" href="#idl-USVString">USVString</a> type
@@ -5571,7 +5670,7 @@ interface Person {
           </div>
 
           <div id="idl-object" class="section">
-            <h4 data-dfn-type="interface" data-lt="object" id="dom-object">3.10.18. object</h4>
+            <h4 data-dfn-type="interface" data-lt="object" id="dom-object">3.11.18. object</h4>
 
             <p>
               The <a class="idltype" href="#idl-object">object</a> type corresponds to the set of
@@ -5593,7 +5692,7 @@ interface Person {
           </div>
 
           <div id="idl-interface" class="section">
-            <h4>3.10.19. Interface types</h4>
+            <h4>3.11.19. Interface types</h4>
 
             <p>
               An <a class="dfnref" href="#dfn-identifier">identifier</a> that
@@ -5630,7 +5729,7 @@ interface Person {
           </div>
 
           <div id="idl-dictionary" class="section">
-            <h4>3.10.20. Dictionary types</h4>
+            <h4>3.11.20. Dictionary types</h4>
 
             <p>
               An <a class="dfnref" href="#dfn-identifier">identifier</a> that
@@ -5648,7 +5747,7 @@ interface Person {
           </div>
 
           <div id="idl-enumeration" class="section">
-            <h4>3.10.21. Enumeration types</h4>
+            <h4>3.11.21. Enumeration types</h4>
 
             <p>
               An <a class="dfnref" href="#dfn-identifier">identifier</a> that
@@ -5671,7 +5770,7 @@ interface Person {
           </div>
 
           <div id="idl-callback-function" class="section">
-            <h4>3.10.22. Callback function types</h4>
+            <h4>3.11.22. Callback function types</h4>
 
             <p>
               An <a class="dfnref" href="#dfn-identifier">identifier</a> that identifies
@@ -5699,7 +5798,7 @@ interface Person {
           </div>
 
           <div id="idl-nullable-type" class="section">
-            <h4>3.10.23. Nullable types — <var>T</var>?</h4>
+            <h4>3.11.23. Nullable types — <var>T</var>?</h4>
 
             <p>
               A <dfn data-export="" id="dfn-nullable-type">nullable type</dfn> is an IDL type constructed
@@ -5753,7 +5852,7 @@ interface Person {
           </div>
 
           <div id="idl-sequence" class="section">
-            <h4 data-dfn-type="interface" id="dom-sequence" data-lt="sequence|sequence&lt;T&gt;">3.10.24. Sequences — sequence&lt;<var>T</var>&gt;</h4>
+            <h4 data-dfn-type="interface" id="dom-sequence" data-lt="sequence|sequence&lt;T&gt;">3.11.24. Sequences — sequence&lt;<var>T</var>&gt;</h4>
 
             <p>
               The <a class="idltype" href="#idl-sequence">sequence&lt;<var>T</var>&gt;</a>
@@ -5794,7 +5893,7 @@ interface Person {
           </div>
 
           <div id="idl-promise" class="section">
-            <h4 data-dfn-type="interface" id="dom-promise" data-lt="Promise|Promise&lt;T&gt;">3.10.25. Promise types — Promise&lt;<var>T</var>&gt;</h4>
+            <h4 data-dfn-type="interface" id="dom-promise" data-lt="Promise|Promise&lt;T&gt;">3.11.25. Promise types — Promise&lt;<var>T</var>&gt;</h4>
 
             <p>
               A <dfn data-export="" id="dfn-promise-type">promise type</dfn> is a parameterized type
@@ -5815,7 +5914,7 @@ interface Person {
           </div>
 
           <div id="idl-union" class="section">
-            <h4>3.10.26. Union types</h4>
+            <h4>3.11.26. Union types</h4>
 
             <p>
               A <dfn data-export="" id="dfn-union-type">union type</dfn> is a type whose set of values
@@ -5959,7 +6058,7 @@ interface Person {
           </div>
 
           <div id="idl-RegExp" class="section">
-            <h4 data-dfn-type="interface" data-lt="RegExp" id="dom-RegExp">3.10.27. RegExp</h4>
+            <h4 data-dfn-type="interface" data-lt="RegExp" id="dom-RegExp">3.11.27. RegExp</h4>
 
             <p>
               The <a class="idltype" href="#idl-RegExp">RegExp</a> type is a type
@@ -5978,7 +6077,7 @@ interface Person {
           </div>
 
           <div id="idl-Error" class="section">
-            <h4 data-dfn-type="interface" data-lt="Error" id="dom-Error">3.10.28. Error</h4>
+            <h4 data-dfn-type="interface" data-lt="Error" id="dom-Error">3.11.28. Error</h4>
 
             <p>The <a class="idltype" href="#idl-Error">Error</a> type corresponds to the
               set of all possible non-null references to exception objects, including
@@ -5995,7 +6094,7 @@ interface Person {
           </div>
 
           <div id="idl-DOMException" class="section">
-            <h4>3.10.29. DOMException</h4>
+            <h4>3.11.29. DOMException</h4>
 
             <p>The <a class="idltype" href="#idl-DOMException">DOMException</a> type corresponds to the
               set of all possible non-null references to objects
@@ -6011,7 +6110,7 @@ interface Person {
           </div>
 
           <div id="idl-buffer-source-types" class="section">
-            <h4>3.10.30. Buffer source types</h4>
+            <h4>3.11.30. Buffer source types</h4>
 
             <p>
               There are a number of types that correspond to sets of all possible non-null
@@ -6104,7 +6203,7 @@ interface Person {
           </div>
 
           <div id="idl-frozen-array" class="section">
-            <h4 data-dfn-type="interface" id="dom-FrozenArray" data-lt="FrozenArray|FrozenArray&lt;T&gt;">3.10.31. Frozen arrays — FrozenArray&lt;<var>T</var>&gt;</h4>
+            <h4 data-dfn-type="interface" id="dom-FrozenArray" data-lt="FrozenArray|FrozenArray&lt;T&gt;">3.11.31. Frozen arrays — FrozenArray&lt;<var>T</var>&gt;</h4>
 
             <p>
               A <dfn data-export="" id="dfn-frozen-array-type">frozen array type</dfn> is a parameterized
@@ -6128,13 +6227,14 @@ interface Person {
         </div>
 
         <div id="idl-extended-attributes" class="section">
-          <h3>3.11. Extended attributes</h3>
+          <h3>3.12. Extended attributes</h3>
 
           <p>
             An <dfn data-export="" id="dfn-extended-attribute">extended attribute</dfn> is an annotation
             that can appear on
             <!--a class='dfnref' href='#dfn-definition'-->definitions<!--/a-->,
             <a class="dfnref" href="#dfn-interface-member">interface members</a>,
+            <a class="dfnref" href="#dfn-namespace-member">namespace members</a>,
             <a class="dfnref" href="#dfn-dictionary-member">dictionary members</a>,
             and <a class="dfnref" href="#dfn-operation">operation</a> arguments, and
             is used to control how language bindings will handle those constructs.
@@ -6380,7 +6480,7 @@ interface Person {
         </p>
         <ul>
           <li>Its <span class="prop">[[Prototype]]</span> internal property is
-          <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%FunctionPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4) unless otherwise specified.</li>
+          <a class="external" href="https://tc39.github.io/ecma262/#sec-properties-of-the-function-prototype-object">%FunctionPrototype%</a> unless otherwise specified.</li>
           <li>Its <span class="prop">[[Get]]</span> internal property is set as described in <a class="external" href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver">ECMA-262 section 9.1.8</a>.</li>
           <li>Its <span class="prop">[[Construct]]</span> internal property is set as described in <a class="external" href="https://tc39.github.io/ecma262/#sec-function-@@create">ECMA-262 section 19.2.2.3</a>.</li>
           <li>Its <span class="prop">@@hasInstance</span> property is set as described in <a class="external" href="https://tc39.github.io/ecma262/#sec-function.prototype-@@hasinstance">ECMA-262 section 19.2.3.8</a>, unless otherwise specified.</li>
@@ -8657,9 +8757,11 @@ context.setColorEnforcedRange(-1, 255, 256);</code></pre></div></div>
               If the <a class="xattr" href="#Exposed">[Exposed]</a>
               <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>
               appears on an <a class="dfnref" href="#dfn-interface">interface</a>,
-              <a class="dfnref" href="#dfn-partial-interface">partial interface</a>, or
-              an individual <a class="dfnref" href="#dfn-interface-member">interface member</a>,
-              it indicates that the interface or interface member is exposed
+              <a class="dfnref" href="#dfn-partial-interface">partial interface</a>,
+              <a class="dfnref" href="#dfn-namespace">namespace</a>, or
+              an individual <a class="dfnref" href="#dfn-interface-member">interface member</a> or
+              <a class="dfnref" href="#dfn-namespace-member">namespace member</a>,
+              it indicates that the construct is exposed
               on a particular set of global interfaces, rather than the default of
               being exposed only on the <a class="dfnref" href="#dfn-primary-global-interface">primary global interface</a>.
             </p>
@@ -8697,6 +8799,7 @@ context.setColorEnforcedRange(-1, 255, 256);</code></pre></div></div>
                 implicitly, depending on the type of construct:</p>
                 <dl class="switch">
                   <dt>interface</dt>
+                  <dt>namespace</dt>
                   <dd>The <a class="dfnref" href="#dfn-exposure-set">exposure set</a> of the interface
                   only contains the
                   <a class="dfnref" href="#dfn-primary-global-interface">primary global interface</a>.</dd>
@@ -8708,6 +8811,10 @@ context.setColorEnforcedRange(-1, 255, 256);</code></pre></div></div>
                   <dd>The <a class="dfnref" href="#dfn-exposure-set">exposure set</a> of the interface member
                   is the <a class="dfnref" href="#dfn-exposure-set">exposure set</a> of the interface or
                   partial interface the member is declared on.</dd>
+                  <dt>namespace member</dt>
+                  <dd>The <a class="dfnref" href="#dfn-exposure-set">exposure set</a> of the
+                  namespace member is the <a class="dfnref" href="#dfn-exposure-set">exposure
+                  set</a> of the namespace the member is declared on.</dd>
                 </dl>
               </li>
             </ul>
@@ -8727,6 +8834,11 @@ context.setColorEnforcedRange(-1, 255, 256);</code></pre></div></div>
               <a class="dfnref" href="#dfn-exposure-set">exposure set</a>
               <span class="rfc2119">MUST</span> be a subset of the interface's
               <a class="dfnref" href="#dfn-exposure-set">exposure set</a>.
+              Similarly, if <a class="xattr" href="#Exposed">[Exposed]</a> appears on both a
+              namespace and one of its namespace members, then the namespace member's
+              <a class="dfnref" href="#dfn-exposure-set">exposure set</a>
+              <span class="rfc2119">MUST</span> be a subset of the namespace's
+              <a class="dfnref" href="#dfn-exposure-set">exposure set</a>.
             </p>
             <p>
               An interface's <a class="dfnref" href="#dfn-exposure-set">exposure set</a>
@@ -8745,17 +8857,12 @@ context.setColorEnforcedRange(-1, 255, 256);</code></pre></div></div>
               <var>Y</var>.
             </p>
             <p>
-              An <a class="dfnref" href="#dfn-interface">interface</a> or
-              <a class="dfnref" href="#dfn-interface-member">interface member</a>
-              is <dfn data-export="" id="dfn-exposed">exposed</dfn> in a given ECMAScript global environment if
-              the ECMAScript global object implements an interface that is in the
-              interface or interface member's
-              <a class="dfnref" href="#dfn-exposure-set">exposure set</a>,
-              and either:
+              An <a class="dfnref" href="#dfn-interface">interface</a>, <a class="dfnref" href="#dfn-namespace">namespace</a>, <a class="dfnref" href="#dfn-interface-member">interface member</a>, or <a class="dfnref" href="#dfn-namespace-member">namespace member</a> is <dfn data-export="" id="dfn-exposed">exposed</dfn> in a given ECMAScript global environment if the
+              ECMAScript global object implements an interface that is in the construct's <a class="dfnref" href="#dfn-exposure-set">exposure set</a>, and either:
             </p>
             <ul>
               <li>the <a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a> for the ECMAScript global object is a <a class="external" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>; or</li>
-              <li>the interface or interface member is not <a class="dfnref" href="#dfn-available-only-in-secure-contexts">available only in secure contexts</a>.</li>
+              <li>the construct is not <a class="dfnref" href="#dfn-available-only-in-secure-contexts">available only in secure contexts</a>.</li>
             </ul>
             <div class="note"><div class="noteHeader">Note</div>
               <p>Since it is not possible for the <a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>
@@ -8778,9 +8885,9 @@ context.setColorEnforcedRange(-1, 255, 256);</code></pre></div></div>
             </p>
             <div class="example"><div class="exampleHeader">Example</div>
               <p><a class="xattr" href="#Exposed">[Exposed]</a>
-              is intended to be used to control whether interfaces or individual interface
-              members are available for use only in workers, only in the <span class="idltype">Window</span>,
-              or in both.</p>
+              is intended to be used to control whether interfaces, namespaces, or individual
+              interface or namespace members are available for use only in workers, only in the
+              <span class="idltype">Window</span>, or in both.</p>
               <p>The following IDL fragment shows how that might be achieved:</p>
               <div class="block"><div class="blockTitleDiv"><span class="blockTitle">IDL</span></div><div class="blockContent"><pre class="code"><code class="idl-code">[PrimaryGlobal]
 interface Window {
@@ -8800,24 +8907,45 @@ interface DedicatedWorkerGlobalScope : WorkerGlobalScope {
   ...
 };
 
-<span class="comment">// MathUtils is available for use in workers and on the main thread.</span>
-[Exposed=(Window,Worker)]
-interface MathUtils {
-  static double someComplicatedFunction(double x, double y);
+<span class="comment">// Dimensions is available for use in workers and on the main thread.</span>
+[Exposed=(Window,Worker), Constructor(double width, double height)]
+interface Dimensions {
+  readonly attribute double width;
+  readonly attribute double height;
 };
 
-<span class="comment">// WorkerUtils is only available in workers.  Evaluating WorkerUtils
+<span class="comment">// WorkerNavigator is only available in workers.  Evaluating WorkerNavigator
 // in the global scope of a worker would give you its interface object, while
 // doing so on the main thread will give you a ReferenceError.</span>
 [Exposed=Worker]
-interface WorkerUtils {
-  static void setPriority(double x);
+interface WorkerNavigator {
+  ...
 };
 
 <span class="comment">// Node is only available on the main thread.  Evaluating Node
 // in the global scope of a worker would give you a ReferenceError.</span>
 interface Node {
   ...
+};
+
+<span class="comment">// MathUtils is available for use in workers and on the main thread.</span>
+[Exposed=(Window,Worker)]
+namespace MathUtils {
+  double someComplicatedFunction(double x, double y);
+};
+
+<span class="comment">// WorkerUtils is only available in workers.  Evaluating WorkerUtils
+// in the global scope of a worker would give you its namespace object, while
+// doing so on the main thread will give you a ReferenceError.</span>
+[Exposed=Worker]
+namespace WorkerUtils {
+  void setPriority(double x);
+};
+
+<span class="comment">// NodeUtils is only available in the main thread.  Evaluating NodeUtils
+// in the global scope of a worker would give you a ReferenceError.</span>
+namespace NodeUtils {
+  DOMString getAllText(Node node);
 };</code></pre></div></div>
             </div>
           </div>
@@ -9965,8 +10093,9 @@ counter.value;                                           <span class="comment">/
               <a class="dfnref" href="#dfn-extended-attribute">extended attribute</a>
               appears on an <a class="dfnref" href="#dfn-interface">interface</a>,
               <a class="dfnref" href="#dfn-partial-interface">partial interface</a>,
-              an individual <a class="dfnref" href="#dfn-interface-member">interface member</a>,
-              it indicates that the interface or interface member is exposed
+              <a class="dfnref" href="#dfn-interface-member">interface member</a>, or
+              <a class="dfnref" href="#dfn-namespace-member">namespace member</a>,
+              it indicates that the construct is exposed
               only within a
               <a href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>
               (<a href="#ref-SECURE-CONTEXTS">[SECURE-CONTEXTS]</a>, section 2).
@@ -9981,8 +10110,9 @@ counter.value;                                           <span class="comment">/
               extended attribute <span class="rfc2119">MUST NOT</span>
               be used on anything other than an
               <a class="dfnref" href="#dfn-interface">interface</a>,
-              <a class="dfnref" href="#dfn-partial-interface">partial interface</a>, or
-              an individual <a class="dfnref" href="#dfn-interface-member">interface member</a>.
+              <a class="dfnref" href="#dfn-partial-interface">partial interface</a>,
+              <a class="dfnref" href="#dfn-interface-member">interface member</a>, or
+              <a class="dfnref" href="#dfn-namespace-member">namespace member</a>.
             </p>
             <p>
               Whether a construct that the <a class="xattr" href="#SecureContext">[SecureContext]</a>
@@ -10013,6 +10143,9 @@ counter.value;                                           <span class="comment">/
                   <dt>interface member</dt>
                   <dd>The interface member is <a class="dfnre" href="#dfn-available-only-in-secure-contexts">available only in secure contexts</a>
                   if and only if the interface or partial interface the member is declared on is.</dd>
+                  <dt>namespace member</dt>
+                  <dd>The namespace member is <a class="dfnre" href="#dfn-available-only-in-secure-contexts">available only in secure contexts</a>
+                  if and only if the namspace the member is declared on is.</dd>
                 </dl>
               </li>
             </ul>
@@ -10033,7 +10166,8 @@ counter.value;                                           <span class="comment">/
               The <a class="xattr" href="#SecureContext">[SecureContext]</a> extended attribute
               <span class="rfc2119">MUST NOT</span> be specified on both an interface
               member and the interface or partial interface definition the
-              interface member is declared on.
+              interface member is declared within, or on both a namespace member and the namespace
+              definition the namespace member is declared within.
             </p>
             <p>
               An interface without the <a class="xattr" href="#SecureContext">[SecureContext]</a> extended attribute
@@ -10551,6 +10685,19 @@ with (thing) {
                 </li>
 
                 <li>
+                  Otherwise: if <var>V</var> is a <span class="estype">RegExp</span> object and
+                  there is an entry in <var>S</var> that has one of the following types at position <var>i</var> of its type list,
+                  <ul>
+                    <li><a class="idltype" href="#idl-RegExp">RegExp</a></li>
+                    <li><a class="idltype" href="#idl-object">object</a></li>
+                    <li>a <a class="dfnref" href="#dfn-nullable-type">nullable</a> version of either of the above types</li>
+                    <li>a <a class="dfnref" href="#dfn-union-type">union type</a> or <a class="dfnref" href="#dfn-nullable-type">nullable</a> union type
+                       that has one of the above types in its <a class="dfnref" href="#dfn-flattened-union-member-types">flattened member types</a></li>
+                  </ul>
+                  then remove from <var>S</var> all other entries.
+                </li>
+
+                <li>
                   Otherwise: if <var>V</var> is a <a class="dfnref" href="#dfn-DOMException">DOMException</a> platform object and
                   there is an entry in <var>S</var> that has one of the following types at position <var>i</var> of its type list,
                   <ul>
@@ -10928,7 +11075,7 @@ with (thing) {
               <li>
                 If the interface doesn't inherit from any other interface,
                 the value of <span class="prop">[[Prototype]]</span> is
-                <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%FunctionPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
+                <a class="external" href="https://tc39.github.io/ecma262/#sec-properties-of-the-function-prototype-object">%FunctionPrototype%</a>.
               </li>
             </ol>
             <p>
@@ -11237,7 +11384,7 @@ with (thing) {
               for the inherited interface.</li>
               <li>Otherwise, if <var>A</var> is declared with the <a class="xattr" href="#LegacyArrayClass">[LegacyArrayClass]</a>
               extended attribute, then return <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ArrayPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).</li>
-              <li>Otherwise, return <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ObjectPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).
+              <li>Otherwise, return <a class="external" href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a>.
               (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 15.2.4).</li>
             </ol>
             <div class="note"><div class="noteHeader">Note</div>
@@ -11327,7 +11474,7 @@ partial interface Window {
               for the inherited interface.</li>
               <li>Otherwise, if <var>A</var> is declared with the <a class="xattr" href="#LegacyArrayClass">[LegacyArrayClass]</a>
               extended attribute, then return <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ArrayPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).</li>
-              <li>Otherwise, return <a class="external" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ObjectPrototype%</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 6.1.7.4).</li>
+              <li>Otherwise, return <a class="external" href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a>.</li>
             </ol>
             <p>
               The <a class="dfnref" href="#dfn-class-string">class string</a> of a
@@ -11384,7 +11531,7 @@ partial interface Window {
                   </ol>
                 </li>
 
-                <li>Return <a class="external" href="https://tc39.github.io/ecma262/#sec-ordinarygetownproperty">OrdinaryGetOwnProperty</a>(<var>O</var>, <var>P</var>).</li>
+                <li>Return the result of calling the <a class="external" href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p">default <span class="prop">[[GetOwnProperty]]</span> internal method</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 9.1.5) on <var>O</var> passing <var>P</var> as the argument.</li>
               </ol>
             </div>
 
@@ -13615,7 +13762,7 @@ C implements A;</code></pre></div></div>
                 </ol>
               </li>
 
-              <li>Return <a class="external" href="https://tc39.github.io/ecma262/#sec-ordinarygetownproperty">OrdinaryGetOwnProperty</a>(<var>O</var>, <var>P</var>).</li>
+              <li>Return the result of calling the <a class="external" href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p">default <span class="prop">[[GetOwnProperty]]</span> internal method</a> (<a href="#ref-ECMA-262">[ECMA-262]</a>, section 9.1.5) on <var>O</var> passing <var>P</var> as the argument.</li>
             </ol>
           </div>
 
@@ -13880,21 +14027,21 @@ C implements A;</code></pre></div></div>
                 and the result of calling the <a class="dfnref" href="#dfn-named-property-visibility">named property visibility algorithm</a>
                 with property name <var>P</var> and object <var>O</var> is true, then:
                 <ol>
-                  <li>If <var>O</var> does not implement an interface with a <a class="dfnref" href="#dfn-named-property-deleter">named property deleter</a>, then return <span class="esvalue">false</span>.</li>
+                  <li>If <var>O</var> does not implement an interface with a <a class="dfnref" href="#dfn-named-property-deleter">named property deleter</a>, then <span class="esvalue">false</span>.</li>
                   <li>Let <var>operation</var> be the operation used to declare the named property deleter.</li>
                   <li>If <var>operation</var> was defined without an <a class="dfnref" href="#dfn-identifier">identifier</a>, then:
                     <ol>
                       <li>Perform the steps listed in the interface description to
                         <a class="dfnref" href="#dfn-delete-an-existing-named-property">delete an existing named property</a>
                         with <var>P</var> as the name.</li>
-                      <li>If the steps indicated that the deletion failed, then return <span class="esvalue">false</span>.</li>
+                      <li>If the steps indicated that the deletion failed, then <span class="esvalue">false</span>.</li>
                     </ol>
                   </li>
                   <li>Otherwise, <var>operation</var> was defined with an identifier:
                     <ol>
                       <li>Perform the steps listed in the description of <var>operation</var> with <var>P</var> as the only argument value.</li>
                       <li>If <var>operation</var> was declared with a <a class="dfnref" href="#dfn-return-type">return type</a> of <a class="idltype" href="#idl-boolean">boolean</a>
-                        and the steps returned <span class="idlvalue">false</span>, then return <span class="esvalue">false</span>.</li>
+                        and the steps returned <span class="idlvalue">false</span>, then <span class="esvalue">false</span>.</li>
                     </ol>
                   </li>
                   <li>Return <span class="esvalue">true</span>.</li>
@@ -13903,7 +14050,7 @@ C implements A;</code></pre></div></div>
 
               <li>If <var>O</var> has an own property with name <var>P</var>, then:
                 <ol>
-                  <li>If the property is not configurable, then return <span class="esvalue">false</span>.</li>
+                  <li>If the property is not configurable, then <span class="esvalue">false</span>.</li>
                   <li>Otherwise, remove the property from <var>O</var>.</li>
                 </ol>
               </li>
@@ -13975,7 +14122,7 @@ C implements A;</code></pre></div></div>
           <h3>4.9. User objects implementing callback interfaces</h3>
 
           <p>
-            As described in <a href="#idl-objects">section 3.9 above</a>,
+            As described in <a href="#idl-objects">section 3.10 above</a>,
             <a class="dfnref" href="#dfn-callback-interface">callback interfaces</a> can be
             implemented in script by an ECMAScript object.
             The following cases determine whether and how a given object
@@ -14398,8 +14545,140 @@ C implements A;</code></pre></div></div>
           </ol>
         </div>
 
+        <div id="es-namespaces" class="section">
+          <h3>4.11. Namespaces</h3>
+
+          <p>
+            For every <a class="dfnref" href="#dfn-namespace">namespace</a> that is <a class="dfnref" href="#dfn-exposed">exposed</a> in a given ECMAScript global environment,
+            a corresponding property <span class="rfc2119">MUST</span> exist on the ECMAScript
+            environment's global object. The name of the property is the <a class="dfnref" href="#dfn-identifier">identifier</a> of the namespace, and its value is an object
+            called the <dfn data-export="" id="dfn-namespace-object">namespace object</dfn>.
+          </p>
+          <p>
+            The property has the attributes <span class="descriptor">{ [[Writable]]: <span class="esvalue">true</span>, [[Enumerable]]: <span class="esvalue">false</span>,
+            [[Configurable]]: <span class="esvalue">true</span> }</span>. The characteristics of a
+            namespace object are described in <a href="#namespace-object">section 4.11.1</a> below.
+          </p>
+
+          <div id="namespace-object" class="section">
+            <h4>4.11.1. Namespace object</h4>
+
+            <p>
+              The namespace object for a given <a class="dfnref" href="#dfn-namespace">namespace</a>
+              <var>namespace</var> and Realm <var>realm</var> is created as follows:
+            </p>
+
+            <ol class="algorithm">
+              <li>
+                Let <var>namespaceObject</var> be
+                <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a class="external" href="https://tc39.github.io/ecma262/#sec-objectcreate">ObjectCreate</a>(the <a class="external" href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a> of <var>realm</var>).
+              </li>
+
+              <li>
+                For each <a class="dfnref" href="#dfn-exposed">exposed</a> <a class="dfnref" href="#dfn-regular-operation">regular operation</a> <var>op</var> that is a <a class="dfnref" href="#dfn-namespace-member">namespace member</a> of this namespace,
+
+                <ol>
+                  <li>
+                    Let <var>id</var> be <var>op</var>'s <a class="dfnref" href="#dfn-identifier">identifier</a>.
+                  </li>
+
+                  <li>
+                    Let <var>steps</var> be the following series of steps, given function argument
+                    values <var>arg</var><sub>0..<var>n</var>−1</sub>:
+
+                    <ol>
+                      <li>
+                        Try running the following steps:
+                        <ol>
+                          <li>
+                            Let <var>S</var> be the <a class="dfnref" href="#dfn-effective-overload-set">effective overload set</a> for <a class="dfnref" href="#dfn-regular-operation">regular operations</a> with
+                            <a class="dfnref" href="#dfn-identifier">identifier</a> <var>id</var> on
+                            <a class="dfnref" href="#dfn-namespace">namespace</a>
+                            <var>namespace</var> and with argument count <var>n</var>.
+                          </li>
+
+                          <li>
+                            Let &lt;<var>operation</var>, <var>values</var>&gt; be the result of
+                            passing <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to
+                            the <a class="dfnref" href="#dfn-overload-resolution-algorithm">overload
+                            resolution algorithm</a>.
+                          </li>
+
+                          <li>
+                            Let <var>R</var> be the result of performing the actions listed in the
+                            description of <var>operation</var> with <var>values</var> as the
+                            argument values.
+                          </li>
+
+                          <li>
+                            Return the result of <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a> <var>R</var>
+                            to an ECMAScript value of the type <var>op</var> is declared to return.
+                          </li>
+                         </ol>
+                      </li>
+                    </ol>
+
+                    And then, if an exception was thrown:
+
+                    <ol>
+                      <li>
+                        If the operation has a <a class="dfnref" href="#dfn-return-type">return
+                        type</a> that is a <a href="#idl-promise">promise type</a>, then:
+
+                        <ol>
+                          <li>
+                            Let <var>reject</var> be the initial value of <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.
+                          </li>
+                          <li>
+                            Return the result of calling <var>reject</var> with <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a> as the <span class="esvalue">this</span>
+                            object and the exception as the single argument value.
+                          </li>
+                        </ol>
+                      </li>
+                      <li>
+                        Otherwise, end these steps and allow the exception to propagate.
+                      </li>
+                    </ol>
+                  </li>
+
+                  <li>
+                    Let <var>F</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a class="external" href="https://tc39.github.io/ecma262/#sec-createbuiltinfunction">CreateBuiltinFunction</a>(<var>realm</var>,
+                    <var>steps</var>, the <a class="external" href="https://tc39.github.io/ecma262/#sec-properties-of-the-function-prototype-object">%FunctionPrototype%</a> of <var>realm</var>).
+                  </li>
+
+                  <li>
+                    Perform <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a class="external" href="https://tc39.github.io/ecma262/#sec-setfunctionname">SetFunctionName</a>(<var>F</var>, <var>id</var>).
+                  </li>
+
+                  <li>
+                    Let <var>S</var> be the <a class="dfnref" href="#dfn-effective-overload-set">effective overload set</a> for <a class="dfnref" href="#dfn-regular-operation">regular operations</a> with <a class="dfnref" href="#dfn-identifier">identifier</a> <var>id</var> on <a class="dfnref" href="#dfn-namespace">namespace</a> <var>namespace</var> and with
+                    argument count 0.
+                  </li>
+
+                  <li>
+                    Let <var>length</var> be the length of the shortest argument list in the entries
+                    in <var>S</var>.
+                  </li>
+
+                  <li>
+                    Perform <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a class="external" href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow">DefinePropertyOrThrow</a>(<var>F</var>,
+                    <code>"length"</code>, PropertyDescriptor<span class="descriptor">{[[Value]]:
+                    <var>length</var>, [[Writable]]: <span class="esvalue">false</span>,
+                    [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">true</span>}</span>).
+                  </li>
+
+                  <li>
+                    Perform <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a class="external" href="https://tc39.github.io/ecma262/#sec-createdataproperty">CreateDataProperty</a>(<var>namespaceObject</var>,
+                    <var>id</var>, <var>F</var>).
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </div>
+        </div>
+
         <div id="es-exceptions" class="section">
-          <h3>4.11. Exceptions</h3>
+          <h3>4.12. Exceptions</h3>
 
           <p>
             There <span class="rfc2119">MUST</span> exist a property on the ECMAScript global object
@@ -14411,7 +14690,7 @@ C implements A;</code></pre></div></div>
           </p>
 
           <div id="es-DOMException-constructor-object" class="section">
-            <h4>4.11.1. DOMException constructor object</h4>
+            <h4>4.12.1. DOMException constructor object</h4>
 
             <p>
               The DOMException constructor object <span class="rfc2119">MUST</span> be a <a class="dfnref" href="#dfn-function-object">function object</a>
@@ -14432,7 +14711,7 @@ C implements A;</code></pre></div></div>
             </p>
 
             <div id="es-DOMException-call" class="section">
-              <h5>4.11.1.1. DOMException(message, name)</h5>
+              <h5>4.12.1.1. DOMException(message, name)</h5>
 
               <p>When the DOMException function is called with arguments <var>message</var> and <var>name</var>, the following steps are taken:</p>
 
@@ -14459,7 +14738,7 @@ C implements A;</code></pre></div></div>
           </div>
 
           <div id="es-DOMException-prototype-object" class="section">
-            <h4>4.11.2. DOMException prototype object</h4>
+            <h4>4.12.2. DOMException prototype object</h4>
 
             <p>
               The DOMException prototype object <span class="rfc2119">MUST</span>
@@ -14486,7 +14765,7 @@ C implements A;</code></pre></div></div>
         </div>
 
         <div id="es-exception-objects" class="section">
-          <h3>4.12. Exception objects</h3>
+          <h3>4.13. Exception objects</h3>
 
           <p>
             <a class="dfnref" href="#dfn-simple-exception">Simple exceptions</a> are represented
@@ -14529,7 +14808,7 @@ C implements A;</code></pre></div></div>
         </div>
 
         <div id="es-creating-throwing-exceptions" class="section">
-          <h3>4.13. Creating and throwing exceptions</h3>
+          <h3>4.14. Creating and throwing exceptions</h3>
 
           <p>
             First, we define the <dfn data-export="" id="dfn-current-global-environment">current global environment</dfn>
@@ -14668,7 +14947,7 @@ try {
         </div>
 
         <div id="es-handling-exceptions" class="section">
-          <h3>4.14. Handling exceptions</h3>
+          <h3>4.15. Handling exceptions</h3>
 
           <p>
             None of the algorithms or processing requirements in the
@@ -14876,7 +15155,6 @@ d.type = et;
           Marcos Cáceres,
           Giovanni Campagna,
           Domenic Denicola,
-          Chris Dumez,
           Michael Dyck,
           Brendan Eich,
           João Eiras,
@@ -15044,6 +15322,7 @@ d.type = et;
 
         <table class="grammar"><tr id="prod-Definitions"><td><span class="prod-number">[1]</span></td><td><a class="sym" href="#proddef-Definitions">Definitions</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-ExtendedAttributeList">ExtendedAttributeList</a> <a class="sym" href="#prod-Definition">Definition</a> <a class="sym" href="#prod-Definitions">Definitions</a> <br /> |
              ε</span></td></tr><tr id="prod-Definition"><td><span class="prod-number">[2]</span></td><td><a class="sym" href="#proddef-Definition">Definition</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-CallbackOrInterface">CallbackOrInterface</a> <br /> |
+             <a class="sym" href="#prod-Namespace">Namespace</a> <br /> |
              <a class="sym" href="#prod-Partial">Partial</a> <br /> |
              <a class="sym" href="#prod-Dictionary">Dictionary</a> <br /> |
              <a class="sym" href="#prod-Enum">Enum</a> <br /> |
@@ -15051,7 +15330,8 @@ d.type = et;
              <a class="sym" href="#prod-ImplementsStatement">ImplementsStatement</a></span></td></tr><tr id="prod-CallbackOrInterface"><td><span class="prod-number">[3]</span></td><td><a class="sym" href="#proddef-CallbackOrInterface">CallbackOrInterface</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"callback" <a class="sym" href="#prod-CallbackRestOrInterface">CallbackRestOrInterface</a> <br /> |
              <a class="sym" href="#prod-Interface">Interface</a></span></td></tr><tr id="prod-CallbackRestOrInterface"><td><span class="prod-number">[4]</span></td><td><a class="sym" href="#proddef-CallbackRestOrInterface">CallbackRestOrInterface</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-CallbackRest">CallbackRest</a> <br /> |
              <a class="sym" href="#prod-Interface">Interface</a></span></td></tr><tr id="prod-Interface"><td><span class="prod-number">[5]</span></td><td><a class="sym" href="#proddef-Interface">Interface</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"interface" <a class="sym" href="#prod-identifier">identifier</a> <a class="sym" href="#prod-Inheritance">Inheritance</a> "{" <a class="sym" href="#prod-InterfaceMembers">InterfaceMembers</a> "}" ";"</span></td></tr><tr id="prod-Partial"><td><span class="prod-number">[6]</span></td><td><a class="sym" href="#proddef-Partial">Partial</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"partial" <a class="sym" href="#prod-PartialDefinition">PartialDefinition</a></span></td></tr><tr id="prod-PartialDefinition"><td><span class="prod-number">[7]</span></td><td><a class="sym" href="#proddef-PartialDefinition">PartialDefinition</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-PartialInterface">PartialInterface</a> <br /> |
-             <a class="sym" href="#prod-PartialDictionary">PartialDictionary</a></span></td></tr><tr id="prod-PartialInterface"><td><span class="prod-number">[8]</span></td><td><a class="sym" href="#proddef-PartialInterface">PartialInterface</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"interface" <a class="sym" href="#prod-identifier">identifier</a> "{" <a class="sym" href="#prod-InterfaceMembers">InterfaceMembers</a> "}" ";"</span></td></tr><tr id="prod-InterfaceMembers"><td><span class="prod-number">[9]</span></td><td><a class="sym" href="#proddef-InterfaceMembers">InterfaceMembers</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-ExtendedAttributeList">ExtendedAttributeList</a> <a class="sym" href="#prod-InterfaceMember">InterfaceMember</a> <a class="sym" href="#prod-InterfaceMembers">InterfaceMembers</a> <br /> |
+             <a class="sym" href="#prod-PartialDictionary">PartialDictionary</a> <br /> |
+             <a class="sym" href="#prod-Namespace">Namespace</a></span></td></tr><tr id="prod-PartialInterface"><td><span class="prod-number">[8]</span></td><td><a class="sym" href="#proddef-PartialInterface">PartialInterface</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"interface" <a class="sym" href="#prod-identifier">identifier</a> "{" <a class="sym" href="#prod-InterfaceMembers">InterfaceMembers</a> "}" ";"</span></td></tr><tr id="prod-InterfaceMembers"><td><span class="prod-number">[9]</span></td><td><a class="sym" href="#proddef-InterfaceMembers">InterfaceMembers</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-ExtendedAttributeList">ExtendedAttributeList</a> <a class="sym" href="#prod-InterfaceMember">InterfaceMember</a> <a class="sym" href="#prod-InterfaceMembers">InterfaceMembers</a> <br /> |
              ε</span></td></tr><tr id="prod-InterfaceMember"><td><span class="prod-number">[10]</span></td><td><a class="sym" href="#proddef-InterfaceMember">InterfaceMember</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-Const">Const</a> <br /> |
              <a class="sym" href="#prod-Operation">Operation</a> <br /> |
              <a class="sym" href="#prod-Serializer">Serializer</a> <br /> |
@@ -15241,7 +15521,8 @@ d.type = et;
              ε</span></td></tr><tr id="prod-PromiseType"><td><span class="prod-number">[87]</span></td><td><a class="sym" href="#proddef-PromiseType">PromiseType</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"Promise" "&lt;" <a class="sym" href="#prod-ReturnType">ReturnType</a> "&gt;"</span></td></tr><tr id="prod-Null"><td><span class="prod-number">[88]</span></td><td><a class="sym" href="#proddef-Null">Null</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"?" <br /> |
              ε</span></td></tr><tr id="prod-ReturnType"><td><span class="prod-number">[89]</span></td><td><a class="sym" href="#proddef-ReturnType">ReturnType</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-Type">Type</a> <br /> |
              "void"</span></td></tr><tr id="prod-IdentifierList"><td><span class="prod-number">[90]</span></td><td><a class="sym" href="#proddef-IdentifierList">IdentifierList</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-identifier">identifier</a> <a class="sym" href="#prod-Identifiers">Identifiers</a></span></td></tr><tr id="prod-Identifiers"><td><span class="prod-number">[91]</span></td><td><a class="sym" href="#proddef-Identifiers">Identifiers</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"," <a class="sym" href="#prod-identifier">identifier</a> <a class="sym" href="#prod-Identifiers">Identifiers</a> <br /> |
-             ε</span></td></tr><tr id="prod-ExtendedAttributeNoArgs"><td><span class="prod-number">[92]</span></td><td><a class="sym" href="#proddef-ExtendedAttributeNoArgs">ExtendedAttributeNoArgs</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-identifier">identifier</a></span></td></tr><tr id="prod-ExtendedAttributeArgList"><td><span class="prod-number">[93]</span></td><td><a class="sym" href="#proddef-ExtendedAttributeArgList">ExtendedAttributeArgList</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-identifier">identifier</a> "(" <a class="sym" href="#prod-ArgumentList">ArgumentList</a> ")"</span></td></tr><tr id="prod-ExtendedAttributeIdent"><td><span class="prod-number">[94]</span></td><td><a class="sym" href="#proddef-ExtendedAttributeIdent">ExtendedAttributeIdent</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-identifier">identifier</a> "=" <a class="sym" href="#prod-identifier">identifier</a></span></td></tr><tr id="prod-ExtendedAttributeIdentList"><td><span class="prod-number">[95]</span></td><td><a class="sym" href="#proddef-ExtendedAttributeIdentList">ExtendedAttributeIdentList</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-identifier">identifier</a> "=" "(" <a class="sym" href="#prod-IdentifierList">IdentifierList</a> ")"</span></td></tr><tr id="prod-ExtendedAttributeNamedArgList"><td><span class="prod-number">[96]</span></td><td><a class="sym" href="#proddef-ExtendedAttributeNamedArgList">ExtendedAttributeNamedArgList</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-identifier">identifier</a> "=" <a class="sym" href="#prod-identifier">identifier</a> "(" <a class="sym" href="#prod-ArgumentList">ArgumentList</a> ")"</span></td></tr></table>
+             ε</span></td></tr><tr id="prod-ExtendedAttributeNoArgs"><td><span class="prod-number">[92]</span></td><td><a class="sym" href="#proddef-ExtendedAttributeNoArgs">ExtendedAttributeNoArgs</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-identifier">identifier</a></span></td></tr><tr id="prod-ExtendedAttributeArgList"><td><span class="prod-number">[93]</span></td><td><a class="sym" href="#proddef-ExtendedAttributeArgList">ExtendedAttributeArgList</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-identifier">identifier</a> "(" <a class="sym" href="#prod-ArgumentList">ArgumentList</a> ")"</span></td></tr><tr id="prod-ExtendedAttributeIdent"><td><span class="prod-number">[94]</span></td><td><a class="sym" href="#proddef-ExtendedAttributeIdent">ExtendedAttributeIdent</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-identifier">identifier</a> "=" <a class="sym" href="#prod-identifier">identifier</a></span></td></tr><tr id="prod-ExtendedAttributeIdentList"><td><span class="prod-number">[95]</span></td><td><a class="sym" href="#proddef-ExtendedAttributeIdentList">ExtendedAttributeIdentList</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-identifier">identifier</a> "=" "(" <a class="sym" href="#prod-IdentifierList">IdentifierList</a> ")"</span></td></tr><tr id="prod-ExtendedAttributeNamedArgList"><td><span class="prod-number">[96]</span></td><td><a class="sym" href="#proddef-ExtendedAttributeNamedArgList">ExtendedAttributeNamedArgList</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-identifier">identifier</a> "=" <a class="sym" href="#prod-identifier">identifier</a> "(" <a class="sym" href="#prod-ArgumentList">ArgumentList</a> ")"</span></td></tr><tr id="prod-Namespace"><td><span class="prod-number">[97]</span></td><td><a class="sym" href="#proddef-Namespace">Namespace</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines">"namespace" <a class="sym" href="#prod-identifier">identifier</a> "{" <a class="sym" href="#prod-NamespaceMembers">NamespaceMembers</a> "}" ";"</span></td></tr><tr id="prod-NamespaceMembers"><td><span class="prod-number">[98]</span></td><td><a class="sym" href="#proddef-NamespaceMembers">NamespaceMembers</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-ExtendedAttributeList">ExtendedAttributeList</a> <a class="sym" href="#prod-NamespaceMember">NamespaceMember</a> <a class="sym" href="#prod-NamespaceMembers">NamespaceMembers</a> <br /> |
+             ε</span></td></tr><tr id="prod-NamespaceMember"><td><span class="prod-number">[99]</span></td><td><a class="sym" href="#proddef-NamespaceMember">NamespaceMember</a></td><td class="prod-mid">→</td><td class="prod-rhs"><span class="prod-lines"><a class="sym" href="#prod-ReturnType">ReturnType</a> <a class="sym" href="#prod-OperationRest">OperationRest</a></span></td></tr></table>
         <div class="note"><div class="noteHeader">Note</div>
           <p>
             The <a class="sym" href="#prod-Other">Other</a>
@@ -15260,7 +15541,7 @@ d.type = et;
           only a subset of those
           possible sequences are used by the <a class="dfnref" href="#dfn-extended-attribute">extended attributes</a>
           defined in this specification — see
-          <a href="#idl-extended-attributes">section 3.11</a>
+          <a href="#idl-extended-attributes">section 3.12</a>
           for the syntaxes that are used by these extended attributes.
         </p>
       </div>

--- a/index.html
+++ b/index.html
@@ -10173,9 +10173,9 @@ counter.value;                                           <span class="comment">/
             <p>
               The <a class="xattr" href="#SecureContext">[SecureContext]</a> extended attribute
               <span class="rfc2119">MUST NOT</span> be specified on both an interface member and the
-              interface or partial interface definition the interface member is declared within, or
+              interface or partial interface definition the interface member is declared on, or
               on both a namespace member and the namespace or partial namespace definition the
-              namespace member is declared within.
+              namespace member is declared on.
             </p>
             <p>
               An interface without the <a class="xattr" href="#SecureContext">[SecureContext]</a> extended attribute
@@ -12026,6 +12026,105 @@ interface
                 property is a <span class="estype">String</span> whose value is the
                 identifier of the operation.</li>
             </ul>
+
+            <p>We also define <dfn id="dfn-create-operation-function">creating an operation
+            function</dfn>, given an <a class="dfnref" href="#dfn-operation">operation</a>
+            <var>op</var>, a <a class="dfnref" href="#dfn-namespace">namespace</a>
+            <var>namespace</var>, and a <a class="external external" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>:</p>
+
+            <p class="note">The astute reader may notice that what follows is very similar to the
+            above algorithm for operations on interfaces. It is currently only used for namespaces,
+            but we have near-future plans to generalize it slightly and then replace the above
+            definition so that this algorithm is useful both for interfaces and namespaces.</p>
+
+            <ol>
+              <li>
+                Let <var>id</var> be <var>op</var>'s <a class="dfnref" href="#dfn-identifier">identifier</a>.
+              </li>
+
+
+              <li>
+                Let <var>steps</var> be the following series of steps, given function argument
+                values <var>arg</var><sub>0..<var>n</var>−1</sub>:
+
+                <ol>
+                  <li>
+                    Try running the following steps:
+                    <ol>
+                      <li>
+                        Let <var>S</var> be the <a class="dfnref" href="#dfn-effective-overload-set">effective overload set</a> for <a class="dfnref" href="#dfn-regular-operation">regular operations</a> with
+                        <a class="dfnref" href="#dfn-identifier">identifier</a> <var>id</var> on
+                        <a class="dfnref" href="#dfn-namespace">namespace</a> <var>namespace</var>
+                        and with argument count <var>n</var>.
+                      </li>
+
+                      <li>
+                        Let &lt;<var>operation</var>, <var>values</var>&gt; be the result of passing
+                        <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to the <a class="dfnref" href="#dfn-overload-resolution-algorithm">overload resolution
+                        algorithm</a>.
+                      </li>
+
+                      <li>
+                        Let <var>R</var> be the result of performing the actions listed in the
+                        description of <var>operation</var> with <var>values</var> as the argument
+                        values.
+                      </li>
+
+                      <li>
+                        Return the result of <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a> <var>R</var> to
+                        an ECMAScript value of the type <var>op</var> is declared to return.
+                      </li>
+                     </ol>
+                  </li>
+                </ol>
+
+                And then, if an exception was thrown:
+
+                <ol>
+                  <li>
+                    If the operation has a <a class="dfnref" href="#dfn-return-type">return type</a>
+                    that is a <a href="#idl-promise">promise type</a>, then:
+
+                    <ol>
+                      <li>
+                        Let <var>reject</var> be the initial value of <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.
+                      </li>
+                      <li>
+                        Return the result of calling <var>reject</var> with <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a> as the <span class="esvalue">this</span> object
+                        and the exception as the single argument value.
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
+                    Otherwise, end these steps and allow the exception to propagate.
+                  </li>
+                </ol>
+              </li>
+
+              <li>
+                Let <var>F</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a class="external" href="https://tc39.github.io/ecma262/#sec-createbuiltinfunction">CreateBuiltinFunction</a>(<var>realm</var>,
+                <var>steps</var>, the <a class="external" href="https://tc39.github.io/ecma262/#sec-properties-of-the-function-prototype-object">%FunctionPrototype%</a> of <var>realm</var>).
+              </li>
+
+              <li>
+                Perform <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a class="external" href="https://tc39.github.io/ecma262/#sec-setfunctionname">SetFunctionName</a>(<var>F</var>, <var>id</var>).
+              </li>
+
+              <li>
+                Let <var>S</var> be the <a class="dfnref" href="#dfn-effective-overload-set">effective overload set</a> for <a class="dfnref" href="#dfn-regular-operation">regular operations</a> with <a class="dfnref" href="#dfn-identifier">identifier</a> <var>id</var> on <a class="dfnref" href="#dfn-namespace">namespace</a> <var>namespace</var> and with argument count 0.
+              </li>
+
+              <li>
+                Let <var>length</var> be the length of the shortest argument list in the entries in
+                <var>S</var>.
+              </li>
+
+              <li>
+                Perform <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a class="external" href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow">DefinePropertyOrThrow</a>(<var>F</var>, <code>"length"</code>,
+                PropertyDescriptor<span class="descriptor">{[[Value]]: <var>length</var>,
+                [[Writable]]: <span class="esvalue">false</span>, [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">true</span>}</span>).
+              </li>
+            </ol>
 
             <div id="es-stringifier" class="section">
               <h5>4.6.7.1. Stringifiers</h5>
@@ -14560,7 +14659,8 @@ C implements A;</code></pre></div></div>
 
             <p>
               The namespace object for a given <a class="dfnref" href="#dfn-namespace">namespace</a>
-              <var>namespace</var> and Realm <var>realm</var> is created as follows:
+              <var>namespace</var> and <a class="external external" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var> is created as
+              follows:
             </p>
 
             <ol class="algorithm">
@@ -14574,97 +14674,14 @@ C implements A;</code></pre></div></div>
 
                 <ol>
                   <li>
-                    Let <var>id</var> be <var>op</var>'s <a class="dfnref" href="#dfn-identifier">identifier</a>.
-                  </li>
-
-                  <li>
-                    Let <var>steps</var> be the following series of steps, given function argument
-                    values <var>arg</var><sub>0..<var>n</var>−1</sub>:
-
-                    <ol>
-                      <li>
-                        Try running the following steps:
-                        <ol>
-                          <li>
-                            Let <var>S</var> be the <a class="dfnref" href="#dfn-effective-overload-set">effective overload set</a> for <a class="dfnref" href="#dfn-regular-operation">regular operations</a> with
-                            <a class="dfnref" href="#dfn-identifier">identifier</a> <var>id</var> on
-                            <a class="dfnref" href="#dfn-namespace">namespace</a>
-                            <var>namespace</var> and with argument count <var>n</var>.
-                          </li>
-
-                          <li>
-                            Let &lt;<var>operation</var>, <var>values</var>&gt; be the result of
-                            passing <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to
-                            the <a class="dfnref" href="#dfn-overload-resolution-algorithm">overload
-                            resolution algorithm</a>.
-                          </li>
-
-                          <li>
-                            Let <var>R</var> be the result of performing the actions listed in the
-                            description of <var>operation</var> with <var>values</var> as the
-                            argument values.
-                          </li>
-
-                          <li>
-                            Return the result of <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a> <var>R</var>
-                            to an ECMAScript value of the type <var>op</var> is declared to return.
-                          </li>
-                         </ol>
-                      </li>
-                    </ol>
-
-                    And then, if an exception was thrown:
-
-                    <ol>
-                      <li>
-                        If the operation has a <a class="dfnref" href="#dfn-return-type">return
-                        type</a> that is a <a href="#idl-promise">promise type</a>, then:
-
-                        <ol>
-                          <li>
-                            Let <var>reject</var> be the initial value of <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.
-                          </li>
-                          <li>
-                            Return the result of calling <var>reject</var> with <a class="nocite external" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a> as the <span class="esvalue">this</span>
-                            object and the exception as the single argument value.
-                          </li>
-                        </ol>
-                      </li>
-                      <li>
-                        Otherwise, end these steps and allow the exception to propagate.
-                      </li>
-                    </ol>
-                  </li>
-
-                  <li>
-                    Let <var>F</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a class="external" href="https://tc39.github.io/ecma262/#sec-createbuiltinfunction">CreateBuiltinFunction</a>(<var>realm</var>,
-                    <var>steps</var>, the <a class="external" href="https://tc39.github.io/ecma262/#sec-properties-of-the-function-prototype-object">%FunctionPrototype%</a> of <var>realm</var>).
-                  </li>
-
-                  <li>
-                    Perform <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a class="external" href="https://tc39.github.io/ecma262/#sec-setfunctionname">SetFunctionName</a>(<var>F</var>, <var>id</var>).
-                  </li>
-
-                  <li>
-                    Let <var>S</var> be the <a class="dfnref" href="#dfn-effective-overload-set">effective overload set</a> for <a class="dfnref" href="#dfn-regular-operation">regular operations</a> with <a class="dfnref" href="#dfn-identifier">identifier</a> <var>id</var> on <a class="dfnref" href="#dfn-namespace">namespace</a> <var>namespace</var> and with
-                    argument count 0.
-                  </li>
-
-                  <li>
-                    Let <var>length</var> be the length of the shortest argument list in the entries
-                    in <var>S</var>.
-                  </li>
-
-                  <li>
-                    Perform <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a class="external" href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow">DefinePropertyOrThrow</a>(<var>F</var>,
-                    <code>"length"</code>, PropertyDescriptor<span class="descriptor">{[[Value]]:
-                    <var>length</var>, [[Writable]]: <span class="esvalue">false</span>,
-                    [[Enumerable]]: <span class="esvalue">false</span>, [[Configurable]]: <span class="esvalue">true</span>}</span>).
+                    Let <var>F</var> be the result of <a class="dfnref" href="#dfn-create-operation-function">creating an operation function</a> given
+                    <var>op</var>, <var>namespace</var>,  and <var>realm</var>.
                   </li>
 
                   <li>
                     Perform <a class="external" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a class="external" href="https://tc39.github.io/ecma262/#sec-createdataproperty">CreateDataProperty</a>(<var>namespaceObject</var>,
-                    <var>id</var>, <var>F</var>).
+                    <var>op</var>'s <a class="dfnref" href="#dfn-identifier">identifier</a>,
+                    <var>F</var>).
                   </li>
                 </ol>
               </li>

--- a/index.xml
+++ b/index.xml
@@ -769,8 +769,7 @@ interface TextField {
   <i>interface-members…</i>
 };</pre>
           <p>
-            The order that members appear has significance both for <a
-            href='#idl-overloading'>overloading</a> and for property enumeration in the <a
+            The order that members appear in has significance for property enumeration in the <a
             href='#es-interfaces'>ECMAScript binding</a>.
           </p>
           <p>
@@ -4008,15 +4007,14 @@ partial namespace <em>SomeNamespace</em> {
           <div class='note'>
             <p>
               As with partial interface definitions, partial namespace definitions are intended for
-              use as a specification editorial aide, allowing the definition of an interface to be
+              use as a specification editorial aide, allowing the definition of a namespace to be
               separated over more than one section of the document, and sometimes multiple
               documents.
             </p>
           </div>
 
           <p>
-            The order that members appear has significance both for <a
-            href='#idl-overloading'>overloading</a> and for property enumeration in the <a
+            The order that members appear in has significance for property enumeration in the <a
             href='#es-namespaces'>ECMAScript binding</a>.
           </p>
 
@@ -4025,12 +4023,10 @@ partial namespace <em>SomeNamespace</em> {
           </p>
 
           <p>
-            Only the <a class='xattr' href='#Exposed'>[Exposed]</a> and <a class='xattr'
+            Of the extended attributes defined in this specification, only the <a class='xattr'
+            href='#Exposed'>[Exposed]</a> and <a class='xattr'
             href='#SecureContext'>[SecureContext]</a> extended attributes are applicable to
-            namespaces. When declaring a <a class='dfnref' href='#dfn-partial-namespace'>partial
-            namespace</a>, the partial namespace must have the same extended attributes (and
-            extended attribute argument values, if any) specified as the original namespace
-            definition with the same identifier.
+            namespaces.
           </p>
 
           <?productions grammar Partial PartialDefinition Namespace NamespaceMembers NamespaceMember?>
@@ -8671,7 +8667,8 @@ context.setColorEnforcedRange(-1, 255, 256);</x:codeblock>
               <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a>
               appears on an <a class='dfnref' href='#dfn-interface'>interface</a>,
               <a class='dfnref' href='#dfn-partial-interface'>partial interface</a>,
-              <a class='dfnref' href='#dfn-namespace'>namespace</a>, or
+              <a class='dfnref' href='#dfn-namespace'>namespace</a>,
+              <a class='dfnref' href='#dfn-partial-namespace'>partial namespace</a>, or
               an individual <a class='dfnref' href='#dfn-interface-member'>interface member</a> or
               <a class='dfnref' href='#dfn-namespace-member'>namespace member</a>,
               it indicates that the construct is exposed
@@ -8713,13 +8710,14 @@ context.setColorEnforcedRange(-1, 255, 256);</x:codeblock>
                 <dl class='switch'>
                   <dt>interface</dt>
                   <dt>namespace</dt>
-                  <dd>The <a class='dfnref' href='#dfn-exposure-set'>exposure set</a> of the interface
-                  only contains the
+                  <dd>The <a class='dfnref' href='#dfn-exposure-set'>exposure set</a> of the
+                  interface or namespace only contains the
                   <a class='dfnref' href='#dfn-primary-global-interface'>primary global interface</a>.</dd>
                   <dt>partial interface</dt>
+                  <dt>partial namespace</dt>
                   <dd>The <a class='dfnref' href='#dfn-exposure-set'>exposure set</a> of the partial
-                  interface is the <a class='dfnref' href='#dfn-exposure-set'>exposure set</a> of the original
-                  interface definition.</dd>
+                  interface or namespace is the <a class='dfnref' href='#dfn-exposure-set'>exposure
+                  set</a> of the original interface or namespace definition.</dd>
                   <dt>interface member</dt>
                   <dd>The <a class='dfnref' href='#dfn-exposure-set'>exposure set</a> of the interface member
                   is the <a class='dfnref' href='#dfn-exposure-set'>exposure set</a> of the interface or
@@ -8727,7 +8725,7 @@ context.setColorEnforcedRange(-1, 255, 256);</x:codeblock>
                   <dt>namespace member</dt>
                   <dd>The <a class='dfnref' href='#dfn-exposure-set'>exposure set</a> of the
                   namespace member is the <a class='dfnref' href='#dfn-exposure-set'>exposure
-                  set</a> of the namespace the member is declared on.</dd>
+                  set</a> of the namespace or partial namespace the member is declared on.</dd>
                 </dl>
               </li>
             </ul>
@@ -8740,18 +8738,20 @@ context.setColorEnforcedRange(-1, 255, 256);</x:codeblock>
               The <a class='xattr' href='#Exposed'>[Exposed]</a> extended attribute
               <span class='rfc2119'>MUST NOT</span> be specified on both an interface
               member and a partial interface definition the interface member is declared on.
+              Similarly, the <a class='xattr' href='#Exposed'>[Exposed]</a> extended attribute
+              <span class='rfc2119'>MUST NOT</span> be specified on both a namespace
+              member and a partial namespace definition the namespace member is declared on.
             </p>
             <p>
-              If <a class='xattr' href='#Exposed'>[Exposed]</a> appears on both an interface
-              and one of its interface members, then the interface member's
-              <a class='dfnref' href='#dfn-exposure-set'>exposure set</a>
-              <span class='rfc2119'>MUST</span> be a subset of the interface's
-              <a class='dfnref' href='#dfn-exposure-set'>exposure set</a>.
-              Similarly, if <a class='xattr' href='#Exposed'>[Exposed]</a> appears on both a
-              namespace and one of its namespace members, then the namespace member's
-              <a class='dfnref' href='#dfn-exposure-set'>exposure set</a>
-              <span class='rfc2119'>MUST</span> be a subset of the namespace's
-              <a class='dfnref' href='#dfn-exposure-set'>exposure set</a>.
+              If <a class='xattr' href='#Exposed'>[Exposed]</a> appears an interface member, then
+              the interface member's <a class='dfnref' href='#dfn-exposure-set'>exposure set</a>
+              <span class='rfc2119'>MUST</span> be a subset of the <a class='dfnref'
+              href='#dfn-exposure-set'>exposure set</a> of the interface or partial interface it's a
+              member of. Similarly, if <a class='xattr' href='#Exposed'>[Exposed]</a> appears on a
+              namespace member, then the namespace member's <a class='dfnref'
+              href='#dfn-exposure-set'>exposure set</a> <span class='rfc2119'>MUST</span> be a
+              subset of the <a class='dfnref' href='#dfn-exposure-set'>exposure set</a> of the
+              namespace or partial namespace it's a member of.
             </p>
             <p>
               An interface's <a class='dfnref' href='#dfn-exposure-set'>exposure set</a>
@@ -10014,6 +10014,8 @@ counter.value;                                           <span class='comment'>/
               <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a>
               appears on an <a class='dfnref' href='#dfn-interface'>interface</a>,
               <a class='dfnref' href='#dfn-partial-interface'>partial interface</a>,
+              <a class='dfnref' href='#dfn-namespace'>namespace</a>,
+              <a class='dfnref' href='#dfn-partial-namespace'>partial namespace</a>,
               <a class='dfnref' href='#dfn-interface-member'>interface member</a>, or
               <a class='dfnref' href='#dfn-namespace-member'>namespace member</a>,
               it indicates that the construct is exposed
@@ -10032,6 +10034,8 @@ counter.value;                                           <span class='comment'>/
               be used on anything other than an
               <a class='dfnref' href='#dfn-interface'>interface</a>,
               <a class='dfnref' href='#dfn-partial-interface'>partial interface</a>,
+              <a class='dfnref' href='#dfn-namespace'>namespace</a>,
+              <a class='dfnref' href='#dfn-partial-namespace'>partial namespace</a>,
               <a class='dfnref' href='#dfn-interface-member'>interface member</a>, or
               <a class='dfnref' href='#dfn-namespace-member'>namespace member</a>.
             </p>
@@ -10056,17 +10060,24 @@ counter.value;                                           <span class='comment'>/
                 depends on the type of construct:</p>
                 <dl class='switch'>
                   <dt>interface</dt>
-                  <dd>The interface or dictionary is not
+                  <dt>namespace</dt>
+                  <dd>The interface or namespace is not
                   <a class='dfnre' href='#dfn-available-only-in-secure-contexts'>available only in secure contexts</a>.</dd>
+
                   <dt>partial interface</dt>
-                  <dd>The partial interface is <a class='dfnre' href='#dfn-available-only-in-secure-contexts'>available only in secure contexts</a>
-                  if and only if the original interface definition is.</dd>
+                  <dt>partial namespace</dt>
+                  <dd>The partial interface or partial namespace is <a class='dfnre'
+                  href='#dfn-available-only-in-secure-contexts'>available only in secure
+                  contexts</a> if and only if the original interface or namespace definition
+                  is.</dd>
+
                   <dt>interface member</dt>
                   <dd>The interface member is <a class='dfnre' href='#dfn-available-only-in-secure-contexts'>available only in secure contexts</a>
                   if and only if the interface or partial interface the member is declared on is.</dd>
+
                   <dt>namespace member</dt>
                   <dd>The namespace member is <a class='dfnre' href='#dfn-available-only-in-secure-contexts'>available only in secure contexts</a>
-                  if and only if the namspace the member is declared on is.</dd>
+                  if and only if the namspace or partial namespace the member is declared on is.</dd>
                 </dl>
               </li>
             </ul>
@@ -10085,10 +10096,10 @@ counter.value;                                           <span class='comment'>/
             </p>
             <p>
               The <a class='xattr' href='#SecureContext'>[SecureContext]</a> extended attribute
-              <span class='rfc2119'>MUST NOT</span> be specified on both an interface
-              member and the interface or partial interface definition the
-              interface member is declared within, or on both a namespace member and the namespace
-              definition the namespace member is declared within.
+              <span class='rfc2119'>MUST NOT</span> be specified on both an interface member and the
+              interface or partial interface definition the interface member is declared within, or
+              on both a namespace member and the namespace or partial namespace definition the
+              namespace member is declared within.
             </p>
             <p>
               An interface without the <a class='xattr' href='#SecureContext'>[SecureContext]</a> extended attribute

--- a/index.xml
+++ b/index.xml
@@ -11957,6 +11957,118 @@ interface
                 identifier of the operation.</li>
             </ul>
 
+            <p>We also define <dfn id='dfn-create-operation-function'>creating an operation
+            function</dfn>, given an <a class='dfnref' href='#dfn-operation'>operation</a>
+            <var>op</var>, a <a class='dfnref' href='#dfn-namespace'>namespace</a>
+            <var>namespace</var>, and a <a class='external'>Realm</a> <var>realm</var>:</p>
+
+            <p class='note'>The astute reader may notice that what follows is very similar to the
+            above algorithm for operations on interfaces. It is currently only used for namespaces,
+            but we have near-future plans to generalize it slightly and then replace the above
+            definition so that this algorithm is useful both for interfaces and namespaces.</p>
+
+            <ol>
+              <li>
+                Let <var>id</var> be <var>op</var>'s <a class='dfnref'
+                href='#dfn-identifier'>identifier</a>.
+              </li>
+
+
+              <li>
+                Let <var>steps</var> be the following series of steps, given function argument
+                values <var>arg</var><sub>0..<var>n</var>−1</sub>:
+
+                <ol>
+                  <li>
+                    Try running the following steps:
+                    <ol>
+                      <li>
+                        Let <var>S</var> be the <a class='dfnref'
+                        href='#dfn-effective-overload-set'>effective overload set</a> for <a
+                        class='dfnref' href='#dfn-regular-operation'>regular operations</a> with
+                        <a class='dfnref' href='#dfn-identifier'>identifier</a> <var>id</var> on
+                        <a class='dfnref' href='#dfn-namespace'>namespace</a> <var>namespace</var>
+                        and with argument count <var>n</var>.
+                      </li>
+
+                      <li>
+                        Let &lt;<var>operation</var>, <var>values</var>> be the result of passing
+                        <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to the <a
+                        class='dfnref' href='#dfn-overload-resolution-algorithm'>overload resolution
+                        algorithm</a>.
+                      </li>
+
+                      <li>
+                        Let <var>R</var> be the result of performing the actions listed in the
+                        description of <var>operation</var> with <var>values</var> as the argument
+                        values.
+                      </li>
+
+                      <li>
+                        Return the result of <a class='dfnref'
+                        href='#dfn-convert-idl-to-ecmascript-value'>converting</a> <var>R</var> to
+                        an ECMAScript value of the type <var>op</var> is declared to return.
+                      </li>
+                     </ol>
+                  </li>
+                </ol>
+
+                And then, if an exception was thrown:
+
+                <ol>
+                  <li>
+                    If the operation has a <a class='dfnref' href='#dfn-return-type'>return type</a>
+                    that is a <a href='#idl-promise'>promise type</a>, then:
+
+                    <ol>
+                      <li>
+                        Let <var>reject</var> be the initial value of <a
+                        class='nocite'>%Promise%</a>.reject.
+                      </li>
+                      <li>
+                        Return the result of calling <var>reject</var> with <a
+                        class='nocite'>%Promise%</a> as the <span class='esvalue'>this</span> object
+                        and the exception as the single argument value.
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
+                    Otherwise, end these steps and allow the exception to propagate.
+                  </li>
+                </ol>
+              </li>
+
+              <li>
+                Let <var>F</var> be <a>!</a> <a>CreateBuiltinFunction</a>(<var>realm</var>,
+                <var>steps</var>, the <a>%FunctionPrototype%</a> of <var>realm</var>).
+              </li>
+
+              <li>
+                Perform <a>!</a> <a>SetFunctionName</a>(<var>F</var>, <var>id</var>).
+              </li>
+
+              <li>
+                Let <var>S</var> be the <a class='dfnref'
+                href='#dfn-effective-overload-set'>effective overload set</a> for <a class='dfnref'
+                href='#dfn-regular-operation'>regular operations</a> with <a class='dfnref'
+                href='#dfn-identifier'>identifier</a> <var>id</var> on <a class='dfnref'
+                href='#dfn-namespace'>namespace</a> <var>namespace</var> and with argument count 0.
+              </li>
+
+              <li>
+                Let <var>length</var> be the length of the shortest argument list in the entries in
+                <var>S</var>.
+              </li>
+
+              <li>
+                Perform <a>!</a> <a>DefinePropertyOrThrow</a>(<var>F</var>, <code>"length"</code>,
+                PropertyDescriptor<span class='descriptor'>{[[Value]]: <var>length</var>,
+                [[Writable]]: <span class='esvalue'>false</span>, [[Enumerable]]: <span
+                class='esvalue'>false</span>, [[Configurable]]: <span
+                class='esvalue'>true</span>}</span>).
+              </li>
+            </ol>
+
             <div id="es-stringifier" class='section'>
               <h5>Stringifiers</h5>
 
@@ -14549,7 +14661,8 @@ C implements A;</x:codeblock>
 
             <p>
               The namespace object for a given <a class='dfnref' href='#dfn-namespace'>namespace</a>
-              <var>namespace</var> and Realm <var>realm</var> is created as follows:
+              <var>namespace</var> and <a class='external'>Realm</a> <var>realm</var> is created as
+              follows:
             </p>
 
             <ol class='algorithm'>
@@ -14565,108 +14678,15 @@ C implements A;</x:codeblock>
 
                 <ol>
                   <li>
-                    Let <var>id</var> be <var>op</var>'s <a class='dfnref'
-                    href='#dfn-identifier'>identifier</a>.
-                  </li>
-
-                  <li>
-                    Let <var>steps</var> be the following series of steps, given function argument
-                    values <var>arg</var><sub>0..<var>n</var>−1</sub>:
-
-                    <ol>
-                      <li>
-                        Try running the following steps:
-                        <ol>
-                          <li>
-                            Let <var>S</var> be the <a class='dfnref'
-                            href='#dfn-effective-overload-set'>effective overload set</a> for <a
-                            class='dfnref' href='#dfn-regular-operation'>regular operations</a> with
-                            <a class='dfnref' href='#dfn-identifier'>identifier</a> <var>id</var> on
-                            <a class='dfnref' href='#dfn-namespace'>namespace</a>
-                            <var>namespace</var> and with argument count <var>n</var>.
-                          </li>
-
-                          <li>
-                            Let &lt;<var>operation</var>, <var>values</var>> be the result of
-                            passing <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to
-                            the <a class='dfnref' href='#dfn-overload-resolution-algorithm'>overload
-                            resolution algorithm</a>.
-                          </li>
-
-                          <li>
-                            Let <var>R</var> be the result of performing the actions listed in the
-                            description of <var>operation</var> with <var>values</var> as the
-                            argument values.
-                          </li>
-
-                          <li>
-                            Return the result of <a class='dfnref'
-                            href='#dfn-convert-idl-to-ecmascript-value'>converting</a> <var>R</var>
-                            to an ECMAScript value of the type <var>op</var> is declared to return.
-                          </li>
-                         </ol>
-                      </li>
-                    </ol>
-
-                    And then, if an exception was thrown:
-
-                    <ol>
-                      <li>
-                        If the operation has a <a class='dfnref' href='#dfn-return-type'>return
-                        type</a> that is a <a href='#idl-promise'>promise type</a>, then:
-
-                        <ol>
-                          <li>
-                            Let <var>reject</var> be the initial value of <a
-                            class='nocite'>%Promise%</a>.reject.
-                          </li>
-                          <li>
-                            Return the result of calling <var>reject</var> with <a
-                            class='nocite'>%Promise%</a> as the <span class='esvalue'>this</span>
-                            object and the exception as the single argument value.
-                          </li>
-                        </ol>
-                      </li>
-                      <li>
-                        Otherwise, end these steps and allow the exception to propagate.
-                      </li>
-                    </ol>
-                  </li>
-
-                  <li>
-                    Let <var>F</var> be <a>!</a> <a>CreateBuiltinFunction</a>(<var>realm</var>,
-                    <var>steps</var>, the <a>%FunctionPrototype%</a> of <var>realm</var>).
-                  </li>
-
-                  <li>
-                    Perform <a>!</a> <a>SetFunctionName</a>(<var>F</var>, <var>id</var>).
-                  </li>
-
-                  <li>
-                    Let <var>S</var> be the <a class='dfnref'
-                    href='#dfn-effective-overload-set'>effective overload set</a> for <a
-                    class='dfnref' href='#dfn-regular-operation'>regular operations</a> with <a
-                    class='dfnref' href='#dfn-identifier'>identifier</a> <var>id</var> on <a
-                    class='dfnref' href='#dfn-namespace'>namespace</a> <var>namespace</var> and with
-                    argument count 0.
-                  </li>
-
-                  <li>
-                    Let <var>length</var> be the length of the shortest argument list in the entries
-                    in <var>S</var>.
-                  </li>
-
-                  <li>
-                    Perform <a>!</a> <a>DefinePropertyOrThrow</a>(<var>F</var>,
-                    <code>"length"</code>, PropertyDescriptor<span class='descriptor'>{[[Value]]:
-                    <var>length</var>, [[Writable]]: <span class='esvalue'>false</span>,
-                    [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span
-                    class='esvalue'>true</span>}</span>).
+                    Let <var>F</var> be the result of <a class='dfnref'
+                    href='#dfn-create-operation-function'>creating an operation function</a> given
+                    <var>op</var>, <var>namespace</var>,  and <var>realm</var>.
                   </li>
 
                   <li>
                     Perform <a>!</a> <a>CreateDataProperty</a>(<var>namespaceObject</var>,
-                    <var>id</var>, <var>F</var>).
+                    <var>op</var>'s <a class='dfnref' href='#dfn-identifier'>identifier</a>,
+                    <var>F</var>).
                   </li>
                 </ol>
               </li>

--- a/index.xml
+++ b/index.xml
@@ -76,11 +76,11 @@
         <term name='%ArrayPrototype%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
         <term name='%ArrayProto_values%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
         <term name='%MapPrototype%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
-        <term name='%ObjectPrototype%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
+        <term name='%ObjectPrototype%' class='external' href='https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object'/>
         <term name='%SetPrototype%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
         <term name='%Error%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
         <term name='%ErrorPrototype%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
-        <term name='%FunctionPrototype%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
+        <term name='%FunctionPrototype%' class='external' href='https://tc39.github.io/ecma262/#sec-properties-of-the-function-prototype-object'/>
         <term name='%ObjProto_toString%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
         <term name='%Promise%' class='external' href='https://tc39.github.io/ecma262/#sec-promise-constructor'/>
         <term name='%IteratorPrototype%' class='external' href='https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects' ref='ECMA-262' section='6.1.7.4'/>
@@ -149,6 +149,14 @@
               href='https://tc39.github.io/ecma262/#sec-code-realms'/>
         <term name='Completion' class='external'
               href='https://tc39.github.io/ecma262/#sec-completion-record-specification-type'/>
+        <term name='!' class='external'
+              href='https://tc39.github.io/ecma262/#sec-algorithm-conventions'/>
+        <term name='ObjectCreate' class='external'
+              href='https://tc39.github.io/ecma262/#sec-objectcreate'/>
+        <term name='CreateBuiltinFunction' class='external'
+              href='https://tc39.github.io/ecma262/#sec-createbuiltinfunction'/>
+        <term name='SetFunctionName' class='external'
+              href='https://tc39.github.io/ecma262/#sec-setfunctionname'/>
         <term name='!' class='external'
               href='https://tc39.github.io/ecma262/#sec-algorithm-conventions'/>
         <term name='?' class='external'
@@ -408,6 +416,8 @@ window.onload = function() { window.alert("loaded"); };</x:codeblock></li>
           <a class='dfnref' href='#dfn-idl-fragment'>IDL fragment</a> are:
           <a class='dfnref' href='#dfn-interface'>interfaces</a>,
           <a class='dfnref' href='#dfn-partial-interface'>partial interface definitions</a>,
+          <a class='dfnref' href='#dfn-namespace'>namespaces</a>,
+          <a class='dfnref' href='#dfn-partial-namespace'>partial namespace definitions</a>,
           <a class='dfnref' href='#dfn-dictionary'>dictionaries</a>,
           <a class='dfnref' href='#dfn-partial-dictionary'>partial dictionary definitions</a>,
           <a class='dfnref' href='#dfn-typedef'>typedefs</a> and
@@ -506,6 +516,8 @@ interface GraphicalWindow {
           <p>
             Every <a class='dfnref' href='#dfn-interface'>interface</a>,
             <a class='dfnref' href='#dfn-partial-interface'>partial interface definition</a>,
+            <a class='dfnref' href='#dfn-namespace'>namespace</a>,
+            <a class='dfnref' href='#dfn-partial-namespace'>partial namespace definition</a>,
             <a class='dfnref' href='#dfn-dictionary'>dictionary</a>,
             <a class='dfnref' href='#dfn-partial-dictionary'>partial dictionary definition</a>,
             <a class='dfnref' href='#dfn-enumeration'>enumeration</a>,
@@ -524,12 +536,14 @@ interface GraphicalWindow {
             <li>
               For <a class='dfnref' href='#dfn-named-definition'>named definitions</a>,
               the <a class='sym' href='#prod-identifier'>identifier</a> token that appears
-              directly after the <code>interface</code>,
+              directly after the <code>interface</code>, <code>namespace</code>,
               <code>dictionary</code>, <code>enum</code>
               or <code>callback</code> keyword
               determines the identifier of that definition.
               <pre class='syntax'>interface <em>interface-identifier</em> { <i>interface-members…</i> };
 partial interface <em>interface-identifier</em> { <i>interface-members…</i> };
+namespace <em>namespace-identifier</em> { <i>namespace-members…</i> };
+partial namespace <em>namespace-identifier</em> { <i>namespace-members…</i> };
 dictionary <em>dictionary-identifier</em> { <i>dictionary-members…</i> };
 partial dictionary <em>dictionary-identifier</em> { <i>dictionary-members…</i> };
 enum <em>enumeration-identifier</em> { <i>enumeration-values…</i> };
@@ -622,6 +636,7 @@ dictionary <i>identifier</i> {
             that a given implementation supports,
             the <a class='dfnref' href='#dfn-identifier'>identifier</a> of every
             <a class='dfnref' href='#dfn-interface'>interface</a>,
+            <a class='dfnref' href='#dfn-namespace'>namespace</a>,
             <a class='dfnref' href='#dfn-dictionary'>dictionary</a>,
             <a class='dfnref' href='#dfn-enumeration'>enumeration</a>,
             <a class='dfnref' href='#dfn-callback-function'>callback function</a> and
@@ -629,6 +644,7 @@ dictionary <i>identifier</i> {
             <span class='rfc2119'>MUST NOT</span>
             be the same as the identifier of any other
             <a class='dfnref' href='#dfn-interface'>interface</a>,
+            <a class='dfnref' href='#dfn-namespace'>namespace</a>,
             <a class='dfnref' href='#dfn-dictionary'>dictionary</a>,
             <a class='dfnref' href='#dfn-enumeration'>enumeration</a>,
             <a class='dfnref' href='#dfn-callback-function'>callback function</a> or
@@ -753,8 +769,9 @@ interface TextField {
   <i>interface-members…</i>
 };</pre>
           <p>
-            The order that members appear in has no significance except in the
-            case of <a href='#idl-overloading'>overloading</a>.
+            The order that members appear has significance both for <a
+            href='#idl-overloading'>overloading</a> and for property enumeration in the <a
+            href='#es-interfaces'>ECMAScript binding</a>.
           </p>
           <p>
             Interfaces may specify an interface member that has the same name as
@@ -1594,7 +1611,9 @@ interface Person : Animal {
               then it declares a special operation.  A single operation can declare
               both a regular operation and a special operation; see
               <a href='#idl-special-operations'>section <?sref idl-special-operations?></a> <?sdir idl-special-operations?>
-              for details on special operations.
+              for details on special operations. Note that in addition to being <a class='dfnref'
+              href='#dfn-interface-member'>interface members</a>, regular operations can also be <a
+              class='dfnref' href='#dfn-namespace-member'>namespace members</a>.
             </p>
             <p>
               If an operation has no identifier,
@@ -3945,6 +3964,101 @@ setlike&lt;<i>type</i>&gt;;</pre>
           </div>
         </div>
 
+        <div id='idl-namespaces' class='section'>
+          <h3>Namespaces</h3>
+
+          <p>
+            A <dfn data-export='' id='dfn-namespace'>namespace</dfn> is a definition (matching <a
+            class='sym' href='#prod-Namespace'>Namespace</a>) that declares a global singleton with
+            associated behaviors.
+          </p>
+
+          <pre class='syntax'>namespace <i>identifier</i> {
+  <i>namespace-members…</i>
+};</pre>
+
+          <p>
+            A namespace is a specification of a set of <dfn data-export='' data-lt='namespace
+            member' id='dfn-namespace-member'>namespace members</dfn> (matching <a class='sym'
+            href='#prod-NamespaceMembers'>NamespaceMembers</a>), which are the <a class='dfnref'
+            href='#dfn-regular-operation'>regular operations</a> that appear between the braces in
+            the namespace declaration. These operations describe the behaviors packaged into the
+            namespace.
+          </p>
+
+          <p>
+            As with interfaces, the IDL for namespaces can be split into multiple parts by using
+            <dfn data-export='' id='dfn-partial-namespace'>partial namespace</dfn> definitions
+            (matching <span class='sym'>"partial"</span> <a class='sym'
+            href='#prod-Namespace'>Namespace</a>). The <a class='dfnref'
+            href='#dfn-identifier'>identifier</a> of a partial namespace definition <span
+            class='rfc2119'>MUST</span> be the same as the identifier of a namespace definition.
+            All of the members that appear on each of the partial namespace definitions are
+            considered to be members of the namespace itself.
+          </p>
+
+          <pre class='syntax'>namespace <em>SomeNamespace</em> {
+  <i>namespace-members…</i>
+};
+
+partial namespace <em>SomeNamespace</em> {
+  <i>namespace-members…</i>
+};</pre>
+
+          <div class='note'>
+            <p>
+              As with partial interface definitions, partial namespace definitions are intended for
+              use as a specification editorial aide, allowing the definition of an interface to be
+              separated over more than one section of the document, and sometimes multiple
+              documents.
+            </p>
+          </div>
+
+          <p>
+            The order that members appear has significance both for <a
+            href='#idl-overloading'>overloading</a> and for property enumeration in the <a
+            href='#es-namespaces'>ECMAScript binding</a>.
+          </p>
+
+          <p>
+            Note that unlike interfaces or dictionaries, namespaces do not create types.
+          </p>
+
+          <p>
+            Only the <a class='xattr' href='#Exposed'>[Exposed]</a> and <a class='xattr'
+            href='#SecureContext'>[SecureContext]</a> extended attributes are applicable to
+            namespaces. When declaring a <a class='dfnref' href='#dfn-partial-namespace'>partial
+            namespace</a>, the partial namespace must have the same extended attributes (and
+            extended attribute argument values, if any) specified as the original namespace
+            definition with the same identifier.
+          </p>
+
+          <?productions grammar Partial PartialDefinition Namespace NamespaceMembers NamespaceMember?>
+
+
+          <div class='example'>
+            <p>
+              The following <a class='dfnref' href='#dfn-idl-fragment'>IDL fragment</a> defines an
+              <a class='dfnref' href='#dfn-namespace'>namespace</a>.
+            </p>
+            <x:codeblock language='idl'>namespace VectorUtils {
+  double dotProduct(Vector x, Vector y);
+  Vector crossProduct(Vector x, Vector y);
+};</x:codeblock>
+
+            <p>
+              An ECMAScript implementation would then expose a global property named
+              <code>VectorUtils</code> which was a simple object (with prototype
+              <a>%ObjectPrototype%</a>) with enumerable data properties for each declared operation:
+            </p>
+
+            <x:codeblock language='es'>Object.getPrototypeOf(VectorUtils);                         <span class='comment'>// Evaluates to Object.prototype.</span>
+Object.keys(VectorUtils);                                   <span class='comment'>// Evaluates to ["dotProduct", "crossProduct"].</span>
+Object.getOwnPropertyDescriptor(VectorUtils, "dotProduct"); <span class='comment'>// Evaluates to { value: &lt;a function&gt;, enumerable: true, configurable: true, writable: true }.</span></x:codeblock>
+          </div>
+
+        </div>
+
         <div id='idl-dictionaries' class='section'>
           <h3>Dictionaries</h3>
 
@@ -6091,6 +6205,7 @@ interface Person {
             that can appear on
             <!--a class='dfnref' href='#dfn-definition'-->definitions<!--/a-->,
             <a class='dfnref' href='#dfn-interface-member'>interface members</a>,
+            <a class='dfnref' href='#dfn-namespace-member'>namespace members</a>,
             <a class='dfnref' href='#dfn-dictionary-member'>dictionary members</a>,
             and <a class='dfnref' href='#dfn-operation'>operation</a> arguments, and
             is used to control how language bindings will handle those constructs.
@@ -8555,9 +8670,11 @@ context.setColorEnforcedRange(-1, 255, 256);</x:codeblock>
               If the <a class='xattr' href='#Exposed'>[Exposed]</a>
               <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a>
               appears on an <a class='dfnref' href='#dfn-interface'>interface</a>,
-              <a class='dfnref' href='#dfn-partial-interface'>partial interface</a>, or
-              an individual <a class='dfnref' href='#dfn-interface-member'>interface member</a>,
-              it indicates that the interface or interface member is exposed
+              <a class='dfnref' href='#dfn-partial-interface'>partial interface</a>,
+              <a class='dfnref' href='#dfn-namespace'>namespace</a>, or
+              an individual <a class='dfnref' href='#dfn-interface-member'>interface member</a> or
+              <a class='dfnref' href='#dfn-namespace-member'>namespace member</a>,
+              it indicates that the construct is exposed
               on a particular set of global interfaces, rather than the default of
               being exposed only on the <a class='dfnref' href='#dfn-primary-global-interface'>primary global interface</a>.
             </p>
@@ -8595,6 +8712,7 @@ context.setColorEnforcedRange(-1, 255, 256);</x:codeblock>
                 implicitly, depending on the type of construct:</p>
                 <dl class='switch'>
                   <dt>interface</dt>
+                  <dt>namespace</dt>
                   <dd>The <a class='dfnref' href='#dfn-exposure-set'>exposure set</a> of the interface
                   only contains the
                   <a class='dfnref' href='#dfn-primary-global-interface'>primary global interface</a>.</dd>
@@ -8606,6 +8724,10 @@ context.setColorEnforcedRange(-1, 255, 256);</x:codeblock>
                   <dd>The <a class='dfnref' href='#dfn-exposure-set'>exposure set</a> of the interface member
                   is the <a class='dfnref' href='#dfn-exposure-set'>exposure set</a> of the interface or
                   partial interface the member is declared on.</dd>
+                  <dt>namespace member</dt>
+                  <dd>The <a class='dfnref' href='#dfn-exposure-set'>exposure set</a> of the
+                  namespace member is the <a class='dfnref' href='#dfn-exposure-set'>exposure
+                  set</a> of the namespace the member is declared on.</dd>
                 </dl>
               </li>
             </ul>
@@ -8624,6 +8746,11 @@ context.setColorEnforcedRange(-1, 255, 256);</x:codeblock>
               and one of its interface members, then the interface member's
               <a class='dfnref' href='#dfn-exposure-set'>exposure set</a>
               <span class='rfc2119'>MUST</span> be a subset of the interface's
+              <a class='dfnref' href='#dfn-exposure-set'>exposure set</a>.
+              Similarly, if <a class='xattr' href='#Exposed'>[Exposed]</a> appears on both a
+              namespace and one of its namespace members, then the namespace member's
+              <a class='dfnref' href='#dfn-exposure-set'>exposure set</a>
+              <span class='rfc2119'>MUST</span> be a subset of the namespace's
               <a class='dfnref' href='#dfn-exposure-set'>exposure set</a>.
             </p>
             <p>
@@ -8644,17 +8771,17 @@ context.setColorEnforcedRange(-1, 255, 256);</x:codeblock>
               <var>Y</var>.
             </p>
             <p>
-              An <a class='dfnref' href='#dfn-interface'>interface</a> or
-              <a class='dfnref' href='#dfn-interface-member'>interface member</a>
-              is <dfn data-export="" id='dfn-exposed'>exposed</dfn> in a given ECMAScript global environment if
-              the ECMAScript global object implements an interface that is in the
-              interface or interface member's
-              <a class='dfnref' href='#dfn-exposure-set'>exposure set</a>,
-              and either:
+              An <a class='dfnref' href='#dfn-interface'>interface</a>, <a class='dfnref'
+              href='#dfn-namespace'>namespace</a>, <a class='dfnref'
+              href='#dfn-interface-member'>interface member</a>, or <a class='dfnref'
+              href='#dfn-namespace-member'>namespace member</a> is <dfn data-export=''
+              id='dfn-exposed'>exposed</dfn> in a given ECMAScript global environment if the
+              ECMAScript global object implements an interface that is in the construct's <a
+              class='dfnref' href='#dfn-exposure-set'>exposure set</a>, and either:
             </p>
             <ul>
               <li>the <a>relevant settings object</a> for the ECMAScript global object is a <a>secure context</a>; or</li>
-              <li>the interface or interface member is not <a class='dfnref' href='#dfn-available-only-in-secure-contexts'>available only in secure contexts</a>.</li>
+              <li>the construct is not <a class='dfnref' href='#dfn-available-only-in-secure-contexts'>available only in secure contexts</a>.</li>
             </ul>
             <div class='note'>
               <p>Since it is not possible for the <a>relevant settings object</a>
@@ -8677,9 +8804,9 @@ context.setColorEnforcedRange(-1, 255, 256);</x:codeblock>
             </p>
             <div class='example'>
               <p><a class='xattr' href='#Exposed'>[Exposed]</a>
-              is intended to be used to control whether interfaces or individual interface
-              members are available for use only in workers, only in the <span class='idltype'>Window</span>,
-              or in both.</p>
+              is intended to be used to control whether interfaces, namespaces, or individual
+              interface or namespace members are available for use only in workers, only in the
+              <span class='idltype'>Window</span>, or in both.</p>
               <p>The following IDL fragment shows how that might be achieved:</p>
               <x:codeblock language='idl'>[PrimaryGlobal]
 interface Window {
@@ -8699,24 +8826,45 @@ interface DedicatedWorkerGlobalScope : WorkerGlobalScope {
   ...
 };
 
-<span class='comment'>// MathUtils is available for use in workers and on the main thread.</span>
-[Exposed=(Window,Worker)]
-interface MathUtils {
-  static double someComplicatedFunction(double x, double y);
+<span class='comment'>// Dimensions is available for use in workers and on the main thread.</span>
+[Exposed=(Window,Worker), Constructor(double width, double height)]
+interface Dimensions {
+  readonly attribute double width;
+  readonly attribute double height;
 };
 
-<span class='comment'>// WorkerUtils is only available in workers.  Evaluating WorkerUtils
+<span class='comment'>// WorkerNavigator is only available in workers.  Evaluating WorkerNavigator
 // in the global scope of a worker would give you its interface object, while
 // doing so on the main thread will give you a ReferenceError.</span>
 [Exposed=Worker]
-interface WorkerUtils {
-  static void setPriority(double x);
+interface WorkerNavigator {
+  ...
 };
 
 <span class='comment'>// Node is only available on the main thread.  Evaluating Node
 // in the global scope of a worker would give you a ReferenceError.</span>
 interface Node {
   ...
+};
+
+<span class='comment'>// MathUtils is available for use in workers and on the main thread.</span>
+[Exposed=(Window,Worker)]
+namespace MathUtils {
+  double someComplicatedFunction(double x, double y);
+};
+
+<span class='comment'>// WorkerUtils is only available in workers.  Evaluating WorkerUtils
+// in the global scope of a worker would give you its namespace object, while
+// doing so on the main thread will give you a ReferenceError.</span>
+[Exposed=Worker]
+namespace WorkerUtils {
+  void setPriority(double x);
+};
+
+<span class='comment'>// NodeUtils is only available in the main thread.  Evaluating NodeUtils
+// in the global scope of a worker would give you a ReferenceError.</span>
+namespace NodeUtils {
+  DOMString getAllText(Node node);
 };</x:codeblock>
             </div>
           </div>
@@ -9866,8 +10014,9 @@ counter.value;                                           <span class='comment'>/
               <a class='dfnref' href='#dfn-extended-attribute'>extended attribute</a>
               appears on an <a class='dfnref' href='#dfn-interface'>interface</a>,
               <a class='dfnref' href='#dfn-partial-interface'>partial interface</a>,
-              an individual <a class='dfnref' href='#dfn-interface-member'>interface member</a>,
-              it indicates that the interface or interface member is exposed
+              <a class='dfnref' href='#dfn-interface-member'>interface member</a>, or
+              <a class='dfnref' href='#dfn-namespace-member'>namespace member</a>,
+              it indicates that the construct is exposed
               only within a
               <a href='https://w3c.github.io/webappsec-secure-contexts/#secure-context'>secure context</a>
               (<a href='#ref-SECURE-CONTEXTS'>[SECURE-CONTEXTS]</a>, section 2).
@@ -9882,8 +10031,9 @@ counter.value;                                           <span class='comment'>/
               extended attribute <span class='rfc2119'>MUST NOT</span>
               be used on anything other than an
               <a class='dfnref' href='#dfn-interface'>interface</a>,
-              <a class='dfnref' href='#dfn-partial-interface'>partial interface</a>, or
-              an individual <a class='dfnref' href='#dfn-interface-member'>interface member</a>.
+              <a class='dfnref' href='#dfn-partial-interface'>partial interface</a>,
+              <a class='dfnref' href='#dfn-interface-member'>interface member</a>, or
+              <a class='dfnref' href='#dfn-namespace-member'>namespace member</a>.
             </p>
             <p>
               Whether a construct that the <a class='xattr' href='#SecureContext'>[SecureContext]</a>
@@ -9914,6 +10064,9 @@ counter.value;                                           <span class='comment'>/
                   <dt>interface member</dt>
                   <dd>The interface member is <a class='dfnre' href='#dfn-available-only-in-secure-contexts'>available only in secure contexts</a>
                   if and only if the interface or partial interface the member is declared on is.</dd>
+                  <dt>namespace member</dt>
+                  <dd>The namespace member is <a class='dfnre' href='#dfn-available-only-in-secure-contexts'>available only in secure contexts</a>
+                  if and only if the namspace the member is declared on is.</dd>
                 </dl>
               </li>
             </ul>
@@ -9934,7 +10087,8 @@ counter.value;                                           <span class='comment'>/
               The <a class='xattr' href='#SecureContext'>[SecureContext]</a> extended attribute
               <span class='rfc2119'>MUST NOT</span> be specified on both an interface
               member and the interface or partial interface definition the
-              interface member is declared on.
+              interface member is declared within, or on both a namespace member and the namespace
+              definition the namespace member is declared within.
             </p>
             <p>
               An interface without the <a class='xattr' href='#SecureContext'>[SecureContext]</a> extended attribute
@@ -14360,6 +14514,155 @@ C implements A;</x:codeblock>
           </ol>
         </div>
 
+        <div id='es-namespaces' class='section'>
+          <h3>Namespaces</h3>
+
+          <p>
+            For every <a class='dfnref' href='#dfn-namespace'>namespace</a> that is <a
+            class='dfnref' href='#dfn-exposed'>exposed</a> in a given ECMAScript global environment,
+            a corresponding property <span class='rfc2119'>MUST</span> exist on the ECMAScript
+            environment's global object. The name of the property is the <a class='dfnref'
+            href='#dfn-identifier'>identifier</a> of the namespace, and its value is an object
+            called the <dfn data-export='' id='dfn-namespace-object'>namespace object</dfn>.
+          </p>
+          <p>
+            The property has the attributes <span class='descriptor'>{ [[Writable]]: <span
+            class='esvalue'>true</span>, [[Enumerable]]: <span class='esvalue'>false</span>,
+            [[Configurable]]: <span class='esvalue'>true</span> }</span>. The characteristics of a
+            namespace object are described in <a href='#namespace-object'>section <?sref
+            namespace-object?></a> <?sdir namespace-object?>.
+          </p>
+
+          <div id='namespace-object' class='section'>
+            <h4>Namespace object</h4>
+
+            <p>
+              The namespace object for a given <a class='dfnref' href='#dfn-namespace'>namespace</a>
+              <var>namespace</var> and Realm <var>realm</var> is created as follows:
+            </p>
+
+            <ol class='algorithm'>
+              <li>
+                Let <var>namespaceObject</var> be
+                <a>!</a> <a>ObjectCreate</a>(the <a>%ObjectPrototype%</a> of <var>realm</var>).
+              </li>
+
+              <li>
+                For each <a class='dfnref' href='#dfn-exposed'>exposed</a> <a class='dfnref'
+                href='#dfn-regular-operation'>regular operation</a> <var>op</var> that is a <a
+                class='dfnref' href='#dfn-namespace-member'>namespace member</a> of this namespace,
+
+                <ol>
+                  <li>
+                    Let <var>id</var> be <var>op</var>'s <a class='dfnref'
+                    href='#dfn-identifier'>identifier</a>.
+                  </li>
+
+                  <li>
+                    Let <var>steps</var> be the following series of steps, given function argument
+                    values <var>arg</var><sub>0..<var>n</var>−1</sub>:
+
+                    <ol>
+                      <li>
+                        Try running the following steps:
+                        <ol>
+                          <li>
+                            Let <var>S</var> be the <a class='dfnref'
+                            href='#dfn-effective-overload-set'>effective overload set</a> for <a
+                            class='dfnref' href='#dfn-regular-operation'>regular operations</a> with
+                            <a class='dfnref' href='#dfn-identifier'>identifier</a> <var>id</var> on
+                            <a class='dfnref' href='#dfn-namespace'>namespace</a>
+                            <var>namespace</var> and with argument count <var>n</var>.
+                          </li>
+
+                          <li>
+                            Let &lt;<var>operation</var>, <var>values</var>> be the result of
+                            passing <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to
+                            the <a class='dfnref' href='#dfn-overload-resolution-algorithm'>overload
+                            resolution algorithm</a>.
+                          </li>
+
+                          <li>
+                            Let <var>R</var> be the result of performing the actions listed in the
+                            description of <var>operation</var> with <var>values</var> as the
+                            argument values.
+                          </li>
+
+                          <li>
+                            Return the result of <a class='dfnref'
+                            href='#dfn-convert-idl-to-ecmascript-value'>converting</a> <var>R</var>
+                            to an ECMAScript value of the type <var>op</var> is declared to return.
+                          </li>
+                         </ol>
+                      </li>
+                    </ol>
+
+                    And then, if an exception was thrown:
+
+                    <ol>
+                      <li>
+                        If the operation has a <a class='dfnref' href='#dfn-return-type'>return
+                        type</a> that is a <a href='#idl-promise'>promise type</a>, then:
+
+                        <ol>
+                          <li>
+                            Let <var>reject</var> be the initial value of <a
+                            class='nocite'>%Promise%</a>.reject.
+                          </li>
+                          <li>
+                            Return the result of calling <var>reject</var> with <a
+                            class='nocite'>%Promise%</a> as the <span class='esvalue'>this</span>
+                            object and the exception as the single argument value.
+                          </li>
+                        </ol>
+                      </li>
+                      <li>
+                        Otherwise, end these steps and allow the exception to propagate.
+                      </li>
+                    </ol>
+                  </li>
+
+                  <li>
+                    Let <var>F</var> be <a>!</a> <a>CreateBuiltinFunction</a>(<var>realm</var>,
+                    <var>steps</var>, the <a>%FunctionPrototype%</a> of <var>realm</var>).
+                  </li>
+
+                  <li>
+                    Perform <a>!</a> <a>SetFunctionName</a>(<var>F</var>, <var>id</var>).
+                  </li>
+
+                  <li>
+                    Let <var>S</var> be the <a class='dfnref'
+                    href='#dfn-effective-overload-set'>effective overload set</a> for <a
+                    class='dfnref' href='#dfn-regular-operation'>regular operations</a> with <a
+                    class='dfnref' href='#dfn-identifier'>identifier</a> <var>id</var> on <a
+                    class='dfnref' href='#dfn-namespace'>namespace</a> <var>namespace</var> and with
+                    argument count 0.
+                  </li>
+
+                  <li>
+                    Let <var>length</var> be the length of the shortest argument list in the entries
+                    in <var>S</var>.
+                  </li>
+
+                  <li>
+                    Perform <a>!</a> <a>DefinePropertyOrThrow</a>(<var>F</var>,
+                    <code>"length"</code>, PropertyDescriptor<span class='descriptor'>{[[Value]]:
+                    <var>length</var>, [[Writable]]: <span class='esvalue'>false</span>,
+                    [[Enumerable]]: <span class='esvalue'>false</span>, [[Configurable]]: <span
+                    class='esvalue'>true</span>}</span>).
+                  </li>
+
+                  <li>
+                    Perform <a>!</a> <a>CreateDataProperty</a>(<var>namespaceObject</var>,
+                    <var>id</var>, <var>F</var>).
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </div>
+        </div>
+
         <div id='es-exceptions' class='section'>
           <h3>Exceptions</h3>
 
@@ -15006,12 +15309,12 @@ d.type = et;
 
         <grammar id='grammar' xmlns='http://mcc.id.au/ns/local'>
           <prod nt='Definitions'>ExtendedAttributeList Definition Definitions | ε</prod>
-          <prod nt='Definition'>CallbackOrInterface | Partial | Dictionary | Enum | Typedef | ImplementsStatement</prod>
+          <prod nt='Definition'>CallbackOrInterface | Namespace | Partial | Dictionary | Enum | Typedef | ImplementsStatement</prod>
           <prod nt='CallbackOrInterface'>"callback" CallbackRestOrInterface | Interface</prod>
           <prod nt='CallbackRestOrInterface'>CallbackRest | Interface</prod>
           <prod nt='Interface'>"interface" identifier Inheritance "{" InterfaceMembers "}" ";"</prod>
           <prod nt='Partial'>"partial" PartialDefinition</prod>
-          <prod nt='PartialDefinition'>PartialInterface | PartialDictionary</prod>
+          <prod nt='PartialDefinition'>PartialInterface | PartialDictionary | Namespace</prod>
           <prod nt='PartialInterface'>"interface" identifier "{" InterfaceMembers "}" ";"</prod>
           <prod nt='InterfaceMembers'>ExtendedAttributeList InterfaceMember InterfaceMembers | ε</prod>
           <prod nt='InterfaceMember'>Const | Operation | Serializer | Stringifier | StaticMember | Iterable | ReadOnlyMember | ReadWriteAttribute | ReadWriteMaplike | ReadWriteSetlike</prod>
@@ -15143,6 +15446,11 @@ d.type = et;
           <prod nt='ExtendedAttributeIdent'>identifier "=" identifier</prod>
           <prod nt='ExtendedAttributeIdentList'>identifier "=" "(" IdentifierList ")"</prod>
           <prod nt='ExtendedAttributeNamedArgList'>identifier "=" identifier "(" ArgumentList ")"</prod>
+
+          <prod nt='Namespace'>"namespace" identifier "{" NamespaceMembers "}" ";"</prod>
+
+          <prod nt='NamespaceMembers'>ExtendedAttributeList NamespaceMember NamespaceMembers | ε</prod>
+          <prod nt='NamespaceMember'>ReturnType OperationRest</prod>
 
           <!--prod nt='Keyword'>"any" | "attribute" | "boolean" | "byte" | "const" | "double" | "exception" | "float" | "getraises" | "in" | "interface" | "long" | "Object" | "octet" | "raises" | "readonly" | "sequence" | "setraises" | "short" | "typedef" | "unsigned | "void"</prod-->
           <!-- the following are the remaining OMG IDL 3 keywords:

--- a/index.xml
+++ b/index.xml
@@ -10097,9 +10097,9 @@ counter.value;                                           <span class='comment'>/
             <p>
               The <a class='xattr' href='#SecureContext'>[SecureContext]</a> extended attribute
               <span class='rfc2119'>MUST NOT</span> be specified on both an interface member and the
-              interface or partial interface definition the interface member is declared within, or
+              interface or partial interface definition the interface member is declared on, or
               on both a namespace member and the namespace or partial namespace definition the
-              namespace member is declared within.
+              namespace member is declared on.
             </p>
             <p>
               An interface without the <a class='xattr' href='#SecureContext'>[SecureContext]</a> extended attribute


### PR DESCRIPTION
This adds the concept of namespaces, as discussed in https://github.com/whatwg/console/issues/3 (starting especially around https://github.com/whatwg/console/issues/3#issuecomment-214586757). They can only contain regular operations.

The ES binding for namespaces here is written in a fully modern style, and so differs slightly from similar prose for interfaces' ES binding. It is hoped that it can provide a template for eventually updating interfaces' ES binding to modern ES.