### PR TITLE
Update method creation for operations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -144,7 +144,8 @@ urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html; spec: HTML
         text: Clean up after running a callback
         text: incumbent settings object
         text: event handler IDL attributes; url: event-handler-attributes
-        text: settings object; url: concept-realm-settings-object            
+        text: settings object; url: concept-realm-settings-object
+        text: global object; url: concept-realm-global; for: Realm
 </pre>
 
 <style>
@@ -1030,7 +1031,6 @@ definition.
 limitations.  The following extended attributes must not
 be specified on partial interface definitions:
 [{{Constructor}}],
-[{{ImplicitThis}}],
 [{{LegacyArrayClass}}],
 [{{NamedConstructor}}],
 [{{NoInterfaceObject}}].
@@ -1057,7 +1057,6 @@ The following extended attributes are applicable to interfaces:
 [{{Constructor}}],
 [{{Exposed}}],
 [{{Global}}],
-[{{ImplicitThis}}],
 [{{LegacyArrayClass}}],
 [{{NamedConstructor}}],
 [{{NoInterfaceObject}}],
@@ -8495,63 +8494,6 @@ for the specific requirements that the use of
 </div>
 
 
-<h4 id="ImplicitThis" extended-attribute lt="ImplicitThis">[ImplicitThis]</h4>
-
-If the [{{ImplicitThis}}]
-[=extended attribute=]
-appears on an [=interface=],
-it indicates that when a <emu-val>Function</emu-val> corresponding
-to one of the interface’s [=operations=]
-is invoked with the <emu-val>null</emu-val> or <emu-val>undefined</emu-val>
-value as the <emu-val>this</emu-val> value, that the ECMAScript global
-object will be used as the <emu-val>this</emu-val> value instead.
-This is regardless of whether the calling code is in strict mode.
-
-The [{{ImplicitThis}}]
-extended attribute must
-[=takes no arguments|take no arguments=].
-
-See [[#es-operations]]
-for the specific requirements that the use of
-[{{ImplicitThis}}] entails.
-
-Note: The [{{ImplicitThis}}] [=extended attribute=]
-is intended for use on the {{Window}} [=interface=].
-
-<div class="example">
-    
-    In the following example, the <code class="idl">Window</code>
-    [=interface=] is defined
-    with the [{{ImplicitThis}}]
-    [=extended attribute=].
-    
-    <pre highlight="webidl">
-        [ImplicitThis]
-        interface Window {
-          // ...
-          attribute DOMString name;
-          void alert(DOMString message);
-        };
-    </pre>
-    
-    Since the <code class="idl">Window</code> object is used as
-    the ECMAScript global object, calls to its functions can be made
-    without an explicit object, even in strict mode:
-    
-    <pre highlight="js">
-        "use strict";
-        
-        window.alert("hello");      // Calling alert with an explicit window object works.
-        alert("hello");             // This also works, even though we are in strict mode.
-        alert.call(null, "hello");  // As does passing null explicitly as the this value.
-        
-        // This does not apply to getters for attributes on the interface, though.
-        // The following will throw a TypeError.
-        Object.getOwnPropertyDescriptor(Window.prototype, "name").get.call(null);
-    </pre>
-</div>
-
-
 <h4 oldids="PrimaryGlobal" id="Global" extended-attribute lt="Global|PrimaryGlobal" dfn>[Global] and [PrimaryGlobal]</h4>
 
 If the [{{Global}}]
@@ -10944,99 +10886,26 @@ The characteristics of this property are as follows:
     where |B| is <emu-val>false</emu-val> if the operation is
     [=unforgeable=] on the interface,
     and <emu-val>true</emu-val> otherwise.
-*   The value of the property is a <emu-val>Function</emu-val> object whose
-    behavior is as follows,
-    assuming |id| is the
-    [=identifier=],
-    |arg|<sub>0..|n|−1</sub> is the list
-    of argument values passed to the function:
-    <ol class="algorithm">
-        1.  Try running the following steps:
-            1.  Let |I| be the [=interface=]
-                whose [=interface prototype object=]
-                (or [=interface object=], for a static
-                operation) this property corresponding to the operation appears on.
-                
-                Note: This means that even if an implements statement was used to make
-                an operation available on the interface, |I| is the interface
-                on the left hand side of the implements statement, and not the one
-                that the operation was originally declared on.
-                
-            1.  Let |O| be a value determined as follows:
-                *   If the operation is a static operation, then |O| is <emu-val>null</emu-val>.
-                *   Otherwise, if the [=interface=] on which the
-                    [=operation=] appears has an
-                    [{{ImplicitThis}}] [=extended attribute=],
-                    and the <emu-val>this</emu-val> value is <emu-val>null</emu-val>
-                    or <emu-val>undefined</emu-val>, then |O| is
-                    the ECMAScript global object associated with the <emu-val>Function</emu-val> object.
-                *   Otherwise, if the <emu-val>this</emu-val> value is not <emu-val>null</emu-val>,
-                    then |O| is the <emu-val>this</emu-val> value.
-                *   Otherwise, <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
-            1.  If |O| is a [=platform object=],
-                then [=perform a security check=], passing:
-                *   the platform object |O|,
-                *   the ECMAScript global environment associated with this <emu-val>Function</emu-val> that
-                    implements the [=operation=],
-                *   the [=identifier=] of the [=operation=], and
-                *   the type “method”.
-            1.  If |O| is not <emu-val>null</emu-val> and is also not a [=platform object=]
-                that implements interface |I|, <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
-            1.  Initialize |S| to the
-                [=effective overload set=]
-                for [=regular operations=]
-                (if the operation is a regular operation) or for
-                [=static operations=]
-                (if the operation is a static operation) with
-                [=identifier=]
-                |id| on [=interface=]
-                |I| and with argument count |n|.
-            1.  Let &lt;|operation|, |values|&gt; be the result of passing |S| and
-                |arg|<sub>0..|n|−1</sub> to the
-                [=overload resolution algorithm=].
-            1.  Let |R| be the result of performing (on |O|, if the operation
-                is not a static operation) the actions listed in the description of
-                |operation| with |values| as the argument values.
-            1.  Return the result of [=converted to an ECMAScript value|converting=]
-                |R| to an ECMAScript value of
-                the type |op| is declared to return.
-            
-            And then, if an exception was thrown:
-            
-            1.  If the operation has a [=return type=]
-                that is a <a href="#idl-promise">promise type</a>, then:
-                1.  Let |reject| be the initial value of [=%Promise%=].reject.
-                1.  Return the result of calling |reject| with [=%Promise%=] as the
-                    <emu-val>this</emu-val> object and the exception as the single
-                    argument value.
-            1.  Otherwise, end these steps and allow the exception to propagate.
-    </ol>
-*   The value of the <emu-val>Function</emu-val> object’s “length”
-    property is a <emu-val>Number</emu-val> determined as follows:
-    <ol class="algorithm">
-        1.  Let |S| be the
-            [=effective overload set=]
-            for [=regular operations=]
-            (if the operation is a regular operation) or for
-            [=static operations=]
-            (if the operation is a static operation) with
-            [=identifier=]
-            |id| on [=interface=]
-            |I| and with argument count 0.
-        1.  Return the length of the shortest argument list of the entries in |S|.
-    </ol>
-*   The value of the <emu-val>Function</emu-val> object’s “name”
-    property is a <emu-val>String</emu-val> whose value is the
-    identifier of the operation.
+*   The value of the property is the result of [=creating an operation function=] given the
+    operation, the interface (or the interface it's being mixed in to, if the interface is actually
+    a mixin), and the [=relevant Realm=] of the object that is the location of the property.
 
-We also define <dfn id="dfn-create-operation-function">creating an operation function</dfn>, given an [=operation=]
-|op|, a [=namespace=]
-|namespace|, and a [=Realm=] |realm|:
+    Note: that is, even if an [=implements statement=] was used to make an operation
+    available on the interface, we pass in the interface on the left-hand side of the
+    [=implements statement=], and not the really-a-mixin interface on the right-hand side,
+    where the operation was originally declared.
 
-Note: The astute reader may notice that what follows is very similar to the
-above algorithm for operations on interfaces. It is currently only used for namespaces,
-but we have near-future plans to generalize it slightly and then replace the above
-definition so that this algorithm is useful both for interfaces and namespaces.
+<p class="advisement">
+    The above description has some bugs, especially around partial interfaces. See
+    <a href="https://github.com/heycam/webidl/issues/164">issue #164</a>.
+</p>
+
+For [=namespaces=], the properties corresponding to each declared operation are described in
+[[#namespace-object]]. (We hope to eventually move interfaces to the same explicit
+property-installation style as namespaces.)
+
+To <dfn id="dfn-create-operation-function" lt="creating an operation function">create an operation function</dfn>,
+given an [=operation=] |op|, a [=namespace=] or [=interface=] |target|, and a [=Realm=] |realm|:
 
 1.  Let |id| be |op|'s [=identifier=].
 
@@ -11044,18 +10913,38 @@ definition so that this algorithm is useful both for interfaces and namespaces.
     values |arg|<sub>0..|n|−1</sub>:
     
     1.  Try running the following steps:
-        1.  Let |S| be the [=effective overload set=] for [=regular operations=] with
+        1.  Let |O| be <emu-val>null</emu-val>.
+
+        1.  If |target| is an [=interface=], and |op| is not a [=static operation=]:
+
+            1.  If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or
+                <emu-val>undefined</emu-val>, set |O| to |realm|'s [=Realm/global object=]. (This
+                will subsequently cause a <emu-val>TypeError</emu-val> in a few steps, if the global
+                object does not implement |target|.)
+
+                <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
+
+            1.  Otherwise, set |O| to the <emu-val>this</emu-val> value.
+
+            1.  If |O| is a [=platform object=], then [=perform a security check=], passing |O|,
+                |realm|, |id|, and "method".
+
+            1.  If |O| is not a [=platform object=] that implements the interface |target|,
+                <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+
+        1.  Let |S| be the [=effective overload set=] for [=regular operations=] (if |op| is a
+            regular operation) or for [=static operations=] (if |op| is a static operation) with
             [=identifier=] |id| on
-            [=namespace=] |namespace|
+            |target|
             and with argument count |n|.
         
         1.  Let &lt;|operation|, |values|&gt; be the result of passing
             |S| and |arg|<sub>0..|n|−1</sub> to the [=overload resolution algorithm=].
         
         1.  Let |R| be the result of performing the actions listed in the
-            description of |operation| with |values| as the argument
-            values.
-        
+            description of |operation|, on |O| if |O| is not <emu-val>null</emu-val>, with |values|
+            as the argument values.
+
         1.  Return the result of [=converted to an ECMAScript value|converting=] |R| to
             an ECMAScript value of the type |op| is declared to return.
     
@@ -11074,12 +10963,14 @@ definition so that this algorithm is useful both for interfaces and namespaces.
 
 1.  Perform [=!=] [=SetFunctionName=](|F|, |id|).
 
-1.  Let |S| be the [=effective overload set=] for [=regular operations=] with [=identifier=] |id| on [=namespace=] |namespace| and with argument count 0.
+1.  Let |S| be the [=effective overload set=] for [=regular operations=] (if |op| is a regular
+    operation) or for [=static operations=] (if |op| is a static operation) with [=identifier=] |id|
+    on |target| and with argument count 0.
 
 1.  Let |length| be the length of the shortest argument list in the entries in
     |S|.
 
-1.  Perform [=!=] [=DefinePropertyOrThrow=](|F|, <code>"length"</code>,
+1.  Perform [=!=] [=DefinePropertyOrThrow=](|F|, "length",
     PropertyDescriptor<span class="descriptor">{\[[Value]]: |length|,
     \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}</span>).
 

--- a/index.html
+++ b/index.html
@@ -1740,24 +1740,23 @@ are interoperable.</p>
         <li><a href="#Constructor"><span class="secno">4.3.2</span> <span class="content">[Constructor]</span></a>
         <li><a href="#EnforceRange"><span class="secno">4.3.3</span> <span class="content">[EnforceRange]</span></a>
         <li><a href="#Exposed"><span class="secno">4.3.4</span> <span class="content">[Exposed]</span></a>
-        <li><a href="#ImplicitThis"><span class="secno">4.3.5</span> <span class="content">[ImplicitThis]</span></a>
-        <li><a href="#Global"><span class="secno">4.3.6</span> <span class="content">[Global] and [PrimaryGlobal]</span></a>
-        <li><a href="#LegacyArrayClass"><span class="secno">4.3.7</span> <span class="content">[LegacyArrayClass]</span></a>
-        <li><a href="#LegacyUnenumerableNamedProperties"><span class="secno">4.3.8</span> <span class="content">[LegacyUnenumerableNamedProperties]</span></a>
-        <li><a href="#LenientSetter"><span class="secno">4.3.9</span> <span class="content">[LenientSetter]</span></a>
-        <li><a href="#LenientThis"><span class="secno">4.3.10</span> <span class="content">[LenientThis]</span></a>
-        <li><a href="#NamedConstructor"><span class="secno">4.3.11</span> <span class="content">[NamedConstructor]</span></a>
-        <li><a href="#NewObject"><span class="secno">4.3.12</span> <span class="content">[NewObject]</span></a>
-        <li><a href="#NoInterfaceObject"><span class="secno">4.3.13</span> <span class="content">[NoInterfaceObject]</span></a>
-        <li><a href="#OverrideBuiltins"><span class="secno">4.3.14</span> <span class="content">[OverrideBuiltins]</span></a>
-        <li><a href="#PutForwards"><span class="secno">4.3.15</span> <span class="content">[PutForwards]</span></a>
-        <li><a href="#Replaceable"><span class="secno">4.3.16</span> <span class="content">[Replaceable]</span></a>
-        <li><a href="#SameObject"><span class="secno">4.3.17</span> <span class="content">[SameObject]</span></a>
-        <li><a href="#SecureContext"><span class="secno">4.3.18</span> <span class="content">[SecureContext]</span></a>
-        <li><a href="#TreatNonObjectAsNull"><span class="secno">4.3.19</span> <span class="content">[TreatNonObjectAsNull]</span></a>
-        <li><a href="#TreatNullAs"><span class="secno">4.3.20</span> <span class="content">[TreatNullAs]</span></a>
-        <li><a href="#Unforgeable"><span class="secno">4.3.21</span> <span class="content">[Unforgeable]</span></a>
-        <li><a href="#Unscopable"><span class="secno">4.3.22</span> <span class="content">[Unscopable]</span></a>
+        <li><a href="#Global"><span class="secno">4.3.5</span> <span class="content">[Global] and [PrimaryGlobal]</span></a>
+        <li><a href="#LegacyArrayClass"><span class="secno">4.3.6</span> <span class="content">[LegacyArrayClass]</span></a>
+        <li><a href="#LegacyUnenumerableNamedProperties"><span class="secno">4.3.7</span> <span class="content">[LegacyUnenumerableNamedProperties]</span></a>
+        <li><a href="#LenientSetter"><span class="secno">4.3.8</span> <span class="content">[LenientSetter]</span></a>
+        <li><a href="#LenientThis"><span class="secno">4.3.9</span> <span class="content">[LenientThis]</span></a>
+        <li><a href="#NamedConstructor"><span class="secno">4.3.10</span> <span class="content">[NamedConstructor]</span></a>
+        <li><a href="#NewObject"><span class="secno">4.3.11</span> <span class="content">[NewObject]</span></a>
+        <li><a href="#NoInterfaceObject"><span class="secno">4.3.12</span> <span class="content">[NoInterfaceObject]</span></a>
+        <li><a href="#OverrideBuiltins"><span class="secno">4.3.13</span> <span class="content">[OverrideBuiltins]</span></a>
+        <li><a href="#PutForwards"><span class="secno">4.3.14</span> <span class="content">[PutForwards]</span></a>
+        <li><a href="#Replaceable"><span class="secno">4.3.15</span> <span class="content">[Replaceable]</span></a>
+        <li><a href="#SameObject"><span class="secno">4.3.16</span> <span class="content">[SameObject]</span></a>
+        <li><a href="#SecureContext"><span class="secno">4.3.17</span> <span class="content">[SecureContext]</span></a>
+        <li><a href="#TreatNonObjectAsNull"><span class="secno">4.3.18</span> <span class="content">[TreatNonObjectAsNull]</span></a>
+        <li><a href="#TreatNullAs"><span class="secno">4.3.19</span> <span class="content">[TreatNullAs]</span></a>
+        <li><a href="#Unforgeable"><span class="secno">4.3.20</span> <span class="content">[Unforgeable]</span></a>
+        <li><a href="#Unscopable"><span class="secno">4.3.21</span> <span class="content">[Unscopable]</span></a>
        </ol>
       <li><a href="#es-security"><span class="secno">4.4</span> <span class="content">Security</span></a>
       <li><a href="#es-overloads"><span class="secno">4.5</span> <span class="content">Overload resolution algorithm</span></a>
@@ -2442,7 +2441,6 @@ Inheritance must be specified on the original <a data-link-type="dfn" href="#dfn
 limitations.  The following extended attributes must not
 be specified on partial interface definitions:
 [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-2">Constructor</a></code>],
-[<code class="idl"><a data-link-type="idl" href="#ImplicitThis" id="ref-for-ImplicitThis-1">ImplicitThis</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-1">LegacyArrayClass</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-1">NamedConstructor</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-1">NoInterfaceObject</a></code>].</p>
@@ -2462,7 +2460,6 @@ in the language.</p>
 [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-3">Constructor</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-2">Exposed</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-3">Global</a></code>],
-[<code class="idl"><a data-link-type="idl" href="#ImplicitThis" id="ref-for-ImplicitThis-2">ImplicitThis</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-2">LegacyArrayClass</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-2">NamedConstructor</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-2">NoInterfaceObject</a></code>],
@@ -8090,44 +8087,9 @@ can be made once, at the time the <a data-link-type="dfn" href="#dfn-initial-obj
 };
 </pre>
    </div>
-   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.5" data-lt="ImplicitThis" id="ImplicitThis"><span class="secno">4.3.5. </span><span class="content">[ImplicitThis]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#ImplicitThis" id="ref-for-ImplicitThis-3">ImplicitThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-49">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-60">interface</a>,
-it indicates that when a <emu-val>Function</emu-val> corresponding
-to one of the interface’s <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-54">operations</a> is invoked with the <emu-val>null</emu-val> or <emu-val>undefined</emu-val> value as the <emu-val>this</emu-val> value, that the ECMAScript global
-object will be used as the <emu-val>this</emu-val> value instead.
-This is regardless of whether the calling code is in strict mode.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#ImplicitThis" id="ref-for-ImplicitThis-4">ImplicitThis</a></code>]
-extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-4">take no arguments</a>.</p>
-   <p>See <a href="#es-operations">§4.6.7 Operations</a> for the specific requirements that the use of
-[<code class="idl"><a data-link-type="idl" href="#ImplicitThis" id="ref-for-ImplicitThis-5">ImplicitThis</a></code>] entails.</p>
-   <p class="note" role="note">Note: The [<code class="idl"><a data-link-type="idl" href="#ImplicitThis" id="ref-for-ImplicitThis-6">ImplicitThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-50">extended attribute</a> is intended for use on the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-61">interface</a>.</p>
-   <div class="example" id="example-555bc8a6">
-    <a class="self-link" href="#example-555bc8a6"></a> 
-    <p>In the following example, the <code class="idl">Window</code> <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-62">interface</a> is defined
-    with the [<code class="idl"><a data-link-type="idl" href="#ImplicitThis" id="ref-for-ImplicitThis-7">ImplicitThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-51">extended attribute</a>.</p>
-<pre class="highlight">[<span class="nv">ImplicitThis</span>]
-<span class="kt">interface</span> <span class="nv">Window</span> {
-  // ...
-  <span class="kt">attribute</span> <span class="kt">DOMString</span> <span class="nv">name</span>;
-  <span class="kt">void</span> <span class="nv">alert</span>(<span class="kt">DOMString</span> <span class="nv">message</span>);
-};
-</pre>
-    <p>Since the <code class="idl">Window</code> object is used as
-    the ECMAScript global object, calls to its functions can be made
-    without an explicit object, even in strict mode:</p>
-<pre class="highlight"><span class="s2">"use strict"</span><span class="p">;</span>
-        
-<span class="nb">window</span><span class="p">.</span><span class="nx">alert</span><span class="p">(</span><span class="s2">"hello"</span><span class="p">);</span>      <span class="c1">// Calling alert with an explicit window object works.</span>
-<span class="nx">alert</span><span class="p">(</span><span class="s2">"hello"</span><span class="p">);</span>             <span class="c1">// This also works, even though we are in strict mode.</span>
-<span class="nx">alert</span><span class="p">.</span><span class="nx">call</span><span class="p">(</span><span class="kc">null</span><span class="p">,</span> <span class="s2">"hello"</span><span class="p">);</span>  <span class="c1">// As does passing null explicitly as the this value.</span>
-        
-<span class="c1">// This does not apply to getters for attributes on the interface, though.</span>
-<span class="c1">// The following will throw a TypeError.</span>
-<span class="nb">Object</span><span class="p">.</span><span class="nx">getOwnPropertyDescriptor</span><span class="p">(</span><span class="nx">Window</span><span class="p">.</span><span class="nx">prototype</span><span class="p">,</span> <span class="s2">"name"</span><span class="p">).</span><span class="nx">get</span><span class="p">.</span><span class="nx">call</span><span class="p">(</span><span class="kc">null</span><span class="p">);</span></pre>
-   </div>
-   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.6" data-lt="Global|PrimaryGlobal" dfn="" id="Global"><span class="secno">4.3.6. </span><span class="content">[Global] and [PrimaryGlobal]</span><span id="PrimaryGlobal"></span></h4>
+   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.5" data-lt="Global|PrimaryGlobal" dfn="" id="Global"><span class="secno">4.3.5. </span><span class="content">[Global] and [PrimaryGlobal]</span><span id="PrimaryGlobal"></span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-5">Global</a></code>]
-or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-6">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-52">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-63">interface</a>,
+or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-6">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-49">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-60">interface</a>,
 it indicates that objects implementing this interface can
 be used as the global object in an ECMAScript environment,
 and that the structure of the prototype chain and how
@@ -8138,7 +8100,7 @@ interfaces.  Specifically:</p>
      <p>Any <a href="#idl-named-properties">named properties</a> will be exposed on an object in the prototype chain – the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-3">named properties object</a> –
 rather than on the object itself.</p>
     <li data-md="">
-     <p><a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-14">Interface members</a> from the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-64">interface</a> (or <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-14">consequential interfaces</a>)
+     <p><a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-14">Interface members</a> from the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-61">interface</a> (or <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-14">consequential interfaces</a>)
 will correspond to properties on the object itself rather than on <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-4">interface prototype objects</a>.</p>
    </ol>
    <div class="note" role="note">
@@ -8161,7 +8123,7 @@ will correspond to properties on the object itself rather than on <a data-link-t
     assignment is evaluated.</p>
    </div>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-7">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-8">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-53">extended attributes</a> is used on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-65">interface</a>, then:</p>
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-8">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-50">extended attributes</a> is used on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-62">interface</a>, then:</p>
    <ul>
     <li data-md="">
      <p>The interface must not define a <a data-link-type="dfn" href="#dfn-named-property-setter" id="ref-for-dfn-named-property-setter-3">named property setter</a>.</p>
@@ -8178,15 +8140,15 @@ extended attribute.</p>
 a <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-9">partial interface</a> definition, then that partial interface definition must
 be the part of the interface definition that defines
 the <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-named-property-getter-5">named property getter</a>.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-11">Global</a></code>] and [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-12">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-54">extended attribute</a> must not
-be used on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-66">interface</a> that can have more
+   <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-11">Global</a></code>] and [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-12">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-51">extended attribute</a> must not
+be used on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-63">interface</a> that can have more
 than one object implementing it in the same ECMAScript global environment.</p>
    <p class="note" role="note">Note: This is because the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-4">named properties object</a>,
 which exposes the named properties, is in the prototype chain, and it would not make
 sense for more than one object’s named properties to be exposed on an object that
 all of those objects inherit from.</p>
    <p>If an interface is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-13">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-14">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-55">extended attribute</a>, then
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-14">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-52">extended attribute</a>, then
 there must not be more than one <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-15">interface member</a> across
 the interface and its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-15">consequential interfaces</a> with the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-51">identifier</a>.
 There also must not be more than
@@ -8202,14 +8164,14 @@ which can then be referenced by the [<code class="idl"><a data-link-type="idl" h
 extended attribute.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-17">Global</a></code>] and
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-18">PrimaryGlobal</a></code>]
-extended attributes must either <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-5">take no arguments</a> or <a data-link-type="dfn" href="#dfn-xattr-identifier-list" id="ref-for-dfn-xattr-identifier-list-2">take an identifier list</a>.</p>
+extended attributes must either <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-4">take no arguments</a> or <a data-link-type="dfn" href="#dfn-xattr-identifier-list" id="ref-for-dfn-xattr-identifier-list-2">take an identifier list</a>.</p>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-19">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-20">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-56">extended attribute</a> is declared with an identifier list argument, then those identifiers are the interface’s <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-global-name">global names</dfn>; otherwise, the interface has
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-20">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-53">extended attribute</a> is declared with an identifier list argument, then those identifiers are the interface’s <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-global-name">global names</dfn>; otherwise, the interface has
 a single global name, which is the interface’s identifier.</p>
    <p class="note" role="note">Note: The identifier argument list exists so that more than one global interface can
-be addressed with a single name in an [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-22">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-57">extended attribute</a>.</p>
+be addressed with a single name in an [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-22">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-54">extended attribute</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-21">Global</a></code>] and
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-22">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-58">extended attributes</a> must not be declared on the same
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-22">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-55">extended attributes</a> must not be declared on the same
 interface.  The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-23">PrimaryGlobal</a></code>]
 extended attribute must be declared on
 at most one interface.  The interface [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-24">PrimaryGlobal</a></code>]
@@ -8221,7 +8183,7 @@ and <a href="#es-constants">§4.6.5 Constants</a>, <a href="#es-attributes">§4.
 corresponding to <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-16">interface members</a>.</p>
    <div class="example" id="example-b5485ed2">
     <a class="self-link" href="#example-b5485ed2"></a> 
-    <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-27">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-59">extended attribute</a> is intended
+    <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-27">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-56">extended attribute</a> is intended
     to be used by the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> interface.
     ([<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-28">Global</a></code>] is intended to be used by worker global interfaces.)
     The <code class="idl">Window</code> interface exposes frames as properties on the <code class="idl">Window</code> object.  Since the <code class="idl">Window</code> object also serves as the
@@ -8262,13 +8224,13 @@ corresponding to <a data-link-type="dfn" href="#dfn-interface-member" id="ref-fo
   <span class="nx">def</span><span class="p">;</span>                              <span class="c1">// Evaluates to undefined.</span>
 <span class="nt">&lt;/script></span></pre>
    </div>
-   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.7" data-lt="LegacyArrayClass" id="LegacyArrayClass"><span class="secno">4.3.7. </span><span class="content">[LegacyArrayClass]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-3">LegacyArrayClass</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-60">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-67">interface</a> that is not defined to <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-12">inherit</a> from another, it indicates that the internal [[Prototype]]
+   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.6" data-lt="LegacyArrayClass" id="LegacyArrayClass"><span class="secno">4.3.6. </span><span class="content">[LegacyArrayClass]</span></h4>
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-3">LegacyArrayClass</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-57">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-64">interface</a> that is not defined to <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-12">inherit</a> from another, it indicates that the internal [[Prototype]]
 property of its <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-5">interface prototype object</a> will be the <emu-val>Array</emu-val> prototype object rather than
 the <emu-val>Object</emu-val> prototype object.  This allows <emu-val>Array</emu-val> methods to be used more easily
 with objects implementing the interface.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-4">LegacyArrayClass</a></code>] extended attribute
-must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-6">take no arguments</a>.
+must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-5">take no arguments</a>.
 It must not be used on an interface that
 has any <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces-14">inherited interfaces</a>.</p>
    <p class="note" role="note">Note: Interfaces using [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-5">LegacyArrayClass</a></code>] will
@@ -8280,7 +8242,7 @@ specific requirements that the use of [<code class="idl"><a data-link-type="idl"
 entails.</p>
    <div class="example" id="example-48890bf2">
     <a class="self-link" href="#example-48890bf2"></a> 
-    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-37">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-68">interfaces</a> that use [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-7">LegacyArrayClass</a></code>].</p>
+    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-37">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-65">interfaces</a> that use [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-7">LegacyArrayClass</a></code>].</p>
 <pre class="highlight">[<span class="nv">LegacyArrayClass</span>]
 <span class="kt">interface</span> <span class="nv">ItemList</span> {
   <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <span class="nv">length</span>;
@@ -8308,11 +8270,11 @@ entails.</p>
     succeed on objects implementing <code class="idl">ImmutableItemList</code>.
     The exact behavior depends on the definition of the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-array-prototype-object">Array methods</a> themselves.</p>
    </div>
-   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.8" data-lt="LegacyUnenumerableNamedProperties" id="LegacyUnenumerableNamedProperties"><span class="secno">4.3.8. </span><span class="content">[LegacyUnenumerableNamedProperties]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-1">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-61">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-69">interface</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-2">supports named properties</a>,
+   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.7" data-lt="LegacyUnenumerableNamedProperties" id="LegacyUnenumerableNamedProperties"><span class="secno">4.3.7. </span><span class="content">[LegacyUnenumerableNamedProperties]</span></h4>
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-1">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-58">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-66">interface</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-2">supports named properties</a>,
 it indicates that all the interface’s named properties are unenumerable.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-2">LegacyUnenumerableNamedProperties</a></code>]
-extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-7">take no arguments</a> and must not appear on an interface
+extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-6">take no arguments</a> and must not appear on an interface
 that does not define a <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-named-property-getter-6">named property getter</a>.</p>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-3">LegacyUnenumerableNamedProperties</a></code>]
 extended attribute is specified on an interface, then it applies to all its derived interfaces and
@@ -8320,8 +8282,8 @@ must not be specified on any of them.</p>
    <p>See <a href="#property-enumeration">§4.8.10 Property enumeration</a> for the specific requirements that the use of
 [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-4">LegacyUnenumerableNamedProperties</a></code>]
 entails.</p>
-   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.9" data-lt="LenientSetter" id="LenientSetter"><span class="secno">4.3.9. </span><span class="content">[LenientSetter]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-2">LenientSetter</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-62">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-6">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-5">regular attribute</a>,
+   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.8" data-lt="LenientSetter" id="LenientSetter"><span class="secno">4.3.8. </span><span class="content">[LenientSetter]</span></h4>
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-2">LenientSetter</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-59">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-6">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-5">regular attribute</a>,
 it indicates that a no-op setter will be generated for the attribute’s
 accessor property.  This results in erroneous assignments to the property
 in strict mode to be ignored rather than causing an exception to be thrown.</p>
@@ -8337,7 +8299,7 @@ in strict mode to be ignored rather than causing an exception to be thrown.</p>
     wish to use this feature are strongly advised to discuss this on the <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a> mailing list before proceeding.</p>
    </div>
    <p>The [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-2">LenientThis</a></code>] extended attribute
-must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-8">take no arguments</a>.
+must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-7">take no arguments</a>.
 It must not be used on anything other than
 a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-7">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-6">regular attribute</a>.</p>
    <p>An attribute with the [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-5">LenientSetter</a></code>]
@@ -8370,13 +8332,13 @@ is to be implemented.</p>
 <span class="c1">// Throws a TypeError, since we are in strict mode and there is no setter.</span>
 <span class="nx">example</span><span class="p">.</span><span class="nx">y</span> <span class="o">=</span> <span class="mi">1</span><span class="p">;</span></pre>
    </div>
-   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.10" data-lt="LenientThis" id="LenientThis"><span class="secno">4.3.10. </span><span class="content">[LenientThis]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-3">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-63">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-7">regular attribute</a>,
+   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.9" data-lt="LenientThis" id="LenientThis"><span class="secno">4.3.9. </span><span class="content">[LenientThis]</span></h4>
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-3">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-60">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-7">regular attribute</a>,
 it indicates that invocations of the attribute’s getter or setter
 with a <emu-val>this</emu-val> value that is not an
-object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-70">interface</a> on which the attribute appears will be ignored.</p>
+object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-67">interface</a> on which the attribute appears will be ignored.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-4">LenientThis</a></code>] extended attribute
-must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-9">take no arguments</a>.
+must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-8">take no arguments</a>.
 It must not be used on a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-7">static attribute</a>.</p>
    <p class="advisement"> Specifications should not use [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-5">LenientThis</a></code>]
     unless required for compatibility reasons.  Specification authors who
@@ -8412,8 +8374,8 @@ is to be implemented.</p>
 <span class="c1">// Throws a TypeError, since Example.prototype is not an Example object.</span>
 <span class="nx">Example</span><span class="p">.</span><span class="nx">prototype</span><span class="p">.</span><span class="nx">y</span><span class="p">;</span></pre>
    </div>
-   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.11" data-lt="NamedConstructor" id="NamedConstructor"><span class="secno">4.3.11. </span><span class="content">[NamedConstructor]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-8">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-64">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-71">interface</a>,
+   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.10" data-lt="NamedConstructor" id="NamedConstructor"><span class="secno">4.3.10. </span><span class="content">[NamedConstructor]</span></h4>
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-8">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-61">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-68">interface</a>,
 it indicates that the ECMAScript global object will have a property with the
 specified name whose value is a constructor function that can
 create objects that implement the interface.
@@ -8459,16 +8421,16 @@ are to be implemented.</p>
 <span class="kd">var</span> <span class="nx">a2</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Audio</span><span class="p">(</span><span class="s1">'a.flac'</span><span class="p">);</span>   <span class="c1">// Creates an HTMLAudioElement using the</span>
                                 <span class="c1">// one-argument constructor.</span></pre>
    </div>
-   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.12" data-lt="NewObject" id="NewObject"><span class="secno">4.3.12. </span><span class="content">[NewObject]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#NewObject" id="ref-for-NewObject-2">NewObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-65">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-9">regular</a> or <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-7">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-55">operation</a>,
+   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.11" data-lt="NewObject" id="NewObject"><span class="secno">4.3.11. </span><span class="content">[NewObject]</span></h4>
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#NewObject" id="ref-for-NewObject-2">NewObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-62">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-9">regular</a> or <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-7">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-54">operation</a>,
 then it indicates that when calling the operation,
 a reference to a newly created object
 must always be returned.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#NewObject" id="ref-for-NewObject-3">NewObject</a></code>]
-extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-10">take no arguments</a>.</p>
+extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-9">take no arguments</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#NewObject" id="ref-for-NewObject-4">NewObject</a></code>]
 extended attribute must not
-be used on anything other than a <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-10">regular</a> or <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-8">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-56">operation</a> whose <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-4">return type</a> is an <a href="#idl-interface" id="ref-for-idl-interface-11">interface type</a> or
+be used on anything other than a <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-10">regular</a> or <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-8">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-55">operation</a> whose <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-4">return type</a> is an <a href="#idl-interface" id="ref-for-idl-interface-11">interface type</a> or
 a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-1">promise type</a>.</p>
    <div class="example" id="example-245e5507">
     <a class="self-link" href="#example-245e5507"></a> 
@@ -8482,8 +8444,8 @@ a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-
 };
 </pre>
    </div>
-   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.13" data-lt="NoInterfaceObject" id="NoInterfaceObject"><span class="secno">4.3.13. </span><span class="content">[NoInterfaceObject]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-4">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-66">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-72">interface</a>,
+   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.12" data-lt="NoInterfaceObject" id="NoInterfaceObject"><span class="secno">4.3.12. </span><span class="content">[NoInterfaceObject]</span></h4>
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-4">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-63">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-69">interface</a>,
 it indicates that an <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-5">interface object</a> will not exist for the interface in the ECMAScript binding.</p>
    <p class="advisement"> The [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-5">NoInterfaceObject</a></code>] extended attribute
     should not be used on interfaces that are not
@@ -8491,7 +8453,7 @@ it indicates that an <a data-link-type="dfn" href="#dfn-interface-object" id="re
     unless there are clear Web compatibility reasons for doing so.  Specification authors who
     wish to use this feature are strongly advised to discuss this on the <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a> mailing list before proceeding. </p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-6">NoInterfaceObject</a></code>] extended attribute
-must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-11">take no arguments</a>.</p>
+must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-10">take no arguments</a>.</p>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-7">NoInterfaceObject</a></code>] extended attribute
 is specified on an interface, then the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-19">Constructor</a></code>]
 extended attribute must not also be specified on that interface.
@@ -8536,8 +8498,8 @@ attribute specified.</p>
 <span class="k">typeof</span> <span class="nx">Query</span><span class="p">;</span>                          <span class="c1">// evaluates to "undefined"</span>
 <span class="kd">var</span> <span class="nx">fn</span> <span class="o">=</span> <span class="nx">Query</span><span class="p">.</span><span class="nx">prototype</span><span class="p">.</span><span class="nx">lookupEntry</span><span class="p">;</span>  <span class="c1">// exception, Query isn’t defined</span></pre>
    </div>
-   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.14" data-lt="OverrideBuiltins" id="OverrideBuiltins"><span class="secno">4.3.14. </span><span class="content">[OverrideBuiltins]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-5">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-67">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-73">interface</a>,
+   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.13" data-lt="OverrideBuiltins" id="OverrideBuiltins"><span class="secno">4.3.13. </span><span class="content">[OverrideBuiltins]</span></h4>
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-5">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-64">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-70">interface</a>,
 it indicates that for a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-14">platform object</a> implementing the interface,
 properties corresponding to all of
 the object’s <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-3">supported property names</a> will appear to be on the object,
@@ -8548,7 +8510,7 @@ This is in contrast to the usual behavior, which is for named properties
 to be exposed only if there is no property with the
 same name on the object itself or somewhere on its prototype chain.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-6">OverrideBuiltins</a></code>]
-extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-12">take no arguments</a> and must not appear on an interface
+extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-11">take no arguments</a> and must not appear on an interface
 that does not define a <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-named-property-getter-7">named property getter</a> or that also is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-29">Global</a></code>]
 or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-30">PrimaryGlobal</a></code>]
 extended attribute.  If the extended attribute is specified on
@@ -8559,7 +8521,7 @@ the <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-na
 [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-7">OverrideBuiltins</a></code>] entails.</p>
    <div class="example" id="example-f9378b88">
     <a class="self-link" href="#example-f9378b88"></a> 
-    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-39">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-74">interfaces</a>,
+    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-39">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-71">interfaces</a>,
     one that has a <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-named-property-getter-9">named property getter</a> and one that does not.</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">StringMap</span> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <span class="nv">length</span>;
@@ -8604,8 +8566,8 @@ the <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-na
 <span class="c1">// a property in map2’s prototype chain.</span>
 <span class="nx">map2</span><span class="p">.</span><span class="nx">toString</span><span class="p">;</span></pre>
    </div>
-   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.15" data-lt="PutForwards" id="PutForwards"><span class="secno">4.3.15. </span><span class="content">[PutForwards]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-3">PutForwards</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-68">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-8">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-8">regular attribute</a> declaration whose type is
+   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.14" data-lt="PutForwards" id="PutForwards"><span class="secno">4.3.14. </span><span class="content">[PutForwards]</span></h4>
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-3">PutForwards</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-65">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-8">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-8">regular attribute</a> declaration whose type is
 an <a href="#idl-interface" id="ref-for-idl-interface-12">interface type</a>,
 it indicates that assigning to the attribute will have specific behavior.
 Namely, the assignment is “forwarded” to the attribute (specified by
@@ -8619,7 +8581,7 @@ Assuming that:</p>
      <p><var>A</var> is the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-47">attribute</a> on which the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-5">PutForwards</a></code>]
 extended attribute appears,</p>
     <li data-md="">
-     <p><var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-75">interface</a> on which <var>A</var> is declared,</p>
+     <p><var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-72">interface</a> on which <var>A</var> is declared,</p>
     <li data-md="">
      <p><var>J</var> is the <a href="#idl-interface" id="ref-for-idl-interface-13">interface type</a> that <var>A</var> is declared to be of, and</p>
     <li data-md="">
@@ -8628,11 +8590,11 @@ extended attribute appears,</p>
    <p>then there must be another <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-48">attribute</a> <var>B</var> declared on <var>J</var> whose <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-53">identifier</a> is <var>N</var>.  Assignment of a value to the attribute <var>A</var> on an object implementing <var>I</var> will result in that value
 being assigned to attribute <var>B</var> of the object that <var>A</var> references, instead.</p>
    <p>Note that [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-6">PutForwards</a></code>]-annotated <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-49">attributes</a> can be
-chained.  That is, an attribute with the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-7">PutForwards</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-69">extended attribute</a> can refer to an attribute that itself has that extended attribute.
+chained.  That is, an attribute with the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-7">PutForwards</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-66">extended attribute</a> can refer to an attribute that itself has that extended attribute.
 There must not exist a cycle in a
 chain of forwarded assignments.  A cycle exists if, when following
 the chain of forwarded assignments, a particular attribute on
-an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-76">interface</a> is
+an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-73">interface</a> is
 encountered more than once.</p>
    <p>An attribute with the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-8">PutForwards</a></code>]
 extended attribute must not also be declared
@@ -8675,15 +8637,15 @@ is to be implemented.</p>
 <span class="nx">p</span><span class="p">.</span><span class="nx">name</span> <span class="o">=</span> <span class="s1">'John Citizen'</span><span class="p">;</span>       <span class="c1">// This statement...</span>
 <span class="nx">p</span><span class="p">.</span><span class="nx">name</span><span class="p">.</span><span class="nx">full</span> <span class="o">=</span> <span class="s1">'John Citizen'</span><span class="p">;</span>  <span class="c1">// ...has the same behavior as this one.</span></pre>
    </div>
-   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.16" data-lt="Replaceable" id="Replaceable"><span class="secno">4.3.16. </span><span class="content">[Replaceable]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-4">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-70">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-10">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-9">regular attribute</a>,
+   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.15" data-lt="Replaceable" id="Replaceable"><span class="secno">4.3.15. </span><span class="content">[Replaceable]</span></h4>
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-4">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-67">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-10">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-9">regular attribute</a>,
 it indicates that setting the corresponding property on the <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-15">platform object</a> will result in
 an own property with the same name being created on the object
 which has the value being assigned.  This property will shadow
 the accessor property corresponding to the attribute, which
 exists on the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-6">interface prototype object</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-5">Replaceable</a></code>]
-extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-13">take no arguments</a>.</p>
+extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-12">take no arguments</a>.</p>
    <p>An attribute with the [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-6">Replaceable</a></code>]
 extended attribute must not also be declared
 with the [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-9">LenientSetter</a></code>] or
@@ -8701,7 +8663,7 @@ a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callbac
 [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-10">Replaceable</a></code>] entails.</p>
    <div class="example" id="example-f33d3303">
     <a class="self-link" href="#example-f33d3303"></a> 
-    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-41">IDL fragment</a> defines an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-77">interface</a> with an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-57">operation</a> that increments a counter, and an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-52">attribute</a> that exposes the counter’s value, which is initially 0:</p>
+    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-41">IDL fragment</a> defines an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-74">interface</a> with an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-56">operation</a> that increments a counter, and an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-52">attribute</a> that exposes the counter’s value, which is initially 0:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Counter</span> {
   [<span class="nv">Replaceable</span>] <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <span class="nv">value</span>;
   <span class="kt">void</span> <span class="nv">increment</span>();
@@ -8730,13 +8692,13 @@ a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callbac
 <span class="k">delete</span> <span class="nx">counter</span><span class="p">.</span><span class="nx">value</span><span class="p">;</span>                                    <span class="c1">// Reveals the original property.</span>
 <span class="nx">counter</span><span class="p">.</span><span class="nx">value</span><span class="p">;</span>                                           <span class="c1">// Evaluates to 3.</span></pre>
    </div>
-   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.17" data-lt="SameObject" id="SameObject"><span class="secno">4.3.17. </span><span class="content">[SameObject]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-2">SameObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-71">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-12">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-54">attribute</a>, then it
+   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.16" data-lt="SameObject" id="SameObject"><span class="secno">4.3.16. </span><span class="content">[SameObject]</span></h4>
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-2">SameObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-68">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-12">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-54">attribute</a>, then it
 indicates that when getting the value of the attribute on a given
 object, the same value must always
 be returned.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-3">SameObject</a></code>]
-extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-14">take no arguments</a>.</p>
+extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-13">take no arguments</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-4">SameObject</a></code>]
 extended attribute must not
 be used on anything other than a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-13">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-55">attribute</a> whose type is an <a href="#idl-interface" id="ref-for-idl-interface-14">interface type</a> or <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-25">object</a></code>.</p>
@@ -8751,21 +8713,21 @@ be used on anything other than a <a data-link-type="dfn" href="#dfn-read-only" i
 };
 </pre>
    </div>
-   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.18" data-lt="SecureContext" id="SecureContext"><span class="secno">4.3.18. </span><span class="content">[SecureContext]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-9">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-72">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-78">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-11">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-8">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-4">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-17">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-5">namespace member</a>,
+   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.17" data-lt="SecureContext" id="SecureContext"><span class="secno">4.3.17. </span><span class="content">[SecureContext]</span></h4>
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-9">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-69">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-75">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-11">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-8">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-4">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-17">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-5">namespace member</a>,
 it indicates that the construct is exposed
 only within a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-10">SecureContext</a></code>]
-extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-15">take no arguments</a>.</p>
+extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-14">take no arguments</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-11">SecureContext</a></code>]
 extended attribute must not
-be used on anything other than an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-79">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-12">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-9">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-5">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-18">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-6">namespace member</a>.</p>
-   <p>Whether a construct that the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-12">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-73">extended attribute</a> can be specified on is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-available-only-in-secure-contexts">available only in secure contexts</dfn> is defined as follows:</p>
+be used on anything other than an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-76">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-12">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-9">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-5">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-18">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-6">namespace member</a>.</p>
+   <p>Whether a construct that the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-12">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-70">extended attribute</a> can be specified on is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-available-only-in-secure-contexts">available only in secure contexts</dfn> is defined as follows:</p>
    <ul>
     <li data-md="">
-     <p>If the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-13">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-74">extended attribute</a> is specified on the construct, then it is <a data-link-type="dfn" href="#dfn-available-only-in-secure-contexts" id="ref-for-dfn-available-only-in-secure-contexts-2">available only in secure contexts</a>.</p>
+     <p>If the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-13">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-71">extended attribute</a> is specified on the construct, then it is <a data-link-type="dfn" href="#dfn-available-only-in-secure-contexts" id="ref-for-dfn-available-only-in-secure-contexts-2">available only in secure contexts</a>.</p>
     <li data-md="">
-     <p>Otherwise, if the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-14">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-75">extended attribute</a> does not appear on a construct, then whether it is <a data-link-type="dfn" href="#dfn-available-only-in-secure-contexts" id="ref-for-dfn-available-only-in-secure-contexts-3">available only in secure contexts</a> depends on the type of construct:</p>
+     <p>Otherwise, if the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-14">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-72">extended attribute</a> does not appear on a construct, then whether it is <a data-link-type="dfn" href="#dfn-available-only-in-secure-contexts" id="ref-for-dfn-available-only-in-secure-contexts-3">available only in secure contexts</a> depends on the type of construct:</p>
      <dl class="switch">
       <dt data-md="">
        <p>interface</p>
@@ -8792,7 +8754,7 @@ is.</p>
    </ul>
    <p class="note" role="note">Note: Whether a construct is <a data-link-type="dfn" href="#dfn-available-only-in-secure-contexts" id="ref-for-dfn-available-only-in-secure-contexts-8">available only in secure contexts</a> influences whether it is <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-1">exposed</a> in a given
 ECMAScript global environment.</p>
-   <p>If [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-15">SecureContext</a></code>] appears on an <a data-link-type="dfn" href="#dfn-overloaded" id="ref-for-dfn-overloaded-3">overloaded</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-58">operation</a>,
+   <p>If [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-15">SecureContext</a></code>] appears on an <a data-link-type="dfn" href="#dfn-overloaded" id="ref-for-dfn-overloaded-3">overloaded</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-57">operation</a>,
 then it must appear on all overloads.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-16">SecureContext</a></code>] extended attribute
 must not be specified on both an interface member and the
@@ -8805,7 +8767,7 @@ that does specify [<code class="idl"><a data-link-type="idl" href="#SecureContex
    <div class="example" id="example-951337eb">
     <a class="self-link" href="#example-951337eb"></a> 
     <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-42">IDL fragment</a> defines an interface
-    with one <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-59">operation</a> that is executable from all
+    with one <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-58">operation</a> that is executable from all
     contexts, and two which are executable only from secure contexts.</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">PowerfulFeature</span> {
   // This call will succeed in all contexts.
@@ -8822,8 +8784,8 @@ that does specify [<code class="idl"><a data-link-type="idl" href="#SecureContex
 };
 </pre>
    </div>
-   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.19" data-lt="TreatNonObjectAsNull" id="TreatNonObjectAsNull"><span class="secno">4.3.19. </span><span class="content">[TreatNonObjectAsNull]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-5">TreatNonObjectAsNull</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-76">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-22">callback function</a>,
+   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.18" data-lt="TreatNonObjectAsNull" id="TreatNonObjectAsNull"><span class="secno">4.3.18. </span><span class="content">[TreatNonObjectAsNull]</span></h4>
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-5">TreatNonObjectAsNull</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-73">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-22">callback function</a>,
 then it indicates that any value assigned to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-56">attribute</a> whose type is a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-24">nullable</a> <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-23">callback function</a> that is not an object will be converted to
 the <emu-val>null</emu-val> value.</p>
    <p class="advisement"> Specifications should not use [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-6">TreatNonObjectAsNull</a></code>]
@@ -8838,7 +8800,7 @@ the <emu-val>null</emu-val> value.</p>
    <div class="example" id="example-5b770cce">
     <a class="self-link" href="#example-5b770cce"></a> 
     <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-43">IDL fragment</a> defines an interface that has one
-    attribute whose type is a [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-9">TreatNonObjectAsNull</a></code>]-annotated <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-25">callback function</a> and another whose type is a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-26">callback function</a> without the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-77">extended attribute</a>:</p>
+    attribute whose type is a [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-9">TreatNonObjectAsNull</a></code>]-annotated <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-25">callback function</a> and another whose type is a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-26">callback function</a> without the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-74">extended attribute</a>:</p>
 <pre class="highlight"><span class="kt">callback</span> <span class="nv">OccurrenceHandler</span> = <span class="kt">void</span> (<span class="kt">DOMString</span> <span class="nv">details</span>);
         
 [<span class="nv">TreatNonObjectAsNull</span>]
@@ -8869,8 +8831,8 @@ the <emu-val>null</emu-val> value.</p>
 <span class="nx">manager</span><span class="p">.</span><span class="nx">handler2</span> <span class="o">=</span> <span class="mi">123</span><span class="p">;</span>
 <span class="nx">manager</span><span class="p">.</span><span class="nx">handler2</span><span class="p">;</span>            <span class="c1">// Evaluates to null.</span></pre>
    </div>
-   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.20" data-lt="TreatNullAs" id="TreatNullAs"><span class="secno">4.3.20. </span><span class="content">[TreatNullAs]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#TreatNullAs" id="ref-for-TreatNullAs-8">TreatNullAs</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-78">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-57">attribute</a> or <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-60">operation</a> argument whose type is <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-43">DOMString</a></code>,
+   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.19" data-lt="TreatNullAs" id="TreatNullAs"><span class="secno">4.3.19. </span><span class="content">[TreatNullAs]</span></h4>
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#TreatNullAs" id="ref-for-TreatNullAs-8">TreatNullAs</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-75">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-57">attribute</a> or <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-59">operation</a> argument whose type is <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-43">DOMString</a></code>,
 it indicates that a <emu-val>null</emu-val> value
 assigned to the attribute or passed as the operation argument will be
 handled differently from its default handling.  Instead of being stringified
@@ -8921,16 +8883,16 @@ a non-callback interface.</p>
 <span class="nx">d</span><span class="p">.</span><span class="nx">isMemberOfBreed</span><span class="p">(</span><span class="kc">null</span><span class="p">);</span>  <span class="c1">// This passes the string "" to the isMemberOfBreed</span>
                           <span class="c1">// function.</span></pre>
    </div>
-   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.21" data-lt="Unforgeable" id="Unforgeable"><span class="secno">4.3.21. </span><span class="content">[Unforgeable]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-5">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-79">extended attribute</a> appears on a non-<a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-10">static</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-58">attribute</a> or non-<a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-10">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-61">operations</a>, it indicates
+   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.20" data-lt="Unforgeable" id="Unforgeable"><span class="secno">4.3.20. </span><span class="content">[Unforgeable]</span></h4>
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-5">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-76">extended attribute</a> appears on a non-<a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-10">static</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-58">attribute</a> or non-<a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-10">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-60">operations</a>, it indicates
 that the attribute or operation will be reflected as an ECMAScript property in
 a way that means its behavior cannot be modified and that performing
 a property lookup on the object will always result in the attribute’s
 property value being returned.  In particular, the property will be
 non-configurable and will exist as an own property on the object
 itself rather than on its prototype.</p>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-6">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-80">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-80">interface</a>,
-it indicates that all of the non-<a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-11">static</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-59">attributes</a> and non-<a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-11">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-62">operations</a> declared on
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-6">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-77">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-77">interface</a>,
+it indicates that all of the non-<a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-11">static</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-59">attributes</a> and non-<a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-11">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-61">operations</a> declared on
 that interface and its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-16">consequential interfaces</a> will be similarly reflected as own ECMAScript properties on objects
 that implement the interface, rather than on the prototype.</p>
    <p>An attribute or operation is said to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-unforgeable-on-an-interface">unforgeable</dfn> on a given interface <var>A</var> if any of the following are true:</p>
@@ -8938,22 +8900,22 @@ that implement the interface, rather than on the prototype.</p>
     <li data-md="">
      <p>The attribute or operation is declared on <var>A</var> or one
 of <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-17">consequential interfaces</a>,
-and is annotated with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-7">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-81">extended attribute</a>.</p>
+and is annotated with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-7">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-78">extended attribute</a>.</p>
     <li data-md="">
      <p>The attribute or operation is declared on <var>A</var> or one
 of <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-18">consequential interfaces</a>,
-and that interface is annotated with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-8">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-82">extended attribute</a>.</p>
+and that interface is annotated with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-8">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-79">extended attribute</a>.</p>
     <li data-md="">
-     <p>There exists an interface <var>B</var>, which is either <var>A</var> or one of <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-19">consequential interfaces</a>, <var>B</var> is annotated with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-9">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-83">extended attribute</a>,
+     <p>There exists an interface <var>B</var>, which is either <var>A</var> or one of <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-19">consequential interfaces</a>, <var>B</var> is annotated with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-9">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-80">extended attribute</a>,
 and the attribute or operation is declared on one of <var>B</var>’s consequential interfaces.</p>
    </ul>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-10">Unforgeable</a></code>]
-extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-16">take no arguments</a>.</p>
+extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-15">take no arguments</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-11">Unforgeable</a></code>]
 extended attribute must not appear on
 anything other than an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-60">attribute</a>,
-non-<a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-12">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-63">operation</a> or an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-81">interface</a>.  If it does
-appear on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-64">operation</a>, then
+non-<a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-12">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-62">operation</a> or an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-78">interface</a>.  If it does
+appear on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-63">operation</a>, then
 it must appear on all operations with
 the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-54">identifier</a> on that interface.</p>
    <p>If an attribute or operation <var>X</var> is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-1">unforgeable</a> on an interface <var>A</var>, and <var>A</var> is one of the <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces-15">inherited interfaces</a> of another interface <var>B</var>, then <var>B</var> and all of its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-20">consequential interfaces</a> must not have a non-static attribute or <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-11">regular operation</a> with the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-55">identifier</a> as <var>X</var>.</p>
@@ -9026,8 +8988,8 @@ the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifi
         
 <span class="nx">system</span><span class="p">.</span><span class="nx">loginTime</span><span class="p">;</span>  <span class="c1">// So this now evaluates to forgedLoginTime.</span></pre>
    </div>
-   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.22" data-lt="Unscopable" id="Unscopable"><span class="secno">4.3.22. </span><span class="content">[Unscopable]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-1">Unscopable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-84">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-10">regular attribute</a> or <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-12">regular operation</a>, it
+   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.21" data-lt="Unscopable" id="Unscopable"><span class="secno">4.3.21. </span><span class="content">[Unscopable]</span></h4>
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-1">Unscopable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-81">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-10">regular attribute</a> or <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-12">regular operation</a>, it
 indicates that an object that implements an interface with the given
 interface member will not include its property name in any object
 environment record with it as its base object.  The result of this is
@@ -9035,7 +8997,7 @@ that bare identifiers matching the property name will not resolve to
 the property in a <code>with</code> statement.  This is achieved by
 including the property name on the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-7">interface prototype object</a>’s <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@unscopables</a> property’s value.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-2">Unscopable</a></code>]
-extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-17">take no arguments</a>.</p>
+extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-16">take no arguments</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-3">Unscopable</a></code>]
 extended attribute must not appear on
 anything other than a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-11">regular attribute</a> or <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-13">regular operation</a>.</p>
@@ -9058,7 +9020,7 @@ anything other than a <a data-link-type="dfn" href="#dfn-regular-attribute" id="
    </div>
    <h3 class="heading settled" data-level="4.4" id="es-security"><span class="secno">4.4. </span><span class="content">Security</span><a class="self-link" href="#es-security"></a></h3>
    <p>Certain algorithms in the sections below are defined to <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-perform-a-security-check">perform a security check</dfn> on a given
-object.  This check is used to determine whether a given <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-65">operation</a> invocation or <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-62">attribute</a> access should be
+object.  This check is used to determine whether a given <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-64">operation</a> invocation or <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-62">attribute</a> access should be
 allowed.  The security check takes the following four inputs:</p>
    <ol>
     <li data-md="">
@@ -9080,7 +9042,7 @@ security check is performed, and that it will either throw an
 appropriate exception or return normally. <a data-link-type="biblio" href="#biblio-html">[HTML]</a></p>
    <h3 class="heading settled" data-level="4.5" id="es-overloads"><span class="secno">4.5. </span><span class="content">Overload resolution algorithm</span><a class="self-link" href="#es-overloads"></a></h3>
    <p>In order to define how overloaded function invocations are resolved, the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-overload-resolution-algorithm">overload resolution algorithm</dfn> is defined.  Its input is an <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-4">effective overload set</a>, <var>S</var>, and a list of ECMAScript values, <var>arg</var><sub>0..<var>n</var>−1</sub>.
-Its output is a pair consisting of the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-66">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-85">extended attribute</a> of one of <var>S</var>’s entries
+Its output is a pair consisting of the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-65">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-82">extended attribute</a> of one of <var>S</var>’s entries
 and a list of IDL values or the special value “missing”.  The algorithm behaves as follows:</p>
    <ol class="algorithm">
     <li data-md="">
@@ -9381,7 +9343,7 @@ that has one of the above types in its <a data-link-type="dfn" href="#dfn-flatte
        <p>Otherwise: <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-41">throw a <emu-val>TypeError</emu-val></a>.</p>
      </ol>
     <li data-md="">
-     <p>Let <var>callable</var> be the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-67">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-86">extended attribute</a> of the single entry in <var>S</var>.</p>
+     <p>Let <var>callable</var> be the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-66">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-83">extended attribute</a> of the single entry in <var>S</var>.</p>
     <li data-md="">
      <p>If <var>i</var> = <var>d</var> and <var>method</var> is not <emu-val>undefined</emu-val>, then</p>
      <ol>
@@ -9485,14 +9447,14 @@ If there are none, then a <emu-val>TypeError</emu-val> is thrown.</p>
     of variadic argument as would be done for a non-optional argument.</p>
    </div>
    <h3 class="heading settled" data-level="4.6" id="es-interfaces"><span class="secno">4.6. </span><span class="content">Interfaces</span><a class="self-link" href="#es-interfaces"></a></h3>
-   <p>For every <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-82">interface</a> that
+   <p>For every <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-79">interface</a> that
 is <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-2">exposed</a> in a given
 ECMAScript global environment and:</p>
    <ul>
     <li data-md="">
      <p>is a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-25">callback interface</a> that has <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-20">constants</a> declared on it, or</p>
     <li data-md="">
-     <p>is a non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-83">interface</a> that is not declared with the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-13">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-87">extended attribute</a>,</p>
+     <p>is a non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-80">interface</a> that is not declared with the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-13">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-84">extended attribute</a>,</p>
    </ul>
    <p>a corresponding property must exist on the
 ECMAScript environment’s global object.
@@ -9508,7 +9470,7 @@ construction of objects that implement the interface.  The property has the
 attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.
 The characteristics of a named constructor are described in <a href="#named-constructors">§4.6.2 Named constructors</a>.</p>
    <h4 class="heading settled" data-level="4.6.1" id="interface-object"><span class="secno">4.6.1. </span><span class="content">Interface object</span><a class="self-link" href="#interface-object"></a></h4>
-   <p>The interface object for a given non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-84">interface</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-3">function object</a>.
+   <p>The interface object for a given non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-81">interface</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-3">function object</a>.
 It has properties that correspond to
 the <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-21">constants</a> and <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-13">static operations</a> defined on that interface, as described in sections <a href="#es-constants">§4.6.5 Constants</a> and <a href="#es-operations">§4.6.7 Operations</a>.</p>
    <p>The [[Prototype]] internal property of
@@ -9536,21 +9498,21 @@ the Object.prototype object.</p>
    <p class="note" role="note">Note: Remember that interface objects for callback interfaces only exist if they have <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-22">constants</a> declared on them;
 when they do exist, they are not <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-5">function objects</a>.</p>
    <h5 class="heading settled" data-level="4.6.1.1" id="es-interface-call"><span class="secno">4.6.1.1. </span><span class="content">Interface object [[Call]] method</span><a class="self-link" href="#es-interface-call"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-85">interface</a> is declared with a
-[<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-20">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-88">extended attribute</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-82">interface</a> is declared with a
+[<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-20">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-85">extended attribute</a>,
 then the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-7">interface object</a> can be called as a function to create an object that implements that
 interface.  Interfaces that do not have a constructor will throw
 an exception when called as a function.</p>
    <p>The internal [[Call]] method
 of the interface object behaves as follows, assuming <var>arg</var><sub>0..<var>n</var>−1</sub> is the list
-of argument values passed to the constructor, and <var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-86">interface</a>:</p>
+of argument values passed to the constructor, and <var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-83">interface</a>:</p>
    <ol class="algorithm">
     <li data-md="">
-     <p>If <var>I</var> was not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-21">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-89">extended attribute</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-42">throw a <emu-val>TypeError</emu-val></a>.</p>
+     <p>If <var>I</var> was not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-21">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-86">extended attribute</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-42">throw a <emu-val>TypeError</emu-val></a>.</p>
     <li data-md="">
      <p>Let <var>id</var> be the identifier of interface <var>I</var>.</p>
     <li data-md="">
-     <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-5">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-58">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-87">interface</a> <var>I</var> and with argument count <var>n</var>.</p>
+     <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-5">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-58">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-84">interface</a> <var>I</var> and with argument count <var>n</var>.</p>
     <li data-md="">
      <p>Let &lt;<var>constructor</var>, <var>values</var>> be the result of passing <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to the <a data-link-type="dfn" href="#dfn-overload-resolution-algorithm" id="ref-for-dfn-overload-resolution-algorithm-1">overload resolution algorithm</a>.</p>
     <li data-md="">
@@ -9566,13 +9528,13 @@ associated with the ECMAScript global environment associated
 with the interface object.</p>
    <p>Interface objects for non-callback interfaces must have a property named “length”
 with attributes <span class="descriptor">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> whose value is a <emu-val>Number</emu-val>.
-If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-22">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-90">extended attribute</a> does not appear on the interface definition, then the value is 0.
+If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-22">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-87">extended attribute</a> does not appear on the interface definition, then the value is 0.
 Otherwise, the value is determined as follows:</p>
    <ol class="algorithm">
     <li data-md="">
      <p>Let <var>id</var> be the identifier of interface <var>I</var>.</p>
     <li data-md="">
-     <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-6">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-59">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-88">interface</a> <var>I</var> and with argument count 0.</p>
+     <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-6">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-59">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-85">interface</a> <var>I</var> and with argument count 0.</p>
     <li data-md="">
      <p>Return the length of the shortest argument list of the entries in <var>S</var>.</p>
    </ol>
@@ -9607,7 +9569,7 @@ return <emu-val>true</emu-val>.</p>
    </ol>
    <h4 class="heading settled" data-level="4.6.2" id="named-constructors"><span class="secno">4.6.2. </span><span class="content">Named constructors</span><a class="self-link" href="#named-constructors"></a></h4>
    <p>A <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-2">named constructor</a> that exists due to one or more
-[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-17">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-91">extended attributes</a> with a given <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-60">identifier</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-6">function object</a>.
+[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-17">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-88">extended attributes</a> with a given <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-60">identifier</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-6">function object</a>.
 It must have a [[Call]]
 internal property, which allows construction of objects that
 implement the interface on which the
@@ -9615,11 +9577,11 @@ implement the interface on which the
 extended attributes appear.  It behaves as follows, assuming <var>arg</var><sub>0..<var>n</var>−1</sub> is the list
 of argument values passed to the constructor, <var>id</var> is the identifier of the constructor specified in the
 extended attribute <a data-link-type="dfn" href="#dfn-xattr-named-argument-list" id="ref-for-dfn-xattr-named-argument-list-4">named argument list</a>,
-and <var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-89">interface</a> on which the [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-19">NamedConstructor</a></code>]
+and <var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-86">interface</a> on which the [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-19">NamedConstructor</a></code>]
 extended attribute appears:</p>
    <ol class="algorithm">
     <li data-md="">
-     <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-7">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-61">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-90">interface</a> <var>I</var> and with argument count <var>n</var>.</p>
+     <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-7">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-61">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-87">interface</a> <var>I</var> and with argument count <var>n</var>.</p>
     <li data-md="">
      <p>Let &lt;<var>constructor</var>, <var>values</var>> be the result of passing <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to the <a data-link-type="dfn" href="#dfn-overload-resolution-algorithm" id="ref-for-dfn-overload-resolution-algorithm-2">overload resolution algorithm</a>.</p>
     <li data-md="">
@@ -9637,18 +9599,18 @@ with the <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-n
 with attributes <span class="descriptor">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> whose value is a <emu-val>Number</emu-val> determined as follows:</p>
    <ol class="algorithm">
     <li data-md="">
-     <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-8">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-62">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-91">interface</a> <var>I</var> and with argument count 0.</p>
+     <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-8">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-62">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-88">interface</a> <var>I</var> and with argument count 0.</p>
     <li data-md="">
      <p>Return the length of the shortest argument list of the entries in <var>S</var>.</p>
    </ol>
    <p>A named constructor must have a property named “name”
 with attributes <span class="descriptor">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> whose value is the identifier used for the named constructor.</p>
    <p>A named constructor must also have a property named
-“prototype” with attributes <span class="descriptor">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span> whose value is the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-9">interface prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-92">interface</a> on which the
-[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-20">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-92">extended attribute</a> appears.</p>
+“prototype” with attributes <span class="descriptor">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span> whose value is the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-9">interface prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-89">interface</a> on which the
+[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-20">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-89">extended attribute</a> appears.</p>
    <h4 class="heading settled" data-level="4.6.3" id="interface-prototype-object"><span class="secno">4.6.3. </span><span class="content">Interface prototype object</span><a class="self-link" href="#interface-prototype-object"></a></h4>
-   <p>There must exist an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-10">interface prototype object</a> for every non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-93">interface</a> defined, regardless of whether the interface was declared with the
-[<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-14">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-93">extended attribute</a>.
+   <p>There must exist an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-10">interface prototype object</a> for every non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-90">interface</a> defined, regardless of whether the interface was declared with the
+[<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-14">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-90">extended attribute</a>.
 The interface prototype object for a particular interface has
 properties that correspond to the <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-13">regular attributes</a> and <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-15">regular operations</a> defined on that interface.  These properties are described in more detail in
 sections <a href="#es-attributes">§4.6.6 Attributes</a> and <a href="#es-operations">§4.6.7 Operations</a>.</p>
@@ -9666,7 +9628,7 @@ the following steps:</p>
    <ol class="algorithm">
     <li data-md="">
      <p>If <var>A</var> is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-31">Global</a></code>]
-or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-32">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-94">extended attribute</a>, and <var>A</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-3">supports named properties</a>, then
+or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-32">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-91">extended attribute</a>, and <var>A</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-3">supports named properties</a>, then
 return the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-5">named properties object</a> for <var>A</var>, as defined in <a href="#named-properties-object">§4.6.4 Named properties object</a>.</p>
     <li data-md="">
      <p>Otherwise, if <var>A</var> is declared to inherit from another
@@ -9678,8 +9640,8 @@ extended attribute, then return <a data-link-type="dfn" href="https://tc39.githu
      <p>Otherwise, return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a>.</p>
    </ol>
    <div class="note" role="note">
-    <p>The <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-13">interface prototype object</a> of an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-94">interface</a> that is defined with
-    the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-16">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-95">extended attribute</a> will be accessible if the interface is used as a <a data-link-type="dfn" href="#dfn-supplemental-interface" id="ref-for-dfn-supplemental-interface-5">non-supplemental interface</a>.
+    <p>The <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-13">interface prototype object</a> of an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-91">interface</a> that is defined with
+    the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-16">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-92">extended attribute</a> will be accessible if the interface is used as a <a data-link-type="dfn" href="#dfn-supplemental-interface" id="ref-for-dfn-supplemental-interface-5">non-supplemental interface</a>.
     For example, with the following IDL:</p>
 <pre class="highlight">[<span class="nv">NoInterfaceObject</span>]
 <span class="kt">interface</span> <span class="nv">Foo</span> {
@@ -9718,15 +9680,15 @@ interface member, <emu-val>true</emu-val>).</p>
      <p>Return <var>object</var>.</p>
    </ol>
    <p>If the interface is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-33">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-34">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-96">extended attribute</a>, or the interface is in the set
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-34">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-93">extended attribute</a>, or the interface is in the set
 of <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces-16">inherited interfaces</a> for any
 other interface that is declared with one of these attributes, then the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-14">interface prototype object</a> must be an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">immutable prototype exotic object</a>.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-1">class string</a> of an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-15">interface prototype object</a> is the concatenation of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-95">interface</a>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-64">identifier</a> and the string
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-1">class string</a> of an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-15">interface prototype object</a> is the concatenation of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-92">interface</a>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-64">identifier</a> and the string
 “Prototype”.</p>
    <h4 class="heading settled" data-level="4.6.4" id="named-properties-object"><span class="secno">4.6.4. </span><span class="content">Named properties object</span><a class="self-link" href="#named-properties-object"></a></h4>
-   <p>For every <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-96">interface</a> declared with the
+   <p>For every <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-93">interface</a> declared with the
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-35">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-36">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-97">extended attribute</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-4">supports named properties</a>,
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-36">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-94">extended attribute</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-4">supports named properties</a>,
 there must exist an object known as the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-named-properties-object">named properties object</dfn> for that
 interface.</p>
    <p>The <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-6">named properties object</a> for a given interface <var>A</var> must have an internal
@@ -9741,17 +9703,17 @@ extended attribute, then return <a data-link-type="dfn" href="https://tc39.githu
     <li data-md="">
      <p>Otherwise, return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a>.</p>
    </ol>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-2">class string</a> of a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-7">named properties object</a> is the concatenation of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-97">interface</a>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-65">identifier</a> and the string
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-2">class string</a> of a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-7">named properties object</a> is the concatenation of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-94">interface</a>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-65">identifier</a> and the string
 “Properties”.</p>
    <h5 class="heading settled" data-level="4.6.4.1" id="named-properties-object-getownproperty"><span class="secno">4.6.4.1. </span><span class="content">Named properties object [[GetOwnProperty]] method</span><a class="self-link" href="#named-properties-object-getownproperty"></a></h5>
    <p>When the [[GetOwnProperty]] internal method of a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-8">named properties object</a> <var>O</var> is called with property key <var>P</var>, the following steps are
 taken:</p>
    <ol class="algorithm">
     <li data-md="">
-     <p>Let <var>A</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-98">interface</a> for the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-9">named properties object</a> <var>O</var>.</p>
+     <p>Let <var>A</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-95">interface</a> for the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-9">named properties object</a> <var>O</var>.</p>
     <li data-md="">
      <p>Let <var>object</var> be the sole object from <var>O</var>’s ECMAScript global environment that implements <var>A</var>.</p>
-     <p class="note" role="note">Note: For example, if the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-99">interface</a> is the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> interface,
+     <p class="note" role="note">Note: For example, if the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-96">interface</a> is the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> interface,
 then the sole object will be this global environment’s window object.</p>
     <li data-md="">
      <p>If the result of running the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-1">named property visibility algorithm</a> with
@@ -9773,7 +9735,7 @@ of performing the steps listed in the description of <var>operation</var> with <
        <p>Set <var>desc</var>.[[Value]] to the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-38">converting</a> <var>value</var> to an ECMAScript value.</p>
       <li data-md="">
        <p>If <var>A</var> implements an interface with the
-[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-5">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-98">extended attribute</a>,
+[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-5">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-95">extended attribute</a>,
 then set <var>desc</var>.[[Enumerable]] to <emu-val>false</emu-val>,
 otherwise set it to <emu-val>true</emu-val>.</p>
       <li data-md="">
@@ -9803,7 +9765,7 @@ following steps are taken:</p>
 called, the same algorithm must be executed as is defined for the [[SetPrototypeOf]] internal method of an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">immutable prototype exotic object</a>.</p>
    <h4 class="heading settled" data-level="4.6.5" id="es-constants"><span class="secno">4.6.5. </span><span class="content">Constants</span><a class="self-link" href="#es-constants"></a></h4>
    <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-4">exposed</a> <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-24">constant</a> defined on
-an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-100">interface</a> <var>A</var>, there
+an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-97">interface</a> <var>A</var>, there
 must be a corresponding property.
 The property has the following characteristics:</p>
    <ul>
@@ -9832,7 +9794,7 @@ the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-pro
 exist on the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-12">interface object</a>, if
 that object exists.</p>
    <h4 class="heading settled" data-level="4.6.6" id="es-attributes"><span class="secno">4.6.6. </span><span class="content">Attributes</span><a class="self-link" href="#es-attributes"></a></h4>
-   <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-5">exposed</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-63">attribute</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-101">interface</a>, whether it
+   <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-5">exposed</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-63">attribute</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-98">interface</a>, whether it
 was declared on the interface itself or one of its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-23">consequential interfaces</a>,
 there must exist a corresponding property.
 The characteristics of this property are as follows:</p>
@@ -9878,7 +9840,7 @@ declared with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable"
        <p>If the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-65">attribute</a> is a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-14">regular attribute</a>, then:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>I</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-102">interface</a> whose <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-21">interface prototype object</a> this property corresponding to the attribute appears on.</p>
+         <p>Let <var>I</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-99">interface</a> whose <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-21">interface prototype object</a> this property corresponding to the attribute appears on.</p>
          <p class="note" role="note">Note: This means that even if an implements statement was used to make
 an attribute available on the interface, <var>I</var> is the interface
 on the left hand side of the implements statement, and not the one
@@ -9904,7 +9866,7 @@ implements the <a data-link-type="dfn" href="#dfn-attribute-getter" id="ref-for-
          <ol>
           <li data-md="">
            <p>If the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-67">attribute</a> was specified with the
-[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-8">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-99">extended attribute</a>,
+[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-8">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-96">extended attribute</a>,
 then return <emu-val>undefined</emu-val>.</p>
           <li data-md="">
            <p>Otherwise, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-44">throw a <emu-val>TypeError</emu-val></a>.</p>
@@ -9930,7 +9892,7 @@ concatenation of “get ” and the identifier of the attribute.</p>
     <li data-md="">
      <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-attribute-setter">attribute setter</dfn> is <emu-val>undefined</emu-val> if the attribute is declared <code>readonly</code> and does not have a
 [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-9">LenientThis</a></code>], [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-15">PutForwards</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-11">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-100">extended attribute</a> declared on it.
+[<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-11">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-97">extended attribute</a> declared on it.
 Otherwise, it is a <emu-val>Function</emu-val> object whose behavior when invoked is as follows:</p>
      <ol class="algorithm">
       <li data-md="">
@@ -9941,7 +9903,7 @@ Otherwise, it is a <emu-val>Function</emu-val> object whose behavior when invoke
        <p>If the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-68">attribute</a> is a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-15">regular attribute</a>, then:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>I</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-103">interface</a> whose <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-22">interface prototype object</a> this property corresponding to the attribute appears on.</p>
+         <p>Let <var>I</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-100">interface</a> whose <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-22">interface prototype object</a> this property corresponding to the attribute appears on.</p>
         <li data-md="">
          <p>Let <var>O</var> be the <strong>this</strong> value.</p>
         <li data-md="">
@@ -9962,7 +9924,7 @@ implements the <a data-link-type="dfn" href="#dfn-attribute-setter" id="ref-for-
          <p>Let <var>validThis</var> be <emu-val>true</emu-val> if <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-22">platform object</a> that implements <var>I</var>, or <emu-val>false</emu-val> otherwise.</p>
         <li data-md="">
          <p>If <var>validThis</var> is <emu-val>false</emu-val> and the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-70">attribute</a> was not specified with the
-[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-10">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-101">extended attribute</a>,
+[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-10">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-98">extended attribute</a>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-46">throw a <emu-val>TypeError</emu-val></a>.</p>
         <li data-md="">
          <p>If the attribute is declared with a [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-12">Replaceable</a></code>]
@@ -10035,9 +9997,9 @@ accessed, they are able to expose instance-specific data.</p>
    <p class="note" role="note">Note: Note that attempting to assign to a property corresponding to a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-14">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-71">attribute</a> results in different behavior depending on whether the script doing so is in strict mode.
 When in strict mode, such an assignment will result in a <emu-val>TypeError</emu-val> being thrown.  When not in strict mode, the assignment attempt will be ignored.</p>
    <h4 class="heading settled" data-level="4.6.7" id="es-operations"><span class="secno">4.6.7. </span><span class="content">Operations</span><a class="self-link" href="#es-operations"></a></h4>
-   <p>For each unique <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-71">identifier</a> of an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-6">exposed</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-68">operation</a> defined on the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-104">interface</a>, there
+   <p>For each unique <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-71">identifier</a> of an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-6">exposed</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-67">operation</a> defined on the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-101">interface</a>, there
 must exist a corresponding property,
-unless the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-9">effective overload set</a> for that <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-72">identifier</a> and <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-69">operation</a> and with an argument count of 0 has no entries.</p>
+unless the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-9">effective overload set</a> for that <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-72">identifier</a> and <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-68">operation</a> and with an argument count of 0 has no entries.</p>
    <p>The characteristics of this property are as follows:</p>
    <ul>
     <li data-md="">
@@ -10065,101 +10027,21 @@ the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-pro
 where <var>B</var> is <emu-val>false</emu-val> if the operation is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-4">unforgeable</a> on the interface,
 and <emu-val>true</emu-val> otherwise.</p>
     <li data-md="">
-     <p>The value of the property is a <emu-val>Function</emu-val> object whose
-behavior is as follows,
-assuming <var>id</var> is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-74">identifier</a>, <var>arg</var><sub>0..<var>n</var>−1</sub> is the list
-of argument values passed to the function:</p>
-     <ol class="algorithm">
-      <li data-md="">
-       <p>Try running the following steps:</p>
-       <ol>
-        <li data-md="">
-         <p>Let <var>I</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-105">interface</a> whose <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-25">interface prototype object</a> (or <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-15">interface object</a>, for a static
-operation) this property corresponding to the operation appears on.</p>
-         <p class="note" role="note">Note: This means that even if an implements statement was used to make
-an operation available on the interface, <var>I</var> is the interface
-on the left hand side of the implements statement, and not the one
-that the operation was originally declared on.</p>
-        <li data-md="">
-         <p>Let <var>O</var> be a value determined as follows:</p>
-         <ul>
-          <li data-md="">
-           <p>If the operation is a static operation, then <var>O</var> is <emu-val>null</emu-val>.</p>
-          <li data-md="">
-           <p>Otherwise, if the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-106">interface</a> on which the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-70">operation</a> appears has an
-[<code class="idl"><a data-link-type="idl" href="#ImplicitThis" id="ref-for-ImplicitThis-8">ImplicitThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-102">extended attribute</a>,
-and the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, then <var>O</var> is
-the ECMAScript global object associated with the <emu-val>Function</emu-val> object.</p>
-          <li data-md="">
-           <p>Otherwise, if the <emu-val>this</emu-val> value is not <emu-val>null</emu-val>,
-then <var>O</var> is the <emu-val>this</emu-val> value.</p>
-          <li data-md="">
-           <p>Otherwise, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-48">throw a <emu-val>TypeError</emu-val></a>.</p>
-         </ul>
-        <li data-md="">
-         <p>If <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-23">platform object</a>,
-then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-dfn-perform-a-security-check-3">perform a security check</a>, passing:</p>
-         <ul>
-          <li data-md="">
-           <p>the platform object <var>O</var>,</p>
-          <li data-md="">
-           <p>the ECMAScript global environment associated with this <emu-val>Function</emu-val> that
-implements the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-71">operation</a>,</p>
-          <li data-md="">
-           <p>the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-75">identifier</a> of the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-72">operation</a>, and</p>
-          <li data-md="">
-           <p>the type “method”.</p>
-         </ul>
-        <li data-md="">
-         <p>If <var>O</var> is not <emu-val>null</emu-val> and is also not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-24">platform object</a> that implements interface <var>I</var>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-49">throw a <emu-val>TypeError</emu-val></a>.</p>
-        <li data-md="">
-         <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-10">effective overload set</a> for <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-16">regular operations</a> (if the operation is a regular operation) or for <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-15">static operations</a> (if the operation is a static operation) with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-76">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-107">interface</a> <var>I</var> and with argument count <var>n</var>.</p>
-        <li data-md="">
-         <p>Let &lt;<var>operation</var>, <var>values</var>> be the result of passing <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to the <a data-link-type="dfn" href="#dfn-overload-resolution-algorithm" id="ref-for-dfn-overload-resolution-algorithm-3">overload resolution algorithm</a>.</p>
-        <li data-md="">
-         <p>Let <var>R</var> be the result of performing (on <var>O</var>, if the operation
-is not a static operation) the actions listed in the description of <var>operation</var> with <var>values</var> as the argument values.</p>
-        <li data-md="">
-         <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-41">converting</a> <var>R</var> to an ECMAScript value of
-the type <var>op</var> is declared to return.</p>
-       </ol>
-       <p>And then, if an exception was thrown:</p>
-       <ol>
-        <li data-md="">
-         <p>If the operation has a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-5">return type</a> that is a <a href="#idl-promise" id="ref-for-idl-promise-9">promise type</a>, then:</p>
-         <ol>
-          <li data-md="">
-           <p>Let <var>reject</var> be the initial value of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.</p>
-          <li data-md="">
-           <p>Return the result of calling <var>reject</var> with <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a> as the <emu-val>this</emu-val> object and the exception as the single
-argument value.</p>
-         </ol>
-        <li data-md="">
-         <p>Otherwise, end these steps and allow the exception to propagate.</p>
-       </ol>
-     </ol>
-    <li data-md="">
-     <p>The value of the <emu-val>Function</emu-val> object’s “length”
-property is a <emu-val>Number</emu-val> determined as follows:</p>
-     <ol class="algorithm">
-      <li data-md="">
-       <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-11">effective overload set</a> for <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-17">regular operations</a> (if the operation is a regular operation) or for <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-16">static operations</a> (if the operation is a static operation) with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-77">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-108">interface</a> <var>I</var> and with argument count 0.</p>
-      <li data-md="">
-       <p>Return the length of the shortest argument list of the entries in <var>S</var>.</p>
-     </ol>
-    <li data-md="">
-     <p>The value of the <emu-val>Function</emu-val> object’s “name”
-property is a <emu-val>String</emu-val> whose value is the
-identifier of the operation.</p>
+     <p>The value of the property is the result of <a data-link-type="dfn" href="#dfn-create-operation-function" id="ref-for-dfn-create-operation-function-1">creating an operation function</a> given the
+operation, the interface (or the interface it’s being mixed in to, if the interface is actually
+a mixin), and the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">relevant Realm</a> of the object that is the location of the property.</p>
+     <p class="note" role="note">Note: that is, even if an <a data-link-type="dfn" href="#dfn-implements-statement" id="ref-for-dfn-implements-statement-6">implements statement</a> was used to make an operation
+available on the interface, we pass in the interface on the left-hand side of the <a data-link-type="dfn" href="#dfn-implements-statement" id="ref-for-dfn-implements-statement-7">implements statement</a>, and not the really-a-mixin interface on the right-hand side,
+where the operation was originally declared.</p>
    </ul>
-   <p>We also define <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dfn-create-operation-function">creating an operation function</dfn>, given an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-73">operation</a> <var>op</var>, a <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-10">namespace</a> <var>namespace</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>:</p>
-   <p class="note" role="note">Note: The astute reader may notice that what follows is very similar to the
-above algorithm for operations on interfaces. It is currently only used for namespaces,
-but we have near-future plans to generalize it slightly and then replace the above
-definition so that this algorithm is useful both for interfaces and namespaces.</p>
+   <p class="advisement"> The above description has some bugs, especially around partial interfaces. See <a href="https://github.com/heycam/webidl/issues/164">issue #164</a>. </p>
+   <p>For <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-10">namespaces</a>, the properties corresponding to each declared operation are described in <a href="#namespace-object">§4.11.1 Namespace object</a>. (We hope to eventually move interfaces to the same explicit
+property-installation style as namespaces.)</p>
+   <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="creating an operation function" data-noexport="" id="dfn-create-operation-function">create an operation function</dfn>,
+given an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-69">operation</a> <var>op</var>, a <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-11">namespace</a> or <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-102">interface</a> <var>target</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>:</p>
    <ol>
     <li data-md="">
-     <p>Let <var>id</var> be <var>op</var>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-78">identifier</a>.</p>
+     <p>Let <var>id</var> be <var>op</var>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-74">identifier</a>.</p>
     <li data-md="">
      <p>Let <var>steps</var> be the following series of steps, given function argument
 values <var>arg</var><sub>0..<var>n</var>−1</sub>:</p>
@@ -10168,22 +10050,38 @@ values <var>arg</var><sub>0..<var>n</var>−1</sub>:</p>
        <p>Try running the following steps:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-12">effective overload set</a> for <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-18">regular operations</a> with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-79">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-11">namespace</a> <var>namespace</var> and with argument count <var>n</var>.</p>
+         <p>Let <var>O</var> be <emu-val>null</emu-val>.</p>
         <li data-md="">
-         <p>Let &lt;<var>operation</var>, <var>values</var>> be the result of passing <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to the <a data-link-type="dfn" href="#dfn-overload-resolution-algorithm" id="ref-for-dfn-overload-resolution-algorithm-4">overload resolution algorithm</a>.</p>
+         <p>If <var>target</var> is an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-103">interface</a>, and <var>op</var> is not a <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-15">static operation</a>:</p>
+         <ol>
+          <li data-md="">
+           <p>If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, set <var>O</var> to <var>realm</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global">global object</a>. (This
+will subsequently cause a <emu-val>TypeError</emu-val> in a few steps, if the global
+object does not implement <var>target</var>.)</p>
+          <li data-md="">
+           <p>Otherwise, set <var>O</var> to the <emu-val>this</emu-val> value.</p>
+          <li data-md="">
+           <p>If <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-23">platform object</a>, then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-dfn-perform-a-security-check-3">perform a security check</a>, passing <var>O</var>, <var>realm</var>, <var>id</var>, and "method".</p>
+          <li data-md="">
+           <p>If <var>O</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-24">platform object</a> that implements the interface <var>target</var>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-48">throw a <emu-val>TypeError</emu-val></a>.</p>
+         </ol>
+        <li data-md="">
+         <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-10">effective overload set</a> for <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-16">regular operations</a> (if <var>op</var> is a
+regular operation) or for <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-16">static operations</a> (if <var>op</var> is a static operation) with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-75">identifier</a> <var>id</var> on <var>target</var> and with argument count <var>n</var>.</p>
+        <li data-md="">
+         <p>Let &lt;<var>operation</var>, <var>values</var>> be the result of passing <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to the <a data-link-type="dfn" href="#dfn-overload-resolution-algorithm" id="ref-for-dfn-overload-resolution-algorithm-3">overload resolution algorithm</a>.</p>
         <li data-md="">
          <p>Let <var>R</var> be the result of performing the actions listed in the
-description of <var>operation</var> with <var>values</var> as the argument
-values.</p>
+description of <var>operation</var>, on <var>O</var> if <var>O</var> is not <emu-val>null</emu-val>, with <var>values</var> as the argument values.</p>
         <li data-md="">
-         <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-42">converting</a> <var>R</var> to
+         <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-41">converting</a> <var>R</var> to
 an ECMAScript value of the type <var>op</var> is declared to return.</p>
        </ol>
      </ol>
      <p>And then, if an exception was thrown:</p>
      <ol>
       <li data-md="">
-       <p>If the operation has a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-6">return type</a> that is a <a href="#idl-promise" id="ref-for-idl-promise-10">promise type</a>, then:</p>
+       <p>If the operation has a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-5">return type</a> that is a <a href="#idl-promise" id="ref-for-idl-promise-9">promise type</a>, then:</p>
        <ol>
         <li data-md="">
          <p>Let <var>reject</var> be the initial value of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.</p>
@@ -10199,16 +10097,17 @@ and the exception as the single argument value.</p>
     <li data-md="">
      <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-setfunctionname">SetFunctionName</a>(<var>F</var>, <var>id</var>).</p>
     <li data-md="">
-     <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-13">effective overload set</a> for <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-19">regular operations</a> with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-80">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-12">namespace</a> <var>namespace</var> and with argument count 0.</p>
+     <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-11">effective overload set</a> for <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-17">regular operations</a> (if <var>op</var> is a regular
+operation) or for <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-17">static operations</a> (if <var>op</var> is a static operation) with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-76">identifier</a> <var>id</var> on <var>target</var> and with argument count 0.</p>
     <li data-md="">
      <p>Let <var>length</var> be the length of the shortest argument list in the entries in <var>S</var>.</p>
     <li data-md="">
-     <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow">DefinePropertyOrThrow</a>(<var>F</var>, <code>"length"</code>,
+     <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow">DefinePropertyOrThrow</a>(<var>F</var>, "length",
 PropertyDescriptor<span class="descriptor">{[[Value]]: <var>length</var>,
 [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val>}</span>).</p>
    </ol>
    <h5 class="heading settled" data-level="4.6.7.1" id="es-stringifier"><span class="secno">4.6.7.1. </span><span class="content">Stringifiers</span><a class="self-link" href="#es-stringifier"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-109">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-7">exposed</a> <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-3">stringifier</a>, then
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-104">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-7">exposed</a> <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-3">stringifier</a>, then
 there must exist a property with
 the following characteristics:</p>
    <ul>
@@ -10218,7 +10117,7 @@ the following characteristics:</p>
      <p>If the <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-4">stringifier</a> is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-5">unforgeable</a> on the interface
 or if the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-55">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-56">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on every object that implements the interface.
-Otherwise, the property exists on the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-26">interface prototype object</a>.</p>
+Otherwise, the property exists on the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-25">interface prototype object</a>.</p>
     <li data-md="">
      <p>The property has attributes <span class="descriptor">{ [[Writable]]: <var>B</var>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <var>B</var> }</span>,
 where <var>B</var> is <emu-val>false</emu-val> if the stringifier is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-6">unforgeable</a> on the interface,
@@ -10238,12 +10137,12 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
          <p>the ECMAScript global environment associated with this <emu-val>Function</emu-val> that
 implements the <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-5">stringifier</a>,</p>
         <li data-md="">
-         <p>the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-81">identifier</a> of the <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-6">stringifier</a>, and</p>
+         <p>the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-77">identifier</a> of the <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-6">stringifier</a>, and</p>
         <li data-md="">
          <p>the type “method”.</p>
        </ul>
       <li data-md="">
-       <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-110">interface</a> on which the stringifier was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-50">throw a <emu-val>TypeError</emu-val></a>.</p>
+       <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-105">interface</a> on which the stringifier was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-49">throw a <emu-val>TypeError</emu-val></a>.</p>
       <li data-md="">
        <p>Let <var>V</var> be an uninitialized variable.</p>
       <li data-md="">
@@ -10256,18 +10155,18 @@ implements the <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-s
 (or those listed in the description of the inherited attribute, if this attribute is declared to <a data-link-type="dfn" href="#dfn-inherit-getter" id="ref-for-dfn-inherit-getter-3">inherit its getter</a>),
 with <var>O</var> as the object.</p>
         <dt data-md="">
-         <p>on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-74">operation</a> with an identifier</p>
+         <p>on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-70">operation</a> with an identifier</p>
         <dd data-md="">
          <p>Set <var>V</var> to the result of performing the actions listed in the description
 of the operation, using <var>O</var> as the <emu-val>this</emu-val> value
 and passing no arguments.</p>
         <dt data-md="">
-         <p>on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-75">operation</a> with no identifier</p>
+         <p>on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-71">operation</a> with no identifier</p>
         <dd data-md="">
          <p>Set <var>V</var> to the result of performing the <a data-link-type="dfn" href="#dfn-stringification-behavior" id="ref-for-dfn-stringification-behavior-1">stringification behavior</a> of the interface.</p>
        </dl>
       <li data-md="">
-       <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-43">converting</a> <var>V</var> to a <emu-val>String</emu-val> value.</p>
+       <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-42">converting</a> <var>V</var> to a <emu-val>String</emu-val> value.</p>
      </ol>
     <li data-md="">
      <p>The value of the <emu-val>Function</emu-val> object’s “length”
@@ -10277,7 +10176,7 @@ property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
 property is the <emu-val>String</emu-val> value “toString”.</p>
    </ul>
    <h5 class="heading settled" data-level="4.6.7.2" id="es-serializer"><span class="secno">4.6.7.2. </span><span class="content">Serializers</span><a class="self-link" href="#es-serializer"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-111">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-8">exposed</a> <a data-link-type="dfn" href="#dfn-serializer" id="ref-for-dfn-serializer-5">serializer</a>, then
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-106">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-8">exposed</a> <a data-link-type="dfn" href="#dfn-serializer" id="ref-for-dfn-serializer-5">serializer</a>, then
 a property must exist
 whose name is “toJSON”,
 with attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <emu-val>Function</emu-val> object.</p>
@@ -10290,9 +10189,9 @@ then the property exists on the single object that implements the interface.</p>
      <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-26">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-59">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-60">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-61">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-62">PrimaryGlobal</a></code>]-annotated interface as well as on
-the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-27">interface prototype object</a>.</p>
+the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-26">interface prototype object</a>.</p>
     <li data-md="">
-     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-28">interface prototype object</a>.</p>
+     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-27">interface prototype object</a>.</p>
    </ul>
    <p>The property’s <emu-val>Function</emu-val> object, when invoked,
 must behave as follows:</p>
@@ -10309,17 +10208,17 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
        <p>the ECMAScript global environment associated with this <emu-val>Function</emu-val> that
 implements the <a data-link-type="dfn" href="#dfn-serializer" id="ref-for-dfn-serializer-6">serializer</a>,</p>
       <li data-md="">
-       <p>the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-82">identifier</a> of the <a data-link-type="dfn" href="#dfn-serializer" id="ref-for-dfn-serializer-7">serializer</a>, and</p>
+       <p>the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-78">identifier</a> of the <a data-link-type="dfn" href="#dfn-serializer" id="ref-for-dfn-serializer-7">serializer</a>, and</p>
       <li data-md="">
        <p>the type “method”.</p>
      </ul>
     <li data-md="">
-     <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-112">interface</a> on which the serializer was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-51">throw a <emu-val>TypeError</emu-val></a>.</p>
+     <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-107">interface</a> on which the serializer was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-50">throw a <emu-val>TypeError</emu-val></a>.</p>
     <li data-md="">
      <p>Depending on how <code>serializer</code> was specified:</p>
      <dl class="switch">
       <dt data-md="">
-       <p>on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-76">operation</a> with an identifier</p>
+       <p>on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-72">operation</a> with an identifier</p>
       <dd data-md="">
        <ol class="algorithm">
         <li data-md="">
@@ -10332,7 +10231,7 @@ and passing no arguments.</p>
       <dd data-md="">
        <ol class="algorithm">
         <li data-md="">
-         <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-serialized-value" id="ref-for-dfn-serialized-value-8">serialized value</a> that is the result of invoking the <a data-link-type="dfn" href="#dfn-serialization-behavior" id="ref-for-dfn-serialization-behavior-15">serialization behavior</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-113">interface</a> for object <var>O</var>.</p>
+         <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-serialized-value" id="ref-for-dfn-serialized-value-8">serialized value</a> that is the result of invoking the <a data-link-type="dfn" href="#dfn-serialization-behavior" id="ref-for-dfn-serialization-behavior-15">serialization behavior</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-108">interface</a> for object <var>O</var>.</p>
         <li data-md="">
          <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-serialized-value-to-ecmascript-value" id="ref-for-dfn-convert-serialized-value-to-ecmascript-value-1">converting</a> <var>S</var> to an ECMAScript value.</p>
        </ol>
@@ -10394,7 +10293,7 @@ property is the <emu-val>String</emu-val> value “toJSON”.</p>
       <dd data-md="">
        <ol class="algorithm">
         <li data-md="">
-         <p>Let <var>V</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-44">converting</a> <var>S</var> to an ECMAScript value.</p>
+         <p>Let <var>V</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-43">converting</a> <var>S</var> to an ECMAScript value.</p>
         <li data-md="">
          <p>Return <var>V</var>.</p>
        </ol>
@@ -10402,7 +10301,7 @@ property is the <emu-val>String</emu-val> value “toJSON”.</p>
    </ol>
    <h4 class="heading settled" data-level="4.6.8" id="es-iterators"><span class="secno">4.6.8. </span><span class="content">Common iterator behavior</span><a class="self-link" href="#es-iterators"></a></h4>
    <h5 class="heading settled" data-level="4.6.8.1" id="es-iterator"><span class="secno">4.6.8.1. </span><span class="content">@@iterator</span><a class="self-link" href="#es-iterator"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-114">interface</a> has any of the following:</p>
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-109">interface</a> has any of the following:</p>
    <ul>
     <li data-md="">
      <p>an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-9">iterable declaration</a></p>
@@ -10426,9 +10325,9 @@ then the property exists on the single object that implements the interface.</p>
      <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-27">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-65">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-66">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-67">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-68">PrimaryGlobal</a></code>]-annotated interface as well as on
-the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-29">interface prototype object</a>.</p>
+the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-28">interface prototype object</a>.</p>
     <li data-md="">
-     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-30">interface prototype object</a>.</p>
+     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-29">interface prototype object</a>.</p>
    </ul>
    <p>If the interface defines an <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-6">indexed property getter</a>,
 then the <emu-val>Function</emu-val> object is <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ArrayProto_values%</a>.</p>
@@ -10452,10 +10351,10 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
        <p>the type “method”.</p>
      </ul>
     <li data-md="">
-     <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-115">interface</a> the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-10">iterable declaration</a> is on.</p>
+     <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-110">interface</a> the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-10">iterable declaration</a> is on.</p>
     <li data-md="">
      <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-28">platform object</a> that implements <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-52">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-51">throw a <emu-val>TypeError</emu-val></a>.</p>
     <li data-md="">
      <p>Let <var>iterator</var> be a newly created <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-1">default iterator object</a> for <var>interface</var> with <var>object</var> as its target and iterator kind “key+value”.</p>
     <li data-md="">
@@ -10481,8 +10380,8 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
        <p>the type “method”.</p>
      </ul>
     <li data-md="">
-     <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-30">platform object</a> that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-116">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-9">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-9">setlike declaration</a> is defined,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-53">throw a <emu-val>TypeError</emu-val></a>.</p>
+     <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-30">platform object</a> that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-111">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-9">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-9">setlike declaration</a> is defined,
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-52">throw a <emu-val>TypeError</emu-val></a>.</p>
     <li data-md="">
      <p>If the interface has a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-10">maplike declaration</a>, then:</p>
      <ol>
@@ -10506,7 +10405,7 @@ property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
 property is the <emu-val>String</emu-val> value “entries” if the interface has a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-5">pair iterator</a> or a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-11">maplike declaration</a> and the <emu-val>String</emu-val> “values”
 if the interface has a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-10">setlike declaration</a>.</p>
    <h5 class="heading settled" data-level="4.6.8.2" id="es-forEach"><span class="secno">4.6.8.2. </span><span class="content">forEach</span><a class="self-link" href="#es-forEach"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-117">interface</a> has any of the following:</p>
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-112">interface</a> has any of the following:</p>
    <ul>
     <li data-md="">
      <p>an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-11">iterable declaration</a></p>
@@ -10526,9 +10425,9 @@ then the property exists on the single object that implements the interface.</p>
      <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-28">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-71">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-72">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-73">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-74">PrimaryGlobal</a></code>]-annotated interface as well as on
-the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-31">interface prototype object</a>.</p>
+the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-30">interface prototype object</a>.</p>
     <li data-md="">
-     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-32">interface prototype object</a>.</p>
+     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-31">interface prototype object</a>.</p>
    </ul>
    <p>If the interface defines an <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-7">indexed property getter</a>,
 then the <emu-val>Function</emu-val> object is
@@ -10536,7 +10435,7 @@ the initial value of the “forEach” data property of <a data-link-type="dfn" 
    <p>If the interface has a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-6">pair iterator</a>,
 then the <emu-val>Function</emu-val> must
 have the same behavior as one that would exist assuming the interface had
-this <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-77">operation</a> instead of the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-12">iterable declaration</a>:</p>
+this <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-73">operation</a> instead of the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-12">iterable declaration</a>:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Iterable</span> {
   <span class="kt">void</span> <span class="nv">forEach</span>(<span class="n">Function</span> <span class="nv">callback</span>, <span class="kt">optional</span> <span class="kt">any</span> <span class="nv">thisArg</span>);
 };
@@ -10586,14 +10485,14 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
        <p>the type “method”.</p>
      </ul>
     <li data-md="">
-     <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-118">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-14">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-13">setlike declaration</a> is declared.</p>
+     <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-113">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-14">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-13">setlike declaration</a> is declared.</p>
     <li data-md="">
      <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-32">platform object</a> that implements <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-54">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-53">throw a <emu-val>TypeError</emu-val></a>.</p>
     <li data-md="">
      <p>Let <var>callbackFn</var> be the value of the first argument passed to the function, or <emu-val>undefined</emu-val> if the argument was not supplied.</p>
     <li data-md="">
-     <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>callbackFn</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-55">throw a <emu-val>TypeError</emu-val></a>.</p>
+     <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>callbackFn</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-54">throw a <emu-val>TypeError</emu-val></a>.</p>
     <li data-md="">
      <p>Let <var>thisArg</var> be the value of the second argument passed to the function, or <emu-val>undefined</emu-val> if the argument was not supplied.</p>
     <li data-md="">
@@ -10617,7 +10516,7 @@ or the [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma2
     <li data-md="">
      <p>Let <var>forEach</var> be the result of calling the [[Get]] internal method of <var>backing</var> with “forEach” and <var>backing</var> as arguments.</p>
     <li data-md="">
-     <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>forEach</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-56">throw a <emu-val>TypeError</emu-val></a>.</p>
+     <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>forEach</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-55">throw a <emu-val>TypeError</emu-val></a>.</p>
     <li data-md="">
      <p>Call the [[Call]] internal method of <var>forEach</var> with <var>backing</var> as <var>thisArgument</var> and <var>callbackWrapper</var> and <var>thisArg</var> as <var>argumentsList</var>.</p>
     <li data-md="">
@@ -10629,7 +10528,7 @@ property is the <emu-val>Number</emu-val> value <emu-val>1</emu-val>.</p>
 property is the <emu-val>String</emu-val> value “forEach”.</p>
    <h4 class="heading settled" data-level="4.6.9" id="es-iterable"><span class="secno">4.6.9. </span><span class="content">Iterable declarations</span><a class="self-link" href="#es-iterable"></a></h4>
    <h5 class="heading settled" data-level="4.6.9.1" id="es-iterable-entries"><span class="secno">4.6.9.1. </span><span class="content">entries</span><a class="self-link" href="#es-iterable-entries"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-119">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-13">iterable declaration</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-114">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-13">iterable declaration</a>,
 then a property named “entries” must exist
 with attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-9">function object</a>.</p>
    <p>The location of the property is determined as follows:</p>
@@ -10641,9 +10540,9 @@ then the property exists on the single object that implements the interface.</p>
      <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-29">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-77">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-78">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-79">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-80">PrimaryGlobal</a></code>]-annotated interface as well as on
-the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-33">interface prototype object</a>.</p>
+the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-32">interface prototype object</a>.</p>
     <li data-md="">
-     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-34">interface prototype object</a>.</p>
+     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-33">interface prototype object</a>.</p>
    </ul>
    <p>If the interface has a <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-7">value iterator</a>,
 then the <emu-val>Function</emu-val> object is
@@ -10652,7 +10551,7 @@ the initial value of the “entries” data property of <a data-link-type="dfn" 
 then the <emu-val>Function</emu-val> object is
 the value of the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> property.</p>
    <h5 class="heading settled" data-level="4.6.9.2" id="es-iterable-keys"><span class="secno">4.6.9.2. </span><span class="content">keys</span><a class="self-link" href="#es-iterable-keys"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-120">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-14">iterable declaration</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-115">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-14">iterable declaration</a>,
 then a property named “keys” must exist
 with attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-10">function object</a>.</p>
    <p>The location of the property is determined as follows:</p>
@@ -10664,9 +10563,9 @@ then the property exists on the single object that implements the interface.</p>
      <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-30">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-83">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-84">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-85">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-86">PrimaryGlobal</a></code>]-annotated interface as well as on
-the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-35">interface prototype object</a>.</p>
+the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-34">interface prototype object</a>.</p>
     <li data-md="">
-     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-36">interface prototype object</a>.</p>
+     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-35">interface prototype object</a>.</p>
    </ul>
    <p>If the interface has a <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-8">value iterator</a>,
 then the <emu-val>Function</emu-val> object is
@@ -10690,10 +10589,10 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
        <p>the type “method”.</p>
      </ul>
     <li data-md="">
-     <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-121">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-15">iterable declaration</a> is declared on.</p>
+     <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-116">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-15">iterable declaration</a> is declared on.</p>
     <li data-md="">
      <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-34">platform object</a> that implements <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-57">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-56">throw a <emu-val>TypeError</emu-val></a>.</p>
     <li data-md="">
      <p>Let <var>iterator</var> be a newly created <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-2">default iterator object</a> for <var>interface</var> with <var>object</var> as its target and iterator kind “key”.</p>
     <li data-md="">
@@ -10702,7 +10601,7 @@ then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-thr
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “keys”.</p>
    <h5 class="heading settled" data-level="4.6.9.3" id="es-iterable-values"><span class="secno">4.6.9.3. </span><span class="content">values</span><a class="self-link" href="#es-iterable-values"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-122">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-16">iterable declaration</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-117">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-16">iterable declaration</a>,
 then a property named “values” must exist
 with attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-11">function object</a>.</p>
    <p>The location of the property is determined as follows:</p>
@@ -10714,9 +10613,9 @@ then the property exists on the single object that implements the interface.</p>
      <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-31">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-89">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-90">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-91">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-92">PrimaryGlobal</a></code>]-annotated interface as well as on
-the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-37">interface prototype object</a>.</p>
+the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-36">interface prototype object</a>.</p>
     <li data-md="">
-     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-38">interface prototype object</a>.</p>
+     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-37">interface prototype object</a>.</p>
    </ul>
    <p>If the interface has a <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-9">value iterator</a>,
 then the <emu-val>Function</emu-val> object is
@@ -10740,10 +10639,10 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
        <p>the type “method”.</p>
      </ul>
     <li data-md="">
-     <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-123">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-17">iterable declaration</a> is declared on.</p>
+     <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-118">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-17">iterable declaration</a> is declared on.</p>
     <li data-md="">
      <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-36">platform object</a> that implements <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-58">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-57">throw a <emu-val>TypeError</emu-val></a>.</p>
     <li data-md="">
      <p>Let <var>iterator</var> be a newly created <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-3">default iterator object</a> for <var>interface</var> with <var>object</var> as its target and iterator kind “value”.</p>
     <li data-md="">
@@ -10752,8 +10651,8 @@ then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-thr
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “values”.</p>
    <h5 class="heading settled" data-level="4.6.9.4" id="es-default-iterator-object"><span class="secno">4.6.9.4. </span><span class="content">Default iterator objects</span><a class="self-link" href="#es-default-iterator-object"></a></h5>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-default-iterator-object">default iterator object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-124">interface</a>, target and iteration kind
-is an object whose internal [[Prototype]] property is the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-2">iterator prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-125">interface</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-default-iterator-object">default iterator object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-119">interface</a>, target and iteration kind
+is an object whose internal [[Prototype]] property is the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-2">iterator prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-120">interface</a>.</p>
    <p>A <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-4">default iterator object</a> has three internal values:</p>
    <ol>
     <li data-md="">
@@ -10768,17 +10667,17 @@ restricted to iterating over an object’s <a data-link-type="dfn" href="#dfn-su
 use standard ECMAScript Array iterator objects.</p>
    <p>When a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-5">default iterator object</a> is first created,
 its index is set to 0.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-3">class string</a> of a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-6">default iterator object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-126">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-83">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-127">interface</a> and
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-3">class string</a> of a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-6">default iterator object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-121">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-79">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-122">interface</a> and
 the string “ Iterator”.</p>
    <h5 class="heading settled" data-level="4.6.9.5" id="es-iterator-prototype-object"><span class="secno">4.6.9.5. </span><span class="content">Iterator prototype object</span><a class="self-link" href="#es-iterator-prototype-object"></a></h5>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-iterator-prototype-object">iterator prototype object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-128">interface</a> is an object that exists for every interface that has a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-11">pair iterator</a>.  It serves as the
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-iterator-prototype-object">iterator prototype object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-123">interface</a> is an object that exists for every interface that has a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-11">pair iterator</a>.  It serves as the
 prototype for <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-7">default iterator objects</a> for the interface.</p>
    <p>The internal [[Prototype]] property of an <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-3">iterator prototype object</a> must be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%IteratorPrototype%</a>.</p>
    <p>An <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-4">iterator prototype object</a> must have a property named “next” with
 attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-12">function object</a> that behaves as follows:</p>
    <ol class="algorithm">
     <li data-md="">
-     <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-129">interface</a> for which the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-5">iterator prototype object</a> exists.</p>
+     <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-124">interface</a> for which the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-5">iterator prototype object</a> exists.</p>
     <li data-md="">
      <p>Let <var>object</var> be the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-toobject">ToObject</a> on the <emu-val>this</emu-val> value.</p>
     <li data-md="">
@@ -10796,7 +10695,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
      </ul>
     <li data-md="">
      <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-8">default iterator object</a> for <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-59">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-58">throw a <emu-val>TypeError</emu-val></a>.</p>
     <li data-md="">
      <p>Let <var>target</var> be <var>object</var>’s target.</p>
     <li data-md="">
@@ -10822,7 +10721,7 @@ return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createi
         <li data-md="">
          <p>Let <var>idlKey</var> be <var>pair</var>’s key.</p>
         <li data-md="">
-         <p>Let <var>key</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-45">converting</a> <var>idlKey</var> to an ECMAScript value.</p>
+         <p>Let <var>key</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-44">converting</a> <var>idlKey</var> to an ECMAScript value.</p>
         <li data-md="">
          <p><var>result</var> is <var>key</var>.</p>
        </ol>
@@ -10833,7 +10732,7 @@ return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createi
         <li data-md="">
          <p>Let <var>idlValue</var> be <var>pair</var>’s value.</p>
         <li data-md="">
-         <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-46">converting</a> <var>idlValue</var> to an ECMAScript value.</p>
+         <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-45">converting</a> <var>idlValue</var> to an ECMAScript value.</p>
         <li data-md="">
          <p><var>result</var> is <var>value</var>.</p>
        </ol>
@@ -10846,9 +10745,9 @@ return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createi
         <li data-md="">
          <p>Let <var>idlValue</var> be <var>pair</var>’s value.</p>
         <li data-md="">
-         <p>Let <var>key</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-47">converting</a> <var>idlKey</var> to an ECMAScript value.</p>
+         <p>Let <var>key</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-46">converting</a> <var>idlKey</var> to an ECMAScript value.</p>
         <li data-md="">
-         <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-48">converting</a> <var>idlValue</var> to an ECMAScript value.</p>
+         <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-47">converting</a> <var>idlValue</var> to an ECMAScript value.</p>
         <li data-md="">
          <p>Let <var>array</var> be the result of performing <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-arraycreate">ArrayCreate</a>(2).</p>
         <li data-md="">
@@ -10862,16 +10761,16 @@ return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createi
     <li data-md="">
      <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createiterresultobject">CreateIterResultObject</a>(<var>result</var>, <emu-val>false</emu-val>).</p>
    </ol>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-4">class string</a> of an <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-6">iterator prototype object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-130">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-84">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-131">interface</a> and
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-4">class string</a> of an <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-6">iterator prototype object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-125">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-80">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-126">interface</a> and
 the string “Iterator”.</p>
    <h4 class="heading settled" data-level="4.6.10" id="es-maplike"><span class="secno">4.6.10. </span><span class="content">Maplike declarations</span><a class="self-link" href="#es-maplike"></a></h4>
-   <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-132">interface</a> that has a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-16">maplike declaration</a> must have a [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
+   <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-127">interface</a> that has a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-16">maplike declaration</a> must have a [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
 initially set to a newly created <emu-val>Map</emu-val> object.
 This <emu-val>Map</emu-val> object’s [[MapData]] internal slot is
 the object’s <a data-link-type="dfn" href="#dfn-map-entries" id="ref-for-dfn-map-entries-3">map entries</a>.</p>
-   <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-133">interface</a> <var>A</var> is declared with
+   <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-128">interface</a> <var>A</var> is declared with
 a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-17">maplike declaration</a>, then
-there exists a number of additional properties on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-39">interface prototype object</a>.
+there exists a number of additional properties on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-38">interface prototype object</a>.
 These additional properties are described in the sub-sections below.</p>
    <p>Some of the properties below are defined to have a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-13">function object</a> value
 that <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-forwards-to-the-internal-map-object">forwards to the internal map object</dfn> for a given function name.  Such functions behave as follows when invoked:</p>
@@ -10896,18 +10795,18 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
        <p>the type “method”.</p>
      </ul>
     <li data-md="">
-     <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-60">throw a <emu-val>TypeError</emu-val></a>.</p>
+     <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-59">throw a <emu-val>TypeError</emu-val></a>.</p>
     <li data-md="">
      <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
     <li data-md="">
      <p>Let <var>function</var> be the result of calling the [[Get]] internal method of <var>map</var> passing <var>name</var> and <var>map</var> as arguments.</p>
     <li data-md="">
-     <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>function</var>) is <emu-val>false</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-61">throw a <emu-val>TypeError</emu-val></a>.</p>
+     <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>function</var>) is <emu-val>false</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-60">throw a <emu-val>TypeError</emu-val></a>.</p>
     <li data-md="">
      <p>Return the result of calling the [[Call]] internal method of <var>function</var> with <var>map</var> as <var>thisArg</var> and <var>arguments</var> as <var>argumentsList</var>.</p>
    </ol>
    <h5 class="heading settled" data-level="4.6.10.1" id="es-map-size"><span class="secno">4.6.10.1. </span><span class="content">size</span><a class="self-link" href="#es-map-size"></a></h5>
-   <p>There must exist a property named “size” on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-40">interface prototype object</a> with the following characteristics:</p>
+   <p>There must exist a property named “size” on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-39">interface prototype object</a> with the following characteristics:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="descriptor">{ [[Get]]: <var>G</var>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>,
@@ -10934,7 +10833,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
          <p>the type “getter”.</p>
        </ul>
       <li data-md="">
-       <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-62">throw a <emu-val>TypeError</emu-val></a>.</p>
+       <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-61">throw a <emu-val>TypeError</emu-val></a>.</p>
       <li data-md="">
        <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
       <li data-md="">
@@ -10944,10 +10843,10 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
      <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “size”.</p>
    </ul>
    <h5 class="heading settled" data-level="4.6.10.2" id="es-map-entries"><span class="secno">4.6.10.2. </span><span class="content">entries</span><a class="self-link" href="#es-map-entries"></a></h5>
-   <p>A property named “entries” must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-41">interface prototype object</a> with attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-14">function object</a> that is the value of
+   <p>A property named “entries” must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-40">interface prototype object</a> with attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-14">function object</a> that is the value of
 the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> property.</p>
    <h5 class="heading settled" data-level="4.6.10.3" id="es-map-keys-values"><span class="secno">4.6.10.3. </span><span class="content">keys and values</span><a class="self-link" href="#es-map-keys-values"></a></h5>
-   <p>For both of “keys” and “values”, there must exist a property with that name on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-42">interface prototype object</a> with the following characteristics:</p>
+   <p>For both of “keys” and “values”, there must exist a property with that name on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-41">interface prototype object</a> with the following characteristics:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
@@ -10957,7 +10856,7 @@ the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known
    <p>The value of the <emu-val>Function</emu-val> objects’ “length” properties is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “keys” or “values”, correspondingly.</p>
    <h5 class="heading settled" data-level="4.6.10.4" id="es-map-get-has"><span class="secno">4.6.10.4. </span><span class="content">get and has</span><a class="self-link" href="#es-map-get-has"></a></h5>
-   <p>For both of “get” and “has”, there must exist a property with that name on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-43">interface prototype object</a> with the following characteristics:</p>
+   <p>For both of “get” and “has”, there must exist a property with that name on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-42">interface prototype object</a> with the following characteristics:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
@@ -10982,7 +10881,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
          <p>the type “method”.</p>
        </ul>
       <li data-md="">
-       <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-63">throw a <emu-val>TypeError</emu-val></a>.</p>
+       <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-62">throw a <emu-val>TypeError</emu-val></a>.</p>
       <li data-md="">
        <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
       <li data-md="">
@@ -10994,7 +10893,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <li data-md="">
        <p>Let <var>keyIDL</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-59">converting</a> <var>keyArg</var> to an IDL value of type <var>keyType</var>.</p>
       <li data-md="">
-       <p>Let <var>key</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-49">converting</a> <var>keyIDL</var> to an ECMAScript value.</p>
+       <p>Let <var>key</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-48">converting</a> <var>keyIDL</var> to an ECMAScript value.</p>
       <li data-md="">
        <p>Return the result of calling the [[Call]] internal method of <var>function</var> with <var>map</var> as <var>thisArg</var> and the single value <var>key</var> as <var>argumentsList</var>.</p>
      </ol>
@@ -11004,7 +10903,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
    <h5 class="heading settled" data-level="4.6.10.5" id="es-map-clear"><span class="secno">4.6.10.5. </span><span class="content">clear</span><a class="self-link" href="#es-map-clear"></a></h5>
    <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-32">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-21">interface member</a> with identifier “clear”, and <var>A</var> was declared with a read–write maplike declaration,
 then a property named “clear” and the following characteristics
-must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-44">interface prototype object</a>:</p>
+must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-43">interface prototype object</a>:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
@@ -11016,7 +10915,7 @@ must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prot
    <h5 class="heading settled" data-level="4.6.10.6" id="es-map-delete"><span class="secno">4.6.10.6. </span><span class="content">delete</span><a class="self-link" href="#es-map-delete"></a></h5>
    <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-33">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-22">interface member</a> with identifier “delete”, and <var>A</var> was declared with a read–write maplike declaration,
 then a property named “delete” and the following characteristics
-must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-45">interface prototype object</a>:</p>
+must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-44">interface prototype object</a>:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
@@ -11039,7 +10938,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
          <p>the type “method”.</p>
        </ul>
       <li data-md="">
-       <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-64">throw a <emu-val>TypeError</emu-val></a>.</p>
+       <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-63">throw a <emu-val>TypeError</emu-val></a>.</p>
       <li data-md="">
        <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
       <li data-md="">
@@ -11051,7 +10950,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <li data-md="">
        <p>Let <var>keyIDL</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-60">converting</a> <var>keyArg</var> to an IDL value of type <var>keyType</var>.</p>
       <li data-md="">
-       <p>Let <var>key</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-50">converting</a> <var>keyIDL</var> to an ECMAScript value.</p>
+       <p>Let <var>key</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-49">converting</a> <var>keyIDL</var> to an ECMAScript value.</p>
       <li data-md="">
        <p>Return the result of calling the [[Call]] internal method of <var>function</var> with <var>map</var> as <var>thisArg</var> and the single value <var>key</var> as <var>argumentsList</var>.</p>
      </ol>
@@ -11061,7 +10960,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
    <h5 class="heading settled" data-level="4.6.10.7" id="es-map-set"><span class="secno">4.6.10.7. </span><span class="content">set</span><a class="self-link" href="#es-map-set"></a></h5>
    <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-34">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-23">interface member</a> with identifier “set”, and <var>A</var> was declared with a read–write maplike declaration,
 then a property named “set” and the following characteristics
-must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-46">interface prototype object</a>:</p>
+must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-45">interface prototype object</a>:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
@@ -11084,7 +10983,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
          <p>the type “method”.</p>
        </ul>
       <li data-md="">
-       <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-65">throw a <emu-val>TypeError</emu-val></a>.</p>
+       <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-64">throw a <emu-val>TypeError</emu-val></a>.</p>
       <li data-md="">
        <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
       <li data-md="">
@@ -11100,9 +10999,9 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <li data-md="">
        <p>Let <var>valueIDL</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-62">converting</a> <var>valueArg</var> to an IDL value of type <var>valueType</var>.</p>
       <li data-md="">
-       <p>Let <var>key</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-51">converting</a> <var>keyIDL</var> to an ECMAScript value.</p>
+       <p>Let <var>key</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-50">converting</a> <var>keyIDL</var> to an ECMAScript value.</p>
       <li data-md="">
-       <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-52">converting</a> <var>valueIDL</var> to an ECMAScript value.</p>
+       <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-51">converting</a> <var>valueIDL</var> to an ECMAScript value.</p>
       <li data-md="">
        <p>Let <var>result</var> be the result of calling the [[Call]] internal method of <var>function</var> with <var>map</var> as <var>thisArg</var> and <var>key</var> and <var>value</var> as <var>argumentsList</var>.</p>
       <li data-md="">
@@ -11114,13 +11013,13 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>2</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “set”.</p>
    <h4 class="heading settled" data-level="4.6.11" id="es-setlike"><span class="secno">4.6.11. </span><span class="content">Setlike declarations</span><a class="self-link" href="#es-setlike"></a></h4>
-   <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-134">interface</a> that has a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-14">setlike declaration</a> must have a [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
+   <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-129">interface</a> that has a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-14">setlike declaration</a> must have a [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
 initially set to a newly created <emu-val>Set</emu-val> object.
 This <emu-val>Set</emu-val> object’s [[SetData]] internal slot is
 the object’s <a data-link-type="dfn" href="#dfn-set-entries" id="ref-for-dfn-set-entries-3">set entries</a>.</p>
-   <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-135">interface</a> <var>A</var> is declared with
+   <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-130">interface</a> <var>A</var> is declared with
 a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-15">setlike declaration</a>, then
-there exists a number of additional properties on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-47">interface prototype object</a>.
+there exists a number of additional properties on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-46">interface prototype object</a>.
 These additional properties are described in the sub-sections below.</p>
    <p>Some of the properties below are defined to have a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-15">function object</a> value
 that <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-forwards-to-the-internal-set-object">forwards to the internal set object</dfn> for a given function name.  Such functions behave as follows when invoked:</p>
@@ -11145,18 +11044,18 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
        <p>the type “method”.</p>
      </ul>
     <li data-md="">
-     <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-66">throw a <emu-val>TypeError</emu-val></a>.</p>
+     <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-65">throw a <emu-val>TypeError</emu-val></a>.</p>
     <li data-md="">
      <p>Let <var>set</var> be the <emu-val>Set</emu-val> object that is the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
     <li data-md="">
      <p>Let <var>function</var> be the result of calling the [[Get]] internal method of <var>set</var> passing <var>name</var> and <var>set</var> as arguments.</p>
     <li data-md="">
-     <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>function</var>) is <emu-val>false</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-67">throw a <emu-val>TypeError</emu-val></a>.</p>
+     <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>function</var>) is <emu-val>false</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-66">throw a <emu-val>TypeError</emu-val></a>.</p>
     <li data-md="">
      <p>Return the result of calling the [[Call]] internal method of <var>function</var> with <var>set</var> as <var>thisArg</var> and <var>arguments</var> as <var>argumentsList</var>.</p>
    </ol>
    <h5 class="heading settled" data-level="4.6.11.1" id="es-set-size"><span class="secno">4.6.11.1. </span><span class="content">size</span><a class="self-link" href="#es-set-size"></a></h5>
-   <p>There must exist a property named “size” on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-48">interface prototype object</a> with the following characteristics:</p>
+   <p>There must exist a property named “size” on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-47">interface prototype object</a> with the following characteristics:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="descriptor">{ [[Get]]: <var>G</var>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>,
@@ -11183,7 +11082,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
          <p>the type “getter”.</p>
        </ul>
       <li data-md="">
-       <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-68">throw a <emu-val>TypeError</emu-val></a>.</p>
+       <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-67">throw a <emu-val>TypeError</emu-val></a>.</p>
       <li data-md="">
        <p>Let <var>set</var> be the <emu-val>Set</emu-val> object that is the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
       <li data-md="">
@@ -11193,10 +11092,10 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
      <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “size”.</p>
    </ul>
    <h5 class="heading settled" data-level="4.6.11.2" id="es-set-values"><span class="secno">4.6.11.2. </span><span class="content">values</span><a class="self-link" href="#es-set-values"></a></h5>
-   <p>A property named “values” must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-49">interface prototype object</a> with attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-16">function object</a> that is the value of
+   <p>A property named “values” must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-48">interface prototype object</a> with attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-16">function object</a> that is the value of
 the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> property.</p>
    <h5 class="heading settled" data-level="4.6.11.3" id="es-set-entries-keys"><span class="secno">4.6.11.3. </span><span class="content">entries and keys</span><a class="self-link" href="#es-set-entries-keys"></a></h5>
-   <p>For both of “entries” and “keys”, there must exist a property with that name on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-50">interface prototype object</a> with the following characteristics:</p>
+   <p>For both of “entries” and “keys”, there must exist a property with that name on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-49">interface prototype object</a> with the following characteristics:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
@@ -11206,7 +11105,7 @@ the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known
    <p>The value of the <emu-val>Function</emu-val> objects’ “length” properties is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “entries” or “keys”, correspondingly.</p>
    <h5 class="heading settled" data-level="4.6.11.4" id="es-set-has"><span class="secno">4.6.11.4. </span><span class="content">has</span><a class="self-link" href="#es-set-has"></a></h5>
-   <p>There must exist a property with named “has” on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-51">interface prototype object</a> with the following characteristics:</p>
+   <p>There must exist a property with named “has” on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-50">interface prototype object</a> with the following characteristics:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
@@ -11229,7 +11128,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
          <p>the type “method”.</p>
        </ul>
       <li data-md="">
-       <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-69">throw a <emu-val>TypeError</emu-val></a>.</p>
+       <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-68">throw a <emu-val>TypeError</emu-val></a>.</p>
       <li data-md="">
        <p>Let <var>set</var> be the <emu-val>Set</emu-val> object that is the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
       <li data-md="">
@@ -11241,7 +11140,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <li data-md="">
        <p>Let <var>idlValue</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-63">converting</a> <var>arg</var> to an IDL value of type <var>type</var>.</p>
       <li data-md="">
-       <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-53">converting</a> <var>idlValue</var> to an ECMAScript value.</p>
+       <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-52">converting</a> <var>idlValue</var> to an ECMAScript value.</p>
       <li data-md="">
        <p>Return the result of calling the [[Call]] internal method of <var>function</var> with <var>set</var> as <var>thisArg</var> and the single value <var>value</var> as <var>argumentsList</var>.</p>
      </ol>
@@ -11257,7 +11156,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
      <p><var>A</var> was declared with a read–write setlike declaration,</p>
    </ul>
    <p>then a property with that name and the following characteristics
-must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-52">interface prototype object</a>:</p>
+must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-51">interface prototype object</a>:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
@@ -11282,7 +11181,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
          <p>the type “method”.</p>
        </ul>
       <li data-md="">
-       <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-70">throw a <emu-val>TypeError</emu-val></a>.</p>
+       <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-69">throw a <emu-val>TypeError</emu-val></a>.</p>
       <li data-md="">
        <p>Let <var>set</var> be the <emu-val>Set</emu-val> object that is the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
       <li data-md="">
@@ -11294,7 +11193,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <li data-md="">
        <p>Let <var>idlValue</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-64">converting</a> <var>arg</var> to an IDL value of type <var>type</var>.</p>
       <li data-md="">
-       <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-54">converting</a> <var>idlValue</var> to an ECMAScript value.</p>
+       <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-53">converting</a> <var>idlValue</var> to an ECMAScript value.</p>
       <li data-md="">
        <p>Let <var>result</var> be the result of calling the [[Call]] internal method of <var>function</var> with <var>set</var> as <var>thisArg</var> and the single value <var>value</var> as <var>argumentsList</var>.</p>
       <li data-md="">
@@ -11318,7 +11217,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
    <h5 class="heading settled" data-level="4.6.11.6" id="es-set-clear"><span class="secno">4.6.11.6. </span><span class="content">clear</span><a class="self-link" href="#es-set-clear"></a></h5>
    <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-36">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-25">interface member</a> with a matching identifier, and <var>A</var> was declared with a read–write setlike declaration,
 then a property named “clear” and the following characteristics
-must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-53">interface prototype object</a>:</p>
+must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-52">interface prototype object</a>:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
@@ -11336,7 +11235,7 @@ the same as the built-in <emu-val>Map</emu-val> and <emu-val>Set</emu-val> objec
 an object <var>destination</var> with adder method name <var>adder</var>, perform the following steps:</p>
    <ol class="algorithm">
     <li data-md="">
-     <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>destination</var>) is not Object, then, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-71">throw a <emu-val>TypeError</emu-val></a>.</p>
+     <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>destination</var>) is not Object, then, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-70">throw a <emu-val>TypeError</emu-val></a>.</p>
     <li data-md="">
      <p>If <var>iterable</var> is not present, let <var>iterable</var> be <emu-val>undefined</emu-val>.</p>
     <li data-md="">
@@ -11349,7 +11248,7 @@ an object <var>destination</var> with adder method name <var>adder</var>, perfor
       <li data-md="">
        <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>adder</var>).</p>
       <li data-md="">
-       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>adder</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-72">throw a <emu-val>TypeError</emu-val></a>.</p>
+       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>adder</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-71">throw a <emu-val>TypeError</emu-val></a>.</p>
       <li data-md="">
        <p>Let <var>iter</var> be the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-getiterator">GetIterator</a>(<var>iterable</var>).</p>
       <li data-md="">
@@ -11371,7 +11270,7 @@ an object <var>destination</var> with adder method name <var>adder</var>, perfor
       <li data-md="">
        <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>nextItem</var>).</p>
       <li data-md="">
-       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>nextItem</var>) is not Object, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-73">throw a <emu-val>TypeError</emu-val></a>.</p>
+       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>nextItem</var>) is not Object, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-72">throw a <emu-val>TypeError</emu-val></a>.</p>
       <li data-md="">
        <p>Let <var>k</var> be the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>nextItem</var>, <code>"0"</code>).</p>
       <li data-md="">
@@ -11387,18 +11286,18 @@ an object <var>destination</var> with adder method name <var>adder</var>, perfor
      </ol>
    </ol>
    <h3 class="heading settled" data-level="4.7" id="es-implements-statements"><span class="secno">4.7. </span><span class="content">Implements statements</span><a class="self-link" href="#es-implements-statements"></a></h3>
-   <p>The <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-54">interface prototype object</a> of an interface <var>A</var> must have a copy of
-each property that corresponds to one of the <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-27">constants</a>, <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-74">attributes</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-78">operations</a>, <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-18">iterable declarations</a>, <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-21">maplike declarations</a> and <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-18">setlike declarations</a> that exist on all of the interface prototype objects of <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-37">consequential interfaces</a>.
+   <p>The <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-53">interface prototype object</a> of an interface <var>A</var> must have a copy of
+each property that corresponds to one of the <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-27">constants</a>, <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-74">attributes</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-74">operations</a>, <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-18">iterable declarations</a>, <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-21">maplike declarations</a> and <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-18">setlike declarations</a> that exist on all of the interface prototype objects of <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-37">consequential interfaces</a>.
 For operations, where the property is a data property with a <emu-val>Function</emu-val> object value, each copy of the property must have
 distinct <emu-val>Function</emu-val> objects.  For attributes, each
 copy of the accessor property must have
 distinct <emu-val>Function</emu-val> objects for their getters,
 and similarly with their setters.</p>
    <div class="note" role="note">
-    <p>When invoking an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-79">operation</a> by calling
+    <p>When invoking an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-75">operation</a> by calling
     a <emu-val>Function</emu-val> object that is the value of one of the copies that exists
     due to an implements statement, the <emu-val>this</emu-val> value is
-    checked to ensure that it is an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-136">interface</a> corresponding to the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-55">interface prototype object</a> that the property is on.</p>
+    checked to ensure that it is an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-131">interface</a> corresponding to the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-54">interface prototype object</a> that the property is on.</p>
     <p>For example, consider the following IDL:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">A</span> {
   <span class="kt">void</span> <span class="nv">f</span>();
@@ -11424,11 +11323,11 @@ which global environment (or, by proxy, which global object) each platform
 object is associated with.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-primary-interface">primary interface</dfn> of a platform object
 that implements one or more interfaces is the most-derived <a data-link-type="dfn" href="#dfn-supplemental-interface" id="ref-for-dfn-supplemental-interface-7">non-supplemental interface</a> that it implements.  The value of the internal [[Prototype]]
-property of the platform object is the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-56">interface prototype object</a> of the <a data-link-type="dfn" href="#dfn-primary-interface" id="ref-for-dfn-primary-interface-1">primary interface</a> from the <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-48">platform object</a>’s associated global environment.</p>
+property of the platform object is the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-55">interface prototype object</a> of the <a data-link-type="dfn" href="#dfn-primary-interface" id="ref-for-dfn-primary-interface-1">primary interface</a> from the <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-48">platform object</a>’s associated global environment.</p>
    <p>The global environment that a given <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-49">platform object</a> is associated with can <dfn data-dfn-for="global environment" data-dfn-type="dfn" data-export="" id="dfn-change-global-environment">change<a class="self-link" href="#dfn-change-global-environment"></a></dfn> after it has been created.  When
 the global environment associated with a platform object is changed, its internal
 [[Prototype]] property must be immediately
-updated to be the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-57">interface prototype object</a> of the <a data-link-type="dfn" href="#dfn-primary-interface" id="ref-for-dfn-primary-interface-2">primary interface</a> from the <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-50">platform object</a>’s newly associated global environment.</p>
+updated to be the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-56">interface prototype object</a> of the <a data-link-type="dfn" href="#dfn-primary-interface" id="ref-for-dfn-primary-interface-2">primary interface</a> from the <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-50">platform object</a>’s newly associated global environment.</p>
    <p>Every platform object that implements an [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-15">Unforgeable</a></code>]-annotated
 interface and which does not have a <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-7">stringifier</a> that is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-7">unforgeable</a> on any of the
 interfaces it implements must have a property with the
@@ -11477,16 +11376,16 @@ property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
    </ul>
    <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-5">class string</a> of
 a platform object that implements one or more interfaces
-must be the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-85">identifier</a> of
+must be the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-81">identifier</a> of
 the <a data-link-type="dfn" href="#dfn-primary-interface" id="ref-for-dfn-primary-interface-3">primary interface</a> of the platform object.</p>
    <h4 class="heading settled" data-level="4.8.1" id="indexed-and-named-properties"><span class="secno">4.8.1. </span><span class="content">Indexed and named properties</span><a class="self-link" href="#indexed-and-named-properties"></a></h4>
-   <p>If a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-51">platform object</a> implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-137">interface</a> that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-9">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-5">named properties</a>,
+   <p>If a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-51">platform object</a> implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-132">interface</a> that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-9">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-5">named properties</a>,
 the object will appear to have additional properties that correspond to the
 object’s indexed and named properties.  These properties are not “real” own
 properties on the object, but are made to look like they are by being exposed
 by the [[GetOwnProperty]] internal method.</p>
    <p>However, when the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-93">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-94">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-103">extended attribute</a> has been used,
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-94">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-99">extended attribute</a> has been used,
 named properties are not exposed on the object but on another object
 in the prototype chain, the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-13">named properties object</a>.</p>
    <p>It is permissible for an object to implement multiple interfaces that support indexed properties.
@@ -11501,10 +11400,10 @@ when indexing the object with an array index.  Similarly for <a data-link-type="
 This way, the definitions of these special operations from
 ancestor interfaces can be overridden.</p>
    <p>Platform objects implementing an interface that supports indexed or named properties cannot be fixed; if <code>Object.freeze</code>, <code>Object.seal</code> or <code>Object.preventExtensions</code> is called on one of these objects, the function
-must <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-74">throw a <emu-val>TypeError</emu-val></a>.
-Similarly, an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-58">interface prototype object</a> that exposes named properties due to the use of [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-95">Global</a></code>] or
+must <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-73">throw a <emu-val>TypeError</emu-val></a>.
+Similarly, an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-57">interface prototype object</a> that exposes named properties due to the use of [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-95">Global</a></code>] or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-96">PrimaryGlobal</a></code>]
-also must <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-75">throw a <emu-val>TypeError</emu-val></a> if one of the three functions above is called on it.</p>
+also must <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-74">throw a <emu-val>TypeError</emu-val></a> if one of the three functions above is called on it.</p>
    <p>The name of each property that appears to exist due to an object supporting indexed properties
 is an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-array-index-property-name">array index property name</dfn>, which is a property
 name <var>P</var> such that <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>P</var>) is String
@@ -11520,26 +11419,26 @@ and for which the following algorithm returns <emu-val>true</emu-val>:</p>
      <p>Return <emu-val>true</emu-val>.</p>
    </ol>
    <p>A property name is an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-unforgeable-property-name">unforgeable property name</dfn> on a
-given platform object if the object implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-138">interface</a> that
+given platform object if the object implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-133">interface</a> that
 has an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-26">interface member</a> with that identifier
 and that interface member is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-9">unforgeable</a> on any of
 the interfaces that <var>O</var> implements.  If the object implements an
-[<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-18">Unforgeable</a></code>]-annotated <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-139">interface</a>, then “toString” and “valueOf” are
+[<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-18">Unforgeable</a></code>]-annotated <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-134">interface</a>, then “toString” and “valueOf” are
 also <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-dfn-unforgeable-property-name-1">unforgeable property names</a> on that object.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-named-property-visibility">named property visibility algorithm</dfn> is used to determine if
 a given named property is exposed on an object.  Some named properties are not exposed on an object
-depending on whether the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-8">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-104">extended attribute</a> was used.  The algorithm
+depending on whether the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-8">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-100">extended attribute</a> was used.  The algorithm
 operates as follows, with property name <var>P</var> and object <var>O</var>:</p>
    <ol class="algorithm">
     <li data-md="">
      <p>If <var>P</var> is an <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-dfn-unforgeable-property-name-2">unforgeable property name</a> on <var>O</var>, then return false.</p>
     <li data-md="">
-     <p>If <var>O</var> implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-140">interface</a> with
-an [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-19">Unforgeable</a></code>]-annotated <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-76">attribute</a> whose <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-86">identifier</a> is <var>P</var>, then return false.</p>
+     <p>If <var>O</var> implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-135">interface</a> with
+an [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-19">Unforgeable</a></code>]-annotated <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-76">attribute</a> whose <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-82">identifier</a> is <var>P</var>, then return false.</p>
     <li data-md="">
      <p>If <var>P</var> is not a <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-4">supported property name</a> of <var>O</var>, then return false.</p>
     <li data-md="">
-     <p>If <var>O</var> implements an interface that has the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-9">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-105">extended attribute</a>, then return true.</p>
+     <p>If <var>O</var> implements an interface that has the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-9">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-101">extended attribute</a>, then return true.</p>
     <li data-md="">
      <p>If <var>O</var> has an own property named <var>P</var>, then return false.</p>
     <li data-md="">
@@ -11606,7 +11505,7 @@ object <var>O</var>, a property name <var>P</var>, and a boolean <var>ignoreName
         <li data-md="">
          <p>Let <var>value</var> be an uninitialized variable.</p>
         <li data-md="">
-         <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-87">identifier</a>, then
+         <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-83">identifier</a>, then
 set <var>value</var> to the result of performing the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-determine-the-value-of-an-indexed-property" id="ref-for-dfn-determine-the-value-of-an-indexed-property-1">determine the value of an indexed property</a> with <var>index</var> as the index.</p>
         <li data-md="">
          <p>Otherwise, <var>operation</var> was defined with an identifier.  Set <var>value</var> to the result
@@ -11614,7 +11513,7 @@ of performing the steps listed in the description of <var>operation</var> with <
         <li data-md="">
          <p>Let <var>desc</var> be a newly created <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">Property Descriptor</a> with no fields.</p>
         <li data-md="">
-         <p>Set <var>desc</var>.[[Value]] to the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-55">converting</a> <var>value</var> to an ECMAScript value.</p>
+         <p>Set <var>desc</var>.[[Value]] to the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-54">converting</a> <var>value</var> to an ECMAScript value.</p>
         <li data-md="">
          <p>If <var>O</var> implements an interface with an <a data-link-type="dfn" href="#dfn-indexed-property-setter" id="ref-for-dfn-indexed-property-setter-5">indexed property setter</a>, then set <var>desc</var>.[[Writable]] to <emu-val>true</emu-val>, otherwise set it to <emu-val>false</emu-val>.</p>
         <li data-md="">
@@ -11627,7 +11526,7 @@ of performing the steps listed in the description of <var>operation</var> with <
      </ol>
     <li data-md="">
      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-6">supports named properties</a>, <var>O</var> does not
-implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-141">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-97">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-98">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-106">extended attribute</a>, the result of running the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-2">named property visibility algorithm</a> with
+implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-136">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-97">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-98">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-102">extended attribute</a>, the result of running the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-2">named property visibility algorithm</a> with
 property name <var>P</var> and object <var>O</var> is true, and <var>ignoreNamedProps</var> is false, then:</p>
      <ol>
       <li data-md="">
@@ -11635,7 +11534,7 @@ property name <var>P</var> and object <var>O</var> is true, and <var>ignoreNamed
       <li data-md="">
        <p>Let <var>value</var> be an uninitialized variable.</p>
       <li data-md="">
-       <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-88">identifier</a>, then
+       <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-84">identifier</a>, then
 set <var>value</var> to the result of performing the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-determine-the-value-of-a-named-property" id="ref-for-dfn-determine-the-value-of-a-named-property-2">determine the value of a named property</a> with <var>P</var> as the name.</p>
       <li data-md="">
        <p>Otherwise, <var>operation</var> was defined with an identifier.  Set <var>value</var> to the result
@@ -11643,12 +11542,12 @@ of performing the steps listed in the description of <var>operation</var> with <
       <li data-md="">
        <p>Let <var>desc</var> be a newly created <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">Property Descriptor</a> with no fields.</p>
       <li data-md="">
-       <p>Set <var>desc</var>.[[Value]] to the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-56">converting</a> <var>value</var> to an ECMAScript value.</p>
+       <p>Set <var>desc</var>.[[Value]] to the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-55">converting</a> <var>value</var> to an ECMAScript value.</p>
       <li data-md="">
        <p>If <var>O</var> implements an interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="ref-for-dfn-named-property-setter-4">named property setter</a>, then set <var>desc</var>.[[Writable]] to <emu-val>true</emu-val>, otherwise set it to <emu-val>false</emu-val>.</p>
       <li data-md="">
        <p>If <var>O</var> implements an interface with the
-[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-6">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-107">extended attribute</a>,
+[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-6">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-103">extended attribute</a>,
 then set <var>desc</var>.[[Enumerable]] to <emu-val>false</emu-val>,
 otherwise set it to <emu-val>true</emu-val>.</p>
       <li data-md="">
@@ -11660,7 +11559,7 @@ otherwise set it to <emu-val>true</emu-val>.</p>
      <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinarygetownproperty">OrdinaryGetOwnProperty</a>(<var>O</var>, <var>P</var>).</p>
    </ol>
    <h4 class="heading settled" data-level="4.8.3" id="getownproperty"><span class="secno">4.8.3. </span><span class="content">Platform object [[GetOwnProperty]] method</span><a class="self-link" href="#getownproperty"></a></h4>
-   <p>The internal [[GetOwnProperty]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-52">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-142">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-11">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-7">named properties</a> must behave as follows when called with property name <var>P</var>:</p>
+   <p>The internal [[GetOwnProperty]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-52">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-137">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-11">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-7">named properties</a> must behave as follows when called with property name <var>P</var>:</p>
    <ol class="algorithm">
     <li data-md="">
      <p>Return the result of invoking the <a data-link-type="dfn" href="#getownproperty-guts" id="ref-for-getownproperty-guts-1">PlatformObjectGetOwnProperty</a> abstract operation with <var>O</var>, <var>P</var>, and <emu-val>false</emu-val> as
@@ -11680,7 +11579,7 @@ arguments.</p>
     <li data-md="">
      <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-65">converting</a> <var>V</var> to an IDL value of type <var>T</var>.</p>
     <li data-md="">
-     <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-89">identifier</a>, then:</p>
+     <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-85">identifier</a>, then:</p>
      <ol>
       <li data-md="">
        <p>If <var>creating</var> is true, then perform the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-set-the-value-of-a-new-indexed-property" id="ref-for-dfn-set-the-value-of-a-new-indexed-property-1">set the value of a new indexed property</a> with <var>index</var> as the index and <var>value</var> as the value.</p>
@@ -11702,7 +11601,7 @@ arguments.</p>
     <li data-md="">
      <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-66">converting</a> <var>V</var> to an IDL value of type <var>T</var>.</p>
     <li data-md="">
-     <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-90">identifier</a>, then:</p>
+     <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-86">identifier</a>, then:</p>
      <ol>
       <li data-md="">
        <p>If <var>creating</var> is true, then perform the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-set-the-value-of-a-new-named-property" id="ref-for-dfn-set-the-value-of-a-new-named-property-1">set the value of a new named property</a> with <var>P</var> as the name and <var>value</var> as the value.</p>
@@ -11713,7 +11612,7 @@ arguments.</p>
      <p>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</p>
    </ol>
    <h4 class="heading settled" data-level="4.8.6" id="platformobjectset"><span class="secno">4.8.6. </span><span class="content">Platform object [[Set]] method</span><a class="self-link" href="#platformobjectset"></a></h4>
-   <p>The internal [[Set]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-53">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-143">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-12">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-8">named properties</a> must behave as follows when called
+   <p>The internal [[Set]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-53">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-138">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-12">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-8">named properties</a> must behave as follows when called
 with property name <var>P</var>, value <var>V</var>, and
 ECMAScript language value <var>Receiver</var>:</p>
    <ol class="algorithm">
@@ -11748,7 +11647,7 @@ arguments.</p>
    </ol>
    <h4 class="heading settled" data-level="4.8.7" id="defineownproperty"><span class="secno">4.8.7. </span><span class="content">Platform object [[DefineOwnProperty]] method</span><a class="self-link" href="#defineownproperty"></a></h4>
    <p>When the internal [[DefineOwnProperty]] method of a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-54">platform object</a> <var>O</var> that
-implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-144">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-14">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-10">named properties</a> is
+implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-139">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-14">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-10">named properties</a> is
 called with property key <var>P</var> and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">Property Descriptor</a> <var>Desc</var>, the following steps must be taken:</p>
    <ol class="algorithm">
     <li data-md="">
@@ -11764,13 +11663,13 @@ called with property key <var>P</var> and <a data-link-type="dfn" href="https://
        <p>Return <emu-val>true</emu-val>.</p>
      </ol>
     <li data-md="">
-     <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-11">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-145">interface</a> with the
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-99">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-100">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-108">extended attribute</a> and <var>P</var> is not an <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-dfn-unforgeable-property-name-3">unforgeable property name</a> of <var>O</var>, then:</p>
+     <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-11">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-140">interface</a> with the
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-99">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-100">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-104">extended attribute</a> and <var>P</var> is not an <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-dfn-unforgeable-property-name-3">unforgeable property name</a> of <var>O</var>, then:</p>
      <ol>
       <li data-md="">
        <p>Let <var>creating</var> be true if <var>P</var> is not a <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-6">supported property name</a>, and false otherwise.</p>
       <li data-md="">
-       <p>If <var>O</var> implements an interface with the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-12">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-109">extended attribute</a> or <var>O</var> does not have an own property
+       <p>If <var>O</var> implements an interface with the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-12">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-105">extended attribute</a> or <var>O</var> does not have an own property
 named <var>P</var>, then:</p>
        <ol>
         <li data-md="">
@@ -11789,14 +11688,14 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
        </ol>
      </ol>
     <li data-md="">
-     <p>If <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-146">interface</a> with the
+     <p>If <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-141">interface</a> with the
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-101">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-102">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-110">extended attribute</a>, then set <var>Desc</var>.[[Configurable]] to <emu-val>true</emu-val>.</p>
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-102">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-106">extended attribute</a>, then set <var>Desc</var>.[[Configurable]] to <emu-val>true</emu-val>.</p>
     <li data-md="">
      <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinarydefineownproperty">OrdinaryDefineOwnProperty</a>(<var>O</var>, <var>P</var>, <var>Desc</var>).</p>
    </ol>
    <h4 class="heading settled" data-level="4.8.8" id="delete"><span class="secno">4.8.8. </span><span class="content">Platform object [[Delete]] method</span><a class="self-link" href="#delete"></a></h4>
-   <p>The internal [[Delete]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-55">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-147">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-16">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-12">named properties</a> must behave as follows when called with property name <var>P</var>.</p>
+   <p>The internal [[Delete]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-55">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-142">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-16">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-12">named properties</a> must behave as follows when called with property name <var>P</var>.</p>
    <ol class="algorithm">
     <li data-md="">
      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-17">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-5">array index property name</a>, then:</p>
@@ -11809,15 +11708,15 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
        <p>Return <emu-val>false</emu-val>.</p>
      </ol>
     <li data-md="">
-     <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-13">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-148">interface</a> with the
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-103">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-104">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-111">extended attribute</a> and the result of calling the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-3">named property visibility algorithm</a> with property name <var>P</var> and object <var>O</var> is true, then:</p>
+     <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-13">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-143">interface</a> with the
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-103">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-104">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-107">extended attribute</a> and the result of calling the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-3">named property visibility algorithm</a> with property name <var>P</var> and object <var>O</var> is true, then:</p>
      <ol>
       <li data-md="">
        <p>If <var>O</var> does not implement an interface with a <a data-link-type="dfn" href="#dfn-named-property-deleter" id="ref-for-dfn-named-property-deleter-5">named property deleter</a>, then return <emu-val>false</emu-val>.</p>
       <li data-md="">
        <p>Let <var>operation</var> be the operation used to declare the named property deleter.</p>
       <li data-md="">
-       <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-91">identifier</a>, then:</p>
+       <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-87">identifier</a>, then:</p>
        <ol>
         <li data-md="">
          <p>Perform the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-delete-an-existing-named-property" id="ref-for-dfn-delete-an-existing-named-property-1">delete an existing named property</a> with <var>P</var> as the name.</p>
@@ -11830,7 +11729,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
         <li data-md="">
          <p>Perform the steps listed in the description of <var>operation</var> with <var>P</var> as the only argument value.</p>
         <li data-md="">
-         <p>If <var>operation</var> was declared with a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-7">return type</a> of <code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref-for-idl-boolean-23">boolean</a></code> and the steps returned <emu-val>false</emu-val>, then return <emu-val>false</emu-val>.</p>
+         <p>If <var>operation</var> was declared with a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-6">return type</a> of <code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref-for-idl-boolean-23">boolean</a></code> and the steps returned <emu-val>false</emu-val>, then return <emu-val>false</emu-val>.</p>
        </ol>
       <li data-md="">
        <p>Return <emu-val>true</emu-val>.</p>
@@ -11847,21 +11746,21 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
      <p>Return <emu-val>true</emu-val>.</p>
    </ol>
    <h4 class="heading settled" data-level="4.8.9" id="call"><span class="secno">4.8.9. </span><span class="content">Platform object [[Call]] method</span><a class="self-link" href="#call"></a></h4>
-   <p>The internal [[Call]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-56">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-149">interface</a> <var>I</var> with at least one <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-8">legacy caller</a> must behave as follows, assuming <var>arg</var><sub>0..<var>n</var>−1</sub> is the list of argument
+   <p>The internal [[Call]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-56">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-144">interface</a> <var>I</var> with at least one <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-8">legacy caller</a> must behave as follows, assuming <var>arg</var><sub>0..<var>n</var>−1</sub> is the list of argument
 values passed to [[Call]]:</p>
    <ol class="algorithm">
     <li data-md="">
-     <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-14">effective overload set</a> for legacy callers on <var>I</var> and with argument count <var>n</var>.</p>
+     <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-12">effective overload set</a> for legacy callers on <var>I</var> and with argument count <var>n</var>.</p>
     <li data-md="">
-     <p>Let &lt;<var>operation</var>, <var>values</var>> be the result of passing <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to the <a data-link-type="dfn" href="#dfn-overload-resolution-algorithm" id="ref-for-dfn-overload-resolution-algorithm-5">overload resolution algorithm</a>.</p>
+     <p>Let &lt;<var>operation</var>, <var>values</var>> be the result of passing <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to the <a data-link-type="dfn" href="#dfn-overload-resolution-algorithm" id="ref-for-dfn-overload-resolution-algorithm-4">overload resolution algorithm</a>.</p>
     <li data-md="">
      <p>Perform the actions listed in the description of the legacy caller <var>operation</var> with <var>values</var> as the argument values.</p>
     <li data-md="">
-     <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-57">converting</a> the return value from those actions to an ECMAScript value of the type <var>operation</var> is declared to return (or <emu-val>undefined</emu-val> if <var>operation</var> is declared to return <code class="idl"><a data-link-type="idl" href="#idl-void" id="ref-for-idl-void-6">void</a></code>).</p>
+     <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-56">converting</a> the return value from those actions to an ECMAScript value of the type <var>operation</var> is declared to return (or <emu-val>undefined</emu-val> if <var>operation</var> is declared to return <code class="idl"><a data-link-type="idl" href="#idl-void" id="ref-for-idl-void-6">void</a></code>).</p>
    </ol>
    <h4 class="heading settled" data-level="4.8.10" id="property-enumeration"><span class="secno">4.8.10. </span><span class="content">Property enumeration</span><a class="self-link" href="#property-enumeration"></a></h4>
    <p>This document does not define a complete property enumeration order
-for all <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-57">platform objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-150">interfaces</a> (or for <a href="#es-exception-objects" id="ref-for-es-exception-objects-1">platform objects representing exceptions</a>).
+for all <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-57">platform objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-145">interfaces</a> (or for <a href="#es-exception-objects" id="ref-for-es-exception-objects-1">platform objects representing exceptions</a>).
 However, if a platform object implements an interface that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-18">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-14">named properties</a>, then
 properties on the object must be
 enumerated in the following order:</p>
@@ -11871,8 +11770,8 @@ enumerated in the following order:</p>
 the object’s <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-8">supported property indices</a> are
 enumerated first, in numerical order.</p>
     <li data-md="">
-     <p>If the object <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-15">supports named properties</a> and doesn’t implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-151">interface</a> with the
-[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-7">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-112">extended attribute</a>, then
+     <p>If the object <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-15">supports named properties</a> and doesn’t implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-146">interface</a> with the
+[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-7">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-108">extended attribute</a>, then
 the object’s <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-7">supported property names</a> that
 are visible according to the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-4">named property visibility algorithm</a> are enumerated next, in the order given in the definition of the set of supported property names.</p>
     <li data-md="">
@@ -11899,17 +11798,17 @@ the callable object itself.</p>
        <p>Otherwise, the object is not <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">callable</a>.
 The implementation of the operation (or set of overloaded operations) is
 the result of invoking the internal [[Get]] method
-on the object with a property name that is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-92">identifier</a> of the operation.</p>
+on the object with a property name that is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-88">identifier</a> of the operation.</p>
      </ul>
     <li data-md="">
      <p>Otherwise, the interface is not a <a data-link-type="dfn" href="#dfn-single-operation-callback-interface" id="ref-for-dfn-single-operation-callback-interface-2">single operation callback interface</a>.
 Any object that is not a native <emu-val>RegExp</emu-val> object is considered to implement the interface.
-For each operation declared on the interface with a given <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-93">identifier</a>, the implementation
+For each operation declared on the interface with a given <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-89">identifier</a>, the implementation
 is the result of invoking [[Get]] on the object with a
 property name that is that identifier.</p>
    </ul>
    <p>Note that ECMAScript objects need not have
-properties corresponding to <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-28">constants</a> on them to be considered as <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-9">user objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-152">interfaces</a> that happen
+properties corresponding to <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-28">constants</a> on them to be considered as <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-9">user objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-147">interfaces</a> that happen
 to have constants declared on them.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-single-operation-callback-interface">single operation callback interface</dfn> is
 a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-27">callback interface</a> that:</p>
@@ -11919,7 +11818,7 @@ a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callbac
     <li data-md="">
      <p>has no <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-77">attributes</a>, and</p>
     <li data-md="">
-     <p>has one or more <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-20">regular operations</a> that all have the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-94">identifier</a>,
+     <p>has one or more <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-18">regular operations</a> that all have the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-90">identifier</a>,
 and no others.</p>
    </ul>
    <p>To <dfn data-dfn-type="dfn" data-export="" id="call-a-user-objects-operation">call a user object’s operation<a class="self-link" href="#call-a-user-objects-operation"></a></dfn>, given a <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-18">callback interface type</a> value <var>value</var>, sometimes-optional operation name <var>opName</var>,
@@ -11985,7 +11884,7 @@ append <emu-val>undefined</emu-val> to <var>esArgs</var>.</p>
        <p>Otherwise, <var>arg</var><sub><var>i</var></sub> is an IDL value:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>convertResult</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-58">converting</a> <var>arg</var><sub><var>i</var></sub> to an ECMAScript value.</p>
+         <p>Let <var>convertResult</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-57">converting</a> <var>arg</var><sub><var>i</var></sub> to an ECMAScript value.</p>
         <li data-md="">
          <p>If <var>convertResult</var> is an abrupt completion, set <var>completion</var> to <var>convertResult</var> and jump to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.</p>
         <li data-md="">
@@ -12016,7 +11915,7 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
       <li data-md="">
        <p>If <var>completion</var> is a normal completion, return <var>completion</var>.</p>
       <li data-md="">
-       <p>If <var>completion</var> is an abrupt completion and the operation has a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-8">return type</a> that is <em>not</em> a <a href="#idl-promise" id="ref-for-idl-promise-11">promise type</a>, return <var>completion</var>.</p>
+       <p>If <var>completion</var> is an abrupt completion and the operation has a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-7">return type</a> that is <em>not</em> a <a href="#idl-promise" id="ref-for-idl-promise-10">promise type</a>, return <var>completion</var>.</p>
       <li data-md="">
        <p>Let <var>reject</var> be the initial value of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.</p>
       <li data-md="">
@@ -12061,7 +11960,7 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
       <li data-md="">
        <p>If <var>completion</var> is a normal completion, return <var>completion</var>.</p>
       <li data-md="">
-       <p>If <var>completion</var> is an abrupt completion and the attribute’s type is <em>not</em> a <a href="#idl-promise" id="ref-for-idl-promise-12">promise type</a>, return <var>completion</var>.</p>
+       <p>If <var>completion</var> is an abrupt completion and the attribute’s type is <em>not</em> a <a href="#idl-promise" id="ref-for-idl-promise-11">promise type</a>, return <var>completion</var>.</p>
       <li data-md="">
        <p>Let <var>reject</var> be the initial value of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.</p>
       <li data-md="">
@@ -12089,7 +11988,7 @@ anything, but could throw an exception.</p>
     <li data-md="">
      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-a-callback">Prepare to run a callback</a> with <var>stored settings</var>.</p>
     <li data-md="">
-     <p>Let <var>convertResult</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-59">converting</a> <var>value</var> to an
+     <p>Let <var>convertResult</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-58">converting</a> <var>value</var> to an
 ECMAScript value.</p>
     <li data-md="">
      <p>If <var>convertResult</var> is an abrupt completion, set <var>completion</var> to <var>convertResult</var> and jump to the step labeled <a href="#set-user-object-attribute-return"><i>return</i></a>.</p>
@@ -12113,7 +12012,7 @@ either an abrupt completion or a normal completion for the value <emu-val>true</
    <h3 class="heading settled" data-level="4.10" id="es-invoking-callback-functions"><span class="secno">4.10. </span><span class="content">Invoking callback functions</span><a class="self-link" href="#es-invoking-callback-functions"></a></h3>
    <p>An ECMAScript <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">callable</a> object that is being
 used as a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-28">callback function</a> value is
-called in a manner similar to how <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-80">operations</a> on <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-10">user objects</a> are called (as
+called in a manner similar to how <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-76">operations</a> on <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-10">user objects</a> are called (as
 described in the previous section).</p>
    <p>To <dfn data-dfn-type="dfn" data-export="" id="invoke-a-callback-function">invoke<a class="self-link" href="#invoke-a-callback-function"></a></dfn> a <a data-link-type="dfn" href="#idl-callback-function" id="ref-for-idl-callback-function-6">callback function type</a> value <var>callable</var> with
 a list of arguments <var>arg</var><sub>0..<var>n</var>−1</sub>, each of which is either
@@ -12164,7 +12063,7 @@ append <emu-val>undefined</emu-val> to <var>esArgs</var>.</p>
        <p>Otherwise, <var>arg</var><sub><var>i</var></sub> is an IDL value:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>convertResult</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-60">converting</a> <var>arg</var><sub><var>i</var></sub> to an ECMAScript value.</p>
+         <p>Let <var>convertResult</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-59">converting</a> <var>arg</var><sub><var>i</var></sub> to an ECMAScript value.</p>
         <li data-md="">
          <p>If <var>convertResult</var> is an abrupt completion, set <var>completion</var> to <var>convertResult</var> and jump to the step labeled <a href="#invoke-return"><i>return</i></a>.</p>
         <li data-md="">
@@ -12195,7 +12094,7 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
       <li data-md="">
        <p>If <var>completion</var> is a normal completion, return <var>completion</var>.</p>
       <li data-md="">
-       <p>If <var>completion</var> is an abrupt completion and the callback function has a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-9">return type</a> that is <em>not</em> a <a href="#idl-promise" id="ref-for-idl-promise-13">promise type</a>, return <var>completion</var>.</p>
+       <p>If <var>completion</var> is an abrupt completion and the callback function has a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-8">return type</a> that is <em>not</em> a <a href="#idl-promise" id="ref-for-idl-promise-12">promise type</a>, return <var>completion</var>.</p>
       <li data-md="">
        <p>Let <var>reject</var> be the initial value of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.</p>
       <li data-md="">
@@ -12205,26 +12104,26 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
      </ol>
    </ol>
    <h3 class="heading settled" data-level="4.11" id="es-namespaces"><span class="secno">4.11. </span><span class="content">Namespaces</span><a class="self-link" href="#es-namespaces"></a></h3>
-   <p>For every <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-13">namespace</a> that is <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-9">exposed</a> in a given ECMAScript global environment,
+   <p>For every <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-12">namespace</a> that is <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-9">exposed</a> in a given ECMAScript global environment,
 a corresponding property must exist on the ECMAScript
-environment’s global object. The name of the property is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-95">identifier</a> of the namespace, and its value is an object
+environment’s global object. The name of the property is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-91">identifier</a> of the namespace, and its value is an object
 called the <dfn data-dfn-type="dfn" data-export="" id="dfn-namespace-object">namespace object<a class="self-link" href="#dfn-namespace-object"></a></dfn>.</p>
    <p>The property has the attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>,
 [[Configurable]]: <emu-val>true</emu-val> }</span>. The characteristics of a
 namespace object are described in <a href="#namespace-object">§4.11.1 Namespace object</a>.</p>
    <h4 class="heading settled" data-level="4.11.1" id="namespace-object"><span class="secno">4.11.1. </span><span class="content">Namespace object</span><a class="self-link" href="#namespace-object"></a></h4>
-   <p>The namespace object for a given <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-14">namespace</a> <var>namespace</var> and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var> is created as
+   <p>The namespace object for a given <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-13">namespace</a> <var>namespace</var> and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var> is created as
 follows:</p>
    <ol class="algorithm">
     <li data-md="">
      <p>Let <var>namespaceObject</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-objectcreate">ObjectCreate</a>(the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a> of <var>realm</var>).</p>
     <li data-md="">
-     <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-10">exposed</a> <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-21">regular operation</a> <var>op</var> that is a <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-7">namespace member</a> of this namespace,</p>
+     <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-10">exposed</a> <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-19">regular operation</a> <var>op</var> that is a <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-7">namespace member</a> of this namespace,</p>
      <ol>
       <li data-md="">
-       <p>Let <var>F</var> be the result of <a data-link-type="dfn" href="#dfn-create-operation-function" id="ref-for-dfn-create-operation-function-1">creating an operation function</a> given <var>op</var>, <var>namespace</var>,  and <var>realm</var>.</p>
+       <p>Let <var>F</var> be the result of <a data-link-type="dfn" href="#dfn-create-operation-function" id="ref-for-dfn-create-operation-function-2">creating an operation function</a> given <var>op</var>, <var>namespace</var>,  and <var>realm</var>.</p>
       <li data-md="">
-       <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createdataproperty">CreateDataProperty</a>(<var>namespaceObject</var>, <var>op</var>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-96">identifier</a>, <var>F</var>).</p>
+       <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createdataproperty">CreateDataProperty</a>(<var>namespaceObject</var>, <var>op</var>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-92">identifier</a>, <var>F</var>).</p>
      </ol>
    </ol>
    <h3 class="heading settled" data-level="4.12" id="es-exceptions"><span class="secno">4.12. </span><span class="content">Exceptions</span><a class="self-link" href="#es-exceptions"></a></h3>
@@ -12313,17 +12212,17 @@ on exception objects too.</p>
     <li data-md="">
      <p>Let <var>F</var> be the <emu-val>Function</emu-val> object used
 as the <emu-val>this</emu-val> value in the top-most call
-on the ECMAScript call stack where <var>F</var> corresponds to an IDL <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-78">attribute</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-81">operation</a>, <a href="#idl-indexed-properties">indexed property</a>, <a href="#idl-named-properties">named property</a>, <a href="#Constructor" id="ref-for-Constructor-23">constructor</a>, <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-5">named constructor</a> or <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-8">stringifier</a>.</p>
+on the ECMAScript call stack where <var>F</var> corresponds to an IDL <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-78">attribute</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-77">operation</a>, <a href="#idl-indexed-properties">indexed property</a>, <a href="#idl-named-properties">named property</a>, <a href="#Constructor" id="ref-for-Constructor-23">constructor</a>, <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-5">named constructor</a> or <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-8">stringifier</a>.</p>
     <li data-md="">
      <p>If <var>F</var> corresponds to an attribute, operation or stringifier, then return
-the global environment associated with the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-153">interface</a> that definition appears on.</p>
+the global environment associated with the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-148">interface</a> that definition appears on.</p>
     <li data-md="">
      <p>Otherwise, if <var>F</var> corresponds to an indexed or named property, then return
 the global environment associated with the interface that
 the indexed or named property getter, setter or deleter was defined on.</p>
     <li data-md="">
      <p>Otherwise, if <var>F</var> is a named constructor for an interface, or is
-an <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-16">interface object</a> for an
+an <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-15">interface object</a> for an
 interface that is a constructor, then return the global environment
 associated with that interface.</p>
     <li data-md="">
@@ -12337,9 +12236,9 @@ optional user agent-defined message <var>M</var>,
 the following steps must be followed:</p>
    <ol class="algorithm">
     <li data-md="">
-     <p>If <var>M</var> was not specified, let <var>M</var> be <emu-val>undefined</emu-val>. Otherwise, let it be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-61">converting</a> <var>M</var> to a <emu-val>String</emu-val> value.</p>
+     <p>If <var>M</var> was not specified, let <var>M</var> be <emu-val>undefined</emu-val>. Otherwise, let it be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-60">converting</a> <var>M</var> to a <emu-val>String</emu-val> value.</p>
     <li data-md="">
-     <p>Let <var>N</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-62">converting</a> <var>N</var> to a <emu-val>String</emu-val> value.</p>
+     <p>Let <var>N</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-61">converting</a> <var>N</var> to a <emu-val>String</emu-val> value.</p>
     <li data-md="">
      <p>Let <var>args</var> be a list of ECMAScript values.</p>
      <dl class="switch">
@@ -12433,7 +12332,7 @@ must propagate to the caller, and if
 not caught there, to its caller, and so on.</p>
    <div class="example" id="example-7a6383b5">
     <a class="self-link" href="#example-7a6383b5"></a> 
-    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-46">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-154">interfaces</a> and an <a data-link-type="dfn" href="#dfn-exception" id="ref-for-dfn-exception-1">exception</a>.
+    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-46">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-149">interfaces</a> and an <a data-link-type="dfn" href="#dfn-exception" id="ref-for-dfn-exception-1">exception</a>.
     The <code>valueOf</code> attribute on <code class="idl">ExceptionThrower</code> is defined to throw an exception whenever an attempt is made
     to get its value.</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Dahut</span> {
@@ -12504,7 +12403,7 @@ return any value.</p>
    <h2 class="heading settled" data-level="6" id="extensibility"><span class="secno">6. </span><span class="content">Extensibility</span><a class="self-link" href="#extensibility"></a></h2>
    <p><i>This section is informative.</i></p>
    <p>Extensions to language binding requirements can be specified
-using <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-113">extended attributes</a> that do not conflict with those defined in this document.  Extensions for
+using <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-109">extended attributes</a> that do not conflict with those defined in this document.  Extensions for
 private, project-specific use should not be included in <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-47">IDL fragments</a> appearing in other specifications.  It is recommended that extensions
 that are required for use in other specifications be coordinated
 with the group responsible for work on <cite>Web IDL</cite>, which
@@ -12663,7 +12562,7 @@ and “<span class="input">.</span>” is tokenized as the quoted terminal symbo
 used in the grammar and the values used for <emu-t><a href="#prod-identifier">identifier</a></emu-t> terminals.  Thus, for
 example, the input text “<span class="input">Const</span>” is tokenized as
 an <emu-t><a href="#prod-identifier">identifier</a></emu-t> rather than the
-terminal symbol <emu-t>const</emu-t>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-155">interface</a> with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-97">identifier</a> “A” is distinct from one named “a”, and an <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-114">extended attribute</a> [<code class="idl">constructor</code>] will not be recognized as
+terminal symbol <emu-t>const</emu-t>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-150">interface</a> with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-93">identifier</a> “A” is distinct from one named “a”, and an <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-110">extended attribute</a> [<code class="idl">constructor</code>] will not be recognized as
 the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-24">Constructor</a></code>]
 extended attribute.</p>
    <p>Implicitly, any number of <emu-t><a href="#prod-whitespace">whitespace</a></emu-t> and <emu-t><a href="#prod-comment">comment</a></emu-t> terminals are allowed between every other terminal
@@ -12675,7 +12574,7 @@ matches an <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-
    <p>While the <emu-nt><a href="#prod-ExtendedAttribute">ExtendedAttribute</a></emu-nt> non-terminal matches any non-empty sequence of terminal symbols (as long as any
 parentheses, square brackets or braces are balanced, and the <emu-t>,</emu-t> token appears only within those balanced brackets),
 only a subset of those
-possible sequences are used by the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-115">extended attributes</a> defined in this specification — see <a href="#idl-extended-attributes">§3.12 Extended attributes</a> for the syntaxes that are used by these extended attributes.</p>
+possible sequences are used by the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-111">extended attributes</a> defined in this specification — see <a href="#idl-extended-attributes">§3.12 Extended attributes</a> for the syntaxes that are used by these extended attributes.</p>
    <h2 class="no-num heading settled" id="changes"><span class="content">Changes</span><a class="self-link" href="#changes"></a></h2>
    <p><i>This section is informative.</i></p>
    <p>The following is a list of substantial changes to the document on each publication.
@@ -12758,7 +12657,7 @@ on objects.</p>
      <p>Rewrote ES to IDL sequence conversion so that any iterable is
 convertible to a sequence.</p>
     <li data-md="">
-     <p>Added grammar production for <a class="idl-code" data-link-type="interface" href="#idl-promise" id="ref-for-idl-promise-14">Promise&lt;<var>T</var>></a> types
+     <p>Added grammar production for <a class="idl-code" data-link-type="interface" href="#idl-promise" id="ref-for-idl-promise-13">Promise&lt;<var>T</var>></a> types
 and allowed <var>T</var> to be <code class="idl"><a data-link-type="idl" href="#idl-void" id="ref-for-idl-void-9">void</a></code>.</p>
     <li data-md="">
      <p>Added a definition to "initialize an object from an iterable",
@@ -13045,7 +12944,7 @@ this was to the right.)</p>
    <li><a href="#dfn-attribute">attribute</a><span>, in §3.2.2</span>
    <li><a href="#dfn-attribute-getter">attribute getter</a><span>, in §4.6.6</span>
    <li><a href="#dfn-attribute-setter">attribute setter</a><span>, in §4.6.6</span>
-   <li><a href="#dfn-available-only-in-secure-contexts">available only in secure contexts</a><span>, in §4.3.18</span>
+   <li><a href="#dfn-available-only-in-secure-contexts">available only in secure contexts</a><span>, in §4.3.17</span>
    <li><a href="#idl-boolean">boolean</a><span>, in §3.11.1</span>
    <li><a href="#BufferSource">BufferSource</a><span>, in §5.1</span>
    <li><a href="#dfn-buffer-source-type">buffer source types</a><span>, in §3.11</span>
@@ -13150,14 +13049,13 @@ this was to the right.)</p>
    <li><a href="#dfn-get-buffer-source-reference">get a reference to the buffer source</a><span>, in §3.11.30</span>
    <li><a href="#get-a-user-objects-attribute-value">get a user object’s attribute value</a><span>, in §4.9</span>
    <li><a href="#dfn-getter">getter</a><span>, in §3.2.4</span>
-   <li><a href="#Global">Global</a><span>, in §4.3.5</span>
-   <li><a href="#dfn-global-name">global names</a><span>, in §4.3.6</span>
+   <li><a href="#Global">Global</a><span>, in §4.3.4</span>
+   <li><a href="#dfn-global-name">global names</a><span>, in §4.3.5</span>
    <li><a href="#dom-domexception-hierarchy_request_err">HIERARCHY_REQUEST_ERR</a><span>, in §3.5.1</span>
    <li><a href="#hierarchyrequesterror">HierarchyRequestError</a><span>, in §3.5.1</span>
    <li><a href="#dfn-identifier">identifier</a><span>, in §3.1</span>
    <li><a href="#dfn-idl-fragment">IDL fragment</a><span>, in §3</span>
    <li><a href="#dfn-implements-statement">implements statement</a><span>, in §3.9</span>
-   <li><a href="#ImplicitThis">ImplicitThis</a><span>, in §4.3.4</span>
    <li><a href="#dfn-includes-a-nullable-type">includes a nullable type</a><span>, in §3.11.26</span>
    <li><a href="#dfn-indexed-property-getter">indexed property getter</a><span>, in §3.2.4</span>
    <li><a href="#dfn-indexed-property-setter">indexed property setter</a><span>, in §3.2.4</span>
@@ -13202,11 +13100,11 @@ this was to the right.)</p>
    <li><a href="#dfn-iterable-declaration">iterable declaration</a><span>, in §3.2.7</span>
    <li><a href="#dfn-iterator-prototype-object">iterator prototype object</a><span>, in §4.6.9.5</span>
    <li><a href="#dfn-legacy-caller">legacy</a><span>, in §3.2.4</span>
-   <li><a href="#LegacyArrayClass">LegacyArrayClass</a><span>, in §4.3.6</span>
+   <li><a href="#LegacyArrayClass">LegacyArrayClass</a><span>, in §4.3.5</span>
    <li><a href="#idl-legacy-callers">Legacy callers</a><span>, in §3.2.4</span>
-   <li><a href="#LegacyUnenumerableNamedProperties">LegacyUnenumerableNamedProperties</a><span>, in §4.3.7</span>
-   <li><a href="#LenientSetter">LenientSetter</a><span>, in §4.3.8</span>
-   <li><a href="#LenientThis">LenientThis</a><span>, in §4.3.9</span>
+   <li><a href="#LegacyUnenumerableNamedProperties">LegacyUnenumerableNamedProperties</a><span>, in §4.3.6</span>
+   <li><a href="#LenientSetter">LenientSetter</a><span>, in §4.3.7</span>
+   <li><a href="#LenientThis">LenientThis</a><span>, in §4.3.8</span>
    <li><a href="#idl-long">long</a><span>, in §3.11.6</span>
    <li><a href="#idl-long-long">long long</a><span>, in §3.11.8</span>
    <li><a href="#dfn-map-entries">map entries</a><span>, in §3.2.8</span>
@@ -13216,7 +13114,7 @@ this was to the right.)</p>
    <li><a href="#dfn-union-member-type">member types</a><span>, in §3.11.26</span>
    <li><a href="#dfn-exception-message">message</a><span>, in §3.5</span>
    <li><a href="#dfn-named-constructor">named constructor</a><span>, in §4.6</span>
-   <li><a href="#NamedConstructor">NamedConstructor</a><span>, in §4.3.10</span>
+   <li><a href="#NamedConstructor">NamedConstructor</a><span>, in §4.3.9</span>
    <li><a href="#dfn-named-definition">named definition</a><span>, in §3.1</span>
    <li><a href="#dfn-named-properties-object">named properties object</a><span>, in §4.6.4</span>
    <li><a href="#dfn-named-property-deleter">named property deleter</a><span>, in §3.2.4</span>
@@ -13230,8 +13128,8 @@ this was to the right.)</p>
    <li><a href="#dfn-namespace-object">namespace object</a><span>, in §4.11</span>
    <li><a href="#dom-domexception-network_err">NETWORK_ERR</a><span>, in §3.5.1</span>
    <li><a href="#networkerror">NetworkError</a><span>, in §3.5.1</span>
-   <li><a href="#NewObject">NewObject</a><span>, in §4.3.11</span>
-   <li><a href="#NoInterfaceObject">NoInterfaceObject</a><span>, in §4.3.12</span>
+   <li><a href="#NewObject">NewObject</a><span>, in §4.3.10</span>
+   <li><a href="#NoInterfaceObject">NoInterfaceObject</a><span>, in §4.3.11</span>
    <li><a href="#dom-domexception-no_modification_allowed_err">NO_MODIFICATION_ALLOWED_ERR</a><span>, in §3.5.1</span>
    <li><a href="#nomodificationallowederror">NoModificationAllowedError</a><span>, in §3.5.1</span>
    <li><a href="#notallowederror">NotAllowedError</a><span>, in §3.5.1</span>
@@ -13253,7 +13151,7 @@ this was to the right.)</p>
    <li><a href="#dfn-optionality-value">optionality values</a><span>, in §3.2.6</span>
    <li><a href="#dfn-overloaded">overloaded</a><span>, in §3.2.6</span>
    <li><a href="#dfn-overload-resolution-algorithm">overload resolution algorithm</a><span>, in §4.5</span>
-   <li><a href="#OverrideBuiltins">OverrideBuiltins</a><span>, in §4.3.13</span>
+   <li><a href="#OverrideBuiltins">OverrideBuiltins</a><span>, in §4.3.12</span>
    <li><a href="#dfn-pair-iterator">pair iterator</a><span>, in §3.2.7</span>
    <li><a href="#dfn-partial-dictionary">partial dictionary</a><span>, in §3.4</span>
    <li><a href="#dfn-partial-interface">partial interface</a><span>, in §3.2</span>
@@ -13261,15 +13159,15 @@ this was to the right.)</p>
    <li><a href="#dfn-perform-a-security-check">perform a security check</a><span>, in §4.4</span>
    <li><a href="#dfn-platform-object">platform object</a><span>, in §3.10</span>
    <li><a href="#dfn-present">present</a><span>, in §3.4</span>
-   <li><a href="#Global">PrimaryGlobal</a><span>, in §4.3.5</span>
-   <li><a href="#dfn-primary-global-interface">primary global interface</a><span>, in §4.3.6</span>
+   <li><a href="#Global">PrimaryGlobal</a><span>, in §4.3.4</span>
+   <li><a href="#dfn-primary-global-interface">primary global interface</a><span>, in §4.3.5</span>
    <li><a href="#dfn-primary-interface">primary interface</a><span>, in §4.8</span>
    <li><a href="#dfn-primitive-type">primitive types</a><span>, in §3.11</span>
    <li><a href="#dfn-processing-equivalence">processing equivalence</a><span>, in §2.1</span>
    <li><a href="#idl-promise">Promise</a><span>, in §3.11.24</span>
    <li><a href="#idl-promise">Promise&lt;T></a><span>, in §3.11.24</span>
    <li><a href="#dfn-promise-type">promise type</a><span>, in §3.11.25</span>
-   <li><a href="#PutForwards">PutForwards</a><span>, in §4.3.14</span>
+   <li><a href="#PutForwards">PutForwards</a><span>, in §4.3.13</span>
    <li><a href="#dom-domexception-quota_exceeded_err">QUOTA_EXCEEDED_ERR</a><span>, in §3.5.1</span>
    <li><a href="#quotaexceedederror">QuotaExceededError</a><span>, in §3.5.1</span>
    <li><a href="#exceptiondef-rangeerror">RangeError</a><span>, in §3.5</span>
@@ -13279,12 +13177,12 @@ this was to the right.)</p>
    <li><a href="#idl-RegExp">RegExp</a><span>, in §3.11.26</span>
    <li><a href="#dfn-regular-attribute">regular attribute</a><span>, in §3.2.2</span>
    <li><a href="#dfn-regular-operation">regular operation</a><span>, in §3.2.3</span>
-   <li><a href="#Replaceable">Replaceable</a><span>, in §4.3.15</span>
+   <li><a href="#Replaceable">Replaceable</a><span>, in §4.3.14</span>
    <li><a href="#required-dictionary-member">required dictionary member</a><span>, in §3.4</span>
    <li><a href="#dfn-reserved-identifier">reserved identifiers</a><span>, in §3.1</span>
    <li><a href="#dfn-return-type">return type</a><span>, in §3.2.3</span>
-   <li><a href="#SameObject">SameObject</a><span>, in §4.3.16</span>
-   <li><a href="#SecureContext">SecureContext</a><span>, in §4.3.17</span>
+   <li><a href="#SameObject">SameObject</a><span>, in §4.3.15</span>
+   <li><a href="#SecureContext">SecureContext</a><span>, in §4.3.16</span>
    <li><a href="#dom-domexception-security_err">SECURITY_ERR</a><span>, in §3.5.1</span>
    <li><a href="#securityerror">SecurityError</a><span>, in §3.5.1</span>
    <li><a href="#idl-sequence">sequence</a><span>, in §3.11.23</span>
@@ -13333,8 +13231,8 @@ this was to the right.)</p>
    <li><a href="#dom-domexception-timeout_err">TIMEOUT_ERR</a><span>, in §3.5.1</span>
    <li><a href="#timeouterror">TimeoutError</a><span>, in §3.5.1</span>
    <li><a href="#transactioninactiveerror">TransactionInactiveError</a><span>, in §3.5.1</span>
-   <li><a href="#TreatNonObjectAsNull">TreatNonObjectAsNull</a><span>, in §4.3.18</span>
-   <li><a href="#TreatNullAs">TreatNullAs</a><span>, in §4.3.19</span>
+   <li><a href="#TreatNonObjectAsNull">TreatNonObjectAsNull</a><span>, in §4.3.17</span>
+   <li><a href="#TreatNullAs">TreatNullAs</a><span>, in §4.3.18</span>
    <li><a href="#dfn-typed-array-type">typed array types</a><span>, in §3.11</span>
    <li><a href="#dfn-typedef">typedef</a><span>, in §3.8</span>
    <li><a href="#exceptiondef-typeerror">TypeError</a><span>, in §3.5</span>
@@ -13343,14 +13241,14 @@ this was to the right.)</p>
    <li><a href="#idl-Uint32Array">Uint32Array</a><span>, in §3.11.30</span>
    <li><a href="#idl-Uint8Array">Uint8Array</a><span>, in §3.11.30</span>
    <li><a href="#idl-Uint8ClampedArray">Uint8ClampedArray</a><span>, in §3.11.30</span>
-   <li><a href="#dfn-unforgeable-on-an-interface">unforgeable</a><span>, in §4.3.21</span>
-   <li><a href="#Unforgeable">Unforgeable</a><span>, in §4.3.20</span>
+   <li><a href="#dfn-unforgeable-on-an-interface">unforgeable</a><span>, in §4.3.20</span>
+   <li><a href="#Unforgeable">Unforgeable</a><span>, in §4.3.19</span>
    <li><a href="#dfn-unforgeable-property-name">unforgeable property name</a><span>, in §4.8.1</span>
    <li><a href="#dfn-union-type">union type</a><span>, in §3.11.26</span>
    <li><a href="#unknownerror">UnknownError</a><span>, in §3.5.1</span>
    <li><a href="#idl-unrestricted-double">unrestricted double</a><span>, in §3.11.13</span>
    <li><a href="#idl-unrestricted-float">unrestricted float</a><span>, in §3.11.11</span>
-   <li><a href="#Unscopable">Unscopable</a><span>, in §4.3.21</span>
+   <li><a href="#Unscopable">Unscopable</a><span>, in §4.3.20</span>
    <li><a href="#idl-unsigned-long">unsigned long</a><span>, in §3.11.7</span>
    <li><a href="#idl-unsigned-long-long">unsigned long long</a><span>, in §3.11.9</span>
    <li><a href="#idl-unsigned-short">unsigned short</a><span>, in §3.11.5</span>
@@ -13455,6 +13353,7 @@ this was to the right.)</p>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-a-callback">clean up after running a callback</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script">clean up after running script</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-attributes">event handler idl attributes</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global">global object</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-a-callback">prepare to run a callback</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script">prepare to run script</a>
@@ -13571,15 +13470,15 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-idl-fragment-33">4.1. ECMAScript environment</a> <a href="#ref-for-dfn-idl-fragment-34">(2)</a>
     <li><a href="#ref-for-dfn-idl-fragment-35">4.3.1. [Clamp]</a>
     <li><a href="#ref-for-dfn-idl-fragment-36">4.3.3. [EnforceRange]</a>
-    <li><a href="#ref-for-dfn-idl-fragment-37">4.3.7. [LegacyArrayClass]</a>
-    <li><a href="#ref-for-dfn-idl-fragment-38">4.3.13. [NoInterfaceObject]</a>
-    <li><a href="#ref-for-dfn-idl-fragment-39">4.3.14. [OverrideBuiltins]</a>
-    <li><a href="#ref-for-dfn-idl-fragment-40">4.3.15. [PutForwards]</a>
-    <li><a href="#ref-for-dfn-idl-fragment-41">4.3.16. [Replaceable]</a>
-    <li><a href="#ref-for-dfn-idl-fragment-42">4.3.18. [SecureContext]</a>
-    <li><a href="#ref-for-dfn-idl-fragment-43">4.3.19. [TreatNonObjectAsNull]</a>
-    <li><a href="#ref-for-dfn-idl-fragment-44">4.3.20. [TreatNullAs]</a>
-    <li><a href="#ref-for-dfn-idl-fragment-45">4.3.21. [Unforgeable]</a>
+    <li><a href="#ref-for-dfn-idl-fragment-37">4.3.6. [LegacyArrayClass]</a>
+    <li><a href="#ref-for-dfn-idl-fragment-38">4.3.12. [NoInterfaceObject]</a>
+    <li><a href="#ref-for-dfn-idl-fragment-39">4.3.13. [OverrideBuiltins]</a>
+    <li><a href="#ref-for-dfn-idl-fragment-40">4.3.14. [PutForwards]</a>
+    <li><a href="#ref-for-dfn-idl-fragment-41">4.3.15. [Replaceable]</a>
+    <li><a href="#ref-for-dfn-idl-fragment-42">4.3.17. [SecureContext]</a>
+    <li><a href="#ref-for-dfn-idl-fragment-43">4.3.18. [TreatNonObjectAsNull]</a>
+    <li><a href="#ref-for-dfn-idl-fragment-44">4.3.19. [TreatNullAs]</a>
+    <li><a href="#ref-for-dfn-idl-fragment-45">4.3.20. [Unforgeable]</a>
     <li><a href="#ref-for-dfn-idl-fragment-46">4.15. Handling exceptions</a>
     <li><a href="#ref-for-dfn-idl-fragment-47">6. Extensibility</a>
     <li><a href="#ref-for-dfn-idl-fragment-48">7. Referencing this specification</a>
@@ -13623,9 +13522,9 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-identifier-45">3.11.21. Enumeration types</a> <a href="#ref-for-dfn-identifier-46">(2)</a>
     <li><a href="#ref-for-dfn-identifier-47">3.11.22. Callback function types</a> <a href="#ref-for-dfn-identifier-48">(2)</a>
     <li><a href="#ref-for-dfn-identifier-49">4.2.21. Dictionary types</a> <a href="#ref-for-dfn-identifier-50">(2)</a>
-    <li><a href="#ref-for-dfn-identifier-51">4.3.6. [Global] and [PrimaryGlobal]</a>
-    <li><a href="#ref-for-dfn-identifier-52">4.3.15. [PutForwards]</a> <a href="#ref-for-dfn-identifier-53">(2)</a>
-    <li><a href="#ref-for-dfn-identifier-54">4.3.21. [Unforgeable]</a> <a href="#ref-for-dfn-identifier-55">(2)</a>
+    <li><a href="#ref-for-dfn-identifier-51">4.3.5. [Global] and [PrimaryGlobal]</a>
+    <li><a href="#ref-for-dfn-identifier-52">4.3.14. [PutForwards]</a> <a href="#ref-for-dfn-identifier-53">(2)</a>
+    <li><a href="#ref-for-dfn-identifier-54">4.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-identifier-55">(2)</a>
     <li><a href="#ref-for-dfn-identifier-56">4.4. Security</a>
     <li><a href="#ref-for-dfn-identifier-57">4.6. Interfaces</a>
     <li><a href="#ref-for-dfn-identifier-58">4.6.1.1. Interface object [[Call]] method</a> <a href="#ref-for-dfn-identifier-59">(2)</a>
@@ -13635,27 +13534,27 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-identifier-66">4.6.4.1. Named properties object [[GetOwnProperty]] method</a>
     <li><a href="#ref-for-dfn-identifier-67">4.6.5. Constants</a>
     <li><a href="#ref-for-dfn-identifier-68">4.6.6. Attributes</a> <a href="#ref-for-dfn-identifier-69">(2)</a> <a href="#ref-for-dfn-identifier-70">(3)</a>
-    <li><a href="#ref-for-dfn-identifier-71">4.6.7. Operations</a> <a href="#ref-for-dfn-identifier-72">(2)</a> <a href="#ref-for-dfn-identifier-73">(3)</a> <a href="#ref-for-dfn-identifier-74">(4)</a> <a href="#ref-for-dfn-identifier-75">(5)</a> <a href="#ref-for-dfn-identifier-76">(6)</a> <a href="#ref-for-dfn-identifier-77">(7)</a> <a href="#ref-for-dfn-identifier-78">(8)</a> <a href="#ref-for-dfn-identifier-79">(9)</a> <a href="#ref-for-dfn-identifier-80">(10)</a>
-    <li><a href="#ref-for-dfn-identifier-81">4.6.7.1. Stringifiers</a>
-    <li><a href="#ref-for-dfn-identifier-82">4.6.7.2. Serializers</a>
-    <li><a href="#ref-for-dfn-identifier-83">4.6.9.4. Default iterator objects</a>
-    <li><a href="#ref-for-dfn-identifier-84">4.6.9.5. Iterator prototype object</a>
-    <li><a href="#ref-for-dfn-identifier-85">4.8. Platform objects implementing interfaces</a>
-    <li><a href="#ref-for-dfn-identifier-86">4.8.1. Indexed and named properties</a>
-    <li><a href="#ref-for-dfn-identifier-87">4.8.2. The PlatformObjectGetOwnProperty abstract operation</a> <a href="#ref-for-dfn-identifier-88">(2)</a>
-    <li><a href="#ref-for-dfn-identifier-89">4.8.4. Invoking a platform object indexed property setter</a>
-    <li><a href="#ref-for-dfn-identifier-90">4.8.5. Invoking a platform object named property setter</a>
-    <li><a href="#ref-for-dfn-identifier-91">4.8.8. Platform object [[Delete]] method</a>
-    <li><a href="#ref-for-dfn-identifier-92">4.9. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-identifier-93">(2)</a> <a href="#ref-for-dfn-identifier-94">(3)</a>
-    <li><a href="#ref-for-dfn-identifier-95">4.11. Namespaces</a>
-    <li><a href="#ref-for-dfn-identifier-96">4.11.1. Namespace object</a>
-    <li><a href="#ref-for-dfn-identifier-97">IDL grammar</a>
+    <li><a href="#ref-for-dfn-identifier-71">4.6.7. Operations</a> <a href="#ref-for-dfn-identifier-72">(2)</a> <a href="#ref-for-dfn-identifier-73">(3)</a> <a href="#ref-for-dfn-identifier-74">(4)</a> <a href="#ref-for-dfn-identifier-75">(5)</a> <a href="#ref-for-dfn-identifier-76">(6)</a>
+    <li><a href="#ref-for-dfn-identifier-77">4.6.7.1. Stringifiers</a>
+    <li><a href="#ref-for-dfn-identifier-78">4.6.7.2. Serializers</a>
+    <li><a href="#ref-for-dfn-identifier-79">4.6.9.4. Default iterator objects</a>
+    <li><a href="#ref-for-dfn-identifier-80">4.6.9.5. Iterator prototype object</a>
+    <li><a href="#ref-for-dfn-identifier-81">4.8. Platform objects implementing interfaces</a>
+    <li><a href="#ref-for-dfn-identifier-82">4.8.1. Indexed and named properties</a>
+    <li><a href="#ref-for-dfn-identifier-83">4.8.2. The PlatformObjectGetOwnProperty abstract operation</a> <a href="#ref-for-dfn-identifier-84">(2)</a>
+    <li><a href="#ref-for-dfn-identifier-85">4.8.4. Invoking a platform object indexed property setter</a>
+    <li><a href="#ref-for-dfn-identifier-86">4.8.5. Invoking a platform object named property setter</a>
+    <li><a href="#ref-for-dfn-identifier-87">4.8.8. Platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-identifier-88">4.9. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-identifier-89">(2)</a> <a href="#ref-for-dfn-identifier-90">(3)</a>
+    <li><a href="#ref-for-dfn-identifier-91">4.11. Namespaces</a>
+    <li><a href="#ref-for-dfn-identifier-92">4.11.1. Namespace object</a>
+    <li><a href="#ref-for-dfn-identifier-93">IDL grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-reserved-identifier">
    <b><a href="#dfn-reserved-identifier">#dfn-reserved-identifier</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-reserved-identifier-1">4.3.11. [NamedConstructor]</a>
+    <li><a href="#ref-for-dfn-reserved-identifier-1">4.3.10. [NamedConstructor]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-interface">
@@ -13688,52 +13587,51 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-interface-55">4.2.25.1. Creating a sequence from an iterable</a>
     <li><a href="#ref-for-dfn-interface-56">4.3.2. [Constructor]</a>
     <li><a href="#ref-for-dfn-interface-57">4.3.4. [Exposed]</a> <a href="#ref-for-dfn-interface-58">(2)</a> <a href="#ref-for-dfn-interface-59">(3)</a>
-    <li><a href="#ref-for-dfn-interface-60">4.3.5. [ImplicitThis]</a> <a href="#ref-for-dfn-interface-61">(2)</a> <a href="#ref-for-dfn-interface-62">(3)</a>
-    <li><a href="#ref-for-dfn-interface-63">4.3.6. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-interface-64">(2)</a> <a href="#ref-for-dfn-interface-65">(3)</a> <a href="#ref-for-dfn-interface-66">(4)</a>
-    <li><a href="#ref-for-dfn-interface-67">4.3.7. [LegacyArrayClass]</a> <a href="#ref-for-dfn-interface-68">(2)</a>
-    <li><a href="#ref-for-dfn-interface-69">4.3.8. [LegacyUnenumerableNamedProperties]</a>
-    <li><a href="#ref-for-dfn-interface-70">4.3.10. [LenientThis]</a>
-    <li><a href="#ref-for-dfn-interface-71">4.3.11. [NamedConstructor]</a>
-    <li><a href="#ref-for-dfn-interface-72">4.3.13. [NoInterfaceObject]</a>
-    <li><a href="#ref-for-dfn-interface-73">4.3.14. [OverrideBuiltins]</a> <a href="#ref-for-dfn-interface-74">(2)</a>
-    <li><a href="#ref-for-dfn-interface-75">4.3.15. [PutForwards]</a> <a href="#ref-for-dfn-interface-76">(2)</a>
-    <li><a href="#ref-for-dfn-interface-77">4.3.16. [Replaceable]</a>
-    <li><a href="#ref-for-dfn-interface-78">4.3.18. [SecureContext]</a> <a href="#ref-for-dfn-interface-79">(2)</a>
-    <li><a href="#ref-for-dfn-interface-80">4.3.21. [Unforgeable]</a> <a href="#ref-for-dfn-interface-81">(2)</a>
-    <li><a href="#ref-for-dfn-interface-82">4.6. Interfaces</a> <a href="#ref-for-dfn-interface-83">(2)</a>
-    <li><a href="#ref-for-dfn-interface-84">4.6.1. Interface object</a>
-    <li><a href="#ref-for-dfn-interface-85">4.6.1.1. Interface object [[Call]] method</a> <a href="#ref-for-dfn-interface-86">(2)</a> <a href="#ref-for-dfn-interface-87">(3)</a> <a href="#ref-for-dfn-interface-88">(4)</a>
-    <li><a href="#ref-for-dfn-interface-89">4.6.2. Named constructors</a> <a href="#ref-for-dfn-interface-90">(2)</a> <a href="#ref-for-dfn-interface-91">(3)</a> <a href="#ref-for-dfn-interface-92">(4)</a>
-    <li><a href="#ref-for-dfn-interface-93">4.6.3. Interface prototype object</a> <a href="#ref-for-dfn-interface-94">(2)</a> <a href="#ref-for-dfn-interface-95">(3)</a>
-    <li><a href="#ref-for-dfn-interface-96">4.6.4. Named properties object</a> <a href="#ref-for-dfn-interface-97">(2)</a>
-    <li><a href="#ref-for-dfn-interface-98">4.6.4.1. Named properties object [[GetOwnProperty]] method</a> <a href="#ref-for-dfn-interface-99">(2)</a>
-    <li><a href="#ref-for-dfn-interface-100">4.6.5. Constants</a>
-    <li><a href="#ref-for-dfn-interface-101">4.6.6. Attributes</a> <a href="#ref-for-dfn-interface-102">(2)</a> <a href="#ref-for-dfn-interface-103">(3)</a>
-    <li><a href="#ref-for-dfn-interface-104">4.6.7. Operations</a> <a href="#ref-for-dfn-interface-105">(2)</a> <a href="#ref-for-dfn-interface-106">(3)</a> <a href="#ref-for-dfn-interface-107">(4)</a> <a href="#ref-for-dfn-interface-108">(5)</a>
-    <li><a href="#ref-for-dfn-interface-109">4.6.7.1. Stringifiers</a> <a href="#ref-for-dfn-interface-110">(2)</a>
-    <li><a href="#ref-for-dfn-interface-111">4.6.7.2. Serializers</a> <a href="#ref-for-dfn-interface-112">(2)</a> <a href="#ref-for-dfn-interface-113">(3)</a>
-    <li><a href="#ref-for-dfn-interface-114">4.6.8.1. @@iterator</a> <a href="#ref-for-dfn-interface-115">(2)</a> <a href="#ref-for-dfn-interface-116">(3)</a>
-    <li><a href="#ref-for-dfn-interface-117">4.6.8.2. forEach</a> <a href="#ref-for-dfn-interface-118">(2)</a>
-    <li><a href="#ref-for-dfn-interface-119">4.6.9.1. entries</a>
-    <li><a href="#ref-for-dfn-interface-120">4.6.9.2. keys</a> <a href="#ref-for-dfn-interface-121">(2)</a>
-    <li><a href="#ref-for-dfn-interface-122">4.6.9.3. values</a> <a href="#ref-for-dfn-interface-123">(2)</a>
-    <li><a href="#ref-for-dfn-interface-124">4.6.9.4. Default iterator objects</a> <a href="#ref-for-dfn-interface-125">(2)</a> <a href="#ref-for-dfn-interface-126">(3)</a> <a href="#ref-for-dfn-interface-127">(4)</a>
-    <li><a href="#ref-for-dfn-interface-128">4.6.9.5. Iterator prototype object</a> <a href="#ref-for-dfn-interface-129">(2)</a> <a href="#ref-for-dfn-interface-130">(3)</a> <a href="#ref-for-dfn-interface-131">(4)</a>
-    <li><a href="#ref-for-dfn-interface-132">4.6.10. Maplike declarations</a> <a href="#ref-for-dfn-interface-133">(2)</a>
-    <li><a href="#ref-for-dfn-interface-134">4.6.11. Setlike declarations</a> <a href="#ref-for-dfn-interface-135">(2)</a>
-    <li><a href="#ref-for-dfn-interface-136">4.7. Implements statements</a>
-    <li><a href="#ref-for-dfn-interface-137">4.8.1. Indexed and named properties</a> <a href="#ref-for-dfn-interface-138">(2)</a> <a href="#ref-for-dfn-interface-139">(3)</a> <a href="#ref-for-dfn-interface-140">(4)</a>
-    <li><a href="#ref-for-dfn-interface-141">4.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-dfn-interface-142">4.8.3. Platform object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-interface-143">4.8.6. Platform object [[Set]] method</a>
-    <li><a href="#ref-for-dfn-interface-144">4.8.7. Platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-interface-145">(2)</a> <a href="#ref-for-dfn-interface-146">(3)</a>
-    <li><a href="#ref-for-dfn-interface-147">4.8.8. Platform object [[Delete]] method</a> <a href="#ref-for-dfn-interface-148">(2)</a>
-    <li><a href="#ref-for-dfn-interface-149">4.8.9. Platform object [[Call]] method</a>
-    <li><a href="#ref-for-dfn-interface-150">4.8.10. Property enumeration</a> <a href="#ref-for-dfn-interface-151">(2)</a>
-    <li><a href="#ref-for-dfn-interface-152">4.9. User objects implementing callback interfaces</a>
-    <li><a href="#ref-for-dfn-interface-153">4.14. Creating and throwing exceptions</a>
-    <li><a href="#ref-for-dfn-interface-154">4.15. Handling exceptions</a>
-    <li><a href="#ref-for-dfn-interface-155">IDL grammar</a>
+    <li><a href="#ref-for-dfn-interface-60">4.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-interface-61">(2)</a> <a href="#ref-for-dfn-interface-62">(3)</a> <a href="#ref-for-dfn-interface-63">(4)</a>
+    <li><a href="#ref-for-dfn-interface-64">4.3.6. [LegacyArrayClass]</a> <a href="#ref-for-dfn-interface-65">(2)</a>
+    <li><a href="#ref-for-dfn-interface-66">4.3.7. [LegacyUnenumerableNamedProperties]</a>
+    <li><a href="#ref-for-dfn-interface-67">4.3.9. [LenientThis]</a>
+    <li><a href="#ref-for-dfn-interface-68">4.3.10. [NamedConstructor]</a>
+    <li><a href="#ref-for-dfn-interface-69">4.3.12. [NoInterfaceObject]</a>
+    <li><a href="#ref-for-dfn-interface-70">4.3.13. [OverrideBuiltins]</a> <a href="#ref-for-dfn-interface-71">(2)</a>
+    <li><a href="#ref-for-dfn-interface-72">4.3.14. [PutForwards]</a> <a href="#ref-for-dfn-interface-73">(2)</a>
+    <li><a href="#ref-for-dfn-interface-74">4.3.15. [Replaceable]</a>
+    <li><a href="#ref-for-dfn-interface-75">4.3.17. [SecureContext]</a> <a href="#ref-for-dfn-interface-76">(2)</a>
+    <li><a href="#ref-for-dfn-interface-77">4.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-interface-78">(2)</a>
+    <li><a href="#ref-for-dfn-interface-79">4.6. Interfaces</a> <a href="#ref-for-dfn-interface-80">(2)</a>
+    <li><a href="#ref-for-dfn-interface-81">4.6.1. Interface object</a>
+    <li><a href="#ref-for-dfn-interface-82">4.6.1.1. Interface object [[Call]] method</a> <a href="#ref-for-dfn-interface-83">(2)</a> <a href="#ref-for-dfn-interface-84">(3)</a> <a href="#ref-for-dfn-interface-85">(4)</a>
+    <li><a href="#ref-for-dfn-interface-86">4.6.2. Named constructors</a> <a href="#ref-for-dfn-interface-87">(2)</a> <a href="#ref-for-dfn-interface-88">(3)</a> <a href="#ref-for-dfn-interface-89">(4)</a>
+    <li><a href="#ref-for-dfn-interface-90">4.6.3. Interface prototype object</a> <a href="#ref-for-dfn-interface-91">(2)</a> <a href="#ref-for-dfn-interface-92">(3)</a>
+    <li><a href="#ref-for-dfn-interface-93">4.6.4. Named properties object</a> <a href="#ref-for-dfn-interface-94">(2)</a>
+    <li><a href="#ref-for-dfn-interface-95">4.6.4.1. Named properties object [[GetOwnProperty]] method</a> <a href="#ref-for-dfn-interface-96">(2)</a>
+    <li><a href="#ref-for-dfn-interface-97">4.6.5. Constants</a>
+    <li><a href="#ref-for-dfn-interface-98">4.6.6. Attributes</a> <a href="#ref-for-dfn-interface-99">(2)</a> <a href="#ref-for-dfn-interface-100">(3)</a>
+    <li><a href="#ref-for-dfn-interface-101">4.6.7. Operations</a> <a href="#ref-for-dfn-interface-102">(2)</a> <a href="#ref-for-dfn-interface-103">(3)</a>
+    <li><a href="#ref-for-dfn-interface-104">4.6.7.1. Stringifiers</a> <a href="#ref-for-dfn-interface-105">(2)</a>
+    <li><a href="#ref-for-dfn-interface-106">4.6.7.2. Serializers</a> <a href="#ref-for-dfn-interface-107">(2)</a> <a href="#ref-for-dfn-interface-108">(3)</a>
+    <li><a href="#ref-for-dfn-interface-109">4.6.8.1. @@iterator</a> <a href="#ref-for-dfn-interface-110">(2)</a> <a href="#ref-for-dfn-interface-111">(3)</a>
+    <li><a href="#ref-for-dfn-interface-112">4.6.8.2. forEach</a> <a href="#ref-for-dfn-interface-113">(2)</a>
+    <li><a href="#ref-for-dfn-interface-114">4.6.9.1. entries</a>
+    <li><a href="#ref-for-dfn-interface-115">4.6.9.2. keys</a> <a href="#ref-for-dfn-interface-116">(2)</a>
+    <li><a href="#ref-for-dfn-interface-117">4.6.9.3. values</a> <a href="#ref-for-dfn-interface-118">(2)</a>
+    <li><a href="#ref-for-dfn-interface-119">4.6.9.4. Default iterator objects</a> <a href="#ref-for-dfn-interface-120">(2)</a> <a href="#ref-for-dfn-interface-121">(3)</a> <a href="#ref-for-dfn-interface-122">(4)</a>
+    <li><a href="#ref-for-dfn-interface-123">4.6.9.5. Iterator prototype object</a> <a href="#ref-for-dfn-interface-124">(2)</a> <a href="#ref-for-dfn-interface-125">(3)</a> <a href="#ref-for-dfn-interface-126">(4)</a>
+    <li><a href="#ref-for-dfn-interface-127">4.6.10. Maplike declarations</a> <a href="#ref-for-dfn-interface-128">(2)</a>
+    <li><a href="#ref-for-dfn-interface-129">4.6.11. Setlike declarations</a> <a href="#ref-for-dfn-interface-130">(2)</a>
+    <li><a href="#ref-for-dfn-interface-131">4.7. Implements statements</a>
+    <li><a href="#ref-for-dfn-interface-132">4.8.1. Indexed and named properties</a> <a href="#ref-for-dfn-interface-133">(2)</a> <a href="#ref-for-dfn-interface-134">(3)</a> <a href="#ref-for-dfn-interface-135">(4)</a>
+    <li><a href="#ref-for-dfn-interface-136">4.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
+    <li><a href="#ref-for-dfn-interface-137">4.8.3. Platform object [[GetOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-interface-138">4.8.6. Platform object [[Set]] method</a>
+    <li><a href="#ref-for-dfn-interface-139">4.8.7. Platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-interface-140">(2)</a> <a href="#ref-for-dfn-interface-141">(3)</a>
+    <li><a href="#ref-for-dfn-interface-142">4.8.8. Platform object [[Delete]] method</a> <a href="#ref-for-dfn-interface-143">(2)</a>
+    <li><a href="#ref-for-dfn-interface-144">4.8.9. Platform object [[Call]] method</a>
+    <li><a href="#ref-for-dfn-interface-145">4.8.10. Property enumeration</a> <a href="#ref-for-dfn-interface-146">(2)</a>
+    <li><a href="#ref-for-dfn-interface-147">4.9. User objects implementing callback interfaces</a>
+    <li><a href="#ref-for-dfn-interface-148">4.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-interface-149">4.15. Handling exceptions</a>
+    <li><a href="#ref-for-dfn-interface-150">IDL grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-interface-member">
@@ -13748,8 +13646,8 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-interface-member-9">3.2.9. Setlike declarations</a>
     <li><a href="#ref-for-dfn-interface-member-10">3.12. Extended attributes</a>
     <li><a href="#ref-for-dfn-interface-member-11">4.3.4. [Exposed]</a> <a href="#ref-for-dfn-interface-member-12">(2)</a>
-    <li><a href="#ref-for-dfn-interface-member-13">4.3.6. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-interface-member-14">(2)</a> <a href="#ref-for-dfn-interface-member-15">(3)</a> <a href="#ref-for-dfn-interface-member-16">(4)</a>
-    <li><a href="#ref-for-dfn-interface-member-17">4.3.18. [SecureContext]</a> <a href="#ref-for-dfn-interface-member-18">(2)</a>
+    <li><a href="#ref-for-dfn-interface-member-13">4.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-interface-member-14">(2)</a> <a href="#ref-for-dfn-interface-member-15">(3)</a> <a href="#ref-for-dfn-interface-member-16">(4)</a>
+    <li><a href="#ref-for-dfn-interface-member-17">4.3.17. [SecureContext]</a> <a href="#ref-for-dfn-interface-member-18">(2)</a>
     <li><a href="#ref-for-dfn-interface-member-19">4.6.3. Interface prototype object</a> <a href="#ref-for-dfn-interface-member-20">(2)</a>
     <li><a href="#ref-for-dfn-interface-member-21">4.6.10.5. clear</a>
     <li><a href="#ref-for-dfn-interface-member-22">4.6.10.6. delete</a>
@@ -13766,9 +13664,9 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-inherit-5">3.4. Dictionaries</a> <a href="#ref-for-dfn-inherit-6">(2)</a>
     <li><a href="#ref-for-dfn-inherit-7">3.9. Implements statements</a> <a href="#ref-for-dfn-inherit-8">(2)</a>
     <li><a href="#ref-for-dfn-inherit-9">4.3.4. [Exposed]</a>
-    <li><a href="#ref-for-dfn-inherit-10">4.3.6. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-inherit-11">(2)</a>
-    <li><a href="#ref-for-dfn-inherit-12">4.3.7. [LegacyArrayClass]</a>
-    <li><a href="#ref-for-dfn-inherit-13">4.3.18. [SecureContext]</a>
+    <li><a href="#ref-for-dfn-inherit-10">4.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-inherit-11">(2)</a>
+    <li><a href="#ref-for-dfn-inherit-12">4.3.6. [LegacyArrayClass]</a>
+    <li><a href="#ref-for-dfn-inherit-13">4.3.17. [SecureContext]</a>
     <li><a href="#ref-for-dfn-inherit-14">4.9. User objects implementing callback interfaces</a>
    </ul>
   </aside>
@@ -13779,8 +13677,8 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-inherited-interfaces-3">3.2.7. Iterable declarations</a> <a href="#ref-for-dfn-inherited-interfaces-4">(2)</a> <a href="#ref-for-dfn-inherited-interfaces-5">(3)</a>
     <li><a href="#ref-for-dfn-inherited-interfaces-6">3.2.8. Maplike declarations</a> <a href="#ref-for-dfn-inherited-interfaces-7">(2)</a> <a href="#ref-for-dfn-inherited-interfaces-8">(3)</a> <a href="#ref-for-dfn-inherited-interfaces-9">(4)</a>
     <li><a href="#ref-for-dfn-inherited-interfaces-10">3.2.9. Setlike declarations</a> <a href="#ref-for-dfn-inherited-interfaces-11">(2)</a> <a href="#ref-for-dfn-inherited-interfaces-12">(3)</a> <a href="#ref-for-dfn-inherited-interfaces-13">(4)</a>
-    <li><a href="#ref-for-dfn-inherited-interfaces-14">4.3.7. [LegacyArrayClass]</a>
-    <li><a href="#ref-for-dfn-inherited-interfaces-15">4.3.21. [Unforgeable]</a>
+    <li><a href="#ref-for-dfn-inherited-interfaces-14">4.3.6. [LegacyArrayClass]</a>
+    <li><a href="#ref-for-dfn-inherited-interfaces-15">4.3.20. [Unforgeable]</a>
     <li><a href="#ref-for-dfn-inherited-interfaces-16">4.6.3. Interface prototype object</a>
    </ul>
   </aside>
@@ -13797,11 +13695,11 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-callback-interface-16">3.11.19. Interface types</a>
     <li><a href="#ref-for-dfn-callback-interface-17">4.2.27. Union types</a>
     <li><a href="#ref-for-dfn-callback-interface-18">4.3.2. [Constructor]</a>
-    <li><a href="#ref-for-dfn-callback-interface-19">4.3.11. [NamedConstructor]</a>
-    <li><a href="#ref-for-dfn-callback-interface-20">4.3.13. [NoInterfaceObject]</a>
-    <li><a href="#ref-for-dfn-callback-interface-21">4.3.15. [PutForwards]</a>
-    <li><a href="#ref-for-dfn-callback-interface-22">4.3.16. [Replaceable]</a>
-    <li><a href="#ref-for-dfn-callback-interface-23">4.3.20. [TreatNullAs]</a>
+    <li><a href="#ref-for-dfn-callback-interface-19">4.3.10. [NamedConstructor]</a>
+    <li><a href="#ref-for-dfn-callback-interface-20">4.3.12. [NoInterfaceObject]</a>
+    <li><a href="#ref-for-dfn-callback-interface-21">4.3.14. [PutForwards]</a>
+    <li><a href="#ref-for-dfn-callback-interface-22">4.3.15. [Replaceable]</a>
+    <li><a href="#ref-for-dfn-callback-interface-23">4.3.19. [TreatNullAs]</a>
     <li><a href="#ref-for-dfn-callback-interface-24">4.5. Overload resolution algorithm</a>
     <li><a href="#ref-for-dfn-callback-interface-25">4.6. Interfaces</a>
     <li><a href="#ref-for-dfn-callback-interface-26">4.9. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-callback-interface-27">(2)</a>
@@ -13815,9 +13713,9 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-partial-interface-3">3.2. Interfaces</a> <a href="#ref-for-dfn-partial-interface-4">(2)</a> <a href="#ref-for-dfn-partial-interface-5">(3)</a>
     <li><a href="#ref-for-dfn-partial-interface-6">3.2.6. Overloading</a> <a href="#ref-for-dfn-partial-interface-7">(2)</a>
     <li><a href="#ref-for-dfn-partial-interface-8">4.3.4. [Exposed]</a>
-    <li><a href="#ref-for-dfn-partial-interface-9">4.3.6. [Global] and [PrimaryGlobal]</a>
-    <li><a href="#ref-for-dfn-partial-interface-10">4.3.14. [OverrideBuiltins]</a>
-    <li><a href="#ref-for-dfn-partial-interface-11">4.3.18. [SecureContext]</a> <a href="#ref-for-dfn-partial-interface-12">(2)</a>
+    <li><a href="#ref-for-dfn-partial-interface-9">4.3.5. [Global] and [PrimaryGlobal]</a>
+    <li><a href="#ref-for-dfn-partial-interface-10">4.3.13. [OverrideBuiltins]</a>
+    <li><a href="#ref-for-dfn-partial-interface-11">4.3.17. [SecureContext]</a> <a href="#ref-for-dfn-partial-interface-12">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-constant">
@@ -13833,7 +13731,7 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-constant-16">3.7. Callback functions</a>
     <li><a href="#ref-for-dfn-constant-17">3.11. Types</a>
     <li><a href="#ref-for-dfn-constant-18">3.11.24. Sequences — sequence&lt;T></a>
-    <li><a href="#ref-for-dfn-constant-19">4.3.13. [NoInterfaceObject]</a>
+    <li><a href="#ref-for-dfn-constant-19">4.3.12. [NoInterfaceObject]</a>
     <li><a href="#ref-for-dfn-constant-20">4.6. Interfaces</a>
     <li><a href="#ref-for-dfn-constant-21">4.6.1. Interface object</a> <a href="#ref-for-dfn-constant-22">(2)</a>
     <li><a href="#ref-for-dfn-constant-23">4.6.3. Interface prototype object</a>
@@ -13873,13 +13771,13 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-attribute-42">4.2.24. Nullable types — T?</a>
     <li><a href="#ref-for-dfn-attribute-43">4.2.25.1. Creating a sequence from an iterable</a>
     <li><a href="#ref-for-dfn-attribute-44">4.3.1. [Clamp]</a>
-    <li><a href="#ref-for-dfn-attribute-45">4.3.7. [LegacyArrayClass]</a> <a href="#ref-for-dfn-attribute-46">(2)</a>
-    <li><a href="#ref-for-dfn-attribute-47">4.3.15. [PutForwards]</a> <a href="#ref-for-dfn-attribute-48">(2)</a> <a href="#ref-for-dfn-attribute-49">(3)</a> <a href="#ref-for-dfn-attribute-50">(4)</a>
-    <li><a href="#ref-for-dfn-attribute-51">4.3.16. [Replaceable]</a> <a href="#ref-for-dfn-attribute-52">(2)</a> <a href="#ref-for-dfn-attribute-53">(3)</a>
-    <li><a href="#ref-for-dfn-attribute-54">4.3.17. [SameObject]</a> <a href="#ref-for-dfn-attribute-55">(2)</a>
-    <li><a href="#ref-for-dfn-attribute-56">4.3.19. [TreatNonObjectAsNull]</a>
-    <li><a href="#ref-for-dfn-attribute-57">4.3.20. [TreatNullAs]</a>
-    <li><a href="#ref-for-dfn-attribute-58">4.3.21. [Unforgeable]</a> <a href="#ref-for-dfn-attribute-59">(2)</a> <a href="#ref-for-dfn-attribute-60">(3)</a> <a href="#ref-for-dfn-attribute-61">(4)</a>
+    <li><a href="#ref-for-dfn-attribute-45">4.3.6. [LegacyArrayClass]</a> <a href="#ref-for-dfn-attribute-46">(2)</a>
+    <li><a href="#ref-for-dfn-attribute-47">4.3.14. [PutForwards]</a> <a href="#ref-for-dfn-attribute-48">(2)</a> <a href="#ref-for-dfn-attribute-49">(3)</a> <a href="#ref-for-dfn-attribute-50">(4)</a>
+    <li><a href="#ref-for-dfn-attribute-51">4.3.15. [Replaceable]</a> <a href="#ref-for-dfn-attribute-52">(2)</a> <a href="#ref-for-dfn-attribute-53">(3)</a>
+    <li><a href="#ref-for-dfn-attribute-54">4.3.16. [SameObject]</a> <a href="#ref-for-dfn-attribute-55">(2)</a>
+    <li><a href="#ref-for-dfn-attribute-56">4.3.18. [TreatNonObjectAsNull]</a>
+    <li><a href="#ref-for-dfn-attribute-57">4.3.19. [TreatNullAs]</a>
+    <li><a href="#ref-for-dfn-attribute-58">4.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-attribute-59">(2)</a> <a href="#ref-for-dfn-attribute-60">(3)</a> <a href="#ref-for-dfn-attribute-61">(4)</a>
     <li><a href="#ref-for-dfn-attribute-62">4.4. Security</a>
     <li><a href="#ref-for-dfn-attribute-63">4.6.6. Attributes</a> <a href="#ref-for-dfn-attribute-64">(2)</a> <a href="#ref-for-dfn-attribute-65">(3)</a> <a href="#ref-for-dfn-attribute-66">(4)</a> <a href="#ref-for-dfn-attribute-67">(5)</a> <a href="#ref-for-dfn-attribute-68">(6)</a> <a href="#ref-for-dfn-attribute-69">(7)</a> <a href="#ref-for-dfn-attribute-70">(8)</a> <a href="#ref-for-dfn-attribute-71">(9)</a>
     <li><a href="#ref-for-dfn-attribute-72">4.6.7.1. Stringifiers</a>
@@ -13895,11 +13793,11 @@ this was to the right.)</p>
    <ul>
     <li><a href="#ref-for-dfn-regular-attribute-1">3.2.2. Attributes</a> <a href="#ref-for-dfn-regular-attribute-2">(2)</a> <a href="#ref-for-dfn-regular-attribute-3">(3)</a>
     <li><a href="#ref-for-dfn-regular-attribute-4">4.3.3. [EnforceRange]</a>
-    <li><a href="#ref-for-dfn-regular-attribute-5">4.3.9. [LenientSetter]</a> <a href="#ref-for-dfn-regular-attribute-6">(2)</a>
-    <li><a href="#ref-for-dfn-regular-attribute-7">4.3.10. [LenientThis]</a>
-    <li><a href="#ref-for-dfn-regular-attribute-8">4.3.15. [PutForwards]</a>
-    <li><a href="#ref-for-dfn-regular-attribute-9">4.3.16. [Replaceable]</a>
-    <li><a href="#ref-for-dfn-regular-attribute-10">4.3.22. [Unscopable]</a> <a href="#ref-for-dfn-regular-attribute-11">(2)</a>
+    <li><a href="#ref-for-dfn-regular-attribute-5">4.3.8. [LenientSetter]</a> <a href="#ref-for-dfn-regular-attribute-6">(2)</a>
+    <li><a href="#ref-for-dfn-regular-attribute-7">4.3.9. [LenientThis]</a>
+    <li><a href="#ref-for-dfn-regular-attribute-8">4.3.14. [PutForwards]</a>
+    <li><a href="#ref-for-dfn-regular-attribute-9">4.3.15. [Replaceable]</a>
+    <li><a href="#ref-for-dfn-regular-attribute-10">4.3.21. [Unscopable]</a> <a href="#ref-for-dfn-regular-attribute-11">(2)</a>
     <li><a href="#ref-for-dfn-regular-attribute-12">4.6.1. Interface object</a>
     <li><a href="#ref-for-dfn-regular-attribute-13">4.6.3. Interface prototype object</a>
     <li><a href="#ref-for-dfn-regular-attribute-14">4.6.6. Attributes</a> <a href="#ref-for-dfn-regular-attribute-15">(2)</a>
@@ -13912,10 +13810,10 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-read-only-2">3.2.2. Attributes</a> <a href="#ref-for-dfn-read-only-3">(2)</a>
     <li><a href="#ref-for-dfn-read-only-4">4.3.1. [Clamp]</a>
     <li><a href="#ref-for-dfn-read-only-5">4.3.3. [EnforceRange]</a>
-    <li><a href="#ref-for-dfn-read-only-6">4.3.9. [LenientSetter]</a> <a href="#ref-for-dfn-read-only-7">(2)</a>
-    <li><a href="#ref-for-dfn-read-only-8">4.3.15. [PutForwards]</a> <a href="#ref-for-dfn-read-only-9">(2)</a>
-    <li><a href="#ref-for-dfn-read-only-10">4.3.16. [Replaceable]</a> <a href="#ref-for-dfn-read-only-11">(2)</a>
-    <li><a href="#ref-for-dfn-read-only-12">4.3.17. [SameObject]</a> <a href="#ref-for-dfn-read-only-13">(2)</a>
+    <li><a href="#ref-for-dfn-read-only-6">4.3.8. [LenientSetter]</a> <a href="#ref-for-dfn-read-only-7">(2)</a>
+    <li><a href="#ref-for-dfn-read-only-8">4.3.14. [PutForwards]</a> <a href="#ref-for-dfn-read-only-9">(2)</a>
+    <li><a href="#ref-for-dfn-read-only-10">4.3.15. [Replaceable]</a> <a href="#ref-for-dfn-read-only-11">(2)</a>
+    <li><a href="#ref-for-dfn-read-only-12">4.3.16. [SameObject]</a> <a href="#ref-for-dfn-read-only-13">(2)</a>
     <li><a href="#ref-for-dfn-read-only-14">4.6.6. Attributes</a>
    </ul>
   </aside>
@@ -13960,21 +13858,20 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-operation-49">4.3.1. [Clamp]</a> <a href="#ref-for-dfn-operation-50">(2)</a>
     <li><a href="#ref-for-dfn-operation-51">4.3.3. [EnforceRange]</a> <a href="#ref-for-dfn-operation-52">(2)</a>
     <li><a href="#ref-for-dfn-operation-53">4.3.4. [Exposed]</a>
-    <li><a href="#ref-for-dfn-operation-54">4.3.5. [ImplicitThis]</a>
-    <li><a href="#ref-for-dfn-operation-55">4.3.12. [NewObject]</a> <a href="#ref-for-dfn-operation-56">(2)</a>
-    <li><a href="#ref-for-dfn-operation-57">4.3.16. [Replaceable]</a>
-    <li><a href="#ref-for-dfn-operation-58">4.3.18. [SecureContext]</a> <a href="#ref-for-dfn-operation-59">(2)</a>
-    <li><a href="#ref-for-dfn-operation-60">4.3.20. [TreatNullAs]</a>
-    <li><a href="#ref-for-dfn-operation-61">4.3.21. [Unforgeable]</a> <a href="#ref-for-dfn-operation-62">(2)</a> <a href="#ref-for-dfn-operation-63">(3)</a> <a href="#ref-for-dfn-operation-64">(4)</a>
-    <li><a href="#ref-for-dfn-operation-65">4.4. Security</a>
-    <li><a href="#ref-for-dfn-operation-66">4.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-operation-67">(2)</a>
-    <li><a href="#ref-for-dfn-operation-68">4.6.7. Operations</a> <a href="#ref-for-dfn-operation-69">(2)</a> <a href="#ref-for-dfn-operation-70">(3)</a> <a href="#ref-for-dfn-operation-71">(4)</a> <a href="#ref-for-dfn-operation-72">(5)</a> <a href="#ref-for-dfn-operation-73">(6)</a>
-    <li><a href="#ref-for-dfn-operation-74">4.6.7.1. Stringifiers</a> <a href="#ref-for-dfn-operation-75">(2)</a>
-    <li><a href="#ref-for-dfn-operation-76">4.6.7.2. Serializers</a>
-    <li><a href="#ref-for-dfn-operation-77">4.6.8.2. forEach</a>
-    <li><a href="#ref-for-dfn-operation-78">4.7. Implements statements</a> <a href="#ref-for-dfn-operation-79">(2)</a>
-    <li><a href="#ref-for-dfn-operation-80">4.10. Invoking callback functions</a>
-    <li><a href="#ref-for-dfn-operation-81">4.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-operation-54">4.3.11. [NewObject]</a> <a href="#ref-for-dfn-operation-55">(2)</a>
+    <li><a href="#ref-for-dfn-operation-56">4.3.15. [Replaceable]</a>
+    <li><a href="#ref-for-dfn-operation-57">4.3.17. [SecureContext]</a> <a href="#ref-for-dfn-operation-58">(2)</a>
+    <li><a href="#ref-for-dfn-operation-59">4.3.19. [TreatNullAs]</a>
+    <li><a href="#ref-for-dfn-operation-60">4.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-operation-61">(2)</a> <a href="#ref-for-dfn-operation-62">(3)</a> <a href="#ref-for-dfn-operation-63">(4)</a>
+    <li><a href="#ref-for-dfn-operation-64">4.4. Security</a>
+    <li><a href="#ref-for-dfn-operation-65">4.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-operation-66">(2)</a>
+    <li><a href="#ref-for-dfn-operation-67">4.6.7. Operations</a> <a href="#ref-for-dfn-operation-68">(2)</a> <a href="#ref-for-dfn-operation-69">(3)</a>
+    <li><a href="#ref-for-dfn-operation-70">4.6.7.1. Stringifiers</a> <a href="#ref-for-dfn-operation-71">(2)</a>
+    <li><a href="#ref-for-dfn-operation-72">4.6.7.2. Serializers</a>
+    <li><a href="#ref-for-dfn-operation-73">4.6.8.2. forEach</a>
+    <li><a href="#ref-for-dfn-operation-74">4.7. Implements statements</a> <a href="#ref-for-dfn-operation-75">(2)</a>
+    <li><a href="#ref-for-dfn-operation-76">4.10. Invoking callback functions</a>
+    <li><a href="#ref-for-dfn-operation-77">4.14. Creating and throwing exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-regular-operation">
@@ -13983,14 +13880,14 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-regular-operation-1">3.2.3. Operations</a> <a href="#ref-for-dfn-regular-operation-2">(2)</a> <a href="#ref-for-dfn-regular-operation-3">(3)</a> <a href="#ref-for-dfn-regular-operation-4">(4)</a>
     <li><a href="#ref-for-dfn-regular-operation-5">3.2.6. Overloading</a> <a href="#ref-for-dfn-regular-operation-6">(2)</a> <a href="#ref-for-dfn-regular-operation-7">(3)</a>
     <li><a href="#ref-for-dfn-regular-operation-8">3.3. Namespaces</a>
-    <li><a href="#ref-for-dfn-regular-operation-9">4.3.12. [NewObject]</a> <a href="#ref-for-dfn-regular-operation-10">(2)</a>
-    <li><a href="#ref-for-dfn-regular-operation-11">4.3.21. [Unforgeable]</a>
-    <li><a href="#ref-for-dfn-regular-operation-12">4.3.22. [Unscopable]</a> <a href="#ref-for-dfn-regular-operation-13">(2)</a>
+    <li><a href="#ref-for-dfn-regular-operation-9">4.3.11. [NewObject]</a> <a href="#ref-for-dfn-regular-operation-10">(2)</a>
+    <li><a href="#ref-for-dfn-regular-operation-11">4.3.20. [Unforgeable]</a>
+    <li><a href="#ref-for-dfn-regular-operation-12">4.3.21. [Unscopable]</a> <a href="#ref-for-dfn-regular-operation-13">(2)</a>
     <li><a href="#ref-for-dfn-regular-operation-14">4.6.1. Interface object</a>
     <li><a href="#ref-for-dfn-regular-operation-15">4.6.3. Interface prototype object</a>
-    <li><a href="#ref-for-dfn-regular-operation-16">4.6.7. Operations</a> <a href="#ref-for-dfn-regular-operation-17">(2)</a> <a href="#ref-for-dfn-regular-operation-18">(3)</a> <a href="#ref-for-dfn-regular-operation-19">(4)</a>
-    <li><a href="#ref-for-dfn-regular-operation-20">4.9. User objects implementing callback interfaces</a>
-    <li><a href="#ref-for-dfn-regular-operation-21">4.11.1. Namespace object</a>
+    <li><a href="#ref-for-dfn-regular-operation-16">4.6.7. Operations</a> <a href="#ref-for-dfn-regular-operation-17">(2)</a>
+    <li><a href="#ref-for-dfn-regular-operation-18">4.9. User objects implementing callback interfaces</a>
+    <li><a href="#ref-for-dfn-regular-operation-19">4.11.1. Namespace object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-return-type">
@@ -13999,11 +13896,11 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-return-type-1">3.2.4.2. Stringifiers</a>
     <li><a href="#ref-for-dfn-return-type-2">3.5. Exceptions</a>
     <li><a href="#ref-for-dfn-return-type-3">4.2.2. void</a>
-    <li><a href="#ref-for-dfn-return-type-4">4.3.12. [NewObject]</a>
-    <li><a href="#ref-for-dfn-return-type-5">4.6.7. Operations</a> <a href="#ref-for-dfn-return-type-6">(2)</a>
-    <li><a href="#ref-for-dfn-return-type-7">4.8.8. Platform object [[Delete]] method</a>
-    <li><a href="#ref-for-dfn-return-type-8">4.9. User objects implementing callback interfaces</a>
-    <li><a href="#ref-for-dfn-return-type-9">4.10. Invoking callback functions</a>
+    <li><a href="#ref-for-dfn-return-type-4">4.3.11. [NewObject]</a>
+    <li><a href="#ref-for-dfn-return-type-5">4.6.7. Operations</a>
+    <li><a href="#ref-for-dfn-return-type-6">4.8.8. Platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-return-type-7">4.9. User objects implementing callback interfaces</a>
+    <li><a href="#ref-for-dfn-return-type-8">4.10. Invoking callback functions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="idl-void">
@@ -14086,7 +13983,7 @@ this was to the right.)</p>
    <b><a href="#dfn-stringifier">#dfn-stringifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-stringifier-1">3.2.4.2. Stringifiers</a>
-    <li><a href="#ref-for-dfn-stringifier-2">4.3.6. [Global] and [PrimaryGlobal]</a>
+    <li><a href="#ref-for-dfn-stringifier-2">4.3.5. [Global] and [PrimaryGlobal]</a>
     <li><a href="#ref-for-dfn-stringifier-3">4.6.7.1. Stringifiers</a> <a href="#ref-for-dfn-stringifier-4">(2)</a> <a href="#ref-for-dfn-stringifier-5">(3)</a> <a href="#ref-for-dfn-stringifier-6">(4)</a>
     <li><a href="#ref-for-dfn-stringifier-7">4.8. Platform objects implementing interfaces</a>
     <li><a href="#ref-for-dfn-stringifier-8">4.14. Creating and throwing exceptions</a>
@@ -14096,7 +13993,7 @@ this was to the right.)</p>
    <b><a href="#dfn-serializer">#dfn-serializer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-serializer-1">3.2.4.3. Serializers</a> <a href="#ref-for-dfn-serializer-2">(2)</a> <a href="#ref-for-dfn-serializer-3">(3)</a>
-    <li><a href="#ref-for-dfn-serializer-4">4.3.6. [Global] and [PrimaryGlobal]</a>
+    <li><a href="#ref-for-dfn-serializer-4">4.3.5. [Global] and [PrimaryGlobal]</a>
     <li><a href="#ref-for-dfn-serializer-5">4.6.7.2. Serializers</a> <a href="#ref-for-dfn-serializer-6">(2)</a> <a href="#ref-for-dfn-serializer-7">(3)</a>
     <li><a href="#ref-for-dfn-serializer-8">4.8. Platform objects implementing interfaces</a>
    </ul>
@@ -14106,16 +14003,16 @@ this was to the right.)</p>
    <ul>
     <li><a href="#ref-for-dfn-named-property-getter-1">3.2.4. Special operations</a>
     <li><a href="#ref-for-dfn-named-property-getter-2">3.2.4.5. Named properties</a> <a href="#ref-for-dfn-named-property-getter-3">(2)</a> <a href="#ref-for-dfn-named-property-getter-4">(3)</a>
-    <li><a href="#ref-for-dfn-named-property-getter-5">4.3.6. [Global] and [PrimaryGlobal]</a>
-    <li><a href="#ref-for-dfn-named-property-getter-6">4.3.8. [LegacyUnenumerableNamedProperties]</a>
-    <li><a href="#ref-for-dfn-named-property-getter-7">4.3.14. [OverrideBuiltins]</a> <a href="#ref-for-dfn-named-property-getter-8">(2)</a> <a href="#ref-for-dfn-named-property-getter-9">(3)</a>
+    <li><a href="#ref-for-dfn-named-property-getter-5">4.3.5. [Global] and [PrimaryGlobal]</a>
+    <li><a href="#ref-for-dfn-named-property-getter-6">4.3.7. [LegacyUnenumerableNamedProperties]</a>
+    <li><a href="#ref-for-dfn-named-property-getter-7">4.3.13. [OverrideBuiltins]</a> <a href="#ref-for-dfn-named-property-getter-8">(2)</a> <a href="#ref-for-dfn-named-property-getter-9">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-named-property-setter">
    <b><a href="#dfn-named-property-setter">#dfn-named-property-setter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-named-property-setter-1">3.2.4.5. Named properties</a> <a href="#ref-for-dfn-named-property-setter-2">(2)</a>
-    <li><a href="#ref-for-dfn-named-property-setter-3">4.3.6. [Global] and [PrimaryGlobal]</a>
+    <li><a href="#ref-for-dfn-named-property-setter-3">4.3.5. [Global] and [PrimaryGlobal]</a>
     <li><a href="#ref-for-dfn-named-property-setter-4">4.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
     <li><a href="#ref-for-dfn-named-property-setter-5">4.8.6. Platform object [[Set]] method</a>
     <li><a href="#ref-for-dfn-named-property-setter-6">4.8.7. Platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-named-property-setter-7">(2)</a>
@@ -14135,7 +14032,7 @@ this was to the right.)</p>
    <b><a href="#dfn-indexed-property-setter">#dfn-indexed-property-setter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-indexed-property-setter-1">3.2.4.4. Indexed properties</a> <a href="#ref-for-dfn-indexed-property-setter-2">(2)</a>
-    <li><a href="#ref-for-dfn-indexed-property-setter-3">4.3.7. [LegacyArrayClass]</a>
+    <li><a href="#ref-for-dfn-indexed-property-setter-3">4.3.6. [LegacyArrayClass]</a>
     <li><a href="#ref-for-dfn-indexed-property-setter-4">4.8.1. Indexed and named properties</a>
     <li><a href="#ref-for-dfn-indexed-property-setter-5">4.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
     <li><a href="#ref-for-dfn-indexed-property-setter-6">4.8.6. Platform object [[Set]] method</a>
@@ -14202,7 +14099,7 @@ this was to the right.)</p>
    <ul>
     <li><a href="#ref-for-dfn-support-indexed-properties-1">3.2.4.4. Indexed properties</a>
     <li><a href="#ref-for-dfn-support-indexed-properties-2">3.2.7. Iterable declarations</a> <a href="#ref-for-dfn-support-indexed-properties-3">(2)</a> <a href="#ref-for-dfn-support-indexed-properties-4">(3)</a> <a href="#ref-for-dfn-support-indexed-properties-5">(4)</a> <a href="#ref-for-dfn-support-indexed-properties-6">(5)</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-7">4.3.7. [LegacyArrayClass]</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-7">4.3.6. [LegacyArrayClass]</a>
     <li><a href="#ref-for-dfn-support-indexed-properties-8">4.6.9.4. Default iterator objects</a>
     <li><a href="#ref-for-dfn-support-indexed-properties-9">4.8.1. Indexed and named properties</a>
     <li><a href="#ref-for-dfn-support-indexed-properties-10">4.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
@@ -14246,7 +14143,7 @@ this was to the right.)</p>
    <b><a href="#dfn-support-named-properties">#dfn-support-named-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-support-named-properties-1">3.2.4.5. Named properties</a>
-    <li><a href="#ref-for-dfn-support-named-properties-2">4.3.8. [LegacyUnenumerableNamedProperties]</a>
+    <li><a href="#ref-for-dfn-support-named-properties-2">4.3.7. [LegacyUnenumerableNamedProperties]</a>
     <li><a href="#ref-for-dfn-support-named-properties-3">4.6.3. Interface prototype object</a>
     <li><a href="#ref-for-dfn-support-named-properties-4">4.6.4. Named properties object</a>
     <li><a href="#ref-for-dfn-support-named-properties-5">4.8.1. Indexed and named properties</a>
@@ -14262,7 +14159,7 @@ this was to the right.)</p>
    <b><a href="#dfn-supported-property-names">#dfn-supported-property-names</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-supported-property-names-1">3.2.4.5. Named properties</a> <a href="#ref-for-dfn-supported-property-names-2">(2)</a>
-    <li><a href="#ref-for-dfn-supported-property-names-3">4.3.14. [OverrideBuiltins]</a>
+    <li><a href="#ref-for-dfn-supported-property-names-3">4.3.13. [OverrideBuiltins]</a>
     <li><a href="#ref-for-dfn-supported-property-names-4">4.8.1. Indexed and named properties</a>
     <li><a href="#ref-for-dfn-supported-property-names-5">4.8.5. Invoking a platform object named property setter</a>
     <li><a href="#ref-for-dfn-supported-property-names-6">4.8.7. Platform object [[DefineOwnProperty]] method</a>
@@ -14301,10 +14198,10 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-static-attribute-2">3.2.2. Attributes</a> <a href="#ref-for-dfn-static-attribute-3">(2)</a> <a href="#ref-for-dfn-static-attribute-4">(3)</a>
     <li><a href="#ref-for-dfn-static-attribute-5">3.2.4.2. Stringifiers</a>
     <li><a href="#ref-for-dfn-static-attribute-6">4.3.3. [EnforceRange]</a>
-    <li><a href="#ref-for-dfn-static-attribute-7">4.3.10. [LenientThis]</a>
-    <li><a href="#ref-for-dfn-static-attribute-8">4.3.15. [PutForwards]</a>
-    <li><a href="#ref-for-dfn-static-attribute-9">4.3.16. [Replaceable]</a>
-    <li><a href="#ref-for-dfn-static-attribute-10">4.3.21. [Unforgeable]</a> <a href="#ref-for-dfn-static-attribute-11">(2)</a>
+    <li><a href="#ref-for-dfn-static-attribute-7">4.3.9. [LenientThis]</a>
+    <li><a href="#ref-for-dfn-static-attribute-8">4.3.14. [PutForwards]</a>
+    <li><a href="#ref-for-dfn-static-attribute-9">4.3.15. [Replaceable]</a>
+    <li><a href="#ref-for-dfn-static-attribute-10">4.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-static-attribute-11">(2)</a>
     <li><a href="#ref-for-dfn-static-attribute-12">4.6.6. Attributes</a> <a href="#ref-for-dfn-static-attribute-13">(2)</a> <a href="#ref-for-dfn-static-attribute-14">(3)</a>
    </ul>
   </aside>
@@ -14314,11 +14211,11 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-static-operation-1">3.2. Interfaces</a>
     <li><a href="#ref-for-dfn-static-operation-2">3.2.3. Operations</a> <a href="#ref-for-dfn-static-operation-3">(2)</a> <a href="#ref-for-dfn-static-operation-4">(3)</a>
     <li><a href="#ref-for-dfn-static-operation-5">3.2.6. Overloading</a> <a href="#ref-for-dfn-static-operation-6">(2)</a>
-    <li><a href="#ref-for-dfn-static-operation-7">4.3.12. [NewObject]</a> <a href="#ref-for-dfn-static-operation-8">(2)</a>
-    <li><a href="#ref-for-dfn-static-operation-9">4.3.13. [NoInterfaceObject]</a>
-    <li><a href="#ref-for-dfn-static-operation-10">4.3.21. [Unforgeable]</a> <a href="#ref-for-dfn-static-operation-11">(2)</a> <a href="#ref-for-dfn-static-operation-12">(3)</a>
+    <li><a href="#ref-for-dfn-static-operation-7">4.3.11. [NewObject]</a> <a href="#ref-for-dfn-static-operation-8">(2)</a>
+    <li><a href="#ref-for-dfn-static-operation-9">4.3.12. [NoInterfaceObject]</a>
+    <li><a href="#ref-for-dfn-static-operation-10">4.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-static-operation-11">(2)</a> <a href="#ref-for-dfn-static-operation-12">(3)</a>
     <li><a href="#ref-for-dfn-static-operation-13">4.6.1. Interface object</a>
-    <li><a href="#ref-for-dfn-static-operation-14">4.6.7. Operations</a> <a href="#ref-for-dfn-static-operation-15">(2)</a> <a href="#ref-for-dfn-static-operation-16">(3)</a>
+    <li><a href="#ref-for-dfn-static-operation-14">4.6.7. Operations</a> <a href="#ref-for-dfn-static-operation-15">(2)</a> <a href="#ref-for-dfn-static-operation-16">(3)</a> <a href="#ref-for-dfn-static-operation-17">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-overloaded">
@@ -14326,7 +14223,7 @@ this was to the right.)</p>
    <ul>
     <li><a href="#ref-for-dfn-overloaded-1">3.2.3. Operations</a>
     <li><a href="#ref-for-dfn-overloaded-2">4.3.4. [Exposed]</a>
-    <li><a href="#ref-for-dfn-overloaded-3">4.3.18. [SecureContext]</a>
+    <li><a href="#ref-for-dfn-overloaded-3">4.3.17. [SecureContext]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-effective-overload-set">
@@ -14336,8 +14233,8 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-effective-overload-set-4">4.5. Overload resolution algorithm</a>
     <li><a href="#ref-for-dfn-effective-overload-set-5">4.6.1.1. Interface object [[Call]] method</a> <a href="#ref-for-dfn-effective-overload-set-6">(2)</a>
     <li><a href="#ref-for-dfn-effective-overload-set-7">4.6.2. Named constructors</a> <a href="#ref-for-dfn-effective-overload-set-8">(2)</a>
-    <li><a href="#ref-for-dfn-effective-overload-set-9">4.6.7. Operations</a> <a href="#ref-for-dfn-effective-overload-set-10">(2)</a> <a href="#ref-for-dfn-effective-overload-set-11">(3)</a> <a href="#ref-for-dfn-effective-overload-set-12">(4)</a> <a href="#ref-for-dfn-effective-overload-set-13">(5)</a>
-    <li><a href="#ref-for-dfn-effective-overload-set-14">4.8.9. Platform object [[Call]] method</a>
+    <li><a href="#ref-for-dfn-effective-overload-set-9">4.6.7. Operations</a> <a href="#ref-for-dfn-effective-overload-set-10">(2)</a> <a href="#ref-for-dfn-effective-overload-set-11">(3)</a>
+    <li><a href="#ref-for-dfn-effective-overload-set-12">4.8.9. Platform object [[Call]] method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-optionality-value">
@@ -14367,7 +14264,7 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-iterable-declaration-1">3.2.7. Iterable declarations</a> <a href="#ref-for-dfn-iterable-declaration-2">(2)</a> <a href="#ref-for-dfn-iterable-declaration-3">(3)</a> <a href="#ref-for-dfn-iterable-declaration-4">(4)</a> <a href="#ref-for-dfn-iterable-declaration-5">(5)</a>
     <li><a href="#ref-for-dfn-iterable-declaration-6">3.2.8. Maplike declarations</a>
     <li><a href="#ref-for-dfn-iterable-declaration-7">3.2.9. Setlike declarations</a>
-    <li><a href="#ref-for-dfn-iterable-declaration-8">4.3.6. [Global] and [PrimaryGlobal]</a>
+    <li><a href="#ref-for-dfn-iterable-declaration-8">4.3.5. [Global] and [PrimaryGlobal]</a>
     <li><a href="#ref-for-dfn-iterable-declaration-9">4.6.8.1. @@iterator</a> <a href="#ref-for-dfn-iterable-declaration-10">(2)</a>
     <li><a href="#ref-for-dfn-iterable-declaration-11">4.6.8.2. forEach</a> <a href="#ref-for-dfn-iterable-declaration-12">(2)</a>
     <li><a href="#ref-for-dfn-iterable-declaration-13">4.6.9.1. entries</a>
@@ -14418,7 +14315,7 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-maplike-declaration-1">3.2.7. Iterable declarations</a>
     <li><a href="#ref-for-dfn-maplike-declaration-2">3.2.8. Maplike declarations</a> <a href="#ref-for-dfn-maplike-declaration-3">(2)</a> <a href="#ref-for-dfn-maplike-declaration-4">(3)</a>
     <li><a href="#ref-for-dfn-maplike-declaration-5">3.2.9. Setlike declarations</a>
-    <li><a href="#ref-for-dfn-maplike-declaration-6">4.3.6. [Global] and [PrimaryGlobal]</a>
+    <li><a href="#ref-for-dfn-maplike-declaration-6">4.3.5. [Global] and [PrimaryGlobal]</a>
     <li><a href="#ref-for-dfn-maplike-declaration-7">4.6.8.1. @@iterator</a> <a href="#ref-for-dfn-maplike-declaration-8">(2)</a> <a href="#ref-for-dfn-maplike-declaration-9">(3)</a> <a href="#ref-for-dfn-maplike-declaration-10">(4)</a> <a href="#ref-for-dfn-maplike-declaration-11">(5)</a>
     <li><a href="#ref-for-dfn-maplike-declaration-12">4.6.8.2. forEach</a> <a href="#ref-for-dfn-maplike-declaration-13">(2)</a> <a href="#ref-for-dfn-maplike-declaration-14">(3)</a> <a href="#ref-for-dfn-maplike-declaration-15">(4)</a>
     <li><a href="#ref-for-dfn-maplike-declaration-16">4.6.10. Maplike declarations</a> <a href="#ref-for-dfn-maplike-declaration-17">(2)</a>
@@ -14447,7 +14344,7 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-setlike-declaration-1">3.2.7. Iterable declarations</a>
     <li><a href="#ref-for-dfn-setlike-declaration-2">3.2.8. Maplike declarations</a>
     <li><a href="#ref-for-dfn-setlike-declaration-3">3.2.9. Setlike declarations</a> <a href="#ref-for-dfn-setlike-declaration-4">(2)</a> <a href="#ref-for-dfn-setlike-declaration-5">(3)</a>
-    <li><a href="#ref-for-dfn-setlike-declaration-6">4.3.6. [Global] and [PrimaryGlobal]</a>
+    <li><a href="#ref-for-dfn-setlike-declaration-6">4.3.5. [Global] and [PrimaryGlobal]</a>
     <li><a href="#ref-for-dfn-setlike-declaration-7">4.6.8.1. @@iterator</a> <a href="#ref-for-dfn-setlike-declaration-8">(2)</a> <a href="#ref-for-dfn-setlike-declaration-9">(3)</a> <a href="#ref-for-dfn-setlike-declaration-10">(4)</a>
     <li><a href="#ref-for-dfn-setlike-declaration-11">4.6.8.2. forEach</a> <a href="#ref-for-dfn-setlike-declaration-12">(2)</a> <a href="#ref-for-dfn-setlike-declaration-13">(3)</a>
     <li><a href="#ref-for-dfn-setlike-declaration-14">4.6.11. Setlike declarations</a> <a href="#ref-for-dfn-setlike-declaration-15">(2)</a>
@@ -14470,10 +14367,10 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-namespace-2">3.1. Names</a> <a href="#ref-for-dfn-namespace-3">(2)</a> <a href="#ref-for-dfn-namespace-4">(3)</a>
     <li><a href="#ref-for-dfn-namespace-5">3.3. Namespaces</a>
     <li><a href="#ref-for-dfn-namespace-6">4.3.4. [Exposed]</a> <a href="#ref-for-dfn-namespace-7">(2)</a>
-    <li><a href="#ref-for-dfn-namespace-8">4.3.18. [SecureContext]</a> <a href="#ref-for-dfn-namespace-9">(2)</a>
-    <li><a href="#ref-for-dfn-namespace-10">4.6.7. Operations</a> <a href="#ref-for-dfn-namespace-11">(2)</a> <a href="#ref-for-dfn-namespace-12">(3)</a>
-    <li><a href="#ref-for-dfn-namespace-13">4.11. Namespaces</a>
-    <li><a href="#ref-for-dfn-namespace-14">4.11.1. Namespace object</a>
+    <li><a href="#ref-for-dfn-namespace-8">4.3.17. [SecureContext]</a> <a href="#ref-for-dfn-namespace-9">(2)</a>
+    <li><a href="#ref-for-dfn-namespace-10">4.6.7. Operations</a> <a href="#ref-for-dfn-namespace-11">(2)</a>
+    <li><a href="#ref-for-dfn-namespace-12">4.11. Namespaces</a>
+    <li><a href="#ref-for-dfn-namespace-13">4.11.1. Namespace object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-namespace-member">
@@ -14482,7 +14379,7 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-namespace-member-1">3.2.3. Operations</a>
     <li><a href="#ref-for-dfn-namespace-member-2">3.12. Extended attributes</a>
     <li><a href="#ref-for-dfn-namespace-member-3">4.3.4. [Exposed]</a> <a href="#ref-for-dfn-namespace-member-4">(2)</a>
-    <li><a href="#ref-for-dfn-namespace-member-5">4.3.18. [SecureContext]</a> <a href="#ref-for-dfn-namespace-member-6">(2)</a>
+    <li><a href="#ref-for-dfn-namespace-member-5">4.3.17. [SecureContext]</a> <a href="#ref-for-dfn-namespace-member-6">(2)</a>
     <li><a href="#ref-for-dfn-namespace-member-7">4.11.1. Namespace object</a>
    </ul>
   </aside>
@@ -14492,7 +14389,7 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-partial-namespace-1">3. Interface definition language</a>
     <li><a href="#ref-for-dfn-partial-namespace-2">3.1. Names</a>
     <li><a href="#ref-for-dfn-partial-namespace-3">4.3.4. [Exposed]</a>
-    <li><a href="#ref-for-dfn-partial-namespace-4">4.3.18. [SecureContext]</a> <a href="#ref-for-dfn-partial-namespace-5">(2)</a>
+    <li><a href="#ref-for-dfn-partial-namespace-4">4.3.17. [SecureContext]</a> <a href="#ref-for-dfn-partial-namespace-5">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-dictionary">
@@ -14704,7 +14601,7 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-callback-function-19">4.2.23. Callback function types</a>
     <li><a href="#ref-for-dfn-callback-function-20">4.2.24. Nullable types — T?</a>
     <li><a href="#ref-for-dfn-callback-function-21">4.2.27. Union types</a>
-    <li><a href="#ref-for-dfn-callback-function-22">4.3.19. [TreatNonObjectAsNull]</a> <a href="#ref-for-dfn-callback-function-23">(2)</a> <a href="#ref-for-dfn-callback-function-24">(3)</a> <a href="#ref-for-dfn-callback-function-25">(4)</a> <a href="#ref-for-dfn-callback-function-26">(5)</a>
+    <li><a href="#ref-for-dfn-callback-function-22">4.3.18. [TreatNonObjectAsNull]</a> <a href="#ref-for-dfn-callback-function-23">(2)</a> <a href="#ref-for-dfn-callback-function-24">(3)</a> <a href="#ref-for-dfn-callback-function-25">(4)</a> <a href="#ref-for-dfn-callback-function-26">(5)</a>
     <li><a href="#ref-for-dfn-callback-function-27">4.5. Overload resolution algorithm</a>
     <li><a href="#ref-for-dfn-callback-function-28">4.10. Invoking callback functions</a>
     <li><a href="#ref-for-dfn-callback-function-29">5.4. Function</a>
@@ -14728,13 +14625,14 @@ this was to the right.)</p>
    <ul>
     <li><a href="#ref-for-dfn-implements-statement-1">3. Interface definition language</a>
     <li><a href="#ref-for-dfn-implements-statement-2">3.9. Implements statements</a> <a href="#ref-for-dfn-implements-statement-3">(2)</a> <a href="#ref-for-dfn-implements-statement-4">(3)</a> <a href="#ref-for-dfn-implements-statement-5">(4)</a>
+    <li><a href="#ref-for-dfn-implements-statement-6">4.6.7. Operations</a> <a href="#ref-for-dfn-implements-statement-7">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-supplemental-interface">
    <b><a href="#dfn-supplemental-interface">#dfn-supplemental-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-supplemental-interface-1">3.9. Implements statements</a> <a href="#ref-for-dfn-supplemental-interface-2">(2)</a> <a href="#ref-for-dfn-supplemental-interface-3">(3)</a>
-    <li><a href="#ref-for-dfn-supplemental-interface-4">4.3.13. [NoInterfaceObject]</a>
+    <li><a href="#ref-for-dfn-supplemental-interface-4">4.3.12. [NoInterfaceObject]</a>
     <li><a href="#ref-for-dfn-supplemental-interface-5">4.6.3. Interface prototype object</a> <a href="#ref-for-dfn-supplemental-interface-6">(2)</a>
     <li><a href="#ref-for-dfn-supplemental-interface-7">4.8. Platform objects implementing interfaces</a>
     <li><a href="#ref-for-dfn-supplemental-interface-8">4.8.1. Indexed and named properties</a>
@@ -14748,8 +14646,8 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-consequential-interfaces-5">3.2.8. Maplike declarations</a> <a href="#ref-for-dfn-consequential-interfaces-6">(2)</a> <a href="#ref-for-dfn-consequential-interfaces-7">(3)</a> <a href="#ref-for-dfn-consequential-interfaces-8">(4)</a>
     <li><a href="#ref-for-dfn-consequential-interfaces-9">3.2.9. Setlike declarations</a> <a href="#ref-for-dfn-consequential-interfaces-10">(2)</a> <a href="#ref-for-dfn-consequential-interfaces-11">(3)</a> <a href="#ref-for-dfn-consequential-interfaces-12">(4)</a>
     <li><a href="#ref-for-dfn-consequential-interfaces-13">4.3.4. [Exposed]</a>
-    <li><a href="#ref-for-dfn-consequential-interfaces-14">4.3.6. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-consequential-interfaces-15">(2)</a>
-    <li><a href="#ref-for-dfn-consequential-interfaces-16">4.3.21. [Unforgeable]</a> <a href="#ref-for-dfn-consequential-interfaces-17">(2)</a> <a href="#ref-for-dfn-consequential-interfaces-18">(3)</a> <a href="#ref-for-dfn-consequential-interfaces-19">(4)</a> <a href="#ref-for-dfn-consequential-interfaces-20">(5)</a>
+    <li><a href="#ref-for-dfn-consequential-interfaces-14">4.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-consequential-interfaces-15">(2)</a>
+    <li><a href="#ref-for-dfn-consequential-interfaces-16">4.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-consequential-interfaces-17">(2)</a> <a href="#ref-for-dfn-consequential-interfaces-18">(3)</a> <a href="#ref-for-dfn-consequential-interfaces-19">(4)</a> <a href="#ref-for-dfn-consequential-interfaces-20">(5)</a>
     <li><a href="#ref-for-dfn-consequential-interfaces-21">4.6.3. Interface prototype object</a>
     <li><a href="#ref-for-dfn-consequential-interfaces-22">4.6.5. Constants</a>
     <li><a href="#ref-for-dfn-consequential-interfaces-23">4.6.6. Attributes</a> <a href="#ref-for-dfn-consequential-interfaces-24">(2)</a>
@@ -14783,8 +14681,8 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-platform-object-11">4.2.2. void</a>
     <li><a href="#ref-for-dfn-platform-object-12">4.2.20. Interface types</a>
     <li><a href="#ref-for-dfn-platform-object-13">4.2.27. Union types</a>
-    <li><a href="#ref-for-dfn-platform-object-14">4.3.14. [OverrideBuiltins]</a>
-    <li><a href="#ref-for-dfn-platform-object-15">4.3.16. [Replaceable]</a> <a href="#ref-for-dfn-platform-object-16">(2)</a>
+    <li><a href="#ref-for-dfn-platform-object-14">4.3.13. [OverrideBuiltins]</a>
+    <li><a href="#ref-for-dfn-platform-object-15">4.3.15. [Replaceable]</a> <a href="#ref-for-dfn-platform-object-16">(2)</a>
     <li><a href="#ref-for-dfn-platform-object-17">4.4. Security</a>
     <li><a href="#ref-for-dfn-platform-object-18">4.5. Overload resolution algorithm</a>
     <li><a href="#ref-for-dfn-platform-object-19">4.6.6. Attributes</a> <a href="#ref-for-dfn-platform-object-20">(2)</a> <a href="#ref-for-dfn-platform-object-21">(3)</a> <a href="#ref-for-dfn-platform-object-22">(4)</a>
@@ -15013,7 +14911,7 @@ this was to the right.)</p>
     <li><a href="#ref-for-idl-unsigned-long-6">3.11.1. any</a>
     <li><a href="#ref-for-idl-unsigned-long-7">3.11.8. unsigned long</a> <a href="#ref-for-idl-unsigned-long-8">(2)</a> <a href="#ref-for-idl-unsigned-long-9">(3)</a>
     <li><a href="#ref-for-idl-unsigned-long-10">4.2.9. unsigned long</a> <a href="#ref-for-idl-unsigned-long-11">(2)</a> <a href="#ref-for-idl-unsigned-long-12">(3)</a> <a href="#ref-for-idl-unsigned-long-13">(4)</a> <a href="#ref-for-idl-unsigned-long-14">(5)</a> <a href="#ref-for-idl-unsigned-long-15">(6)</a>
-    <li><a href="#ref-for-idl-unsigned-long-16">4.3.7. [LegacyArrayClass]</a>
+    <li><a href="#ref-for-idl-unsigned-long-16">4.3.6. [LegacyArrayClass]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="idl-long-long">
@@ -15101,7 +14999,7 @@ this was to the right.)</p>
     <li><a href="#ref-for-idl-DOMString-36">4.2.1. any</a>
     <li><a href="#ref-for-idl-DOMString-37">4.2.16. DOMString</a> <a href="#ref-for-idl-DOMString-38">(2)</a> <a href="#ref-for-idl-DOMString-39">(3)</a> <a href="#ref-for-idl-DOMString-40">(4)</a> <a href="#ref-for-idl-DOMString-41">(5)</a>
     <li><a href="#ref-for-idl-DOMString-42">4.2.18. USVString</a>
-    <li><a href="#ref-for-idl-DOMString-43">4.3.20. [TreatNullAs]</a> <a href="#ref-for-idl-DOMString-44">(2)</a>
+    <li><a href="#ref-for-idl-DOMString-43">4.3.19. [TreatNullAs]</a> <a href="#ref-for-idl-DOMString-44">(2)</a>
     <li><a href="#ref-for-idl-DOMString-45">Changes</a>
    </ul>
   </aside>
@@ -15142,7 +15040,7 @@ this was to the right.)</p>
     <li><a href="#ref-for-idl-object-5">4.2.1. any</a> <a href="#ref-for-idl-object-6">(2)</a> <a href="#ref-for-idl-object-7">(3)</a> <a href="#ref-for-idl-object-8">(4)</a> <a href="#ref-for-idl-object-9">(5)</a>
     <li><a href="#ref-for-idl-object-10">4.2.19. object</a> <a href="#ref-for-idl-object-11">(2)</a> <a href="#ref-for-idl-object-12">(3)</a> <a href="#ref-for-idl-object-13">(4)</a> <a href="#ref-for-idl-object-14">(5)</a>
     <li><a href="#ref-for-idl-object-15">4.2.27. Union types</a> <a href="#ref-for-idl-object-16">(2)</a> <a href="#ref-for-idl-object-17">(3)</a> <a href="#ref-for-idl-object-18">(4)</a> <a href="#ref-for-idl-object-19">(5)</a> <a href="#ref-for-idl-object-20">(6)</a> <a href="#ref-for-idl-object-21">(7)</a> <a href="#ref-for-idl-object-22">(8)</a> <a href="#ref-for-idl-object-23">(9)</a> <a href="#ref-for-idl-object-24">(10)</a>
-    <li><a href="#ref-for-idl-object-25">4.3.17. [SameObject]</a>
+    <li><a href="#ref-for-idl-object-25">4.3.16. [SameObject]</a>
     <li><a href="#ref-for-idl-object-26">4.5. Overload resolution algorithm</a> <a href="#ref-for-idl-object-27">(2)</a> <a href="#ref-for-idl-object-28">(3)</a> <a href="#ref-for-idl-object-29">(4)</a> <a href="#ref-for-idl-object-30">(5)</a> <a href="#ref-for-idl-object-31">(6)</a> <a href="#ref-for-idl-object-32">(7)</a> <a href="#ref-for-idl-object-33">(8)</a> <a href="#ref-for-idl-object-34">(9)</a>
    </ul>
   </aside>
@@ -15154,9 +15052,9 @@ this was to the right.)</p>
     <li><a href="#ref-for-idl-interface-3">3.11.22. Callback function types</a>
     <li><a href="#ref-for-idl-interface-4">4.2.20. Interface types</a> <a href="#ref-for-idl-interface-5">(2)</a> <a href="#ref-for-idl-interface-6">(3)</a> <a href="#ref-for-idl-interface-7">(4)</a> <a href="#ref-for-idl-interface-8">(5)</a> <a href="#ref-for-idl-interface-9">(6)</a>
     <li><a href="#ref-for-idl-interface-10">4.2.27. Union types</a>
-    <li><a href="#ref-for-idl-interface-11">4.3.12. [NewObject]</a>
-    <li><a href="#ref-for-idl-interface-12">4.3.15. [PutForwards]</a> <a href="#ref-for-idl-interface-13">(2)</a>
-    <li><a href="#ref-for-idl-interface-14">4.3.17. [SameObject]</a>
+    <li><a href="#ref-for-idl-interface-11">4.3.11. [NewObject]</a>
+    <li><a href="#ref-for-idl-interface-12">4.3.14. [PutForwards]</a> <a href="#ref-for-idl-interface-13">(2)</a>
+    <li><a href="#ref-for-idl-interface-14">4.3.16. [SameObject]</a>
     <li><a href="#ref-for-idl-interface-15">4.5. Overload resolution algorithm</a>
     <li><a href="#ref-for-idl-interface-16">4.6.1.1. Interface object [[Call]] method</a>
     <li><a href="#ref-for-idl-interface-17">4.6.2. Named constructors</a>
@@ -15207,7 +15105,7 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-nullable-type-12">3.11.26. Union types</a> <a href="#ref-for-dfn-nullable-type-13">(2)</a> <a href="#ref-for-dfn-nullable-type-14">(3)</a>
     <li><a href="#ref-for-dfn-nullable-type-15">4.2.23. Callback function types</a>
     <li><a href="#ref-for-dfn-nullable-type-16">4.2.24. Nullable types — T?</a> <a href="#ref-for-dfn-nullable-type-17">(2)</a> <a href="#ref-for-dfn-nullable-type-18">(3)</a> <a href="#ref-for-dfn-nullable-type-19">(4)</a> <a href="#ref-for-dfn-nullable-type-20">(5)</a> <a href="#ref-for-dfn-nullable-type-21">(6)</a> <a href="#ref-for-dfn-nullable-type-22">(7)</a> <a href="#ref-for-dfn-nullable-type-23">(8)</a>
-    <li><a href="#ref-for-dfn-nullable-type-24">4.3.19. [TreatNonObjectAsNull]</a>
+    <li><a href="#ref-for-dfn-nullable-type-24">4.3.18. [TreatNonObjectAsNull]</a>
     <li><a href="#ref-for-dfn-nullable-type-25">4.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-nullable-type-26">(2)</a> <a href="#ref-for-dfn-nullable-type-27">(3)</a> <a href="#ref-for-dfn-nullable-type-28">(4)</a> <a href="#ref-for-dfn-nullable-type-29">(5)</a> <a href="#ref-for-dfn-nullable-type-30">(6)</a> <a href="#ref-for-dfn-nullable-type-31">(7)</a> <a href="#ref-for-dfn-nullable-type-32">(8)</a> <a href="#ref-for-dfn-nullable-type-33">(9)</a> <a href="#ref-for-dfn-nullable-type-34">(10)</a> <a href="#ref-for-dfn-nullable-type-35">(11)</a> <a href="#ref-for-dfn-nullable-type-36">(12)</a> <a href="#ref-for-dfn-nullable-type-37">(13)</a> <a href="#ref-for-dfn-nullable-type-38">(14)</a> <a href="#ref-for-dfn-nullable-type-39">(15)</a> <a href="#ref-for-dfn-nullable-type-40">(16)</a> <a href="#ref-for-dfn-nullable-type-41">(17)</a> <a href="#ref-for-dfn-nullable-type-42">(18)</a> <a href="#ref-for-dfn-nullable-type-43">(19)</a> <a href="#ref-for-dfn-nullable-type-44">(20)</a> <a href="#ref-for-dfn-nullable-type-45">(21)</a> <a href="#ref-for-dfn-nullable-type-46">(22)</a> <a href="#ref-for-dfn-nullable-type-47">(23)</a> <a href="#ref-for-dfn-nullable-type-48">(24)</a> <a href="#ref-for-dfn-nullable-type-49">(25)</a> <a href="#ref-for-dfn-nullable-type-50">(26)</a> <a href="#ref-for-dfn-nullable-type-51">(27)</a> <a href="#ref-for-dfn-nullable-type-52">(28)</a> <a href="#ref-for-dfn-nullable-type-53">(29)</a> <a href="#ref-for-dfn-nullable-type-54">(30)</a> <a href="#ref-for-dfn-nullable-type-55">(31)</a>
    </ul>
   </aside>
@@ -15249,16 +15147,16 @@ this was to the right.)</p>
     <li><a href="#ref-for-idl-promise-1">3.2.4.1. Legacy callers</a>
     <li><a href="#ref-for-idl-promise-2">3.2.6. Overloading</a>
     <li><a href="#ref-for-idl-promise-3">4.2.26. Promise types — Promise&lt;T></a> <a href="#ref-for-idl-promise-4">(2)</a> <a href="#ref-for-idl-promise-5">(3)</a> <a href="#ref-for-idl-promise-6">(4)</a> <a href="#ref-for-idl-promise-7">(5)</a> <a href="#ref-for-idl-promise-8">(6)</a>
-    <li><a href="#ref-for-idl-promise-9">4.6.7. Operations</a> <a href="#ref-for-idl-promise-10">(2)</a>
-    <li><a href="#ref-for-idl-promise-11">4.9. User objects implementing callback interfaces</a> <a href="#ref-for-idl-promise-12">(2)</a>
-    <li><a href="#ref-for-idl-promise-13">4.10. Invoking callback functions</a>
-    <li><a href="#ref-for-idl-promise-14">Changes</a>
+    <li><a href="#ref-for-idl-promise-9">4.6.7. Operations</a>
+    <li><a href="#ref-for-idl-promise-10">4.9. User objects implementing callback interfaces</a> <a href="#ref-for-idl-promise-11">(2)</a>
+    <li><a href="#ref-for-idl-promise-12">4.10. Invoking callback functions</a>
+    <li><a href="#ref-for-idl-promise-13">Changes</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-promise-type">
    <b><a href="#dfn-promise-type">#dfn-promise-type</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-promise-type-1">4.3.12. [NewObject]</a>
+    <li><a href="#ref-for-dfn-promise-type-1">4.3.11. [NewObject]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-union-type">
@@ -15480,40 +15378,38 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-extended-attribute-41">4.3.2. [Constructor]</a>
     <li><a href="#ref-for-dfn-extended-attribute-42">4.3.3. [EnforceRange]</a> <a href="#ref-for-dfn-extended-attribute-43">(2)</a>
     <li><a href="#ref-for-dfn-extended-attribute-44">4.3.4. [Exposed]</a> <a href="#ref-for-dfn-extended-attribute-45">(2)</a> <a href="#ref-for-dfn-extended-attribute-46">(3)</a> <a href="#ref-for-dfn-extended-attribute-47">(4)</a> <a href="#ref-for-dfn-extended-attribute-48">(5)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-49">4.3.5. [ImplicitThis]</a> <a href="#ref-for-dfn-extended-attribute-50">(2)</a> <a href="#ref-for-dfn-extended-attribute-51">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-52">4.3.6. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-extended-attribute-53">(2)</a> <a href="#ref-for-dfn-extended-attribute-54">(3)</a> <a href="#ref-for-dfn-extended-attribute-55">(4)</a> <a href="#ref-for-dfn-extended-attribute-56">(5)</a> <a href="#ref-for-dfn-extended-attribute-57">(6)</a> <a href="#ref-for-dfn-extended-attribute-58">(7)</a> <a href="#ref-for-dfn-extended-attribute-59">(8)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-60">4.3.7. [LegacyArrayClass]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-61">4.3.8. [LegacyUnenumerableNamedProperties]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-62">4.3.9. [LenientSetter]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-63">4.3.10. [LenientThis]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-64">4.3.11. [NamedConstructor]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-65">4.3.12. [NewObject]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-66">4.3.13. [NoInterfaceObject]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-67">4.3.14. [OverrideBuiltins]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-68">4.3.15. [PutForwards]</a> <a href="#ref-for-dfn-extended-attribute-69">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-70">4.3.16. [Replaceable]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-71">4.3.17. [SameObject]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-72">4.3.18. [SecureContext]</a> <a href="#ref-for-dfn-extended-attribute-73">(2)</a> <a href="#ref-for-dfn-extended-attribute-74">(3)</a> <a href="#ref-for-dfn-extended-attribute-75">(4)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-76">4.3.19. [TreatNonObjectAsNull]</a> <a href="#ref-for-dfn-extended-attribute-77">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-78">4.3.20. [TreatNullAs]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-79">4.3.21. [Unforgeable]</a> <a href="#ref-for-dfn-extended-attribute-80">(2)</a> <a href="#ref-for-dfn-extended-attribute-81">(3)</a> <a href="#ref-for-dfn-extended-attribute-82">(4)</a> <a href="#ref-for-dfn-extended-attribute-83">(5)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-84">4.3.22. [Unscopable]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-85">4.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-extended-attribute-86">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-87">4.6. Interfaces</a>
-    <li><a href="#ref-for-dfn-extended-attribute-88">4.6.1.1. Interface object [[Call]] method</a> <a href="#ref-for-dfn-extended-attribute-89">(2)</a> <a href="#ref-for-dfn-extended-attribute-90">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-91">4.6.2. Named constructors</a> <a href="#ref-for-dfn-extended-attribute-92">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-93">4.6.3. Interface prototype object</a> <a href="#ref-for-dfn-extended-attribute-94">(2)</a> <a href="#ref-for-dfn-extended-attribute-95">(3)</a> <a href="#ref-for-dfn-extended-attribute-96">(4)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-97">4.6.4. Named properties object</a>
-    <li><a href="#ref-for-dfn-extended-attribute-98">4.6.4.1. Named properties object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-extended-attribute-99">4.6.6. Attributes</a> <a href="#ref-for-dfn-extended-attribute-100">(2)</a> <a href="#ref-for-dfn-extended-attribute-101">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-102">4.6.7. Operations</a>
-    <li><a href="#ref-for-dfn-extended-attribute-103">4.8.1. Indexed and named properties</a> <a href="#ref-for-dfn-extended-attribute-104">(2)</a> <a href="#ref-for-dfn-extended-attribute-105">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-106">4.8.2. The PlatformObjectGetOwnProperty abstract operation</a> <a href="#ref-for-dfn-extended-attribute-107">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-108">4.8.7. Platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-extended-attribute-109">(2)</a> <a href="#ref-for-dfn-extended-attribute-110">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-111">4.8.8. Platform object [[Delete]] method</a>
-    <li><a href="#ref-for-dfn-extended-attribute-112">4.8.10. Property enumeration</a>
-    <li><a href="#ref-for-dfn-extended-attribute-113">6. Extensibility</a>
-    <li><a href="#ref-for-dfn-extended-attribute-114">IDL grammar</a> <a href="#ref-for-dfn-extended-attribute-115">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-49">4.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-extended-attribute-50">(2)</a> <a href="#ref-for-dfn-extended-attribute-51">(3)</a> <a href="#ref-for-dfn-extended-attribute-52">(4)</a> <a href="#ref-for-dfn-extended-attribute-53">(5)</a> <a href="#ref-for-dfn-extended-attribute-54">(6)</a> <a href="#ref-for-dfn-extended-attribute-55">(7)</a> <a href="#ref-for-dfn-extended-attribute-56">(8)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-57">4.3.6. [LegacyArrayClass]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-58">4.3.7. [LegacyUnenumerableNamedProperties]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-59">4.3.8. [LenientSetter]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-60">4.3.9. [LenientThis]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-61">4.3.10. [NamedConstructor]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-62">4.3.11. [NewObject]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-63">4.3.12. [NoInterfaceObject]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-64">4.3.13. [OverrideBuiltins]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-65">4.3.14. [PutForwards]</a> <a href="#ref-for-dfn-extended-attribute-66">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-67">4.3.15. [Replaceable]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-68">4.3.16. [SameObject]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-69">4.3.17. [SecureContext]</a> <a href="#ref-for-dfn-extended-attribute-70">(2)</a> <a href="#ref-for-dfn-extended-attribute-71">(3)</a> <a href="#ref-for-dfn-extended-attribute-72">(4)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-73">4.3.18. [TreatNonObjectAsNull]</a> <a href="#ref-for-dfn-extended-attribute-74">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-75">4.3.19. [TreatNullAs]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-76">4.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-extended-attribute-77">(2)</a> <a href="#ref-for-dfn-extended-attribute-78">(3)</a> <a href="#ref-for-dfn-extended-attribute-79">(4)</a> <a href="#ref-for-dfn-extended-attribute-80">(5)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-81">4.3.21. [Unscopable]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-82">4.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-extended-attribute-83">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-84">4.6. Interfaces</a>
+    <li><a href="#ref-for-dfn-extended-attribute-85">4.6.1.1. Interface object [[Call]] method</a> <a href="#ref-for-dfn-extended-attribute-86">(2)</a> <a href="#ref-for-dfn-extended-attribute-87">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-88">4.6.2. Named constructors</a> <a href="#ref-for-dfn-extended-attribute-89">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-90">4.6.3. Interface prototype object</a> <a href="#ref-for-dfn-extended-attribute-91">(2)</a> <a href="#ref-for-dfn-extended-attribute-92">(3)</a> <a href="#ref-for-dfn-extended-attribute-93">(4)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-94">4.6.4. Named properties object</a>
+    <li><a href="#ref-for-dfn-extended-attribute-95">4.6.4.1. Named properties object [[GetOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-extended-attribute-96">4.6.6. Attributes</a> <a href="#ref-for-dfn-extended-attribute-97">(2)</a> <a href="#ref-for-dfn-extended-attribute-98">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-99">4.8.1. Indexed and named properties</a> <a href="#ref-for-dfn-extended-attribute-100">(2)</a> <a href="#ref-for-dfn-extended-attribute-101">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-102">4.8.2. The PlatformObjectGetOwnProperty abstract operation</a> <a href="#ref-for-dfn-extended-attribute-103">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-104">4.8.7. Platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-extended-attribute-105">(2)</a> <a href="#ref-for-dfn-extended-attribute-106">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-107">4.8.8. Platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-extended-attribute-108">4.8.10. Property enumeration</a>
+    <li><a href="#ref-for-dfn-extended-attribute-109">6. Extensibility</a>
+    <li><a href="#ref-for-dfn-extended-attribute-110">IDL grammar</a> <a href="#ref-for-dfn-extended-attribute-111">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-xattr-no-arguments">
@@ -15522,20 +15418,19 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-xattr-no-arguments-1">4.3.1. [Clamp]</a>
     <li><a href="#ref-for-dfn-xattr-no-arguments-2">4.3.2. [Constructor]</a>
     <li><a href="#ref-for-dfn-xattr-no-arguments-3">4.3.3. [EnforceRange]</a>
-    <li><a href="#ref-for-dfn-xattr-no-arguments-4">4.3.5. [ImplicitThis]</a>
-    <li><a href="#ref-for-dfn-xattr-no-arguments-5">4.3.6. [Global] and [PrimaryGlobal]</a>
-    <li><a href="#ref-for-dfn-xattr-no-arguments-6">4.3.7. [LegacyArrayClass]</a>
-    <li><a href="#ref-for-dfn-xattr-no-arguments-7">4.3.8. [LegacyUnenumerableNamedProperties]</a>
-    <li><a href="#ref-for-dfn-xattr-no-arguments-8">4.3.9. [LenientSetter]</a>
-    <li><a href="#ref-for-dfn-xattr-no-arguments-9">4.3.10. [LenientThis]</a>
-    <li><a href="#ref-for-dfn-xattr-no-arguments-10">4.3.12. [NewObject]</a>
-    <li><a href="#ref-for-dfn-xattr-no-arguments-11">4.3.13. [NoInterfaceObject]</a>
-    <li><a href="#ref-for-dfn-xattr-no-arguments-12">4.3.14. [OverrideBuiltins]</a>
-    <li><a href="#ref-for-dfn-xattr-no-arguments-13">4.3.16. [Replaceable]</a>
-    <li><a href="#ref-for-dfn-xattr-no-arguments-14">4.3.17. [SameObject]</a>
-    <li><a href="#ref-for-dfn-xattr-no-arguments-15">4.3.18. [SecureContext]</a>
-    <li><a href="#ref-for-dfn-xattr-no-arguments-16">4.3.21. [Unforgeable]</a>
-    <li><a href="#ref-for-dfn-xattr-no-arguments-17">4.3.22. [Unscopable]</a>
+    <li><a href="#ref-for-dfn-xattr-no-arguments-4">4.3.5. [Global] and [PrimaryGlobal]</a>
+    <li><a href="#ref-for-dfn-xattr-no-arguments-5">4.3.6. [LegacyArrayClass]</a>
+    <li><a href="#ref-for-dfn-xattr-no-arguments-6">4.3.7. [LegacyUnenumerableNamedProperties]</a>
+    <li><a href="#ref-for-dfn-xattr-no-arguments-7">4.3.8. [LenientSetter]</a>
+    <li><a href="#ref-for-dfn-xattr-no-arguments-8">4.3.9. [LenientThis]</a>
+    <li><a href="#ref-for-dfn-xattr-no-arguments-9">4.3.11. [NewObject]</a>
+    <li><a href="#ref-for-dfn-xattr-no-arguments-10">4.3.12. [NoInterfaceObject]</a>
+    <li><a href="#ref-for-dfn-xattr-no-arguments-11">4.3.13. [OverrideBuiltins]</a>
+    <li><a href="#ref-for-dfn-xattr-no-arguments-12">4.3.15. [Replaceable]</a>
+    <li><a href="#ref-for-dfn-xattr-no-arguments-13">4.3.16. [SameObject]</a>
+    <li><a href="#ref-for-dfn-xattr-no-arguments-14">4.3.17. [SecureContext]</a>
+    <li><a href="#ref-for-dfn-xattr-no-arguments-15">4.3.20. [Unforgeable]</a>
+    <li><a href="#ref-for-dfn-xattr-no-arguments-16">4.3.21. [Unscopable]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-xattr-argument-list">
@@ -15549,7 +15444,7 @@ this was to the right.)</p>
    <b><a href="#dfn-xattr-named-argument-list">#dfn-xattr-named-argument-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-xattr-named-argument-list-1">3.2.6. Overloading</a> <a href="#ref-for-dfn-xattr-named-argument-list-2">(2)</a>
-    <li><a href="#ref-for-dfn-xattr-named-argument-list-3">4.3.11. [NamedConstructor]</a>
+    <li><a href="#ref-for-dfn-xattr-named-argument-list-3">4.3.10. [NamedConstructor]</a>
     <li><a href="#ref-for-dfn-xattr-named-argument-list-4">4.6.2. Named constructors</a>
    </ul>
   </aside>
@@ -15557,16 +15452,16 @@ this was to the right.)</p>
    <b><a href="#dfn-xattr-identifier">#dfn-xattr-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-xattr-identifier-1">4.3.4. [Exposed]</a>
-    <li><a href="#ref-for-dfn-xattr-identifier-2">4.3.11. [NamedConstructor]</a>
-    <li><a href="#ref-for-dfn-xattr-identifier-3">4.3.15. [PutForwards]</a>
-    <li><a href="#ref-for-dfn-xattr-identifier-4">4.3.20. [TreatNullAs]</a>
+    <li><a href="#ref-for-dfn-xattr-identifier-2">4.3.10. [NamedConstructor]</a>
+    <li><a href="#ref-for-dfn-xattr-identifier-3">4.3.14. [PutForwards]</a>
+    <li><a href="#ref-for-dfn-xattr-identifier-4">4.3.19. [TreatNullAs]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-xattr-identifier-list">
    <b><a href="#dfn-xattr-identifier-list">#dfn-xattr-identifier-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-xattr-identifier-list-1">4.3.4. [Exposed]</a>
-    <li><a href="#ref-for-dfn-xattr-identifier-list-2">4.3.6. [Global] and [PrimaryGlobal]</a>
+    <li><a href="#ref-for-dfn-xattr-identifier-list-2">4.3.5. [Global] and [PrimaryGlobal]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-class-string">
@@ -15629,25 +15524,25 @@ this was to the right.)</p>
     <li><a href="#ref-for-ecmascript-throw-42">4.6.1.1. Interface object [[Call]] method</a>
     <li><a href="#ref-for-ecmascript-throw-43">4.6.1.2. Interface object [[HasInstance]] method</a>
     <li><a href="#ref-for-ecmascript-throw-44">4.6.6. Attributes</a> <a href="#ref-for-ecmascript-throw-45">(2)</a> <a href="#ref-for-ecmascript-throw-46">(3)</a> <a href="#ref-for-ecmascript-throw-47">(4)</a>
-    <li><a href="#ref-for-ecmascript-throw-48">4.6.7. Operations</a> <a href="#ref-for-ecmascript-throw-49">(2)</a>
-    <li><a href="#ref-for-ecmascript-throw-50">4.6.7.1. Stringifiers</a>
-    <li><a href="#ref-for-ecmascript-throw-51">4.6.7.2. Serializers</a>
-    <li><a href="#ref-for-ecmascript-throw-52">4.6.8.1. @@iterator</a> <a href="#ref-for-ecmascript-throw-53">(2)</a>
-    <li><a href="#ref-for-ecmascript-throw-54">4.6.8.2. forEach</a> <a href="#ref-for-ecmascript-throw-55">(2)</a> <a href="#ref-for-ecmascript-throw-56">(3)</a>
-    <li><a href="#ref-for-ecmascript-throw-57">4.6.9.2. keys</a>
-    <li><a href="#ref-for-ecmascript-throw-58">4.6.9.3. values</a>
-    <li><a href="#ref-for-ecmascript-throw-59">4.6.9.5. Iterator prototype object</a>
-    <li><a href="#ref-for-ecmascript-throw-60">4.6.10. Maplike declarations</a> <a href="#ref-for-ecmascript-throw-61">(2)</a>
-    <li><a href="#ref-for-ecmascript-throw-62">4.6.10.1. size</a>
-    <li><a href="#ref-for-ecmascript-throw-63">4.6.10.4. get and has</a>
-    <li><a href="#ref-for-ecmascript-throw-64">4.6.10.6. delete</a>
-    <li><a href="#ref-for-ecmascript-throw-65">4.6.10.7. set</a>
-    <li><a href="#ref-for-ecmascript-throw-66">4.6.11. Setlike declarations</a> <a href="#ref-for-ecmascript-throw-67">(2)</a>
-    <li><a href="#ref-for-ecmascript-throw-68">4.6.11.1. size</a>
-    <li><a href="#ref-for-ecmascript-throw-69">4.6.11.4. has</a>
-    <li><a href="#ref-for-ecmascript-throw-70">4.6.11.5. add and delete</a>
-    <li><a href="#ref-for-ecmascript-throw-71">4.6.12. Initializing objects from iterables</a> <a href="#ref-for-ecmascript-throw-72">(2)</a> <a href="#ref-for-ecmascript-throw-73">(3)</a>
-    <li><a href="#ref-for-ecmascript-throw-74">4.8.1. Indexed and named properties</a> <a href="#ref-for-ecmascript-throw-75">(2)</a>
+    <li><a href="#ref-for-ecmascript-throw-48">4.6.7. Operations</a>
+    <li><a href="#ref-for-ecmascript-throw-49">4.6.7.1. Stringifiers</a>
+    <li><a href="#ref-for-ecmascript-throw-50">4.6.7.2. Serializers</a>
+    <li><a href="#ref-for-ecmascript-throw-51">4.6.8.1. @@iterator</a> <a href="#ref-for-ecmascript-throw-52">(2)</a>
+    <li><a href="#ref-for-ecmascript-throw-53">4.6.8.2. forEach</a> <a href="#ref-for-ecmascript-throw-54">(2)</a> <a href="#ref-for-ecmascript-throw-55">(3)</a>
+    <li><a href="#ref-for-ecmascript-throw-56">4.6.9.2. keys</a>
+    <li><a href="#ref-for-ecmascript-throw-57">4.6.9.3. values</a>
+    <li><a href="#ref-for-ecmascript-throw-58">4.6.9.5. Iterator prototype object</a>
+    <li><a href="#ref-for-ecmascript-throw-59">4.6.10. Maplike declarations</a> <a href="#ref-for-ecmascript-throw-60">(2)</a>
+    <li><a href="#ref-for-ecmascript-throw-61">4.6.10.1. size</a>
+    <li><a href="#ref-for-ecmascript-throw-62">4.6.10.4. get and has</a>
+    <li><a href="#ref-for-ecmascript-throw-63">4.6.10.6. delete</a>
+    <li><a href="#ref-for-ecmascript-throw-64">4.6.10.7. set</a>
+    <li><a href="#ref-for-ecmascript-throw-65">4.6.11. Setlike declarations</a> <a href="#ref-for-ecmascript-throw-66">(2)</a>
+    <li><a href="#ref-for-ecmascript-throw-67">4.6.11.1. size</a>
+    <li><a href="#ref-for-ecmascript-throw-68">4.6.11.4. has</a>
+    <li><a href="#ref-for-ecmascript-throw-69">4.6.11.5. add and delete</a>
+    <li><a href="#ref-for-ecmascript-throw-70">4.6.12. Initializing objects from iterables</a> <a href="#ref-for-ecmascript-throw-71">(2)</a> <a href="#ref-for-ecmascript-throw-72">(3)</a>
+    <li><a href="#ref-for-ecmascript-throw-73">4.8.1. Indexed and named properties</a> <a href="#ref-for-ecmascript-throw-74">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-initial-object">
@@ -15759,20 +15654,20 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-38">4.6.4.1. Named properties object [[GetOwnProperty]] method</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-39">4.6.5. Constants</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-40">4.6.6. Attributes</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-41">4.6.7. Operations</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-42">(2)</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-43">4.6.7.1. Stringifiers</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-44">4.6.7.2. Serializers</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-45">4.6.9.5. Iterator prototype object</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-46">(2)</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-47">(3)</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-48">(4)</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-49">4.6.10.4. get and has</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-50">4.6.10.6. delete</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-51">4.6.10.7. set</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-52">(2)</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-53">4.6.11.4. has</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-54">4.6.11.5. add and delete</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-55">4.8.2. The PlatformObjectGetOwnProperty abstract operation</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-56">(2)</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-57">4.8.9. Platform object [[Call]] method</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-58">4.9. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-59">(2)</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-60">4.10. Invoking callback functions</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-61">4.14. Creating and throwing exceptions</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-62">(2)</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-41">4.6.7. Operations</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-42">4.6.7.1. Stringifiers</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-43">4.6.7.2. Serializers</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-44">4.6.9.5. Iterator prototype object</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-45">(2)</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-46">(3)</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-47">(4)</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-48">4.6.10.4. get and has</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-49">4.6.10.6. delete</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-50">4.6.10.7. set</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-51">(2)</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-52">4.6.11.4. has</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-53">4.6.11.5. add and delete</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-54">4.8.2. The PlatformObjectGetOwnProperty abstract operation</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-55">(2)</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-56">4.8.9. Platform object [[Call]] method</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-57">4.9. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-58">(2)</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-59">4.10. Invoking callback functions</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-60">4.14. Creating and throwing exceptions</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-61">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="create-sequence-from-iterable">
@@ -15825,7 +15720,7 @@ this was to the right.)</p>
     <li><a href="#ref-for-Constructor-5">3.2.6. Overloading</a> <a href="#ref-for-Constructor-6">(2)</a> <a href="#ref-for-Constructor-7">(3)</a> <a href="#ref-for-Constructor-8">(4)</a> <a href="#ref-for-Constructor-9">(5)</a>
     <li><a href="#ref-for-Constructor-10">3.4. Dictionaries</a>
     <li><a href="#ref-for-Constructor-11">4.3.2. [Constructor]</a> <a href="#ref-for-Constructor-12">(2)</a> <a href="#ref-for-Constructor-13">(3)</a> <a href="#ref-for-Constructor-14">(4)</a> <a href="#ref-for-Constructor-15">(5)</a> <a href="#ref-for-Constructor-16">(6)</a> <a href="#ref-for-Constructor-17">(7)</a> <a href="#ref-for-Constructor-18">(8)</a>
-    <li><a href="#ref-for-Constructor-19">4.3.13. [NoInterfaceObject]</a>
+    <li><a href="#ref-for-Constructor-19">4.3.12. [NoInterfaceObject]</a>
     <li><a href="#ref-for-Constructor-20">4.6.1.1. Interface object [[Call]] method</a> <a href="#ref-for-Constructor-21">(2)</a> <a href="#ref-for-Constructor-22">(3)</a>
     <li><a href="#ref-for-Constructor-23">4.14. Creating and throwing exceptions</a>
     <li><a href="#ref-for-Constructor-24">IDL grammar</a>
@@ -15860,7 +15755,7 @@ this was to the right.)</p>
     <li><a href="#ref-for-Exposed-7">3.3. Namespaces</a>
     <li><a href="#ref-for-Exposed-8">3.4. Dictionaries</a>
     <li><a href="#ref-for-Exposed-9">4.3.4. [Exposed]</a> <a href="#ref-for-Exposed-10">(2)</a> <a href="#ref-for-Exposed-11">(3)</a> <a href="#ref-for-Exposed-12">(4)</a> <a href="#ref-for-Exposed-13">(5)</a> <a href="#ref-for-Exposed-14">(6)</a> <a href="#ref-for-Exposed-15">(7)</a> <a href="#ref-for-Exposed-16">(8)</a> <a href="#ref-for-Exposed-17">(9)</a> <a href="#ref-for-Exposed-18">(10)</a> <a href="#ref-for-Exposed-19">(11)</a> <a href="#ref-for-Exposed-20">(12)</a>
-    <li><a href="#ref-for-Exposed-21">4.3.6. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-Exposed-22">(2)</a>
+    <li><a href="#ref-for-Exposed-21">4.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-Exposed-22">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-exposure-set">
@@ -15872,7 +15767,7 @@ this was to the right.)</p>
   <aside class="dfn-panel" data-for="dfn-exposed">
    <b><a href="#dfn-exposed">#dfn-exposed</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-exposed-1">4.3.18. [SecureContext]</a>
+    <li><a href="#ref-for-dfn-exposed-1">4.3.17. [SecureContext]</a>
     <li><a href="#ref-for-dfn-exposed-2">4.6. Interfaces</a> <a href="#ref-for-dfn-exposed-3">(2)</a>
     <li><a href="#ref-for-dfn-exposed-4">4.6.5. Constants</a>
     <li><a href="#ref-for-dfn-exposed-5">4.6.6. Attributes</a>
@@ -15883,20 +15778,12 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-exposed-10">4.11.1. Namespace object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ImplicitThis">
-   <b><a href="#ImplicitThis">#ImplicitThis</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-ImplicitThis-1">3.2. Interfaces</a> <a href="#ref-for-ImplicitThis-2">(2)</a>
-    <li><a href="#ref-for-ImplicitThis-3">4.3.5. [ImplicitThis]</a> <a href="#ref-for-ImplicitThis-4">(2)</a> <a href="#ref-for-ImplicitThis-5">(3)</a> <a href="#ref-for-ImplicitThis-6">(4)</a> <a href="#ref-for-ImplicitThis-7">(5)</a>
-    <li><a href="#ref-for-ImplicitThis-8">4.6.7. Operations</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="Global">
    <b><a href="#Global">#Global</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Global-1">3.2. Interfaces</a> <a href="#ref-for-Global-2">(2)</a> <a href="#ref-for-Global-3">(3)</a> <a href="#ref-for-Global-4">(4)</a>
-    <li><a href="#ref-for-Global-5">4.3.6. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-Global-6">(2)</a> <a href="#ref-for-Global-7">(3)</a> <a href="#ref-for-Global-8">(4)</a> <a href="#ref-for-Global-9">(5)</a> <a href="#ref-for-Global-10">(6)</a> <a href="#ref-for-Global-11">(7)</a> <a href="#ref-for-Global-12">(8)</a> <a href="#ref-for-Global-13">(9)</a> <a href="#ref-for-Global-14">(10)</a> <a href="#ref-for-Global-15">(11)</a> <a href="#ref-for-Global-16">(12)</a> <a href="#ref-for-Global-17">(13)</a> <a href="#ref-for-Global-18">(14)</a> <a href="#ref-for-Global-19">(15)</a> <a href="#ref-for-Global-20">(16)</a> <a href="#ref-for-Global-21">(17)</a> <a href="#ref-for-Global-22">(18)</a> <a href="#ref-for-Global-23">(19)</a> <a href="#ref-for-Global-24">(20)</a> <a href="#ref-for-Global-25">(21)</a> <a href="#ref-for-Global-26">(22)</a> <a href="#ref-for-Global-27">(23)</a> <a href="#ref-for-Global-28">(24)</a>
-    <li><a href="#ref-for-Global-29">4.3.14. [OverrideBuiltins]</a> <a href="#ref-for-Global-30">(2)</a>
+    <li><a href="#ref-for-Global-5">4.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-Global-6">(2)</a> <a href="#ref-for-Global-7">(3)</a> <a href="#ref-for-Global-8">(4)</a> <a href="#ref-for-Global-9">(5)</a> <a href="#ref-for-Global-10">(6)</a> <a href="#ref-for-Global-11">(7)</a> <a href="#ref-for-Global-12">(8)</a> <a href="#ref-for-Global-13">(9)</a> <a href="#ref-for-Global-14">(10)</a> <a href="#ref-for-Global-15">(11)</a> <a href="#ref-for-Global-16">(12)</a> <a href="#ref-for-Global-17">(13)</a> <a href="#ref-for-Global-18">(14)</a> <a href="#ref-for-Global-19">(15)</a> <a href="#ref-for-Global-20">(16)</a> <a href="#ref-for-Global-21">(17)</a> <a href="#ref-for-Global-22">(18)</a> <a href="#ref-for-Global-23">(19)</a> <a href="#ref-for-Global-24">(20)</a> <a href="#ref-for-Global-25">(21)</a> <a href="#ref-for-Global-26">(22)</a> <a href="#ref-for-Global-27">(23)</a> <a href="#ref-for-Global-28">(24)</a>
+    <li><a href="#ref-for-Global-29">4.3.13. [OverrideBuiltins]</a> <a href="#ref-for-Global-30">(2)</a>
     <li><a href="#ref-for-Global-31">4.6.3. Interface prototype object</a> <a href="#ref-for-Global-32">(2)</a> <a href="#ref-for-Global-33">(3)</a> <a href="#ref-for-Global-34">(4)</a>
     <li><a href="#ref-for-Global-35">4.6.4. Named properties object</a> <a href="#ref-for-Global-36">(2)</a>
     <li><a href="#ref-for-Global-37">4.6.5. Constants</a> <a href="#ref-for-Global-38">(2)</a> <a href="#ref-for-Global-39">(3)</a> <a href="#ref-for-Global-40">(4)</a> <a href="#ref-for-Global-41">(5)</a> <a href="#ref-for-Global-42">(6)</a>
@@ -15931,7 +15818,7 @@ this was to the right.)</p>
    <b><a href="#LegacyArrayClass">#LegacyArrayClass</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyArrayClass-1">3.2. Interfaces</a> <a href="#ref-for-LegacyArrayClass-2">(2)</a>
-    <li><a href="#ref-for-LegacyArrayClass-3">4.3.7. [LegacyArrayClass]</a> <a href="#ref-for-LegacyArrayClass-4">(2)</a> <a href="#ref-for-LegacyArrayClass-5">(3)</a> <a href="#ref-for-LegacyArrayClass-6">(4)</a> <a href="#ref-for-LegacyArrayClass-7">(5)</a>
+    <li><a href="#ref-for-LegacyArrayClass-3">4.3.6. [LegacyArrayClass]</a> <a href="#ref-for-LegacyArrayClass-4">(2)</a> <a href="#ref-for-LegacyArrayClass-5">(3)</a> <a href="#ref-for-LegacyArrayClass-6">(4)</a> <a href="#ref-for-LegacyArrayClass-7">(5)</a>
     <li><a href="#ref-for-LegacyArrayClass-8">4.6.3. Interface prototype object</a>
     <li><a href="#ref-for-LegacyArrayClass-9">4.6.4. Named properties object</a>
    </ul>
@@ -15939,7 +15826,7 @@ this was to the right.)</p>
   <aside class="dfn-panel" data-for="LegacyUnenumerableNamedProperties">
    <b><a href="#LegacyUnenumerableNamedProperties">#LegacyUnenumerableNamedProperties</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-LegacyUnenumerableNamedProperties-1">4.3.8. [LegacyUnenumerableNamedProperties]</a> <a href="#ref-for-LegacyUnenumerableNamedProperties-2">(2)</a> <a href="#ref-for-LegacyUnenumerableNamedProperties-3">(3)</a> <a href="#ref-for-LegacyUnenumerableNamedProperties-4">(4)</a>
+    <li><a href="#ref-for-LegacyUnenumerableNamedProperties-1">4.3.7. [LegacyUnenumerableNamedProperties]</a> <a href="#ref-for-LegacyUnenumerableNamedProperties-2">(2)</a> <a href="#ref-for-LegacyUnenumerableNamedProperties-3">(3)</a> <a href="#ref-for-LegacyUnenumerableNamedProperties-4">(4)</a>
     <li><a href="#ref-for-LegacyUnenumerableNamedProperties-5">4.6.4.1. Named properties object [[GetOwnProperty]] method</a>
     <li><a href="#ref-for-LegacyUnenumerableNamedProperties-6">4.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
     <li><a href="#ref-for-LegacyUnenumerableNamedProperties-7">4.8.10. Property enumeration</a>
@@ -15949,9 +15836,9 @@ this was to the right.)</p>
    <b><a href="#LenientSetter">#LenientSetter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LenientSetter-1">3.2.2. Attributes</a>
-    <li><a href="#ref-for-LenientSetter-2">4.3.9. [LenientSetter]</a> <a href="#ref-for-LenientSetter-3">(2)</a> <a href="#ref-for-LenientSetter-4">(3)</a> <a href="#ref-for-LenientSetter-5">(4)</a> <a href="#ref-for-LenientSetter-6">(5)</a> <a href="#ref-for-LenientSetter-7">(6)</a>
-    <li><a href="#ref-for-LenientSetter-8">4.3.15. [PutForwards]</a>
-    <li><a href="#ref-for-LenientSetter-9">4.3.16. [Replaceable]</a>
+    <li><a href="#ref-for-LenientSetter-2">4.3.8. [LenientSetter]</a> <a href="#ref-for-LenientSetter-3">(2)</a> <a href="#ref-for-LenientSetter-4">(3)</a> <a href="#ref-for-LenientSetter-5">(4)</a> <a href="#ref-for-LenientSetter-6">(5)</a> <a href="#ref-for-LenientSetter-7">(6)</a>
+    <li><a href="#ref-for-LenientSetter-8">4.3.14. [PutForwards]</a>
+    <li><a href="#ref-for-LenientSetter-9">4.3.15. [Replaceable]</a>
     <li><a href="#ref-for-LenientSetter-10">4.6.6. Attributes</a>
    </ul>
   </aside>
@@ -15959,8 +15846,8 @@ this was to the right.)</p>
    <b><a href="#LenientThis">#LenientThis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LenientThis-1">3.2.2. Attributes</a>
-    <li><a href="#ref-for-LenientThis-2">4.3.9. [LenientSetter]</a>
-    <li><a href="#ref-for-LenientThis-3">4.3.10. [LenientThis]</a> <a href="#ref-for-LenientThis-4">(2)</a> <a href="#ref-for-LenientThis-5">(3)</a> <a href="#ref-for-LenientThis-6">(4)</a> <a href="#ref-for-LenientThis-7">(5)</a>
+    <li><a href="#ref-for-LenientThis-2">4.3.8. [LenientSetter]</a>
+    <li><a href="#ref-for-LenientThis-3">4.3.9. [LenientThis]</a> <a href="#ref-for-LenientThis-4">(2)</a> <a href="#ref-for-LenientThis-5">(3)</a> <a href="#ref-for-LenientThis-6">(4)</a> <a href="#ref-for-LenientThis-7">(5)</a>
     <li><a href="#ref-for-LenientThis-8">4.6.6. Attributes</a> <a href="#ref-for-LenientThis-9">(2)</a> <a href="#ref-for-LenientThis-10">(3)</a>
    </ul>
   </aside>
@@ -15970,8 +15857,8 @@ this was to the right.)</p>
     <li><a href="#ref-for-NamedConstructor-1">3.2. Interfaces</a> <a href="#ref-for-NamedConstructor-2">(2)</a>
     <li><a href="#ref-for-NamedConstructor-3">3.2.3. Operations</a>
     <li><a href="#ref-for-NamedConstructor-4">3.2.6. Overloading</a> <a href="#ref-for-NamedConstructor-5">(2)</a> <a href="#ref-for-NamedConstructor-6">(3)</a> <a href="#ref-for-NamedConstructor-7">(4)</a>
-    <li><a href="#ref-for-NamedConstructor-8">4.3.11. [NamedConstructor]</a> <a href="#ref-for-NamedConstructor-9">(2)</a> <a href="#ref-for-NamedConstructor-10">(3)</a> <a href="#ref-for-NamedConstructor-11">(4)</a> <a href="#ref-for-NamedConstructor-12">(5)</a> <a href="#ref-for-NamedConstructor-13">(6)</a> <a href="#ref-for-NamedConstructor-14">(7)</a>
-    <li><a href="#ref-for-NamedConstructor-15">4.3.13. [NoInterfaceObject]</a>
+    <li><a href="#ref-for-NamedConstructor-8">4.3.10. [NamedConstructor]</a> <a href="#ref-for-NamedConstructor-9">(2)</a> <a href="#ref-for-NamedConstructor-10">(3)</a> <a href="#ref-for-NamedConstructor-11">(4)</a> <a href="#ref-for-NamedConstructor-12">(5)</a> <a href="#ref-for-NamedConstructor-13">(6)</a> <a href="#ref-for-NamedConstructor-14">(7)</a>
+    <li><a href="#ref-for-NamedConstructor-15">4.3.12. [NoInterfaceObject]</a>
     <li><a href="#ref-for-NamedConstructor-16">4.6. Interfaces</a>
     <li><a href="#ref-for-NamedConstructor-17">4.6.2. Named constructors</a> <a href="#ref-for-NamedConstructor-18">(2)</a> <a href="#ref-for-NamedConstructor-19">(3)</a> <a href="#ref-for-NamedConstructor-20">(4)</a>
    </ul>
@@ -15980,7 +15867,7 @@ this was to the right.)</p>
    <b><a href="#NewObject">#NewObject</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject-1">3.2.3. Operations</a>
-    <li><a href="#ref-for-NewObject-2">4.3.12. [NewObject]</a> <a href="#ref-for-NewObject-3">(2)</a> <a href="#ref-for-NewObject-4">(3)</a>
+    <li><a href="#ref-for-NewObject-2">4.3.11. [NewObject]</a> <a href="#ref-for-NewObject-3">(2)</a> <a href="#ref-for-NewObject-4">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="NoInterfaceObject">
@@ -15988,7 +15875,7 @@ this was to the right.)</p>
    <ul>
     <li><a href="#ref-for-NoInterfaceObject-1">3.2. Interfaces</a> <a href="#ref-for-NoInterfaceObject-2">(2)</a>
     <li><a href="#ref-for-NoInterfaceObject-3">4.3.2. [Constructor]</a>
-    <li><a href="#ref-for-NoInterfaceObject-4">4.3.13. [NoInterfaceObject]</a> <a href="#ref-for-NoInterfaceObject-5">(2)</a> <a href="#ref-for-NoInterfaceObject-6">(3)</a> <a href="#ref-for-NoInterfaceObject-7">(4)</a> <a href="#ref-for-NoInterfaceObject-8">(5)</a> <a href="#ref-for-NoInterfaceObject-9">(6)</a> <a href="#ref-for-NoInterfaceObject-10">(7)</a> <a href="#ref-for-NoInterfaceObject-11">(8)</a> <a href="#ref-for-NoInterfaceObject-12">(9)</a>
+    <li><a href="#ref-for-NoInterfaceObject-4">4.3.12. [NoInterfaceObject]</a> <a href="#ref-for-NoInterfaceObject-5">(2)</a> <a href="#ref-for-NoInterfaceObject-6">(3)</a> <a href="#ref-for-NoInterfaceObject-7">(4)</a> <a href="#ref-for-NoInterfaceObject-8">(5)</a> <a href="#ref-for-NoInterfaceObject-9">(6)</a> <a href="#ref-for-NoInterfaceObject-10">(7)</a> <a href="#ref-for-NoInterfaceObject-11">(8)</a> <a href="#ref-for-NoInterfaceObject-12">(9)</a>
     <li><a href="#ref-for-NoInterfaceObject-13">4.6. Interfaces</a>
     <li><a href="#ref-for-NoInterfaceObject-14">4.6.3. Interface prototype object</a> <a href="#ref-for-NoInterfaceObject-15">(2)</a> <a href="#ref-for-NoInterfaceObject-16">(3)</a>
    </ul>
@@ -15997,8 +15884,8 @@ this was to the right.)</p>
    <b><a href="#OverrideBuiltins">#OverrideBuiltins</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-OverrideBuiltins-1">3.2. Interfaces</a> <a href="#ref-for-OverrideBuiltins-2">(2)</a>
-    <li><a href="#ref-for-OverrideBuiltins-3">4.3.6. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-OverrideBuiltins-4">(2)</a>
-    <li><a href="#ref-for-OverrideBuiltins-5">4.3.14. [OverrideBuiltins]</a> <a href="#ref-for-OverrideBuiltins-6">(2)</a> <a href="#ref-for-OverrideBuiltins-7">(3)</a>
+    <li><a href="#ref-for-OverrideBuiltins-3">4.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-OverrideBuiltins-4">(2)</a>
+    <li><a href="#ref-for-OverrideBuiltins-5">4.3.13. [OverrideBuiltins]</a> <a href="#ref-for-OverrideBuiltins-6">(2)</a> <a href="#ref-for-OverrideBuiltins-7">(3)</a>
     <li><a href="#ref-for-OverrideBuiltins-8">4.8.1. Indexed and named properties</a> <a href="#ref-for-OverrideBuiltins-9">(2)</a> <a href="#ref-for-OverrideBuiltins-10">(3)</a> <a href="#ref-for-OverrideBuiltins-11">(4)</a>
     <li><a href="#ref-for-OverrideBuiltins-12">4.8.7. Platform object [[DefineOwnProperty]] method</a>
    </ul>
@@ -16007,9 +15894,9 @@ this was to the right.)</p>
    <b><a href="#PutForwards">#PutForwards</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-PutForwards-1">3.2.2. Attributes</a>
-    <li><a href="#ref-for-PutForwards-2">4.3.9. [LenientSetter]</a>
-    <li><a href="#ref-for-PutForwards-3">4.3.15. [PutForwards]</a> <a href="#ref-for-PutForwards-4">(2)</a> <a href="#ref-for-PutForwards-5">(3)</a> <a href="#ref-for-PutForwards-6">(4)</a> <a href="#ref-for-PutForwards-7">(5)</a> <a href="#ref-for-PutForwards-8">(6)</a> <a href="#ref-for-PutForwards-9">(7)</a> <a href="#ref-for-PutForwards-10">(8)</a> <a href="#ref-for-PutForwards-11">(9)</a> <a href="#ref-for-PutForwards-12">(10)</a> <a href="#ref-for-PutForwards-13">(11)</a>
-    <li><a href="#ref-for-PutForwards-14">4.3.16. [Replaceable]</a>
+    <li><a href="#ref-for-PutForwards-2">4.3.8. [LenientSetter]</a>
+    <li><a href="#ref-for-PutForwards-3">4.3.14. [PutForwards]</a> <a href="#ref-for-PutForwards-4">(2)</a> <a href="#ref-for-PutForwards-5">(3)</a> <a href="#ref-for-PutForwards-6">(4)</a> <a href="#ref-for-PutForwards-7">(5)</a> <a href="#ref-for-PutForwards-8">(6)</a> <a href="#ref-for-PutForwards-9">(7)</a> <a href="#ref-for-PutForwards-10">(8)</a> <a href="#ref-for-PutForwards-11">(9)</a> <a href="#ref-for-PutForwards-12">(10)</a> <a href="#ref-for-PutForwards-13">(11)</a>
+    <li><a href="#ref-for-PutForwards-14">4.3.15. [Replaceable]</a>
     <li><a href="#ref-for-PutForwards-15">4.6.6. Attributes</a> <a href="#ref-for-PutForwards-16">(2)</a> <a href="#ref-for-PutForwards-17">(3)</a>
    </ul>
   </aside>
@@ -16017,9 +15904,9 @@ this was to the right.)</p>
    <b><a href="#Replaceable">#Replaceable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Replaceable-1">3.2.2. Attributes</a>
-    <li><a href="#ref-for-Replaceable-2">4.3.9. [LenientSetter]</a>
-    <li><a href="#ref-for-Replaceable-3">4.3.15. [PutForwards]</a>
-    <li><a href="#ref-for-Replaceable-4">4.3.16. [Replaceable]</a> <a href="#ref-for-Replaceable-5">(2)</a> <a href="#ref-for-Replaceable-6">(3)</a> <a href="#ref-for-Replaceable-7">(4)</a> <a href="#ref-for-Replaceable-8">(5)</a> <a href="#ref-for-Replaceable-9">(6)</a> <a href="#ref-for-Replaceable-10">(7)</a>
+    <li><a href="#ref-for-Replaceable-2">4.3.8. [LenientSetter]</a>
+    <li><a href="#ref-for-Replaceable-3">4.3.14. [PutForwards]</a>
+    <li><a href="#ref-for-Replaceable-4">4.3.15. [Replaceable]</a> <a href="#ref-for-Replaceable-5">(2)</a> <a href="#ref-for-Replaceable-6">(3)</a> <a href="#ref-for-Replaceable-7">(4)</a> <a href="#ref-for-Replaceable-8">(5)</a> <a href="#ref-for-Replaceable-9">(6)</a> <a href="#ref-for-Replaceable-10">(7)</a>
     <li><a href="#ref-for-Replaceable-11">4.6.6. Attributes</a> <a href="#ref-for-Replaceable-12">(2)</a>
    </ul>
   </aside>
@@ -16027,7 +15914,7 @@ this was to the right.)</p>
    <b><a href="#SameObject">#SameObject</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject-1">3.2.2. Attributes</a>
-    <li><a href="#ref-for-SameObject-2">4.3.17. [SameObject]</a> <a href="#ref-for-SameObject-3">(2)</a> <a href="#ref-for-SameObject-4">(3)</a>
+    <li><a href="#ref-for-SameObject-2">4.3.16. [SameObject]</a> <a href="#ref-for-SameObject-3">(2)</a> <a href="#ref-for-SameObject-4">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="SecureContext">
@@ -16040,14 +15927,14 @@ this was to the right.)</p>
     <li><a href="#ref-for-SecureContext-6">3.2.7. Iterable declarations</a>
     <li><a href="#ref-for-SecureContext-7">3.3. Namespaces</a>
     <li><a href="#ref-for-SecureContext-8">3.4. Dictionaries</a>
-    <li><a href="#ref-for-SecureContext-9">4.3.18. [SecureContext]</a> <a href="#ref-for-SecureContext-10">(2)</a> <a href="#ref-for-SecureContext-11">(3)</a> <a href="#ref-for-SecureContext-12">(4)</a> <a href="#ref-for-SecureContext-13">(5)</a> <a href="#ref-for-SecureContext-14">(6)</a> <a href="#ref-for-SecureContext-15">(7)</a> <a href="#ref-for-SecureContext-16">(8)</a> <a href="#ref-for-SecureContext-17">(9)</a> <a href="#ref-for-SecureContext-18">(10)</a>
+    <li><a href="#ref-for-SecureContext-9">4.3.17. [SecureContext]</a> <a href="#ref-for-SecureContext-10">(2)</a> <a href="#ref-for-SecureContext-11">(3)</a> <a href="#ref-for-SecureContext-12">(4)</a> <a href="#ref-for-SecureContext-13">(5)</a> <a href="#ref-for-SecureContext-14">(6)</a> <a href="#ref-for-SecureContext-15">(7)</a> <a href="#ref-for-SecureContext-16">(8)</a> <a href="#ref-for-SecureContext-17">(9)</a> <a href="#ref-for-SecureContext-18">(10)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-available-only-in-secure-contexts">
    <b><a href="#dfn-available-only-in-secure-contexts">#dfn-available-only-in-secure-contexts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-available-only-in-secure-contexts-1">4.3.4. [Exposed]</a>
-    <li><a href="#ref-for-dfn-available-only-in-secure-contexts-2">4.3.18. [SecureContext]</a> <a href="#ref-for-dfn-available-only-in-secure-contexts-3">(2)</a> <a href="#ref-for-dfn-available-only-in-secure-contexts-4">(3)</a> <a href="#ref-for-dfn-available-only-in-secure-contexts-5">(4)</a> <a href="#ref-for-dfn-available-only-in-secure-contexts-6">(5)</a> <a href="#ref-for-dfn-available-only-in-secure-contexts-7">(6)</a> <a href="#ref-for-dfn-available-only-in-secure-contexts-8">(7)</a>
+    <li><a href="#ref-for-dfn-available-only-in-secure-contexts-2">4.3.17. [SecureContext]</a> <a href="#ref-for-dfn-available-only-in-secure-contexts-3">(2)</a> <a href="#ref-for-dfn-available-only-in-secure-contexts-4">(3)</a> <a href="#ref-for-dfn-available-only-in-secure-contexts-5">(4)</a> <a href="#ref-for-dfn-available-only-in-secure-contexts-6">(5)</a> <a href="#ref-for-dfn-available-only-in-secure-contexts-7">(6)</a> <a href="#ref-for-dfn-available-only-in-secure-contexts-8">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="TreatNonObjectAsNull">
@@ -16056,7 +15943,7 @@ this was to the right.)</p>
     <li><a href="#ref-for-TreatNonObjectAsNull-1">3.7. Callback functions</a>
     <li><a href="#ref-for-TreatNonObjectAsNull-2">4.2.23. Callback function types</a> <a href="#ref-for-TreatNonObjectAsNull-3">(2)</a>
     <li><a href="#ref-for-TreatNonObjectAsNull-4">4.2.24. Nullable types — T?</a>
-    <li><a href="#ref-for-TreatNonObjectAsNull-5">4.3.19. [TreatNonObjectAsNull]</a> <a href="#ref-for-TreatNonObjectAsNull-6">(2)</a> <a href="#ref-for-TreatNonObjectAsNull-7">(3)</a> <a href="#ref-for-TreatNonObjectAsNull-8">(4)</a> <a href="#ref-for-TreatNonObjectAsNull-9">(5)</a>
+    <li><a href="#ref-for-TreatNonObjectAsNull-5">4.3.18. [TreatNonObjectAsNull]</a> <a href="#ref-for-TreatNonObjectAsNull-6">(2)</a> <a href="#ref-for-TreatNonObjectAsNull-7">(3)</a> <a href="#ref-for-TreatNonObjectAsNull-8">(4)</a> <a href="#ref-for-TreatNonObjectAsNull-9">(5)</a>
     <li><a href="#ref-for-TreatNonObjectAsNull-10">4.10. Invoking callback functions</a>
    </ul>
   </aside>
@@ -16066,7 +15953,7 @@ this was to the right.)</p>
     <li><a href="#ref-for-TreatNullAs-1">3.2.2. Attributes</a>
     <li><a href="#ref-for-TreatNullAs-2">3.2.3. Operations</a> <a href="#ref-for-TreatNullAs-3">(2)</a>
     <li><a href="#ref-for-TreatNullAs-4">4.2.16. DOMString</a> <a href="#ref-for-TreatNullAs-5">(2)</a> <a href="#ref-for-TreatNullAs-6">(3)</a> <a href="#ref-for-TreatNullAs-7">(4)</a>
-    <li><a href="#ref-for-TreatNullAs-8">4.3.20. [TreatNullAs]</a> <a href="#ref-for-TreatNullAs-9">(2)</a> <a href="#ref-for-TreatNullAs-10">(3)</a> <a href="#ref-for-TreatNullAs-11">(4)</a> <a href="#ref-for-TreatNullAs-12">(5)</a> <a href="#ref-for-TreatNullAs-13">(6)</a> <a href="#ref-for-TreatNullAs-14">(7)</a> <a href="#ref-for-TreatNullAs-15">(8)</a>
+    <li><a href="#ref-for-TreatNullAs-8">4.3.19. [TreatNullAs]</a> <a href="#ref-for-TreatNullAs-9">(2)</a> <a href="#ref-for-TreatNullAs-10">(3)</a> <a href="#ref-for-TreatNullAs-11">(4)</a> <a href="#ref-for-TreatNullAs-12">(5)</a> <a href="#ref-for-TreatNullAs-13">(6)</a> <a href="#ref-for-TreatNullAs-14">(7)</a> <a href="#ref-for-TreatNullAs-15">(8)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="Unforgeable">
@@ -16075,7 +15962,7 @@ this was to the right.)</p>
     <li><a href="#ref-for-Unforgeable-1">3.2. Interfaces</a> <a href="#ref-for-Unforgeable-2">(2)</a>
     <li><a href="#ref-for-Unforgeable-3">3.2.2. Attributes</a>
     <li><a href="#ref-for-Unforgeable-4">3.2.3. Operations</a>
-    <li><a href="#ref-for-Unforgeable-5">4.3.21. [Unforgeable]</a> <a href="#ref-for-Unforgeable-6">(2)</a> <a href="#ref-for-Unforgeable-7">(3)</a> <a href="#ref-for-Unforgeable-8">(4)</a> <a href="#ref-for-Unforgeable-9">(5)</a> <a href="#ref-for-Unforgeable-10">(6)</a> <a href="#ref-for-Unforgeable-11">(7)</a> <a href="#ref-for-Unforgeable-12">(8)</a> <a href="#ref-for-Unforgeable-13">(9)</a>
+    <li><a href="#ref-for-Unforgeable-5">4.3.20. [Unforgeable]</a> <a href="#ref-for-Unforgeable-6">(2)</a> <a href="#ref-for-Unforgeable-7">(3)</a> <a href="#ref-for-Unforgeable-8">(4)</a> <a href="#ref-for-Unforgeable-9">(5)</a> <a href="#ref-for-Unforgeable-10">(6)</a> <a href="#ref-for-Unforgeable-11">(7)</a> <a href="#ref-for-Unforgeable-12">(8)</a> <a href="#ref-for-Unforgeable-13">(9)</a>
     <li><a href="#ref-for-Unforgeable-14">4.6.6. Attributes</a>
     <li><a href="#ref-for-Unforgeable-15">4.8. Platform objects implementing interfaces</a> <a href="#ref-for-Unforgeable-16">(2)</a> <a href="#ref-for-Unforgeable-17">(3)</a>
     <li><a href="#ref-for-Unforgeable-18">4.8.1. Indexed and named properties</a> <a href="#ref-for-Unforgeable-19">(2)</a>
@@ -16084,7 +15971,7 @@ this was to the right.)</p>
   <aside class="dfn-panel" data-for="dfn-unforgeable-on-an-interface">
    <b><a href="#dfn-unforgeable-on-an-interface">#dfn-unforgeable-on-an-interface</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-unforgeable-on-an-interface-1">4.3.21. [Unforgeable]</a>
+    <li><a href="#ref-for-dfn-unforgeable-on-an-interface-1">4.3.20. [Unforgeable]</a>
     <li><a href="#ref-for-dfn-unforgeable-on-an-interface-2">4.6.6. Attributes</a>
     <li><a href="#ref-for-dfn-unforgeable-on-an-interface-3">4.6.7. Operations</a> <a href="#ref-for-dfn-unforgeable-on-an-interface-4">(2)</a>
     <li><a href="#ref-for-dfn-unforgeable-on-an-interface-5">4.6.7.1. Stringifiers</a> <a href="#ref-for-dfn-unforgeable-on-an-interface-6">(2)</a>
@@ -16095,7 +15982,7 @@ this was to the right.)</p>
   <aside class="dfn-panel" data-for="Unscopable">
    <b><a href="#Unscopable">#Unscopable</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-Unscopable-1">4.3.22. [Unscopable]</a> <a href="#ref-for-Unscopable-2">(2)</a> <a href="#ref-for-Unscopable-3">(3)</a> <a href="#ref-for-Unscopable-4">(4)</a>
+    <li><a href="#ref-for-Unscopable-1">4.3.21. [Unscopable]</a> <a href="#ref-for-Unscopable-2">(2)</a> <a href="#ref-for-Unscopable-3">(3)</a> <a href="#ref-for-Unscopable-4">(4)</a>
     <li><a href="#ref-for-Unscopable-5">4.6.3. Interface prototype object</a> <a href="#ref-for-Unscopable-6">(2)</a>
    </ul>
   </aside>
@@ -16127,8 +16014,8 @@ this was to the right.)</p>
    <ul>
     <li><a href="#ref-for-dfn-overload-resolution-algorithm-1">4.6.1.1. Interface object [[Call]] method</a>
     <li><a href="#ref-for-dfn-overload-resolution-algorithm-2">4.6.2. Named constructors</a>
-    <li><a href="#ref-for-dfn-overload-resolution-algorithm-3">4.6.7. Operations</a> <a href="#ref-for-dfn-overload-resolution-algorithm-4">(2)</a>
-    <li><a href="#ref-for-dfn-overload-resolution-algorithm-5">4.8.9. Platform object [[Call]] method</a>
+    <li><a href="#ref-for-dfn-overload-resolution-algorithm-3">4.6.7. Operations</a>
+    <li><a href="#ref-for-dfn-overload-resolution-algorithm-4">4.8.9. Platform object [[Call]] method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-interface-object">
@@ -16137,15 +16024,15 @@ this was to the right.)</p>
     <li><a href="#ref-for-dfn-interface-object-1">3.2.5. Static attributes and operations</a>
     <li><a href="#ref-for-dfn-interface-object-2">4.1. ECMAScript environment</a>
     <li><a href="#ref-for-dfn-interface-object-3">4.3.2. [Constructor]</a>
-    <li><a href="#ref-for-dfn-interface-object-4">4.3.11. [NamedConstructor]</a>
-    <li><a href="#ref-for-dfn-interface-object-5">4.3.13. [NoInterfaceObject]</a> <a href="#ref-for-dfn-interface-object-6">(2)</a>
+    <li><a href="#ref-for-dfn-interface-object-4">4.3.10. [NamedConstructor]</a>
+    <li><a href="#ref-for-dfn-interface-object-5">4.3.12. [NoInterfaceObject]</a> <a href="#ref-for-dfn-interface-object-6">(2)</a>
     <li><a href="#ref-for-dfn-interface-object-7">4.6.1.1. Interface object [[Call]] method</a> <a href="#ref-for-dfn-interface-object-8">(2)</a>
     <li><a href="#ref-for-dfn-interface-object-9">4.6.1.2. Interface object [[HasInstance]] method</a>
     <li><a href="#ref-for-dfn-interface-object-10">4.6.3. Interface prototype object</a> <a href="#ref-for-dfn-interface-object-11">(2)</a>
     <li><a href="#ref-for-dfn-interface-object-12">4.6.5. Constants</a>
     <li><a href="#ref-for-dfn-interface-object-13">4.6.6. Attributes</a>
-    <li><a href="#ref-for-dfn-interface-object-14">4.6.7. Operations</a> <a href="#ref-for-dfn-interface-object-15">(2)</a>
-    <li><a href="#ref-for-dfn-interface-object-16">4.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-interface-object-14">4.6.7. Operations</a>
+    <li><a href="#ref-for-dfn-interface-object-15">4.14. Creating and throwing exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-named-constructor">
@@ -16161,49 +16048,49 @@ this was to the right.)</p>
    <ul>
     <li><a href="#ref-for-dfn-interface-prototype-object-1">3.2.7. Iterable declarations</a> <a href="#ref-for-dfn-interface-prototype-object-2">(2)</a>
     <li><a href="#ref-for-dfn-interface-prototype-object-3">4.1. ECMAScript environment</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-4">4.3.6. [Global] and [PrimaryGlobal]</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-5">4.3.7. [LegacyArrayClass]</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-6">4.3.16. [Replaceable]</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-7">4.3.22. [Unscopable]</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-4">4.3.5. [Global] and [PrimaryGlobal]</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-5">4.3.6. [LegacyArrayClass]</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-6">4.3.15. [Replaceable]</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-7">4.3.21. [Unscopable]</a>
     <li><a href="#ref-for-dfn-interface-prototype-object-8">4.6.1.2. Interface object [[HasInstance]] method</a>
     <li><a href="#ref-for-dfn-interface-prototype-object-9">4.6.2. Named constructors</a>
     <li><a href="#ref-for-dfn-interface-prototype-object-10">4.6.3. Interface prototype object</a> <a href="#ref-for-dfn-interface-prototype-object-11">(2)</a> <a href="#ref-for-dfn-interface-prototype-object-12">(3)</a> <a href="#ref-for-dfn-interface-prototype-object-13">(4)</a> <a href="#ref-for-dfn-interface-prototype-object-14">(5)</a> <a href="#ref-for-dfn-interface-prototype-object-15">(6)</a>
     <li><a href="#ref-for-dfn-interface-prototype-object-16">4.6.4. Named properties object</a>
     <li><a href="#ref-for-dfn-interface-prototype-object-17">4.6.5. Constants</a> <a href="#ref-for-dfn-interface-prototype-object-18">(2)</a>
     <li><a href="#ref-for-dfn-interface-prototype-object-19">4.6.6. Attributes</a> <a href="#ref-for-dfn-interface-prototype-object-20">(2)</a> <a href="#ref-for-dfn-interface-prototype-object-21">(3)</a> <a href="#ref-for-dfn-interface-prototype-object-22">(4)</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-23">4.6.7. Operations</a> <a href="#ref-for-dfn-interface-prototype-object-24">(2)</a> <a href="#ref-for-dfn-interface-prototype-object-25">(3)</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-26">4.6.7.1. Stringifiers</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-27">4.6.7.2. Serializers</a> <a href="#ref-for-dfn-interface-prototype-object-28">(2)</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-29">4.6.8.1. @@iterator</a> <a href="#ref-for-dfn-interface-prototype-object-30">(2)</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-31">4.6.8.2. forEach</a> <a href="#ref-for-dfn-interface-prototype-object-32">(2)</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-33">4.6.9.1. entries</a> <a href="#ref-for-dfn-interface-prototype-object-34">(2)</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-35">4.6.9.2. keys</a> <a href="#ref-for-dfn-interface-prototype-object-36">(2)</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-37">4.6.9.3. values</a> <a href="#ref-for-dfn-interface-prototype-object-38">(2)</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-39">4.6.10. Maplike declarations</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-40">4.6.10.1. size</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-41">4.6.10.2. entries</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-42">4.6.10.3. keys and values</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-43">4.6.10.4. get and has</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-44">4.6.10.5. clear</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-45">4.6.10.6. delete</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-46">4.6.10.7. set</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-47">4.6.11. Setlike declarations</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-48">4.6.11.1. size</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-49">4.6.11.2. values</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-50">4.6.11.3. entries and keys</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-51">4.6.11.4. has</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-52">4.6.11.5. add and delete</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-53">4.6.11.6. clear</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-54">4.7. Implements statements</a> <a href="#ref-for-dfn-interface-prototype-object-55">(2)</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-56">4.8. Platform objects implementing interfaces</a> <a href="#ref-for-dfn-interface-prototype-object-57">(2)</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-58">4.8.1. Indexed and named properties</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-23">4.6.7. Operations</a> <a href="#ref-for-dfn-interface-prototype-object-24">(2)</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-25">4.6.7.1. Stringifiers</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-26">4.6.7.2. Serializers</a> <a href="#ref-for-dfn-interface-prototype-object-27">(2)</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-28">4.6.8.1. @@iterator</a> <a href="#ref-for-dfn-interface-prototype-object-29">(2)</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-30">4.6.8.2. forEach</a> <a href="#ref-for-dfn-interface-prototype-object-31">(2)</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-32">4.6.9.1. entries</a> <a href="#ref-for-dfn-interface-prototype-object-33">(2)</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-34">4.6.9.2. keys</a> <a href="#ref-for-dfn-interface-prototype-object-35">(2)</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-36">4.6.9.3. values</a> <a href="#ref-for-dfn-interface-prototype-object-37">(2)</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-38">4.6.10. Maplike declarations</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-39">4.6.10.1. size</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-40">4.6.10.2. entries</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-41">4.6.10.3. keys and values</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-42">4.6.10.4. get and has</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-43">4.6.10.5. clear</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-44">4.6.10.6. delete</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-45">4.6.10.7. set</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-46">4.6.11. Setlike declarations</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-47">4.6.11.1. size</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-48">4.6.11.2. values</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-49">4.6.11.3. entries and keys</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-50">4.6.11.4. has</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-51">4.6.11.5. add and delete</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-52">4.6.11.6. clear</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-53">4.7. Implements statements</a> <a href="#ref-for-dfn-interface-prototype-object-54">(2)</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-55">4.8. Platform objects implementing interfaces</a> <a href="#ref-for-dfn-interface-prototype-object-56">(2)</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-57">4.8.1. Indexed and named properties</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-named-properties-object">
    <b><a href="#dfn-named-properties-object">#dfn-named-properties-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-named-properties-object-1">4.1. ECMAScript environment</a> <a href="#ref-for-dfn-named-properties-object-2">(2)</a>
-    <li><a href="#ref-for-dfn-named-properties-object-3">4.3.6. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-named-properties-object-4">(2)</a>
+    <li><a href="#ref-for-dfn-named-properties-object-3">4.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-named-properties-object-4">(2)</a>
     <li><a href="#ref-for-dfn-named-properties-object-5">4.6.3. Interface prototype object</a>
     <li><a href="#ref-for-dfn-named-properties-object-6">4.6.4. Named properties object</a> <a href="#ref-for-dfn-named-properties-object-7">(2)</a>
     <li><a href="#ref-for-dfn-named-properties-object-8">4.6.4.1. Named properties object [[GetOwnProperty]] method</a> <a href="#ref-for-dfn-named-properties-object-9">(2)</a>
@@ -16230,7 +16117,8 @@ this was to the right.)</p>
   <aside class="dfn-panel" data-for="dfn-create-operation-function">
    <b><a href="#dfn-create-operation-function">#dfn-create-operation-function</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-create-operation-function-1">4.11.1. Namespace object</a>
+    <li><a href="#ref-for-dfn-create-operation-function-1">4.6.7. Operations</a>
+    <li><a href="#ref-for-dfn-create-operation-function-2">4.11.1. Namespace object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-convert-serialized-value-to-ecmascript-value">


### PR DESCRIPTION
This consolidates the spec text for creating the functions for interface operations and namespace operations, using the more modern style seen in namespace operations (introduced in df8c9c4ef7e32298ea3b8b13eed73790957468da) as the base.

Along the way, this fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547 (making all methods [ImplicitThis], and getting rid of [ImplicitThis]), and fixes https://github.com/whatwg/html/issues/643 (a related issue on the HTML side).

This also fixes #106, since we now explicitly use the CreateBuiltinFunction abstract operation.

---

@bzbarsky please take a look! I'm rather pleased that this managed to fix the long-standing [ImplicitThis] issue.