### PR TITLE
Remove mention of OMG IDL

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -255,27 +255,7 @@
         <p class='norm'>This section is informative.</p>
 
         <p>
-          Technical reports published by the W3C that include programming
-          language interfaces have typically been described using the
-          Object Management Group’s Interface Definition Language (IDL)
-          <a href='#ref-OMGIDL'>[OMGIDL]</a>.  The IDL provides a means to
-          describe these interfaces in a language independent manner.  Usually,
-          additional language binding appendices are included in such
-          documents which detail how the interfaces described with the IDL
-          correspond to constructs in the given language.
-        </p>
-        <p>
-          However, the bindings in these specifications for the language most
-          commonly used on the web, ECMAScript, are consistently specified with
-          low enough precision as to result in interoperability issues.  In
-          addition, each specification must describe the same basic information,
-          such as DOM interfaces described in IDL corresponding to properties
-          on the ECMAScript global object, or the <a class='idltype' href='#idl-unsigned-long'>unsigned
-            long</a> IDL type mapping to the <span class='estype'>Number</span>
-          type in ECMAScript.
-        </p>
-        <p>
-          This specification defines an IDL language similar to OMG IDL
+          This specification defines an IDL language
           for use by specifications that define interfaces for Web APIs.  A number of extensions are
           given to the IDL to support common functionality that previously must
           have been written in prose.  In addition, precise language bindings
@@ -4959,15 +4939,6 @@ EventTarget et = (EventTarget) n; <span class='comment'>// This should never thr
           <h3>Valuetypes</h3>
 
           <p>
-            Valuetypes in OMG IDL are used to define types similar to structs in C.
-            That is, they define composite types that can have zero or more
-            member variables that are passed by value.  OMG IDL valuetypes have the
-            additional feature of allowing <span class='idlvalue'>null</span> to
-            be passed in place of an object with those member variables.  An
-            OMG IDL boxed valuetype is a special case, where the valuetype has
-            a single member.
-          </p>
-          <p>
             The IDL defined in this specification supports only
             <dfn id='dfn-boxed-valuetype'>boxed valuetypes</dfn>, which are definitions
             that match the <a class='sym' href='#prod-Valuetype'>Valuetype</a> non-terminal.
@@ -5381,14 +5352,9 @@ interface Person {
               The <a class='idltype' href='#idl-DOMString'>DOMString</a> type
               corresponds to the set of all possible sequences of <a class='dfnref' href='#dfn-code-unit'>code units</a>.
               Such sequences are commonly interpreted as UTF-16 encoded strings <a href='#ref-RFC2781'>[RFC2781]</a>
-              although this is not required.
-              While <span class='idltype'>DOMString</span> is defined to be an OMG IDL boxed
-              <a class='idltype' href='#idl-sequence'>sequence&lt;unsigned short></a>
-              valuetype in <cite><a href='http://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#ID-C74D1578'>DOM Level 3 Core</a></cite>
-              (<a href='#ref-DOM3CORE'>[DOM3CORE]</a>, section 1.2.1),
-              this document defines <span class='idltype'>DOMString</span> to be an intrinsic type so as to avoid
-              special casing that sequence type in various situations where a
-              string is required.
+              although this is not required. This document defines <span class='idltype'>DOMString</span> to be an 
+              intrinsic type so as to avoid special casing that sequence type in various situations where a string
+              is required.
             </p>
             <div class='note'>
               <p>
@@ -15299,12 +15265,6 @@ d.type = et;
               <cite><a href='http://www.w3.org/TR/2011/WD-html5-20110525/'>HTML5</a></cite>.
               I. Hickson, Editor.  World Wide Web Consortium, May 2011.
               <span class="print"><br/>Available at http://www.w3.org/TR/2011/WD-html5-20110525/.</span>
-            </dd>
-            <dt id='ref-OMGIDL'>[OMGIDL]</dt>
-            <dd>
-              <cite><a href='http://www.omg.org/cgi-bin/doc?formal/08-01-04.pdf'>CORBA 3.1 – OMG IDL Syntax and Semantics chapter</a></cite>.
-              Object Management Group, January 2008.
-              <span class="print"><br/>Available at http://www.omg.org/cgi-bin/doc?formal/08-01-04.pdf.</span>
             </dd>
             <dt id='ref-WEBIDL-JAVA'>[WEBIDL-JAVA]</dt>
             <dd>


### PR DESCRIPTION
We haven't used OMG IDL on the web in over a decade (and rapidly approaching two decades). Might be time to erase it from our collective memory. One should not be required to know anything about OMG IDL read this spec, and current spec mentioning it seems to imply otherwise.