### PR TITLE
Fix incumbent settings object handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED" type="text/css" /></head>
 
   <body>
-    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL (Second Edition)</h1><h2>W3C Editor’s Draft <em>19 May 2016</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/">http://heycam.github.io/webidl/</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
+    <div class="head"><div><a href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web IDL (Second Edition)</h1><h2>W3C Editor’s Draft <em>2 June 2016</em></h2><dl><dt>This Version:</dt><dd><a href="http://heycam.github.io/webidl/">http://heycam.github.io/webidl/</a></dd><dt>Latest Version:</dt><dd><a href="http://www.w3.org/TR/WebIDL/">http://www.w3.org/TR/WebIDL/</a></dd><dt>Previous Versions:</dt><dd><a href="http://www.w3.org/TR/2012/CR-WebIDL-20120419/">http://www.w3.org/TR/2012/CR-WebIDL-20120419/</a></dd><dd><a href="http://www.w3.org/TR/2012/WD-WebIDL-20120207/">http://www.w3.org/TR/2012/WD-WebIDL-20120207/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110927/">http://www.w3.org/TR/2011/WD-WebIDL-20110927/</a></dd><dd><a href="http://www.w3.org/TR/2011/WD-WebIDL-20110712/">http://www.w3.org/TR/2011/WD-WebIDL-20110712/</a></dd><dd><a href="http://www.w3.org/TR/2010/WD-WebIDL-20101021/">http://www.w3.org/TR/2010/WD-WebIDL-20101021/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20081219/">http://www.w3.org/TR/2008/WD-WebIDL-20081219/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-WebIDL-20080829/">http://www.w3.org/TR/2008/WD-WebIDL-20080829/</a></dd><dd><a href="http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/">http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/</a></dd><dd><a href="http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/">http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/</a></dd><dt>Participate:</dt><dd>
               Send feedback to <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a> or <a href="https://www.w3.org/Bugs/Public/enter_bug.cgi?product=WebAppsWG&amp;component=WebIDL">file a bug</a> (<a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=WebIDL&amp;resolution=---">open bugs</a>)
             </dd><dt>Editors:</dt><dd><a href="http://mcc.id.au/">Cameron McCormack</a>, Mozilla Corporation &lt;cam@mcc.id.au&gt;</dd><dd>Boris Zbarsky, Mozilla Corporation &lt;bzbarsky@mit.edu&gt;</dd></dl><p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &copy; 2016 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>&reg;</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p></div><hr /><script async="" src="file-bug.js"></script>
 
@@ -72,7 +72,7 @@
         report can be found in the <a href="http://www.w3.org/TR/">W3C technical
           reports index</a> at http://www.w3.org/TR/.
       </em></p><p>
-        This document is the 19 May 2016 <b>Editor’s Draft</b> of the
+        This document is the 2 June 2016 <b>Editor’s Draft</b> of the
         <cite>Web IDL (Second Edition)</cite> specification.
       
       Please send comments about this document to
@@ -5611,12 +5611,9 @@ interface Person {
               the time the language binding specific object reference is converted to an IDL value.
             </p>
             <div class="note"><div class="noteHeader">Note</div>
-              <p>For ECMAScript objects, the <a class="dfnref" href="#dfn-callback-context">callback context</a> is used
-              to hold a reference to the
-              <a class="dfnref external" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#incumbent-script">incumbent script</a>
-              <a href="#ref-HTML">[HTML]</a> at the time the <span class="estype">Object</span> value
-              is converted to an IDL callback interface type value.  See
-              <a href="#es-interface">section 4.2.20</a> below.</p>
+              <p>For ECMAScript objects, the <a class="dfnref" href="#dfn-callback-context">callback
+              context</a> is used to hold a reference to the <a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a> <a href="#ref-HTML">[HTML]</a> at the time the <span class="estype">Object</span> value
+              is converted to an IDL callback interface type value. See <a href="#es-interface">section 4.2.20</a> below.</p>
             </div>
             <p>
               There is no way to represent a constant object reference value for
@@ -5687,12 +5684,10 @@ interface Person {
               reference and a <a class="dfnref" href="#dfn-callback-context">callback context</a>.
             </p>
             <div class="note"><div class="noteHeader">Note</div>
-              <p>As with <a href="#idl-interface">callback interface types</a>, the <a class="dfnref" href="#dfn-callback-context">callback context</a> is used
-              to hold a reference to the
-              <a class="dfnref external" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#incumbent-script">incumbent script</a>
-              <a href="#ref-HTML">[HTML]</a> at the time an ECMAScript <span class="estype">Object</span> value
-              is converted to an IDL callback function type value.  See
-              <a href="#es-callback-function">section 4.2.23</a> below.</p>
+              <p>As with <a href="#idl-interface">callback interface types</a>, the <a class="dfnref" href="#dfn-callback-context">callback context</a> is used to hold a
+              reference to the <a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a> <a href="#ref-HTML">[HTML]</a> at
+              the time an ECMAScript <span class="estype">Object</span> value is converted to an IDL
+              callback function type value.  See <a href="#es-callback-function">section 4.2.23</a> below.</p>
             </div>
             <p>
               There is no way to represent a constant <a class="dfnref" href="#dfn-callback-function">callback function</a>
@@ -7397,11 +7392,8 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
               <li>If <a class="external" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object, then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="estype">TypeError</span></a>.</li>
               <li>If <var>V</var> is a <a class="dfnref" href="#dfn-platform-object">platform object</a> that implements <var>I</var>, then return the IDL <a href="#idl-interface">interface type</a> value that represents a reference to that platform object.</li>
               <li>If <var>V</var> is a <a class="dfnref" href="#dfn-user-object">user object</a>
-                that is considered to implement <var>I</var> according to the rules in
-                <a href="#es-user-objects">section 4.9</a>,
-                then return the IDL <a href="#idl-interface">interface type</a> value that represents a reference to that user object,
-                with the <a class="dfnref external" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#incumbent-script">incumbent script</a>
-                as the <a class="dfnref" href="#dfn-callback-context">callback context</a>. <a href="#ref-HTML">[HTML]</a></li>
+              that is considered to implement <var>I</var> according to the rules in <a href="#es-user-objects">section 4.9</a>, then return the IDL <a href="#idl-interface">interface type</a> value that represents a reference to that
+              user object, with the <a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a> as the <a class="dfnref" href="#dfn-callback-context">callback context</a>. <a href="#ref-HTML">[HTML]</a></li>
               <li><a href="#ecmascript-throw" class="dfnref external">Throw a <span class="esvalue">TypeError</span></a>.</li>
             </ol>
             <p id="interface-to-es">
@@ -7560,11 +7552,9 @@ iframe.appendChild instanceof w.Function;  <span class="comment">// Evaluates to
                 <a class="dfnref" href="#dfn-callback-function">callback function</a>
                 that is annotated with <a class="xattr" href="#TreatNonObjectAsNull">[TreatNonObjectAsNull]</a>,
               then <a href="#ecmascript-throw" class="dfnref external">throw a <span class="esvalue">TypeError</span></a>.</li>
-              <li>Return the IDL <a href="#idl-callback-function">callback
-              function type</a> value that represents a reference to the same
-              object that <var>V</var> represents,
-                with the <a class="dfnref external" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#incumbent-script">incumbent script</a>
-                as the <a class="dfnref" href="#dfn-callback-context">callback context</a>. <a href="#ref-HTML">[HTML]</a>.</li>
+              <li>Return the IDL <a href="#idl-callback-function">callback function type</a> value
+              that represents a reference to the same object that <var>V</var> represents, with the
+              <a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a> as the <a class="dfnref" href="#dfn-callback-context">callback context</a>. <a href="#ref-HTML">[HTML]</a>.</li>
             </ol>
             <p id="callback-function-to-es">
               The result of <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a>
@@ -14060,10 +14050,14 @@ C implements A;</code></pre></div></div>
 
             <li>Let <var>realm</var> be <var>O</var>'s <a class="dfnref" href="#dfn-associated-realm">associated Realm</a>.</li>
 
-            <li>Let <var>settings</var> be <var>realm</var>'s <a class="dfnref external" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object">settings
+            <li>Let <var>relevant settings</var> be <var>realm</var>'s <a class="dfnref external" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object">settings
             object</a>.</li>
 
-            <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script">Prepare to run script</a> with <var>settings</var>.</li>
+            <li>Let <var>stored settings</var> be <var>value</var>'s <a class="dfnref" href="#dfn-callback-context">callback context</a>.</li>
+
+            <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script">Prepare to run script</a> with <var>relevant settings</var>.</li>
+
+            <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-a-callback">Prepare to run a callback</a> with <var>stored settings</var>.</li>
 
             <li>
               Determine the implementation of the operation, <var>X</var>:
@@ -14148,7 +14142,9 @@ C implements A;</code></pre></div></div>
               point <var>completion</var> will be set to an ECMAScript completion value.
 
               <ol>
-                <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script">Clean up after running script</a> with <var>settings</var>.</li>
+                <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-a-callback">Clean up after running a callback</a> with <var>stored settings</var>.</li>
+
+                <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script">Clean up after running script</a> with <var>relevant settings</var>.</li>
 
                 <li>If <var>completion</var> is a normal completion, return
                 <var>completion</var>.</li>
@@ -14180,10 +14176,14 @@ C implements A;</code></pre></div></div>
 
             <li>Let <var>realm</var> be <var>O</var>'s <a class="dfnref" href="#dfn-associated-realm">associated Realm</a>.</li>
 
-            <li>Let <var>settings</var> be <var>realm</var>'s <a class="dfnref external" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object">settings
+            <li>Let <var>relevant settings</var> be <var>realm</var>'s <a class="dfnref external" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object">settings
             object</a>.</li>
 
-            <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script">Prepare to run script</a> with <var>settings</var>.</li>
+            <li>Let <var>stored settings</var> be <var>object</var>'s <a class="dfnref" href="#dfn-callback-context">callback context</a>.</li>
+
+            <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script">Prepare to run script</a> with <var>relevant settings</var>.</li>
+
+            <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-a-callback">Prepare to run a callback</a> with <var>stored settings</var>.</li>
 
             <li>Let <var>getResult</var> be <a class="external" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>O</var>, <var>attributeName</var>).</li>
 
@@ -14199,7 +14199,9 @@ C implements A;</code></pre></div></div>
               point <var>completion</var> will be set to an ECMAScript completion value.
 
               <ol>
-                <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script">Clean up after running script</a> with <var>settings</var>.</li>
+                <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-a-callback">Clean up after running a callback</a> with <var>stored settings</var>.</li>
+
+                <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script">Clean up after running script</a> with <var>relevant settings</var>.</li>
 
                 <li>If <var>completion</var> is a normal completion, return
                 <var>completion</var>.</li>
@@ -14234,10 +14236,14 @@ C implements A;</code></pre></div></div>
 
             <li>Let <var>realm</var> be <var>O</var>'s <a class="dfnref" href="#dfn-associated-realm">associated Realm</a>.</li>
 
-            <li>Let <var>settings</var> be <var>realm</var>'s <a class="dfnref external" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object">settings
+            <li>Let <var>relevant settings</var> be <var>realm</var>'s <a class="dfnref external" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object">settings
             object</a>.</li>
 
-            <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script">Prepare to run script</a> with <var>settings</var>.</li>
+            <li>Let <var>stored settings</var> be <var>object</var>'s <a class="dfnref" href="#dfn-callback-context">callback context</a>.</li>
+
+            <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script">Prepare to run script</a> with <var>relevant settings</var>.</li>
+
+            <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-a-callback">Prepare to run a callback</a> with <var>stored settings</var>.</li>
 
             <li>Let <var>convertResult</var> be the result of <a class="dfnref" href="#dfn-convert-idl-to-ecmascript-value">converting</a> <var>value</var> to an
             ECMAScript value.</li>
@@ -14254,7 +14260,9 @@ C implements A;</code></pre></div></div>
               either an abrupt completion or a normal completion for the value <span class="esvalue">true</span> (as returned by <a class="external" href="https://tc39.github.io/ecma262/#sec-set-o-p-v-throw">Set</a>).
 
               <ol>
-                <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script">Clean up after running script</a> with <var>settings</var>.</li>
+                <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-a-callback">Clean up after running a callback</a> with <var>stored settings</var>.</li>
+
+                <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script">Clean up after running script</a> with <var>relevant settings</var>.</li>
 
                 <li>If <var>completion</var> is an abrupt completion, return
                 <var>completion</var>.</li>
@@ -14312,10 +14320,14 @@ C implements A;</code></pre></div></div>
 
             <li>Let <var>realm</var> be <var>F</var>'s <a class="dfnref" href="#dfn-associated-realm">associated Realm</a>.</li>
 
-            <li>Let <var>settings</var> be <var>realm</var>'s <a class="dfnref external" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object">settings
+            <li>Let <var>relevant settings</var> be <var>realm</var>'s <a class="dfnref external" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object">settings
             object</a>.</li>
 
-            <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script">Prepare to run script</a> with <var>settings</var>.</li>
+            <li>Let <var>stored settings</var> be <var>callable</var>'s <a class="dfnref" href="#dfn-callback-context">callback context</a>.</li>
+
+            <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script">Prepare to run script</a> with <var>relevant settings</var>.</li>
+
+            <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-a-callback">Prepare to run a callback</a> with <var>stored settings</var>.</li>
 
             <li>Let <var>esArgs</var> be an empty List of ECMAScript values.</li>
 
@@ -14367,7 +14379,9 @@ C implements A;</code></pre></div></div>
               point <var>completion</var> will be set to an ECMAScript completion value.
 
               <ol>
-                <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script">Clean up after running script</a> with <var>settings</var>.</li>
+                <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-a-callback">Clean up after running a callback</a> with <var>stored settings</var>.</li>
+
+                <li><a class="external" href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script">Clean up after running script</a> with <var>relevant settings</var>.</li>
 
                 <li>If <var>completion</var> is a normal completion, return
                 <var>completion</var>.</li>

--- a/index.xml
+++ b/index.xml
@@ -163,6 +163,12 @@
               href='https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script'/>
         <term name='Clean up after running script' class='external'
               href='https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script'/>
+        <term name='Prepare to run a callback' class='external'
+              href='https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-a-callback'/>
+        <term name='Clean up after running a callback' class='external'
+              href='https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-a-callback'/>
+        <term name='incumbent settings object' class='external'
+              href='https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object'/>
       </links>
     </options>
   </head>
@@ -5571,12 +5577,11 @@ interface Person {
               the time the language binding specific object reference is converted to an IDL value.
             </p>
             <div class='note'>
-              <p>For ECMAScript objects, the <a class='dfnref' href='#dfn-callback-context'>callback context</a> is used
-              to hold a reference to the
-              <a class='dfnref external' href='http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#incumbent-script'>incumbent script</a>
-              <a href='#ref-HTML'>[HTML]</a> at the time the <span class='estype'>Object</span> value
-              is converted to an IDL callback interface type value.  See
-              <a href='#es-interface'>section <?sref es-interface?></a> <?sdir es-interface?>.</p>
+              <p>For ECMAScript objects, the <a class='dfnref' href='#dfn-callback-context'>callback
+              context</a> is used to hold a reference to the <a>incumbent settings object</a> <a
+              href='#ref-HTML'>[HTML]</a> at the time the <span class='estype'>Object</span> value
+              is converted to an IDL callback interface type value. See <a
+              href='#es-interface'>section <?sref es-interface?></a> <?sdir es-interface?>.</p>
             </div>
             <p>
               There is no way to represent a constant object reference value for
@@ -5647,12 +5652,12 @@ interface Person {
               reference and a <a class='dfnref' href='#dfn-callback-context'>callback context</a>.
             </p>
             <div class='note'>
-              <p>As with <a href='#idl-interface'>callback interface types</a>, the <a class='dfnref' href='#dfn-callback-context'>callback context</a> is used
-              to hold a reference to the
-              <a class='dfnref external' href='http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#incumbent-script'>incumbent script</a>
-              <a href='#ref-HTML'>[HTML]</a> at the time an ECMAScript <span class='estype'>Object</span> value
-              is converted to an IDL callback function type value.  See
-              <a href='#es-callback-function'>section <?sref es-callback-function?></a> <?sdir es-callback-function?>.</p>
+              <p>As with <a href='#idl-interface'>callback interface types</a>, the <a
+              class='dfnref' href='#dfn-callback-context'>callback context</a> is used to hold a
+              reference to the <a>incumbent settings object</a> <a href='#ref-HTML'>[HTML]</a> at
+              the time an ECMAScript <span class='estype'>Object</span> value is converted to an IDL
+              callback function type value.  See <a href='#es-callback-function'>section <?sref
+              es-callback-function?></a> <?sdir es-callback-function?>.</p>
             </div>
             <p>
               There is no way to represent a constant <a class='dfnref' href='#dfn-callback-function'>callback function</a>
@@ -7273,11 +7278,11 @@ iframe.appendChild instanceof w.Function;  <span class='comment'>// Evaluates to
               <li>If <a>Type</a>(<var>V</var>) is not Object, then <a href='#ecmascript-throw' class='dfnref external'>throw a <span class='estype'>TypeError</span></a>.</li>
               <li>If <var>V</var> is a <a class='dfnref' href='#dfn-platform-object'>platform object</a> that implements <var>I</var>, then return the IDL <a href='#idl-interface'>interface type</a> value that represents a reference to that platform object.</li>
               <li>If <var>V</var> is a <a class='dfnref' href='#dfn-user-object'>user object</a>
-                that is considered to implement <var>I</var> according to the rules in
-                <a href='#es-user-objects'>section <?sref es-user-objects?></a>,
-                then return the IDL <a href='#idl-interface'>interface type</a> value that represents a reference to that user object,
-                with the <a class='dfnref external' href='http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#incumbent-script'>incumbent script</a>
-                as the <a class='dfnref' href='#dfn-callback-context'>callback context</a>. <a href='#ref-HTML'>[HTML]</a></li>
+              that is considered to implement <var>I</var> according to the rules in <a
+              href='#es-user-objects'>section <?sref es-user-objects?></a>, then return the IDL <a
+              href='#idl-interface'>interface type</a> value that represents a reference to that
+              user object, with the <a>incumbent settings object</a> as the <a class='dfnref'
+              href='#dfn-callback-context'>callback context</a>. <a href='#ref-HTML'>[HTML]</a></li>
               <li><a href='#ecmascript-throw' class='dfnref external'>Throw a <span class='esvalue'>TypeError</span></a>.</li>
             </ol>
             <p id='interface-to-es'>
@@ -7439,11 +7444,11 @@ iframe.appendChild instanceof w.Function;  <span class='comment'>// Evaluates to
                 <a class='dfnref' href='#dfn-callback-function'>callback function</a>
                 that is annotated with <a class='xattr' href='#TreatNonObjectAsNull'>[TreatNonObjectAsNull]</a>,
               then <a href='#ecmascript-throw' class='dfnref external'>throw a <span class='esvalue'>TypeError</span></a>.</li>
-              <li>Return the IDL <a href='#idl-callback-function'>callback
-              function type</a> value that represents a reference to the same
-              object that <var>V</var> represents,
-                with the <a class='dfnref external' href='http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#incumbent-script'>incumbent script</a>
-                as the <a class='dfnref' href='#dfn-callback-context'>callback context</a>. <a href='#ref-HTML'>[HTML]</a>.</li>
+              <li>Return the IDL <a href='#idl-callback-function'>callback function type</a> value
+              that represents a reference to the same object that <var>V</var> represents, with the
+              <a>incumbent settings object</a> as the <a class='dfnref'
+              href='#dfn-callback-context'>callback context</a>. <a
+              href='#ref-HTML'>[HTML]</a>.</li>
             </ol>
             <p id='callback-function-to-es'>
               The result of <a class='dfnref' href='#dfn-convert-idl-to-ecmascript-value'>converting</a>
@@ -13967,11 +13972,16 @@ C implements A;</x:codeblock>
             <li>Let <var>realm</var> be <var>O</var>'s <a class='dfnref'
             href='#dfn-associated-realm'>associated Realm</a>.</li>
 
-            <li>Let <var>settings</var> be <var>realm</var>'s <a class='dfnref external'
+            <li>Let <var>relevant settings</var> be <var>realm</var>'s <a class='dfnref external'
             href='https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object'>settings
             object</a>.</li>
 
-            <li><a>Prepare to run script</a> with <var>settings</var>.</li>
+            <li>Let <var>stored settings</var> be <var>value</var>'s <a class='dfnref'
+            href='#dfn-callback-context'>callback context</a>.</li>
+
+            <li><a>Prepare to run script</a> with <var>relevant settings</var>.</li>
+
+            <li><a>Prepare to run a callback</a> with <var>stored settings</var>.</li>
 
             <li>
               Determine the implementation of the operation, <var>X</var>:
@@ -14063,7 +14073,9 @@ C implements A;</x:codeblock>
               point <var>completion</var> will be set to an ECMAScript completion value.
 
               <ol>
-                <li><a>Clean up after running script</a> with <var>settings</var>.</li>
+                <li><a>Clean up after running a callback</a> with <var>stored settings</var>.</li>
+
+                <li><a>Clean up after running script</a> with <var>relevant settings</var>.</li>
 
                 <li>If <var>completion</var> is a normal completion, return
                 <var>completion</var>.</li>
@@ -14100,11 +14112,16 @@ C implements A;</x:codeblock>
             <li>Let <var>realm</var> be <var>O</var>'s <a class='dfnref'
             href='#dfn-associated-realm'>associated Realm</a>.</li>
 
-            <li>Let <var>settings</var> be <var>realm</var>'s <a class='dfnref external'
+            <li>Let <var>relevant settings</var> be <var>realm</var>'s <a class='dfnref external'
             href='https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object'>settings
             object</a>.</li>
 
-            <li><a>Prepare to run script</a> with <var>settings</var>.</li>
+            <li>Let <var>stored settings</var> be <var>object</var>'s <a class='dfnref'
+            href='#dfn-callback-context'>callback context</a>.</li>
+
+            <li><a>Prepare to run script</a> with <var>relevant settings</var>.</li>
+
+            <li><a>Prepare to run a callback</a> with <var>stored settings</var>.</li>
 
             <li>Let <var>getResult</var> be <a>Get</a>(<var>O</var>, <var>attributeName</var>).</li>
 
@@ -14122,7 +14139,9 @@ C implements A;</x:codeblock>
               point <var>completion</var> will be set to an ECMAScript completion value.
 
               <ol>
-                <li><a>Clean up after running script</a> with <var>settings</var>.</li>
+                <li><a>Clean up after running a callback</a> with <var>stored settings</var>.</li>
+
+                <li><a>Clean up after running script</a> with <var>relevant settings</var>.</li>
 
                 <li>If <var>completion</var> is a normal completion, return
                 <var>completion</var>.</li>
@@ -14160,11 +14179,16 @@ C implements A;</x:codeblock>
             <li>Let <var>realm</var> be <var>O</var>'s <a class='dfnref'
             href='#dfn-associated-realm'>associated Realm</a>.</li>
 
-            <li>Let <var>settings</var> be <var>realm</var>'s <a class='dfnref external'
+            <li>Let <var>relevant settings</var> be <var>realm</var>'s <a class='dfnref external'
             href='https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object'>settings
             object</a>.</li>
 
-            <li><a>Prepare to run script</a> with <var>settings</var>.</li>
+            <li>Let <var>stored settings</var> be <var>object</var>'s <a class='dfnref'
+            href='#dfn-callback-context'>callback context</a>.</li>
+
+            <li><a>Prepare to run script</a> with <var>relevant settings</var>.</li>
+
+            <li><a>Prepare to run a callback</a> with <var>stored settings</var>.</li>
 
             <li>Let <var>convertResult</var> be the result of <a class='dfnref'
             href='#dfn-convert-idl-to-ecmascript-value'>converting</a> <var>value</var> to an
@@ -14184,7 +14208,9 @@ C implements A;</x:codeblock>
               class='esvalue'>true</span> (as returned by <a>Set</a>).
 
               <ol>
-                <li><a>Clean up after running script</a> with <var>settings</var>.</li>
+                <li><a>Clean up after running a callback</a> with <var>stored settings</var>.</li>
+
+                <li><a>Clean up after running script</a> with <var>relevant settings</var>.</li>
 
                 <li>If <var>completion</var> is an abrupt completion, return
                 <var>completion</var>.</li>
@@ -14248,11 +14274,16 @@ C implements A;</x:codeblock>
             <li>Let <var>realm</var> be <var>F</var>'s <a class='dfnref'
             href='#dfn-associated-realm'>associated Realm</a>.</li>
 
-            <li>Let <var>settings</var> be <var>realm</var>'s <a class='dfnref external'
+            <li>Let <var>relevant settings</var> be <var>realm</var>'s <a class='dfnref external'
             href='https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object'>settings
             object</a>.</li>
 
-            <li><a>Prepare to run script</a> with <var>settings</var>.</li>
+            <li>Let <var>stored settings</var> be <var>callable</var>'s <a class='dfnref'
+            href='#dfn-callback-context'>callback context</a>.</li>
+
+            <li><a>Prepare to run script</a> with <var>relevant settings</var>.</li>
+
+            <li><a>Prepare to run a callback</a> with <var>stored settings</var>.</li>
 
             <li>Let <var>esArgs</var> be an empty List of ECMAScript values.</li>
 
@@ -14308,7 +14339,9 @@ C implements A;</x:codeblock>
               point <var>completion</var> will be set to an ECMAScript completion value.
 
               <ol>
-                <li><a>Clean up after running script</a> with <var>settings</var>.</li>
+                <li><a>Clean up after running a callback</a> with <var>stored settings</var>.</li>
+
+                <li><a>Clean up after running script</a> with <var>relevant settings</var>.</li>
 
                 <li>If <var>completion</var> is a normal completion, return
                 <var>completion</var>.</li>


### PR DESCRIPTION
This is the counterpart to https://github.com/whatwg/html/pull/1189, and properly calls in to HTML's new hooks to handle tracking the incumbent settings object using Web IDL's callback context mechanisms.