### PR TITLE
Callback interface prototype should be Function.prototype

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10330,7 +10330,7 @@ such an interface object.
 
 The internal \[[Prototype]] property
 of an interface object for a callback interface must be
-the Object.prototype object.
+the Function.prototype object.
 
 Note: Remember that interface objects for callback interfaces only exist if they have
 [=constants=] declared on them;

--- a/index.html
+++ b/index.html
@@ -2296,9 +2296,10 @@ be defined on a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-f
 };
 </pre>
     <p>to be used like this:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="nx">getA</span><span class="p">();</span>  <span class="c1">// Get an instance of A.</span>
-
-<span class="nx">a</span><span class="p">.</span><span class="nx">doTask</span><span class="p">(</span><span class="s2">"something"</span><span class="p">,</span> <span class="p">{</span> <span class="nx">option1</span><span class="o">:</span> <span class="s2">"banana"</span><span class="p">,</span> <span class="nx">option3</span><span class="o">:</span> <span class="mi">100</span> <span class="p">});</span></pre>
+<pre class="highlight"><span class="kd">var</span> a <span class="o">=</span> getA<span class="p">(</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// Get an instance of A.
+</span>
+a<span class="p">.</span>doTask<span class="p">(</span><span class="s2">"something"</span><span class="p">,</span> <span class="p">{</span> option1<span class="o">:</span> <span class="s2">"banana"</span><span class="p">,</span> option3<span class="o">:</span> <span class="mi">100</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
+</pre>
     <p>instead write the following:</p>
 <pre class="highlight"><span class="kt">dictionary</span> <span class="nv">Options</span> {
   <span class="kt">DOMString</span>? <span class="nv">option1</span>;
@@ -2437,30 +2438,32 @@ in the language.</p>
 </pre>
     <p>Since the <code class="idl">EventListener</code> interface is annotated
     callback interface, <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-3">user objects</a> can implement it:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">node</span> <span class="o">=</span> <span class="nx">getNode</span><span class="p">();</span>                                <span class="c1">// Obtain an instance of Node.</span>
-
-<span class="kd">var</span> <span class="nx">listener</span> <span class="o">=</span> <span class="p">{</span>
-  <span class="nx">handleEvent</span><span class="o">:</span> <span class="kd">function</span><span class="p">(</span><span class="nx">event</span><span class="p">)</span> <span class="p">{</span>
-    <span class="c1">// ...</span>
-  <span class="p">}</span>
-<span class="p">};</span>
-<span class="nx">node</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"click"</span><span class="p">,</span> <span class="nx">listener</span><span class="p">);</span>            <span class="c1">// This works.</span>
-
-<span class="nx">node</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"click"</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span> <span class="p">...</span> <span class="p">});</span>  <span class="c1">// As does this.</span></pre>
+<pre class="highlight"><span class="kd">var</span> node <span class="o">=</span> getNode<span class="p">(</span><span class="p">)</span><span class="p">;</span>                                <span class="c1">// Obtain an instance of Node.
+</span>
+<span class="kd">var</span> listener <span class="o">=</span> <span class="p">{</span>
+  handleEvent<span class="o">:</span> <span class="kd">function</span><span class="p">(</span>event<span class="p">)</span> <span class="p">{</span>
+    <span class="c1">// ...
+</span>  <span class="p">}</span>
+<span class="p">}</span><span class="p">;</span>
+node<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"click"</span><span class="p">,</span> listener<span class="p">)</span><span class="p">;</span>            <span class="c1">// This works.
+</span>
+node<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"click"</span><span class="p">,</span> <span class="kd">function</span><span class="p">(</span><span class="p">)</span> <span class="p">{</span> <span class="p">...</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// As does this.
+</span></pre>
     <p>It is not possible for a user object to implement <code class="idl">Node</code>, however:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">node</span> <span class="o">=</span> <span class="nx">getNode</span><span class="p">();</span>  <span class="c1">// Obtain an instance of Node.</span>
-
-<span class="kd">var</span> <span class="nx">newNode</span> <span class="o">=</span> <span class="p">{</span>
-  <span class="nx">nodeName</span><span class="o">:</span> <span class="s2">"span"</span><span class="p">,</span>
-  <span class="nx">parentNode</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-  <span class="nx">appendChild</span><span class="o">:</span> <span class="kd">function</span><span class="p">(</span><span class="nx">newchild</span><span class="p">)</span> <span class="p">{</span>
-    <span class="c1">// ...</span>
-  <span class="p">},</span>
-  <span class="nx">addEventListener</span><span class="o">:</span> <span class="kd">function</span><span class="p">(</span><span class="nx">type</span><span class="p">,</span> <span class="nx">listener</span><span class="p">)</span> <span class="p">{</span>
-    <span class="c1">// ...</span>
-  <span class="p">}</span>
-<span class="p">};</span>
-<span class="nx">node</span><span class="p">.</span><span class="nx">appendChild</span><span class="p">(</span><span class="nx">newNode</span><span class="p">);</span>  <span class="c1">// This will throw a TypeError exception.</span></pre>
+<pre class="highlight"><span class="kd">var</span> node <span class="o">=</span> getNode<span class="p">(</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// Obtain an instance of Node.
+</span>
+<span class="kd">var</span> newNode <span class="o">=</span> <span class="p">{</span>
+  nodeName<span class="o">:</span> <span class="s2">"span"</span><span class="p">,</span>
+  parentNode<span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
+  appendChild<span class="o">:</span> <span class="kd">function</span><span class="p">(</span>newchild<span class="p">)</span> <span class="p">{</span>
+    <span class="c1">// ...
+</span>  <span class="p">}</span><span class="p">,</span>
+  addEventListener<span class="o">:</span> <span class="kd">function</span><span class="p">(</span>type<span class="p">,</span> listener<span class="p">)</span> <span class="p">{</span>
+    <span class="c1">// ...
+</span>  <span class="p">}</span>
+<span class="p">}</span><span class="p">;</span>
+node<span class="p">.</span>appendChild<span class="p">(</span>newNode<span class="p">)</span><span class="p">;</span>  <span class="c1">// This will throw a TypeError exception.
+</span></pre>
    </div>
    <h4 class="heading settled" data-level="2.2.1" id="idl-constants"><span class="secno">2.2.1. </span><span class="content">Constants</span><a class="self-link" href="#idl-constants"></a></h4>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-constant">constant</dfn> is a declaration (matching <emu-nt><a href="#prod-Const">Const</a></emu-nt>) used to bind a constant value to a name.
@@ -2918,10 +2921,11 @@ defined in this specification) and <a data-link-type="dfn" href="#dfn-callback-f
 </pre>
     <p>In the ECMAScript binding, variadic operations are implemented by
     functions that can accept the subsequent arguments:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">s</span> <span class="o">=</span> <span class="nx">getIntegerSet</span><span class="p">();</span>  <span class="c1">// Obtain an instance of IntegerSet.</span>
-
-<span class="nx">s</span><span class="p">.</span><span class="nx">union</span><span class="p">();</span>                <span class="c1">// Passing no arguments corresponding to 'ints'.</span>
-<span class="nx">s</span><span class="p">.</span><span class="nx">union</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">4</span><span class="p">,</span> <span class="mi">7</span><span class="p">);</span>         <span class="c1">// Passing three arguments corresponding to 'ints'.</span></pre>
+<pre class="highlight"><span class="kd">var</span> s <span class="o">=</span> getIntegerSet<span class="p">(</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// Obtain an instance of IntegerSet.
+</span>
+s<span class="p">.</span>union<span class="p">(</span><span class="p">)</span><span class="p">;</span>                <span class="c1">// Passing no arguments corresponding to 'ints'.
+</span>s<span class="p">.</span>union<span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">4</span><span class="p">,</span> <span class="mi">7</span><span class="p">)</span><span class="p">;</span>         <span class="c1">// Passing three arguments corresponding to 'ints'.
+</span></pre>
     <p>A binding for a language that does not support variadic functions
     might specify that an explicit array or list of integers be passed
     to such an operation.</p>
@@ -3235,10 +3239,11 @@ as if it were a function.</p>
 </pre>
     <p>An ECMAScript implementation supporting this interface would
     allow a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-2">platform object</a> that implements <code class="idl">NumberQuadrupler</code> to be called as a function:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">f</span> <span class="o">=</span> <span class="nx">getNumberQuadrupler</span><span class="p">();</span>  <span class="c1">// Obtain an instance of NumberQuadrupler.</span>
-
-<span class="nx">f</span><span class="p">.</span><span class="nx">compute</span><span class="p">(</span><span class="mi">3</span><span class="p">);</span>                   <span class="c1">// This evaluates to 12.</span>
-<span class="nx">f</span><span class="p">(</span><span class="mi">3</span><span class="p">);</span>                           <span class="c1">// This also evaluates to 12.</span></pre>
+<pre class="highlight"><span class="kd">var</span> f <span class="o">=</span> getNumberQuadrupler<span class="p">(</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// Obtain an instance of NumberQuadrupler.
+</span>
+f<span class="p">.</span>compute<span class="p">(</span><span class="mi">3</span><span class="p">)</span><span class="p">;</span>                   <span class="c1">// This evaluates to 12.
+</span>f<span class="p">(</span><span class="mi">3</span><span class="p">)</span><span class="p">;</span>                           <span class="c1">// This also evaluates to 12.
+</span></pre>
    </div>
    <h5 class="heading settled" data-level="2.2.4.2" id="idl-stringifiers"><span class="secno">2.2.4.2. </span><span class="content">Stringifiers</span><a class="self-link" href="#idl-stringifiers"></a></h5>
    <p>When an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-30">interface</a> has a <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-1">stringifier</a>, it indicates that objects that implement
@@ -3308,11 +3313,12 @@ a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-at
     <p>In the ECMAScript binding, using a <code class="idl">Student</code> object in a context where a string is expected will result in the
     value of the object’s “name” property being
     used:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">s</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Student</span><span class="p">();</span>
-<span class="nx">s</span><span class="p">.</span><span class="nx">id</span> <span class="o">=</span> <span class="mi">12345678</span><span class="p">;</span>
-<span class="nx">s</span><span class="p">.</span><span class="nx">name</span> <span class="o">=</span> <span class="s1">'周杰倫'</span><span class="p">;</span>
+<pre class="highlight"><span class="kd">var</span> s <span class="o">=</span> <span class="k">new</span> Student<span class="p">(</span><span class="p">)</span><span class="p">;</span>
+s<span class="p">.</span>id <span class="o">=</span> <span class="mi">12345678</span><span class="p">;</span>
+s<span class="p">.</span>name <span class="o">=</span> <span class="s1">'周杰倫'</span><span class="p">;</span>
 
-<span class="kd">var</span> <span class="nx">greeting</span> <span class="o">=</span> <span class="s1">'Hello, '</span> <span class="o">+</span> <span class="nx">s</span> <span class="o">+</span> <span class="s1">'!'</span><span class="p">;</span>  <span class="c1">// Now greeting == 'Hello, 周杰倫!'.</span></pre>
+<span class="kd">var</span> greeting <span class="o">=</span> <span class="s1">'Hello, '</span> <span class="o">+</span> s <span class="o">+</span> <span class="s1">'!'</span><span class="p">;</span>  <span class="c1">// Now greeting == 'Hello, 周杰倫!'.
+</span></pre>
     <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-20">IDL fragment</a> defines an interface that has custom stringification behavior that is
     not specified in the IDL itself.</p>
 <pre class="highlight">[<span class="nv">Constructor</span>]
@@ -3335,12 +3341,13 @@ a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-at
         the <code class="idl">familyName</code> attribute.</p>
     </blockquote>
     <p>An ECMAScript implementation of the IDL would behave as follows:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">s</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Student</span><span class="p">();</span>
-<span class="nx">s</span><span class="p">.</span><span class="nx">id</span> <span class="o">=</span> <span class="mi">12345679</span><span class="p">;</span>
-<span class="nx">s</span><span class="p">.</span><span class="nx">familyName</span> <span class="o">=</span> <span class="s1">'Smithee'</span><span class="p">;</span>
-<span class="nx">s</span><span class="p">.</span><span class="nx">givenName</span> <span class="o">=</span> <span class="s1">'Alan'</span><span class="p">;</span>
+<pre class="highlight"><span class="kd">var</span> s <span class="o">=</span> <span class="k">new</span> Student<span class="p">(</span><span class="p">)</span><span class="p">;</span>
+s<span class="p">.</span>id <span class="o">=</span> <span class="mi">12345679</span><span class="p">;</span>
+s<span class="p">.</span>familyName <span class="o">=</span> <span class="s1">'Smithee'</span><span class="p">;</span>
+s<span class="p">.</span>givenName <span class="o">=</span> <span class="s1">'Alan'</span><span class="p">;</span>
 
-<span class="kd">var</span> <span class="nx">greeting</span> <span class="o">=</span> <span class="s1">'Hi '</span> <span class="o">+</span> <span class="nx">s</span><span class="p">;</span>  <span class="c1">// Now greeting == 'Hi Alan Smithee'.</span></pre>
+<span class="kd">var</span> greeting <span class="o">=</span> <span class="s1">'Hi '</span> <span class="o">+</span> s<span class="p">;</span>  <span class="c1">// Now greeting == 'Hi Alan Smithee'.
+</span></pre>
    </div>
    <h5 class="heading settled" data-level="2.2.4.3" id="idl-serializers"><span class="secno">2.2.4.3. </span><span class="content">Serializers</span><a class="self-link" href="#idl-serializers"></a></h5>
    <p>When an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-31">interface</a> has a <a data-link-type="dfn" href="#dfn-serializer" id="ref-for-dfn-serializer-1">serializer</a>, it indicates that objects provide
@@ -3723,21 +3730,22 @@ and whose value is the <a data-link-type="dfn" href="#dfn-serialized-value" id="
 };
 </pre>
     <p>In the ECMAScript language binding, there would exist a <code>toJSON</code> method on <code class="idl">Transaction</code> objects:</p>
-<pre class="highlight"><span></span><span class="c1">// Get an instance of Transaction.</span>
-<span class="kd">var</span> <span class="nx">txn</span> <span class="o">=</span> <span class="nx">getTransaction</span><span class="p">();</span>
+<pre class="highlight"><span class="c1">// Get an instance of Transaction.
+</span><span class="kd">var</span> txn <span class="o">=</span> getTransaction<span class="p">(</span><span class="p">)</span><span class="p">;</span>
 
-<span class="c1">// Evaluates to an object like this:</span>
-<span class="c1">// {</span>
-<span class="c1">//   from: 1234</span>
-<span class="c1">//   to: 5678</span>
-<span class="c1">//   amount: 110.75</span>
-<span class="c1">//   description: "dinner"</span>
-<span class="c1">// }</span>
-<span class="nx">txn</span><span class="p">.</span><span class="nx">toJSON</span><span class="p">();</span>
+<span class="c1">// Evaluates to an object like this:
+</span><span class="c1">// {
+</span><span class="c1">//   from: 1234
+</span><span class="c1">//   to: 5678
+</span><span class="c1">//   amount: 110.75
+</span><span class="c1">//   description: "dinner"
+</span><span class="c1">// }
+</span>txn<span class="p">.</span>toJSON<span class="p">(</span><span class="p">)</span><span class="p">;</span>
 
-<span class="c1">// Evaluates to a string like this:</span>
-<span class="c1">// '{"from":1234,"to":5678,"amount":110.75,"description":"dinner"}'</span>
-<span class="nx">JSON</span><span class="p">.</span><span class="nx">stringify</span><span class="p">(</span><span class="nx">txn</span><span class="p">);</span></pre>
+<span class="c1">// Evaluates to a string like this:
+</span><span class="c1">// '{"from":1234,"to":5678,"amount":110.75,"description":"dinner"}'
+</span>JSON<span class="p">.</span>stringify<span class="p">(</span>txn<span class="p">)</span><span class="p">;</span>
+</pre>
    </div>
    <h5 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="2.2.4.4" data-lt="Indexed properties" id="idl-indexed-properties"><span class="secno">2.2.4.4. </span><span class="content">Indexed properties</span></h5>
    <p>An <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-32">interface</a> that defines
@@ -3787,13 +3795,14 @@ by a description of how to <dfn class="dfn-paneled" data-dfn-type="dfn" data-exp
     <p>Assume that an object implementing <code class="idl">A</code> has <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-3">supported property indices</a> in the range 0 ≤ <var>index</var> &lt; 2.  Also assume that toWord is defined to return
     its argument converted into an English word.  The behavior when invoking the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-14">operation</a> with an out of range index
     is different from indexing the object directly:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="nx">getA</span><span class="p">();</span>
+<pre class="highlight"><span class="kd">var</span> a <span class="o">=</span> getA<span class="p">(</span><span class="p">)</span><span class="p">;</span>
 
-<span class="nx">a</span><span class="p">.</span><span class="nx">toWord</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span>  <span class="c1">// Evalautes to "zero".</span>
-<span class="nx">a</span><span class="p">[</span><span class="mi">0</span><span class="p">];</span>         <span class="c1">// Also evaluates to "zero".</span>
-
-<span class="nx">a</span><span class="p">.</span><span class="nx">toWord</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span>  <span class="c1">// Evaluates to "five".</span>
-<span class="nx">a</span><span class="p">[</span><span class="mi">5</span><span class="p">];</span>         <span class="c1">// Evaluates to undefined, since there is no property "5".</span></pre>
+a<span class="p">.</span>toWord<span class="p">(</span><span class="mi">0</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// Evalautes to "zero".
+</span>a<span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="p">;</span>         <span class="c1">// Also evaluates to "zero".
+</span>
+a<span class="p">.</span>toWord<span class="p">(</span><span class="mi">5</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// Evaluates to "five".
+</span>a<span class="p">[</span><span class="mi">5</span><span class="p">]</span><span class="p">;</span>         <span class="c1">// Evaluates to undefined, since there is no property "5".
+</span></pre>
    </div>
    <div class="example" id="example-120b3f16">
     <a class="self-link" href="#example-120b3f16"></a> 
@@ -3829,40 +3838,41 @@ by a description of how to <dfn class="dfn-paneled" data-dfn-type="dfn" data-exp
     These properties can then be used to interact
     with the object in the same way as invoking the object’s
     methods, as demonstrated below:</p>
-<pre class="highlight"><span></span><span class="c1">// Assume map is a platform object implementing the OrderedMap interface.</span>
-<span class="kd">var</span> <span class="nx">map</span> <span class="o">=</span> <span class="nx">getOrderedMap</span><span class="p">();</span>
-<span class="kd">var</span> <span class="nx">x</span><span class="p">,</span> <span class="nx">y</span><span class="p">;</span>
+<pre class="highlight"><span class="c1">// Assume map is a platform object implementing the OrderedMap interface.
+</span><span class="kd">var</span> map <span class="o">=</span> getOrderedMap<span class="p">(</span><span class="p">)</span><span class="p">;</span>
+<span class="kd">var</span> x<span class="p">,</span> y<span class="p">;</span>
 
-<span class="nx">x</span> <span class="o">=</span> <span class="nx">map</span><span class="p">[</span><span class="mi">0</span><span class="p">];</span>       <span class="c1">// If map.length > 0, then this is equivalent to:</span>
-                  <span class="c1">//</span>
-                  <span class="c1">//   x = map.getByIndex(0)</span>
-                  <span class="c1">//</span>
-                  <span class="c1">// since a property named "0" will have been placed on map.</span>
-                  <span class="c1">// Otherwise, x will be set to undefined, since there will be</span>
-                  <span class="c1">// no property named "0" on map.</span>
-
-<span class="nx">map</span><span class="p">[</span><span class="mi">1</span><span class="p">]</span> <span class="o">=</span> <span class="kc">false</span><span class="p">;</span>   <span class="c1">// This will do the equivalent of:</span>
-                  <span class="c1">//</span>
-                  <span class="c1">//   map.setByIndex(1, false)</span>
-
-<span class="nx">y</span> <span class="o">=</span> <span class="nx">map</span><span class="p">.</span><span class="nx">apple</span><span class="p">;</span>    <span class="c1">// If there exists a named property named "apple", then this</span>
-                  <span class="c1">// will be equivalent to:</span>
-                  <span class="c1">//</span>
-                  <span class="c1">//   y = map.get('apple')</span>
-                  <span class="c1">//</span>
-                  <span class="c1">// since a property named "apple" will have been placed on</span>
-                  <span class="c1">// map.  Otherwise, y will be set to undefined, since there</span>
-                  <span class="c1">// will be no property named "apple" on map.</span>
-
-<span class="nx">map</span><span class="p">.</span><span class="nx">berry</span> <span class="o">=</span> <span class="mi">123</span><span class="p">;</span>  <span class="c1">// This will do the equivalent of:</span>
-                  <span class="c1">//</span>
-                  <span class="c1">//   map.set('berry', 123)</span>
-
-<span class="k">delete</span> <span class="nx">map</span><span class="p">.</span><span class="nx">cake</span><span class="p">;</span>  <span class="c1">// If a named property named "cake" exists, then the "cake"</span>
-                  <span class="c1">// property will be deleted, and then the equivalent to the</span>
-                  <span class="c1">// following will be performed:</span>
-                  <span class="c1">//</span>
-                  <span class="c1">//   map.remove("cake")</span></pre>
+x <span class="o">=</span> map<span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="p">;</span>       <span class="c1">// If map.length > 0, then this is equivalent to:
+</span>                  <span class="c1">//
+</span>                  <span class="c1">//   x = map.getByIndex(0)
+</span>                  <span class="c1">//
+</span>                  <span class="c1">// since a property named "0" will have been placed on map.
+</span>                  <span class="c1">// Otherwise, x will be set to undefined, since there will be
+</span>                  <span class="c1">// no property named "0" on map.
+</span>
+map<span class="p">[</span><span class="mi">1</span><span class="p">]</span> <span class="o">=</span> <span class="kc">false</span><span class="p">;</span>   <span class="c1">// This will do the equivalent of:
+</span>                  <span class="c1">//
+</span>                  <span class="c1">//   map.setByIndex(1, false)
+</span>
+y <span class="o">=</span> map<span class="p">.</span>apple<span class="p">;</span>    <span class="c1">// If there exists a named property named "apple", then this
+</span>                  <span class="c1">// will be equivalent to:
+</span>                  <span class="c1">//
+</span>                  <span class="c1">//   y = map.get('apple')
+</span>                  <span class="c1">//
+</span>                  <span class="c1">// since a property named "apple" will have been placed on
+</span>                  <span class="c1">// map.  Otherwise, y will be set to undefined, since there
+</span>                  <span class="c1">// will be no property named "apple" on map.
+</span>
+map<span class="p">.</span>berry <span class="o">=</span> <span class="mi">123</span><span class="p">;</span>  <span class="c1">// This will do the equivalent of:
+</span>                  <span class="c1">//
+</span>                  <span class="c1">//   map.set('berry', 123)
+</span>
+<span class="k">delete</span> map<span class="p">.</span>cake<span class="p">;</span>  <span class="c1">// If a named property named "cake" exists, then the "cake"
+</span>                  <span class="c1">// property will be deleted, and then the equivalent to the
+</span>                  <span class="c1">// following will be performed:
+</span>                  <span class="c1">//
+</span>                  <span class="c1">//   map.remove("cake")
+</span></pre>
    </div>
    <h5 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="2.2.4.5" data-lt="Named properties" id="idl-named-properties"><span class="secno">2.2.4.5. </span><span class="content">Named properties</span></h5>
    <p>An <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-33">interface</a> that defines
@@ -3946,20 +3956,21 @@ declared on <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-d
 };
 </pre>
     <p>In the ECMAScript language binding, the <emu-val>Function</emu-val> object for <code>triangulate</code> and the accessor property for <code>triangulationCount</code> will exist on the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-1">interface object</a> for <code class="idl">Circle</code>:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">circles</span> <span class="o">=</span> <span class="nx">getCircles</span><span class="p">();</span>           <span class="c1">// an Array of Circle objects</span>
+<pre class="highlight"><span class="kd">var</span> circles <span class="o">=</span> getCircles<span class="p">(</span><span class="p">)</span><span class="p">;</span>           <span class="c1">// an Array of Circle objects
+</span>
+<span class="k">typeof</span> Circle<span class="p">.</span>triangulate<span class="p">;</span>            <span class="c1">// Evaluates to "function"
+</span><span class="k">typeof</span> Circle<span class="p">.</span>triangulationCount<span class="p">;</span>     <span class="c1">// Evaluates to "number"
+</span>Circle<span class="p">.</span>prototype<span class="p">.</span>triangulate<span class="p">;</span>         <span class="c1">// Evaluates to undefined
+</span>Circle<span class="p">.</span>prototype<span class="p">.</span>triangulationCount<span class="p">;</span>  <span class="c1">// Also evaluates to undefined
+</span>circles<span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="p">.</span>triangulate<span class="p">;</span>               <span class="c1">// As does this
+</span>circles<span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="p">.</span>triangulationCount<span class="p">;</span>        <span class="c1">// And this
+</span>
+<span class="c1">// Call the static operation
+</span><span class="kd">var</span> triangulationPoint <span class="o">=</span> Circle<span class="p">.</span>triangulate<span class="p">(</span>circles<span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="p">,</span> circles<span class="p">[</span><span class="mi">1</span><span class="p">]</span><span class="p">,</span> circles<span class="p">[</span><span class="mi">2</span><span class="p">]</span><span class="p">)</span><span class="p">;</span>
 
-<span class="k">typeof</span> <span class="nx">Circle</span><span class="p">.</span><span class="nx">triangulate</span><span class="p">;</span>            <span class="c1">// Evaluates to "function"</span>
-<span class="k">typeof</span> <span class="nx">Circle</span><span class="p">.</span><span class="nx">triangulationCount</span><span class="p">;</span>     <span class="c1">// Evaluates to "number"</span>
-<span class="nx">Circle</span><span class="p">.</span><span class="nx">prototype</span><span class="p">.</span><span class="nx">triangulate</span><span class="p">;</span>         <span class="c1">// Evaluates to undefined</span>
-<span class="nx">Circle</span><span class="p">.</span><span class="nx">prototype</span><span class="p">.</span><span class="nx">triangulationCount</span><span class="p">;</span>  <span class="c1">// Also evaluates to undefined</span>
-<span class="nx">circles</span><span class="p">[</span><span class="mi">0</span><span class="p">].</span><span class="nx">triangulate</span><span class="p">;</span>               <span class="c1">// As does this</span>
-<span class="nx">circles</span><span class="p">[</span><span class="mi">0</span><span class="p">].</span><span class="nx">triangulationCount</span><span class="p">;</span>        <span class="c1">// And this</span>
-
-<span class="c1">// Call the static operation</span>
-<span class="kd">var</span> <span class="nx">triangulationPoint</span> <span class="o">=</span> <span class="nx">Circle</span><span class="p">.</span><span class="nx">triangulate</span><span class="p">(</span><span class="nx">circles</span><span class="p">[</span><span class="mi">0</span><span class="p">],</span> <span class="nx">circles</span><span class="p">[</span><span class="mi">1</span><span class="p">],</span> <span class="nx">circles</span><span class="p">[</span><span class="mi">2</span><span class="p">]);</span>
-
-<span class="c1">// Find out how many triangulations we have done</span>
-<span class="nb">window</span><span class="p">.</span><span class="nx">alert</span><span class="p">(</span><span class="nx">Circle</span><span class="p">.</span><span class="nx">triangulationCount</span><span class="p">);</span></pre>
+<span class="c1">// Find out how many triangulations we have done
+</span>window<span class="p">.</span>alert<span class="p">(</span>Circle<span class="p">.</span>triangulationCount<span class="p">)</span><span class="p">;</span>
+</pre>
    </div>
    <h4 class="heading settled" data-level="2.2.6" id="idl-overloading"><span class="secno">2.2.6. </span><span class="content">Overloading</span><a class="self-link" href="#idl-overloading"></a></h4>
    <p>If a <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-5">regular operation</a> or <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-5">static operation</a> defined on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-35">interface</a> has an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-29">identifier</a> that is the same as the identifier of another operation on that
@@ -4569,29 +4580,30 @@ or have any <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for
     next value to be iterated over.  It has <code>values</code> and <code>entries</code> methods that iterate over the indexes of the list of session objects
     and [index, session object] pairs, respectively.  It also has
     a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> method that allows a <code class="idl">SessionManager</code> to be used in a <code>for..of</code> loop:</p>
-<pre class="highlight"><span></span><span class="c1">// Get an instance of SessionManager.</span>
-<span class="c1">// Assume that it has sessions for two users, "anna" and "brian".</span>
-<span class="kd">var</span> <span class="nx">sm</span> <span class="o">=</span> <span class="nx">getSessionManager</span><span class="p">();</span>
+<pre class="highlight"><span class="c1">// Get an instance of SessionManager.
+</span><span class="c1">// Assume that it has sessions for two users, "anna" and "brian".
+</span><span class="kd">var</span> sm <span class="o">=</span> getSessionManager<span class="p">(</span><span class="p">)</span><span class="p">;</span>
 
-<span class="k">typeof</span> <span class="nx">SessionManager</span><span class="p">.</span><span class="nx">prototype</span><span class="p">.</span><span class="nx">values</span><span class="p">;</span>            <span class="c1">// Evaluates to "function"</span>
-<span class="kd">var</span> <span class="nx">it</span> <span class="o">=</span> <span class="nx">sm</span><span class="p">.</span><span class="nx">values</span><span class="p">();</span>                              <span class="c1">// values() returns an iterator object</span>
-<span class="nb">String</span><span class="p">(</span><span class="nx">it</span><span class="p">);</span>                                        <span class="c1">// Evaluates to "[object SessionManager Iterator]"</span>
-<span class="k">typeof</span> <span class="nx">it</span><span class="p">.</span><span class="nx">next</span><span class="p">;</span>                                    <span class="c1">// Evaluates to "function"</span>
-
-<span class="c1">// This loop will alert "anna" and then "brian".</span>
-<span class="k">for</span> <span class="p">(;;)</span> <span class="p">{</span>
-  <span class="kd">let</span> <span class="nx">result</span> <span class="o">=</span> <span class="nx">it</span><span class="p">.</span><span class="nx">next</span><span class="p">();</span>
-  <span class="k">if</span> <span class="p">(</span><span class="nx">result</span><span class="p">.</span><span class="nx">done</span><span class="p">)</span> <span class="p">{</span>
+<span class="k">typeof</span> SessionManager<span class="p">.</span>prototype<span class="p">.</span>values<span class="p">;</span>            <span class="c1">// Evaluates to "function"
+</span><span class="kd">var</span> it <span class="o">=</span> sm<span class="p">.</span>values<span class="p">(</span><span class="p">)</span><span class="p">;</span>                              <span class="c1">// values() returns an iterator object
+</span>String<span class="p">(</span>it<span class="p">)</span><span class="p">;</span>                                        <span class="c1">// Evaluates to "[object SessionManager Iterator]"
+</span><span class="k">typeof</span> it<span class="p">.</span>next<span class="p">;</span>                                    <span class="c1">// Evaluates to "function"
+</span>
+<span class="c1">// This loop will alert "anna" and then "brian".
+</span><span class="k">for</span> <span class="p">(</span><span class="p">;</span><span class="p">;</span><span class="p">)</span> <span class="p">{</span>
+  <span class="kd">let</span> result <span class="o">=</span> it<span class="p">.</span>next<span class="p">(</span><span class="p">)</span><span class="p">;</span>
+  <span class="k">if</span> <span class="p">(</span>result<span class="p">.</span>done<span class="p">)</span> <span class="p">{</span>
     <span class="k">break</span><span class="p">;</span>
   <span class="p">}</span>
-  <span class="kd">let</span> <span class="nx">session</span> <span class="o">=</span> <span class="nx">result</span><span class="p">.</span><span class="nx">value</span><span class="p">;</span>
-  <span class="nb">window</span><span class="p">.</span><span class="nx">alert</span><span class="p">(</span><span class="nx">session</span><span class="p">.</span><span class="nx">username</span><span class="p">);</span>
+  <span class="kd">let</span> session <span class="o">=</span> result<span class="p">.</span>value<span class="p">;</span>
+  window<span class="p">.</span>alert<span class="p">(</span>session<span class="p">.</span>username<span class="p">)</span><span class="p">;</span>
 <span class="p">}</span>
 
-<span class="c1">// This loop will also alert "anna" and then "brian".</span>
-<span class="k">for</span> <span class="p">(</span><span class="kd">let</span> <span class="nx">session</span> <span class="k">of</span> <span class="nx">sm</span><span class="p">)</span> <span class="p">{</span>
-  <span class="nb">window</span><span class="p">.</span><span class="nx">alert</span><span class="p">(</span><span class="nx">session</span><span class="p">.</span><span class="nx">username</span><span class="p">);</span>
-<span class="p">}</span></pre>
+<span class="c1">// This loop will also alert "anna" and then "brian".
+</span><span class="k">for</span> <span class="p">(</span><span class="kd">let</span> session <span class="k">of</span> sm<span class="p">)</span> <span class="p">{</span>
+  window<span class="p">.</span>alert<span class="p">(</span>session<span class="p">.</span>username<span class="p">)</span><span class="p">;</span>
+<span class="p">}</span>
+</pre>
    </div>
    <p>An interface must not have more than one <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-1">iterable declaration</a>.
 The <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces-4">inherited</a> and <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-3">consequential</a> interfaces of an interface with an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-2">iterable declaration</a> must not also have an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-3">iterable declaration</a>.
@@ -4750,9 +4762,10 @@ namespaces.</p>
 };
 </pre>
     <p>An ECMAScript implementation would then expose a global property named <code>VectorUtils</code> which was a simple object (with prototype <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a>) with enumerable data properties for each declared operation:</p>
-<pre class="highlight"><span></span><span class="nb">Object</span><span class="p">.</span><span class="nx">getPrototypeOf</span><span class="p">(</span><span class="nx">VectorUtils</span><span class="p">);</span>                         <span class="c1">// Evaluates to Object.prototype.</span>
-<span class="nb">Object</span><span class="p">.</span><span class="nx">keys</span><span class="p">(</span><span class="nx">VectorUtils</span><span class="p">);</span>                                   <span class="c1">// Evaluates to ["dotProduct", "crossProduct"].</span>
-<span class="nb">Object</span><span class="p">.</span><span class="nx">getOwnPropertyDescriptor</span><span class="p">(</span><span class="nx">VectorUtils</span><span class="p">,</span> <span class="s2">"dotProduct"</span><span class="p">);</span> <span class="c1">// Evaluates to { value: &lt;a function>, enumerable: true, configurable: true, writable: true }.</span></pre>
+<pre class="highlight">Object<span class="p">.</span>getPrototypeOf<span class="p">(</span>VectorUtils<span class="p">)</span><span class="p">;</span>                         <span class="c1">// Evaluates to Object.prototype.
+</span>Object<span class="p">.</span>keys<span class="p">(</span>VectorUtils<span class="p">)</span><span class="p">;</span>                                   <span class="c1">// Evaluates to ["dotProduct", "crossProduct"].
+</span>Object<span class="p">.</span>getOwnPropertyDescriptor<span class="p">(</span>VectorUtils<span class="p">,</span> <span class="s2">"dotProduct"</span><span class="p">)</span><span class="p">;</span> <span class="c1">// Evaluates to { value: &lt;a function>, enumerable: true, configurable: true, writable: true }.
+</span></pre>
    </div>
    <h3 class="heading settled" data-level="2.4" id="idl-dictionaries"><span class="secno">2.4. </span><span class="content">Dictionaries</span><a class="self-link" href="#idl-dictionaries"></a></h3>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-dictionary">dictionary</dfn> is a definition (matching <emu-nt><a href="#prod-Dictionary">Dictionary</a></emu-nt>)
@@ -4906,14 +4919,15 @@ identifiers.</p>
 };
 </pre>
     <p>and this ECMAScript code:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">something</span> <span class="o">=</span> <span class="nx">getSomething</span><span class="p">();</span>  <span class="c1">// Get an instance of Something.</span>
-<span class="kd">var</span> <span class="nx">x</span> <span class="o">=</span> <span class="mi">0</span><span class="p">;</span>
+<pre class="highlight"><span class="kd">var</span> something <span class="o">=</span> getSomething<span class="p">(</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// Get an instance of Something.
+</span><span class="kd">var</span> x <span class="o">=</span> <span class="mi">0</span><span class="p">;</span>
 
-<span class="kd">var</span> <span class="nx">dict</span> <span class="o">=</span> <span class="p">{</span> <span class="p">};</span>
-<span class="nb">Object</span><span class="p">.</span><span class="nx">defineProperty</span><span class="p">(</span><span class="nx">dict</span><span class="p">,</span> <span class="s2">"d"</span><span class="p">,</span> <span class="p">{</span> <span class="nx">get</span><span class="o">:</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span> <span class="k">return</span> <span class="o">++</span><span class="nx">x</span><span class="p">;</span> <span class="p">}</span> <span class="p">});</span>
-<span class="nb">Object</span><span class="p">.</span><span class="nx">defineProperty</span><span class="p">(</span><span class="nx">dict</span><span class="p">,</span> <span class="s2">"c"</span><span class="p">,</span> <span class="p">{</span> <span class="nx">get</span><span class="o">:</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span> <span class="k">return</span> <span class="o">++</span><span class="nx">x</span><span class="p">;</span> <span class="p">}</span> <span class="p">});</span>
+<span class="kd">var</span> dict <span class="o">=</span> <span class="p">{</span> <span class="p">}</span><span class="p">;</span>
+Object<span class="p">.</span>defineProperty<span class="p">(</span>dict<span class="p">,</span> <span class="s2">"d"</span><span class="p">,</span> <span class="p">{</span> get<span class="o">:</span> <span class="kd">function</span><span class="p">(</span><span class="p">)</span> <span class="p">{</span> <span class="k">return</span> <span class="o">++</span>x<span class="p">;</span> <span class="p">}</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
+Object<span class="p">.</span>defineProperty<span class="p">(</span>dict<span class="p">,</span> <span class="s2">"c"</span><span class="p">,</span> <span class="p">{</span> get<span class="o">:</span> <span class="kd">function</span><span class="p">(</span><span class="p">)</span> <span class="p">{</span> <span class="k">return</span> <span class="o">++</span>x<span class="p">;</span> <span class="p">}</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
 
-<span class="nx">something</span><span class="p">.</span><span class="nx">f</span><span class="p">(</span><span class="nx">dict</span><span class="p">);</span></pre>
+something<span class="p">.</span>f<span class="p">(</span>dict<span class="p">)</span><span class="p">;</span>
+</pre>
     <p>The order that the dictionary members are fetched in determines
     what values they will be taken to have.  Since the order for <code class="idl">A</code> is defined to be c then d,
     the value for c will be 1 and the value for d will be 2.</p>
@@ -4977,11 +4991,12 @@ on that dictionary’s <a data-link-type="dfn" href="#dfn-inherited-dictionaries
 };
 </pre>
     <p>In an ECMAScript implementation of the IDL, an <emu-val>Object</emu-val> can be passed in for the optional <code class="idl">PaintOptions</code> dictionary:</p>
-<pre class="highlight"><span></span><span class="c1">// Get an instance of GraphicsContext.</span>
-<span class="kd">var</span> <span class="nx">ctx</span> <span class="o">=</span> <span class="nx">getGraphicsContext</span><span class="p">();</span>
+<pre class="highlight"><span class="c1">// Get an instance of GraphicsContext.
+</span><span class="kd">var</span> ctx <span class="o">=</span> getGraphicsContext<span class="p">(</span><span class="p">)</span><span class="p">;</span>
 
-<span class="c1">// Draw a rectangle.</span>
-<span class="nx">ctx</span><span class="p">.</span><span class="nx">drawRectangle</span><span class="p">(</span><span class="mi">300</span><span class="p">,</span> <span class="mi">200</span><span class="p">,</span> <span class="p">{</span> <span class="nx">fillPattern</span><span class="o">:</span> <span class="s2">"red"</span><span class="p">,</span> <span class="nx">position</span><span class="o">:</span> <span class="k">new</span> <span class="nx">Point</span><span class="p">(</span><span class="mi">10</span><span class="p">,</span> <span class="mi">10</span><span class="p">)</span> <span class="p">});</span></pre>
+<span class="c1">// Draw a rectangle.
+</span>ctx<span class="p">.</span>drawRectangle<span class="p">(</span><span class="mi">300</span><span class="p">,</span> <span class="mi">200</span><span class="p">,</span> <span class="p">{</span> fillPattern<span class="o">:</span> <span class="s2">"red"</span><span class="p">,</span> position<span class="o">:</span> <span class="k">new</span> Point<span class="p">(</span><span class="mi">10</span><span class="p">,</span> <span class="mi">10</span><span class="p">)</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
+</pre>
     <p>Both fillPattern and strokePattern are given <a data-link-type="dfn" href="#dfn-dictionary-member-default-value" id="ref-for-dfn-dictionary-member-default-value-6">default values</a>,
     so if they are omitted, the definition of drawRectangle can assume that they
     have the given default values and not include explicit wording to handle
@@ -5246,18 +5261,19 @@ results in an exception being thrown.</p>
     <p>An ECMAScript implementation would restrict the strings that can be
     assigned to the type property or passed to the initializeMeal function
     to those identified in the <a data-link-type="dfn" href="#dfn-enumeration" id="ref-for-dfn-enumeration-14">enumeration</a>.</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">meal</span> <span class="o">=</span> <span class="nx">getMeal</span><span class="p">();</span>                <span class="c1">// Get an instance of Meal.</span>
-
-<span class="nx">meal</span><span class="p">.</span><span class="nx">initialize</span><span class="p">(</span><span class="s2">"rice"</span><span class="p">,</span> <span class="mi">200</span><span class="p">);</span>        <span class="c1">// Operation invoked as normal.</span>
-
+<pre class="highlight"><span class="kd">var</span> meal <span class="o">=</span> getMeal<span class="p">(</span><span class="p">)</span><span class="p">;</span>                <span class="c1">// Get an instance of Meal.
+</span>
+meal<span class="p">.</span>initialize<span class="p">(</span><span class="s2">"rice"</span><span class="p">,</span> <span class="mi">200</span><span class="p">)</span><span class="p">;</span>        <span class="c1">// Operation invoked as normal.
+</span>
 <span class="k">try</span> <span class="p">{</span>
-  <span class="nx">meal</span><span class="p">.</span><span class="nx">initialize</span><span class="p">(</span><span class="s2">"sandwich"</span><span class="p">,</span> <span class="mi">100</span><span class="p">);</span>  <span class="c1">// Throws a TypeError.</span>
-<span class="p">}</span> <span class="k">catch</span> <span class="p">(</span><span class="nx">e</span><span class="p">)</span> <span class="p">{</span>
+  meal<span class="p">.</span>initialize<span class="p">(</span><span class="s2">"sandwich"</span><span class="p">,</span> <span class="mi">100</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// Throws a TypeError.
+</span><span class="p">}</span> <span class="k">catch</span> <span class="p">(</span>e<span class="p">)</span> <span class="p">{</span>
 <span class="p">}</span>
 
-<span class="nx">meal</span><span class="p">.</span><span class="nx">type</span> <span class="o">=</span> <span class="s2">"noodles"</span><span class="p">;</span>               <span class="c1">// Attribute assigned as normal.</span>
-<span class="nx">meal</span><span class="p">.</span><span class="nx">type</span> <span class="o">=</span> <span class="s2">"dumplings"</span><span class="p">;</span>             <span class="c1">// Attribute assignment ignored.</span>
-<span class="nx">meal</span><span class="p">.</span><span class="nx">type</span> <span class="o">==</span> <span class="s2">"noodles"</span><span class="p">;</span>              <span class="c1">// Evaluates to true.</span></pre>
+meal<span class="p">.</span>type <span class="o">=</span> <span class="s2">"noodles"</span><span class="p">;</span>               <span class="c1">// Attribute assigned as normal.
+</span>meal<span class="p">.</span>type <span class="o">=</span> <span class="s2">"dumplings"</span><span class="p">;</span>             <span class="c1">// Attribute assignment ignored.
+</span>meal<span class="p">.</span>type <span class="o">==</span> <span class="s2">"noodles"</span><span class="p">;</span>              <span class="c1">// Evaluates to true.
+</span></pre>
    </div>
    <h3 class="heading settled" data-level="2.7" id="idl-callback-functions"><span class="secno">2.7. </span><span class="content">Callback functions</span><a class="self-link" href="#idl-callback-functions"></a></h3>
    <p class="issue" id="issue-2731c18f"><a class="self-link" href="#issue-2731c18f"></a> The “Custom DOM Elements” spec wants to use callback function types for
@@ -5291,11 +5307,12 @@ be used as the type of a <a data-link-type="dfn" href="#dfn-constant" id="ref-fo
 </pre>
     <p>In the ECMAScript language binding, a <emu-val>Function</emu-val> object is
     passed as the operation argument.</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">ops</span> <span class="o">=</span> <span class="nx">getAsyncOperations</span><span class="p">();</span>  <span class="c1">// Get an instance of AsyncOperations.</span>
-
-<span class="nx">ops</span><span class="p">.</span><span class="nx">performOperation</span><span class="p">(</span><span class="kd">function</span><span class="p">(</span><span class="nx">status</span><span class="p">)</span> <span class="p">{</span>
-  <span class="nb">window</span><span class="p">.</span><span class="nx">alert</span><span class="p">(</span><span class="s2">"Operation finished, status is "</span> <span class="o">+</span> <span class="nx">status</span> <span class="o">+</span> <span class="s2">"."</span><span class="p">);</span>
-<span class="p">});</span></pre>
+<pre class="highlight"><span class="kd">var</span> ops <span class="o">=</span> getAsyncOperations<span class="p">(</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// Get an instance of AsyncOperations.
+</span>
+ops<span class="p">.</span>performOperation<span class="p">(</span><span class="kd">function</span><span class="p">(</span>status<span class="p">)</span> <span class="p">{</span>
+  window<span class="p">.</span>alert<span class="p">(</span><span class="s2">"Operation finished, status is "</span> <span class="o">+</span> status <span class="o">+</span> <span class="s2">"."</span><span class="p">)</span><span class="p">;</span>
+<span class="p">}</span><span class="p">)</span><span class="p">;</span>
+</pre>
    </div>
    <h3 class="heading settled" data-level="2.8" id="idl-typedefs"><span class="secno">2.8. </span><span class="content">Typedefs</span><a class="self-link" href="#idl-typedefs"></a></h3>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-typedef">typedef</dfn> is a definition (matching <emu-nt><a href="#prod-Typedef">Typedef</a></emu-nt>)
@@ -5431,8 +5448,9 @@ of those consequential interfaces or on the original interface itself.</p>
 </pre>
     <p>An ECMAScript implementation would thus have an “addEventListener”
     property in the prototype chain of every <code class="idl">Entry</code>:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">e</span> <span class="o">=</span> <span class="nx">getEntry</span><span class="p">();</span>          <span class="c1">// Obtain an instance of Entry.</span>
-<span class="k">typeof</span> <span class="nx">e</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">;</span>  <span class="c1">// Evaluates to "function".</span></pre>
+<pre class="highlight"><span class="kd">var</span> e <span class="o">=</span> getEntry<span class="p">(</span><span class="p">)</span><span class="p">;</span>          <span class="c1">// Obtain an instance of Entry.
+</span><span class="k">typeof</span> e<span class="p">.</span>addEventListener<span class="p">;</span>  <span class="c1">// Evaluates to "function".
+</span></pre>
     <p>Note that it is not the case that all <code class="idl">Observable</code> objects implement <code class="idl">Entry</code>.</p>
    </div>
    <h3 class="heading settled" data-level="2.10" id="idl-objects"><span class="secno">2.10. </span><span class="content">Objects implementing interfaces</span><a class="self-link" href="#idl-objects"></a></h3>
@@ -6356,20 +6374,21 @@ that same global environment.</p>
     multiple frames or windows are created.  Each frame or window will have
     its own set of <a data-link-type="dfn" href="#dfn-initial-object" id="ref-for-dfn-initial-object-2">initial objects</a>,
     which the following HTML document demonstrates:</p>
-<pre class="highlight"><span></span><span class="cp">&lt;!DOCTYPE html></span>
-<span class="p">&lt;</span><span class="nt">title</span><span class="p">></span>Different global environments<span class="p">&lt;/</span><span class="nt">title</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">id</span><span class="o">=</span><span class="s">a</span><span class="p">>&lt;/</span><span class="nt">iframe</span><span class="p">></span>
+<pre class="highlight"><span class="cp">&lt;!DOCTYPE html></span>
+<span class="p">&lt;</span><span class="nt">title</span><span class="p">></span>Different global environments<span class="p">&lt;</span><span class="p">/</span><span class="nt">title</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">id</span><span class="o">=</span><span class="s">a</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">iframe</span><span class="p">></span>
 <span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
-<span class="kd">var</span> <span class="nx">iframe</span> <span class="o">=</span> <span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"a"</span><span class="p">);</span>
-<span class="kd">var</span> <span class="nx">w</span> <span class="o">=</span> <span class="nx">iframe</span><span class="p">.</span><span class="nx">contentWindow</span><span class="p">;</span>              <span class="c1">// The global object in the frame</span>
-
-<span class="nb">Object</span> <span class="o">==</span> <span class="nx">w</span><span class="p">.</span><span class="nb">Object</span><span class="p">;</span>                        <span class="c1">// Evaluates to false, per ECMA-262</span>
-<span class="nx">Node</span> <span class="o">==</span> <span class="nx">w</span><span class="p">.</span><span class="nx">Node</span><span class="p">;</span>                            <span class="c1">// Evaluates to false</span>
-<span class="nx">iframe</span> <span class="k">instanceof</span> <span class="nx">w</span><span class="p">.</span><span class="nx">Node</span><span class="p">;</span>                  <span class="c1">// Evaluates to false</span>
-<span class="nx">iframe</span> <span class="k">instanceof</span> <span class="nx">w</span><span class="p">.</span><span class="nb">Object</span><span class="p">;</span>                <span class="c1">// Evaluates to false</span>
-<span class="nx">iframe</span><span class="p">.</span><span class="nx">appendChild</span> <span class="k">instanceof</span> <span class="nb">Function</span><span class="p">;</span>    <span class="c1">// Evaluates to true</span>
-<span class="nx">iframe</span><span class="p">.</span><span class="nx">appendChild</span> <span class="k">instanceof</span> <span class="nx">w</span><span class="p">.</span><span class="nb">Function</span><span class="p">;</span>  <span class="c1">// Evaluates to false</span>
-<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span></pre>
+<span class="kd">var</span> iframe <span class="o">=</span> document<span class="p">.</span>getElementById<span class="p">(</span><span class="s2">"a"</span><span class="p">)</span><span class="p">;</span>
+<span class="kd">var</span> w <span class="o">=</span> iframe<span class="p">.</span>contentWindow<span class="p">;</span>              <span class="c1">// The global object in the frame
+</span>
+Object <span class="o">==</span> w<span class="p">.</span>Object<span class="p">;</span>                        <span class="c1">// Evaluates to false, per ECMA-262
+</span>Node <span class="o">==</span> w<span class="p">.</span>Node<span class="p">;</span>                            <span class="c1">// Evaluates to false
+</span>iframe <span class="k">instanceof</span> w<span class="p">.</span>Node<span class="p">;</span>                  <span class="c1">// Evaluates to false
+</span>iframe <span class="k">instanceof</span> w<span class="p">.</span>Object<span class="p">;</span>                <span class="c1">// Evaluates to false
+</span>iframe<span class="p">.</span>appendChild <span class="k">instanceof</span> Function<span class="p">;</span>    <span class="c1">// Evaluates to true
+</span>iframe<span class="p">.</span>appendChild <span class="k">instanceof</span> w<span class="p">.</span>Function<span class="p">;</span>  <span class="c1">// Evaluates to false
+</span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
+</pre>
    </div>
    <p>Unless otherwise specified, each ECMAScript global environment <dfn class="dfn-paneled" data-dfn-for="ECMAScript global environment" data-dfn-type="dfn" data-export="" id="dfn-expose">exposes</dfn> all <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-53">interfaces</a> that the implementation supports.  If a given ECMAScript global environment does not
 expose an interface, then the requirements given in <a href="#es-interfaces">§3.6 Interfaces</a> are
@@ -7408,46 +7427,47 @@ at index <var>j</var> is <var>S</var><sub><var>j</var></sub>.</p>
     returned, and whenever an <emu-val>Array</emu-val> is
     passed to <code>drawPolygon</code> no reference
     will be kept after the call completes.</p>
-<pre class="highlight"><span></span><span class="c1">// Obtain an instance of Canvas.  Assume that getSupportedImageCodecs()</span>
-<span class="c1">// returns a sequence with two DOMString values: "image/png" and "image/svg+xml".</span>
-<span class="kd">var</span> <span class="nx">canvas</span> <span class="o">=</span> <span class="nx">getCanvas</span><span class="p">();</span>
+<pre class="highlight"><span class="c1">// Obtain an instance of Canvas.  Assume that getSupportedImageCodecs()
+</span><span class="c1">// returns a sequence with two DOMString values: "image/png" and "image/svg+xml".
+</span><span class="kd">var</span> canvas <span class="o">=</span> getCanvas<span class="p">(</span><span class="p">)</span><span class="p">;</span>
 
-<span class="c1">// An Array object of length 2.</span>
-<span class="kd">var</span> <span class="nx">supportedImageCodecs</span> <span class="o">=</span> <span class="nx">canvas</span><span class="p">.</span><span class="nx">getSupportedImageCodecs</span><span class="p">();</span>
+<span class="c1">// An Array object of length 2.
+</span><span class="kd">var</span> supportedImageCodecs <span class="o">=</span> canvas<span class="p">.</span>getSupportedImageCodecs<span class="p">(</span><span class="p">)</span><span class="p">;</span>
 
-<span class="c1">// Evaluates to "image/png".</span>
-<span class="nx">supportedImageCodecs</span><span class="p">[</span><span class="mi">0</span><span class="p">];</span>
+<span class="c1">// Evaluates to "image/png".
+</span>supportedImageCodecs<span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="p">;</span>
 
-<span class="c1">// Each time canvas.getSupportedImageCodecs() is called, it returns a</span>
-<span class="c1">// new Array object.  Thus modifying the returned Array will not</span>
-<span class="c1">// affect the value returned from a subsequent call to the function.</span>
-<span class="nx">supportedImageCodecs</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span> <span class="o">=</span> <span class="s2">"image/jpeg"</span><span class="p">;</span>
+<span class="c1">// Each time canvas.getSupportedImageCodecs() is called, it returns a
+</span><span class="c1">// new Array object.  Thus modifying the returned Array will not
+</span><span class="c1">// affect the value returned from a subsequent call to the function.
+</span>supportedImageCodecs<span class="p">[</span><span class="mi">0</span><span class="p">]</span> <span class="o">=</span> <span class="s2">"image/jpeg"</span><span class="p">;</span>
 
-<span class="c1">// Evaluates to "image/png".</span>
-<span class="nx">canvas</span><span class="p">.</span><span class="nx">getSupportedImageCodecs</span><span class="p">()[</span><span class="mi">0</span><span class="p">];</span>
+<span class="c1">// Evaluates to "image/png".
+</span>canvas<span class="p">.</span>getSupportedImageCodecs<span class="p">(</span><span class="p">)</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="p">;</span>
 
-<span class="c1">// This evaluates to false, since a new Array object is returned each call.</span>
-<span class="nx">canvas</span><span class="p">.</span><span class="nx">getSupportedImageCodecs</span><span class="p">()</span> <span class="o">==</span> <span class="nx">canvas</span><span class="p">.</span><span class="nx">getSupportedImageCodecs</span><span class="p">();</span>
+<span class="c1">// This evaluates to false, since a new Array object is returned each call.
+</span>canvas<span class="p">.</span>getSupportedImageCodecs<span class="p">(</span><span class="p">)</span> <span class="o">==</span> canvas<span class="p">.</span>getSupportedImageCodecs<span class="p">(</span><span class="p">)</span><span class="p">;</span>
 
-<span class="c1">// An Array of Numbers...</span>
-<span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="p">[</span><span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">100</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">50</span><span class="p">,</span> <span class="mf">62.5</span><span class="p">];</span>
+<span class="c1">// An Array of Numbers...
+</span><span class="kd">var</span> a <span class="o">=</span> <span class="p">[</span><span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">100</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">50</span><span class="p">,</span> <span class="mf">62.5</span><span class="p">]</span><span class="p">;</span>
 
-<span class="c1">// ...can be passed to a platform object expecting a sequence&lt;double>.</span>
-<span class="nx">canvas</span><span class="p">.</span><span class="nx">drawPolygon</span><span class="p">(</span><span class="nx">a</span><span class="p">);</span>
+<span class="c1">// ...can be passed to a platform object expecting a sequence&lt;double>.
+</span>canvas<span class="p">.</span>drawPolygon<span class="p">(</span>a<span class="p">)</span><span class="p">;</span>
 
-<span class="c1">// Each element will be converted to a double by first calling ToNumber().</span>
-<span class="c1">// So the following call is equivalent to the previous one, except that</span>
-<span class="c1">// "hi" will be alerted before drawPolygon() returns.</span>
-<span class="nx">a</span> <span class="o">=</span> <span class="p">[</span><span class="kc">false</span><span class="p">,</span> <span class="s1">''</span><span class="p">,</span>
-     <span class="p">{</span> <span class="nx">valueOf</span><span class="o">:</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span> <span class="nx">alert</span><span class="p">(</span><span class="s1">'hi'</span><span class="p">);</span> <span class="k">return</span> <span class="mi">100</span><span class="p">;</span> <span class="p">}</span> <span class="p">},</span> <span class="mi">0</span><span class="p">,</span>
-     <span class="s1">'50'</span><span class="p">,</span> <span class="k">new</span> <span class="nb">Number</span><span class="p">(</span><span class="mf">62.5</span><span class="p">)];</span>
-<span class="nx">canvas</span><span class="p">.</span><span class="nx">drawPolygon</span><span class="p">(</span><span class="nx">s</span><span class="p">);</span>
+<span class="c1">// Each element will be converted to a double by first calling ToNumber().
+</span><span class="c1">// So the following call is equivalent to the previous one, except that
+</span><span class="c1">// "hi" will be alerted before drawPolygon() returns.
+</span>a <span class="o">=</span> <span class="p">[</span><span class="kc">false</span><span class="p">,</span> <span class="s1">''</span><span class="p">,</span>
+     <span class="p">{</span> valueOf<span class="o">:</span> <span class="kd">function</span><span class="p">(</span><span class="p">)</span> <span class="p">{</span> alert<span class="p">(</span><span class="s1">'hi'</span><span class="p">)</span><span class="p">;</span> <span class="k">return</span> <span class="mi">100</span><span class="p">;</span> <span class="p">}</span> <span class="p">}</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span>
+     <span class="s1">'50'</span><span class="p">,</span> <span class="k">new</span> Number<span class="p">(</span><span class="mf">62.5</span><span class="p">)</span><span class="p">]</span><span class="p">;</span>
+canvas<span class="p">.</span>drawPolygon<span class="p">(</span>s<span class="p">)</span><span class="p">;</span>
 
-<span class="c1">// Modifying an Array that was passed to drawPolygon() is guaranteed not to</span>
-<span class="c1">// have an effect on the Canvas, since the Array is effectively passed by value.</span>
-<span class="nx">a</span><span class="p">[</span><span class="mi">4</span><span class="p">]</span> <span class="o">=</span> <span class="mi">20</span><span class="p">;</span>
-<span class="kd">var</span> <span class="nx">b</span> <span class="o">=</span> <span class="nx">canvas</span><span class="p">.</span><span class="nx">getLastDrawnPolygon</span><span class="p">();</span>
-<span class="nx">alert</span><span class="p">(</span><span class="nx">b</span><span class="p">[</span><span class="mi">4</span><span class="p">]);</span>    <span class="c1">// This would alert "50".</span></pre>
+<span class="c1">// Modifying an Array that was passed to drawPolygon() is guaranteed not to
+</span><span class="c1">// have an effect on the Canvas, since the Array is effectively passed by value.
+</span>a<span class="p">[</span><span class="mi">4</span><span class="p">]</span> <span class="o">=</span> <span class="mi">20</span><span class="p">;</span>
+<span class="kd">var</span> b <span class="o">=</span> canvas<span class="p">.</span>getLastDrawnPolygon<span class="p">(</span><span class="p">)</span><span class="p">;</span>
+alert<span class="p">(</span>b<span class="p">[</span><span class="mi">4</span><span class="p">]</span><span class="p">)</span><span class="p">;</span>    <span class="c1">// This would alert "50".
+</span></pre>
    </div>
    <h4 class="heading settled" data-level="3.2.26" id="es-record"><span class="secno">3.2.26. </span><span class="content">Records — record&lt;<var>K</var>, <var>V</var>></span><a class="self-link" href="#es-record"></a></h4>
    <p>IDL <code class="idl"><a data-link-type="idl" href="#idl-record" id="ref-for-idl-record-2">record</a></code>&lt;<var>K</var>, <var>V</var>> values are represented by
@@ -7517,18 +7537,19 @@ return <var>result</var>.</p>
     <p>Records only consider <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-own-property">own</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-property-attributes">enumerable</a> properties, so given an IDL operation <code>record&lt;DOMString, double>
     identity(record&lt;DOMString, double> arg)</code> which returns its
     argument, the following code passes its assertions:</p>
-<pre class="highlight"><span></span><span class="kd">let</span> <span class="nx">proto</span> <span class="o">=</span> <span class="p">{</span><span class="nx">a</span><span class="o">:</span> <span class="mi">3</span><span class="p">,</span> <span class="nx">b</span><span class="o">:</span> <span class="mi">4</span><span class="p">};</span>
-<span class="kd">let</span> <span class="nx">obj</span> <span class="o">=</span> <span class="p">{</span><span class="nx">__proto__</span><span class="o">:</span> <span class="nx">proto</span><span class="p">,</span> <span class="nx">d</span><span class="o">:</span> <span class="mi">5</span><span class="p">,</span> <span class="nx">c</span><span class="o">:</span> <span class="mi">6</span><span class="p">}</span>
-<span class="nb">Object</span><span class="p">.</span><span class="nx">defineProperty</span><span class="p">(</span><span class="nx">obj</span><span class="p">,</span> <span class="s2">"e"</span><span class="p">,</span> <span class="p">{</span><span class="nx">value</span><span class="o">:</span> <span class="mi">7</span><span class="p">,</span> <span class="nx">enumerable</span><span class="o">:</span> <span class="kc">false</span><span class="p">});</span>
-<span class="kd">let</span> <span class="nx">result</span> <span class="o">=</span> <span class="nx">identity</span><span class="p">(</span><span class="nx">obj</span><span class="p">);</span>
-<span class="nx">console</span><span class="p">.</span><span class="nx">assert</span><span class="p">(</span><span class="nx">result</span><span class="p">.</span><span class="nx">a</span> <span class="o">===</span> <span class="kc">undefined</span><span class="p">);</span>
-<span class="nx">console</span><span class="p">.</span><span class="nx">assert</span><span class="p">(</span><span class="nx">result</span><span class="p">.</span><span class="nx">b</span> <span class="o">===</span> <span class="kc">undefined</span><span class="p">);</span>
-<span class="nx">console</span><span class="p">.</span><span class="nx">assert</span><span class="p">(</span><span class="nx">result</span><span class="p">.</span><span class="nx">e</span> <span class="o">===</span> <span class="kc">undefined</span><span class="p">);</span>
-<span class="kd">let</span> <span class="nx">entries</span> <span class="o">=</span> <span class="nb">Object</span><span class="p">.</span><span class="nx">entries</span><span class="p">(</span><span class="nx">result</span><span class="p">);</span>
-<span class="nx">console</span><span class="p">.</span><span class="nx">assert</span><span class="p">(</span><span class="nx">entries</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="mi">0</span><span class="p">]</span> <span class="o">===</span> <span class="s2">"d"</span><span class="p">);</span>
-<span class="nx">console</span><span class="p">.</span><span class="nx">assert</span><span class="p">(</span><span class="nx">entries</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="mi">1</span><span class="p">]</span> <span class="o">===</span> <span class="mi">5</span><span class="p">);</span>
-<span class="nx">console</span><span class="p">.</span><span class="nx">assert</span><span class="p">(</span><span class="nx">entries</span><span class="p">[</span><span class="mi">1</span><span class="p">][</span><span class="mi">0</span><span class="p">]</span> <span class="o">===</span> <span class="s2">"c"</span><span class="p">);</span>
-<span class="nx">console</span><span class="p">.</span><span class="nx">assert</span><span class="p">(</span><span class="nx">entries</span><span class="p">[</span><span class="mi">1</span><span class="p">][</span><span class="mi">1</span><span class="p">]</span> <span class="o">===</span> <span class="mi">6</span><span class="p">);</span></pre>
+<pre class="highlight"><span class="kd">let</span> proto <span class="o">=</span> <span class="p">{</span>a<span class="o">:</span> <span class="mi">3</span><span class="p">,</span> b<span class="o">:</span> <span class="mi">4</span><span class="p">}</span><span class="p">;</span>
+<span class="kd">let</span> obj <span class="o">=</span> <span class="p">{</span>__proto__<span class="o">:</span> proto<span class="p">,</span> d<span class="o">:</span> <span class="mi">5</span><span class="p">,</span> c<span class="o">:</span> <span class="mi">6</span><span class="p">}</span>
+Object<span class="p">.</span>defineProperty<span class="p">(</span>obj<span class="p">,</span> <span class="s2">"e"</span><span class="p">,</span> <span class="p">{</span>value<span class="o">:</span> <span class="mi">7</span><span class="p">,</span> enumerable<span class="o">:</span> <span class="kc">false</span><span class="p">}</span><span class="p">)</span><span class="p">;</span>
+<span class="kd">let</span> result <span class="o">=</span> identity<span class="p">(</span>obj<span class="p">)</span><span class="p">;</span>
+console<span class="p">.</span>assert<span class="p">(</span>result<span class="p">.</span>a <span class="o">===</span> <span class="kc">undefined</span><span class="p">)</span><span class="p">;</span>
+console<span class="p">.</span>assert<span class="p">(</span>result<span class="p">.</span>b <span class="o">===</span> <span class="kc">undefined</span><span class="p">)</span><span class="p">;</span>
+console<span class="p">.</span>assert<span class="p">(</span>result<span class="p">.</span>e <span class="o">===</span> <span class="kc">undefined</span><span class="p">)</span><span class="p">;</span>
+<span class="kd">let</span> entries <span class="o">=</span> Object<span class="p">.</span>entries<span class="p">(</span>result<span class="p">)</span><span class="p">;</span>
+console<span class="p">.</span>assert<span class="p">(</span>entries<span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span> <span class="o">===</span> <span class="s2">"d"</span><span class="p">)</span><span class="p">;</span>
+console<span class="p">.</span>assert<span class="p">(</span>entries<span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="p">[</span><span class="mi">1</span><span class="p">]</span> <span class="o">===</span> <span class="mi">5</span><span class="p">)</span><span class="p">;</span>
+console<span class="p">.</span>assert<span class="p">(</span>entries<span class="p">[</span><span class="mi">1</span><span class="p">]</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span> <span class="o">===</span> <span class="s2">"c"</span><span class="p">)</span><span class="p">;</span>
+console<span class="p">.</span>assert<span class="p">(</span>entries<span class="p">[</span><span class="mi">1</span><span class="p">]</span><span class="p">[</span><span class="mi">1</span><span class="p">]</span> <span class="o">===</span> <span class="mi">6</span><span class="p">)</span><span class="p">;</span>
+</pre>
     <p>Record keys and values can be constrained, although keys can only be
     constrained among the three string types.
     The following conversions have the described results:</p>
@@ -8007,16 +8028,17 @@ types in <a href="#es-type-mapping">§3.2 ECMAScript type mapping</a> for the sp
 };
 </pre>
     <p>In an ECMAScript implementation of the IDL, a call to setColorClamped with <emu-val>Number</emu-val> values that are out of range for an <code class="idl"><a data-link-type="idl" href="#idl-octet" id="ref-for-idl-octet-14">octet</a></code> are clamped to the range [0, 255].</p>
-<pre class="highlight"><span></span><span class="c1">// Get an instance of GraphicsContext.</span>
-<span class="kd">var</span> <span class="nx">context</span> <span class="o">=</span> <span class="nx">getGraphicsContext</span><span class="p">();</span>
+<pre class="highlight"><span class="c1">// Get an instance of GraphicsContext.
+</span><span class="kd">var</span> context <span class="o">=</span> getGraphicsContext<span class="p">(</span><span class="p">)</span><span class="p">;</span>
 
-<span class="c1">// Calling the non-[Clamp] version uses ToUint8 to coerce the Numbers to octets.</span>
-<span class="c1">// This is equivalent to calling setColor(255, 255, 1).</span>
-<span class="nx">context</span><span class="p">.</span><span class="nx">setColor</span><span class="p">(</span><span class="o">-</span><span class="mi">1</span><span class="p">,</span> <span class="mi">255</span><span class="p">,</span> <span class="mi">257</span><span class="p">);</span>
+<span class="c1">// Calling the non-[Clamp] version uses ToUint8 to coerce the Numbers to octets.
+</span><span class="c1">// This is equivalent to calling setColor(255, 255, 1).
+</span>context<span class="p">.</span>setColor<span class="p">(</span><span class="o">-</span><span class="mi">1</span><span class="p">,</span> <span class="mi">255</span><span class="p">,</span> <span class="mi">257</span><span class="p">)</span><span class="p">;</span>
 
-<span class="c1">// Call setColorClamped with some out of range values.</span>
-<span class="c1">// This is equivalent to calling setColorClamped(0, 255, 255).</span>
-<span class="nx">context</span><span class="p">.</span><span class="nx">setColorClamped</span><span class="p">(</span><span class="o">-</span><span class="mi">1</span><span class="p">,</span> <span class="mi">255</span><span class="p">,</span> <span class="mi">257</span><span class="p">);</span></pre>
+<span class="c1">// Call setColorClamped with some out of range values.
+</span><span class="c1">// This is equivalent to calling setColorClamped(0, 255, 255).
+</span>context<span class="p">.</span>setColorClamped<span class="p">(</span><span class="o">-</span><span class="mi">1</span><span class="p">,</span> <span class="mi">255</span><span class="p">,</span> <span class="mi">257</span><span class="p">)</span><span class="p">;</span>
+</pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.2" data-lt="Constructor" id="Constructor"><span class="secno">3.3.2. </span><span class="content">[Constructor]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-11">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-41">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-56">interface</a>, it indicates that
@@ -8067,15 +8089,16 @@ for an interface is to be implemented.</p>
     return a new object that implements the interface.  It would take
     either zero or one argument.  The <code class="idl">NodeList</code> interface object would not
     have a [[Construct]] property.</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">x</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Circle</span><span class="p">();</span>      <span class="c1">// The uses the zero-argument constructor to create a</span>
-                           <span class="c1">// reference to a platform object that implements the</span>
-                           <span class="c1">// Circle interface.</span>
-
-<span class="kd">var</span> <span class="nx">y</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Circle</span><span class="p">(</span><span class="mf">1.25</span><span class="p">);</span>  <span class="c1">// This also creates a Circle object, this time using</span>
-                           <span class="c1">// the one-argument constructor.</span>
-
-<span class="kd">var</span> <span class="nx">z</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">NodeList</span><span class="p">();</span>    <span class="c1">// This would throw a TypeError, since no</span>
-                           <span class="c1">// [Constructor] is declared.</span></pre>
+<pre class="highlight"><span class="kd">var</span> x <span class="o">=</span> <span class="k">new</span> Circle<span class="p">(</span><span class="p">)</span><span class="p">;</span>      <span class="c1">// The uses the zero-argument constructor to create a
+</span>                           <span class="c1">// reference to a platform object that implements the
+</span>                           <span class="c1">// Circle interface.
+</span>
+<span class="kd">var</span> y <span class="o">=</span> <span class="k">new</span> Circle<span class="p">(</span><span class="mf">1.25</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// This also creates a Circle object, this time using
+</span>                           <span class="c1">// the one-argument constructor.
+</span>
+<span class="kd">var</span> z <span class="o">=</span> <span class="k">new</span> NodeList<span class="p">(</span><span class="p">)</span><span class="p">;</span>    <span class="c1">// This would throw a TypeError, since no
+</span>                           <span class="c1">// [Constructor] is declared.
+</span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.3" data-lt="EnforceRange" id="EnforceRange"><span class="secno">3.3.3. </span><span class="content">[EnforceRange]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-29">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-42">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-51">operation</a> argument,
@@ -8108,20 +8131,21 @@ types in <a href="#es-type-mapping">§3.2 ECMAScript type mapping</a> for the sp
 </pre>
     <p>In an ECMAScript implementation of the IDL, a call to setColorEnforcedRange with <emu-val>Number</emu-val> values that are out of range for an <code class="idl"><a data-link-type="idl" href="#idl-octet" id="ref-for-idl-octet-16">octet</a></code> will result in an exception being
     thrown.</p>
-<pre class="highlight"><span></span><span class="c1">// Get an instance of GraphicsContext.</span>
-<span class="kd">var</span> <span class="nx">context</span> <span class="o">=</span> <span class="nx">getGraphicsContext</span><span class="p">();</span>
+<pre class="highlight"><span class="c1">// Get an instance of GraphicsContext.
+</span><span class="kd">var</span> context <span class="o">=</span> getGraphicsContext<span class="p">(</span><span class="p">)</span><span class="p">;</span>
 
-<span class="c1">// Calling the non-[EnforceRange] version uses ToUint8 to coerce the Numbers to octets.</span>
-<span class="c1">// This is equivalent to calling setColor(255, 255, 1).</span>
-<span class="nx">context</span><span class="p">.</span><span class="nx">setColor</span><span class="p">(</span><span class="o">-</span><span class="mi">1</span><span class="p">,</span> <span class="mi">255</span><span class="p">,</span> <span class="mi">257</span><span class="p">);</span>
+<span class="c1">// Calling the non-[EnforceRange] version uses ToUint8 to coerce the Numbers to octets.
+</span><span class="c1">// This is equivalent to calling setColor(255, 255, 1).
+</span>context<span class="p">.</span>setColor<span class="p">(</span><span class="o">-</span><span class="mi">1</span><span class="p">,</span> <span class="mi">255</span><span class="p">,</span> <span class="mi">257</span><span class="p">)</span><span class="p">;</span>
 
-<span class="c1">// When setColorEnforcedRange is called, Numbers are rounded towards zero.</span>
-<span class="c1">// This is equivalent to calling setColor(0, 255, 255).</span>
-<span class="nx">context</span><span class="p">.</span><span class="nx">setColorEnforcedRange</span><span class="p">(</span><span class="o">-</span><span class="mf">0.9</span><span class="p">,</span> <span class="mi">255</span><span class="p">,</span> <span class="mf">255.2</span><span class="p">);</span>
+<span class="c1">// When setColorEnforcedRange is called, Numbers are rounded towards zero.
+</span><span class="c1">// This is equivalent to calling setColor(0, 255, 255).
+</span>context<span class="p">.</span>setColorEnforcedRange<span class="p">(</span><span class="o">-</span><span class="mf">0.9</span><span class="p">,</span> <span class="mi">255</span><span class="p">,</span> <span class="mf">255.2</span><span class="p">)</span><span class="p">;</span>
 
-<span class="c1">// The following will cause a TypeError to be thrown, since even after</span>
-<span class="c1">// rounding the first and third argument values are out of range.</span>
-<span class="nx">context</span><span class="p">.</span><span class="nx">setColorEnforcedRange</span><span class="p">(</span><span class="o">-</span><span class="mi">1</span><span class="p">,</span> <span class="mi">255</span><span class="p">,</span> <span class="mi">256</span><span class="p">);</span></pre>
+<span class="c1">// The following will cause a TypeError to be thrown, since even after
+</span><span class="c1">// rounding the first and third argument values are out of range.
+</span>context<span class="p">.</span>setColorEnforcedRange<span class="p">(</span><span class="o">-</span><span class="mi">1</span><span class="p">,</span> <span class="mi">255</span><span class="p">,</span> <span class="mi">256</span><span class="p">)</span><span class="p">;</span>
+</pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.4" data-lt="Exposed" id="Exposed"><span class="secno">3.3.4. </span><span class="content">[Exposed]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-9">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-44">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-57">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-8">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-6">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-3">partial namespace</a>, or
@@ -8289,11 +8313,12 @@ will correspond to properties on the object itself rather than on <a data-link-t
     <p>Placing properties corresponding to interface members on
     the object itself will mean that common feature detection
     methods like the following will work:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">indexedDB</span> <span class="o">=</span> <span class="nb">window</span><span class="p">.</span><span class="nx">indexedDB</span> <span class="o">||</span> <span class="nb">window</span><span class="p">.</span><span class="nx">webkitIndexedDB</span> <span class="o">||</span>
-                <span class="nb">window</span><span class="p">.</span><span class="nx">mozIndexedDB</span> <span class="o">||</span> <span class="nb">window</span><span class="p">.</span><span class="nx">msIndexedDB</span><span class="p">;</span>
+<pre class="highlight"><span class="kd">var</span> indexedDB <span class="o">=</span> window<span class="p">.</span>indexedDB <span class="o">||</span> window<span class="p">.</span>webkitIndexedDB <span class="o">||</span>
+                window<span class="p">.</span>mozIndexedDB <span class="o">||</span> window<span class="p">.</span>msIndexedDB<span class="p">;</span>
 
-<span class="kd">var</span> <span class="nx">requestAnimationFrame</span> <span class="o">=</span> <span class="nb">window</span><span class="p">.</span><span class="nx">requestAnimationFrame</span> <span class="o">||</span>
-                            <span class="nb">window</span><span class="p">.</span><span class="nx">mozRequestAnimationFrame</span> <span class="o">||</span> <span class="p">...;</span></pre>
+<span class="kd">var</span> requestAnimationFrame <span class="o">=</span> window<span class="p">.</span>requestAnimationFrame <span class="o">||</span>
+                            window<span class="p">.</span>mozRequestAnimationFrame <span class="o">||</span> <span class="p">...</span><span class="p">;</span>
+</pre>
     <p>Because of the way variable declarations are handled in
     ECMAScript, the code above would result in the <code>window.indexedDB</code> and <code>window.requestAnimationFrame</code> evaluating
     to <emu-val>undefined</emu-val>, as the shadowing variable
@@ -8378,29 +8403,30 @@ corresponding to <a data-link-type="dfn" href="#dfn-interface-member" id="ref-fo
     <p>The following HTML document illustrates how the named properties on the <code class="idl">Window</code> object can be shadowed, and how
     the property for an attribute will not be replaced when declaring
     a variable of the same name:</p>
-<pre class="highlight"><span></span><span class="cp">&lt;!DOCTYPE html></span>
-<span class="p">&lt;</span><span class="nt">title</span><span class="p">></span>Variable declarations and assignments on Window<span class="p">&lt;/</span><span class="nt">title</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">name</span><span class="o">=</span><span class="s">abc</span><span class="p">>&lt;/</span><span class="nt">iframe</span><span class="p">></span>
-<span class="c">&lt;!-- Shadowing named properties --></span>
+<pre class="highlight"><span class="cp">&lt;!DOCTYPE html></span>
+<span class="p">&lt;</span><span class="nt">title</span><span class="p">></span>Variable declarations and assignments on Window<span class="p">&lt;</span><span class="p">/</span><span class="nt">title</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">name</span><span class="o">=</span><span class="s">abc</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">iframe</span><span class="p">></span>
+<span class="c">&lt;!--</span><span class="c"> Shadowing named properties </span><span class="c">--></span>
 <span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
-  <span class="nb">window</span><span class="p">.</span><span class="nx">abc</span><span class="p">;</span>    <span class="c1">// Evaluates to the iframe’s Window object.</span>
-  <span class="nx">abc</span> <span class="o">=</span> <span class="mi">1</span><span class="p">;</span>       <span class="c1">// Shadows the named property.</span>
-  <span class="nb">window</span><span class="p">.</span><span class="nx">abc</span><span class="p">;</span>    <span class="c1">// Evaluates to 1.</span>
-<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
+  window<span class="p">.</span>abc<span class="p">;</span>    <span class="c1">// Evaluates to the iframe’s Window object.
+</span>  abc <span class="o">=</span> <span class="mi">1</span><span class="p">;</span>       <span class="c1">// Shadows the named property.
+</span>  window<span class="p">.</span>abc<span class="p">;</span>    <span class="c1">// Evaluates to 1.
+</span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
 
-<span class="c">&lt;!-- Preserving properties for IDL attributes --></span>
+<span class="c">&lt;!--</span><span class="c"> Preserving properties for IDL attributes </span><span class="c">--></span>
 <span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
-  <span class="nx">Window</span><span class="p">.</span><span class="nx">prototype</span><span class="p">.</span><span class="nx">def</span> <span class="o">=</span> <span class="mi">2</span><span class="p">;</span>         <span class="c1">// Places a property on the prototype.</span>
-  <span class="nb">window</span><span class="p">.</span><span class="nx">hasOwnProperty</span><span class="p">(</span><span class="s2">"length"</span><span class="p">);</span>  <span class="c1">// Evaluates to true.</span>
-  <span class="nx">length</span><span class="p">;</span>                           <span class="c1">// Evaluates to 1.</span>
-  <span class="nx">def</span><span class="p">;</span>                              <span class="c1">// Evaluates to 2.</span>
-<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
+  Window<span class="p">.</span>prototype<span class="p">.</span>def <span class="o">=</span> <span class="mi">2</span><span class="p">;</span>         <span class="c1">// Places a property on the prototype.
+</span>  window<span class="p">.</span>hasOwnProperty<span class="p">(</span><span class="s2">"length"</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// Evaluates to true.
+</span>  length<span class="p">;</span>                           <span class="c1">// Evaluates to 1.
+</span>  def<span class="p">;</span>                              <span class="c1">// Evaluates to 2.
+</span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
 <span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
-  <span class="kd">var</span> <span class="nx">length</span><span class="p">;</span>                       <span class="c1">// Variable declaration leaves existing property.</span>
-  <span class="nx">length</span><span class="p">;</span>                           <span class="c1">// Evaluates to 1.</span>
-  <span class="kd">var</span> <span class="nx">def</span><span class="p">;</span>                          <span class="c1">// Variable declaration creates shadowing property.</span>
-  <span class="nx">def</span><span class="p">;</span>                              <span class="c1">// Evaluates to undefined.</span>
-<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span></pre>
+  <span class="kd">var</span> length<span class="p">;</span>                       <span class="c1">// Variable declaration leaves existing property.
+</span>  length<span class="p">;</span>                           <span class="c1">// Evaluates to 1.
+</span>  <span class="kd">var</span> def<span class="p">;</span>                          <span class="c1">// Variable declaration creates shadowing property.
+</span>  def<span class="p">;</span>                              <span class="c1">// Evaluates to undefined.
+</span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
+</pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.6" data-lt="LegacyArrayClass" id="LegacyArrayClass"><span class="secno">3.3.6. </span><span class="content">[LegacyArrayClass]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-3">LegacyArrayClass</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-57">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-64">interface</a> that is not defined to <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-12">inherit</a> from another, it indicates that the internal [[Prototype]]
@@ -8437,11 +8463,12 @@ entails.</p>
     <p>In an ECMAScript implementation of the above two interfaces,
     with appropriate definitions for getItem, setItem and removeItem, <emu-val>Array</emu-val> methods to inspect and
     modify the array-like object can be used.</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">list</span> <span class="o">=</span> <span class="nx">getItemList</span><span class="p">();</span>  <span class="c1">// Obtain an instance of ItemList.</span>
-
-<span class="nx">list</span><span class="p">.</span><span class="nx">concat</span><span class="p">();</span>             <span class="c1">// Clone the ItemList into an Array.</span>
-<span class="nx">list</span><span class="p">.</span><span class="nx">pop</span><span class="p">();</span>                <span class="c1">// Remove an item from the ItemList.</span>
-<span class="nx">list</span><span class="p">.</span><span class="nx">unshift</span><span class="p">({</span> <span class="p">});</span>         <span class="c1">// Insert an item at index 0.</span></pre>
+<pre class="highlight"><span class="kd">var</span> list <span class="o">=</span> getItemList<span class="p">(</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// Obtain an instance of ItemList.
+</span>
+list<span class="p">.</span>concat<span class="p">(</span><span class="p">)</span><span class="p">;</span>             <span class="c1">// Clone the ItemList into an Array.
+</span>list<span class="p">.</span>pop<span class="p">(</span><span class="p">)</span><span class="p">;</span>                <span class="c1">// Remove an item from the ItemList.
+</span>list<span class="p">.</span>unshift<span class="p">(</span><span class="p">{</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>         <span class="c1">// Insert an item at index 0.
+</span></pre>
     <p><code class="idl">ImmutableItemList</code> has a read only
     length <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-47">attribute</a> and no indexed property <a data-link-type="dfn" href="#dfn-indexed-property-setter" id="ref-for-dfn-indexed-property-setter-3">setter</a>.  The
     mutating <emu-val>Array</emu-val> methods will generally not
@@ -8499,15 +8526,16 @@ or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Re
     <p>An ECMAScript implementation that supports this interface will
     have a setter on the accessor property that correspond to x,
     which allows any assignment to be ignored in strict mode.</p>
-<pre class="highlight"><span></span><span class="s2">"use strict"</span><span class="p">;</span>
+<pre class="highlight"><span class="s2">"use strict"</span><span class="p">;</span>
 
-<span class="kd">var</span> <span class="nx">example</span> <span class="o">=</span> <span class="nx">getExample</span><span class="p">();</span>  <span class="c1">// Get an instance of Example.</span>
+<span class="kd">var</span> example <span class="o">=</span> getExample<span class="p">(</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// Get an instance of Example.
+</span>
+<span class="c1">// Fine; while we are in strict mode, there is a setter that is a no-op.
+</span>example<span class="p">.</span>x <span class="o">=</span> <span class="mi">1</span><span class="p">;</span>
 
-<span class="c1">// Fine; while we are in strict mode, there is a setter that is a no-op.</span>
-<span class="nx">example</span><span class="p">.</span><span class="nx">x</span> <span class="o">=</span> <span class="mi">1</span><span class="p">;</span>
-
-<span class="c1">// Throws a TypeError, since we are in strict mode and there is no setter.</span>
-<span class="nx">example</span><span class="p">.</span><span class="nx">y</span> <span class="o">=</span> <span class="mi">1</span><span class="p">;</span></pre>
+<span class="c1">// Throws a TypeError, since we are in strict mode and there is no setter.
+</span>example<span class="p">.</span>y <span class="o">=</span> <span class="mi">1</span><span class="p">;</span>
+</pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.9" data-lt="LenientThis" id="LenientThis"><span class="secno">3.3.9. </span><span class="content">[LenientThis]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-3">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-60">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-7">regular attribute</a>,
@@ -8536,20 +8564,21 @@ is to be implemented.</p>
     <p>An ECMAScript implementation that supports this interface will
     allow the getter and setter of the accessor property that corresponds
     to x to be invoked with something other than an <code class="idl">Example</code> object.</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">example</span> <span class="o">=</span> <span class="nx">getExample</span><span class="p">();</span>  <span class="c1">// Get an instance of Example.</span>
-<span class="kd">var</span> <span class="nx">obj</span> <span class="o">=</span> <span class="p">{</span> <span class="p">};</span>
+<pre class="highlight"><span class="kd">var</span> example <span class="o">=</span> getExample<span class="p">(</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// Get an instance of Example.
+</span><span class="kd">var</span> obj <span class="o">=</span> <span class="p">{</span> <span class="p">}</span><span class="p">;</span>
 
-<span class="c1">// Fine.</span>
-<span class="nx">example</span><span class="p">.</span><span class="nx">x</span><span class="p">;</span>
+<span class="c1">// Fine.
+</span>example<span class="p">.</span>x<span class="p">;</span>
 
-<span class="c1">// Ignored, since the this value is not an Example object and [LenientThis] is used.</span>
-<span class="nb">Object</span><span class="p">.</span><span class="nx">getOwnPropertyDescriptor</span><span class="p">(</span><span class="nx">Example</span><span class="p">.</span><span class="nx">prototype</span><span class="p">,</span> <span class="s2">"x"</span><span class="p">).</span><span class="nx">get</span><span class="p">.</span><span class="nx">call</span><span class="p">(</span><span class="nx">obj</span><span class="p">);</span>
+<span class="c1">// Ignored, since the this value is not an Example object and [LenientThis] is used.
+</span>Object<span class="p">.</span>getOwnPropertyDescriptor<span class="p">(</span>Example<span class="p">.</span>prototype<span class="p">,</span> <span class="s2">"x"</span><span class="p">)</span><span class="p">.</span>get<span class="p">.</span>call<span class="p">(</span>obj<span class="p">)</span><span class="p">;</span>
 
-<span class="c1">// Also ignored, since Example.prototype is not an Example object and [LenientThis] is used.</span>
-<span class="nx">Example</span><span class="p">.</span><span class="nx">prototype</span><span class="p">.</span><span class="nx">x</span><span class="p">;</span>
+<span class="c1">// Also ignored, since Example.prototype is not an Example object and [LenientThis] is used.
+</span>Example<span class="p">.</span>prototype<span class="p">.</span>x<span class="p">;</span>
 
-<span class="c1">// Throws a TypeError, since Example.prototype is not an Example object.</span>
-<span class="nx">Example</span><span class="p">.</span><span class="nx">prototype</span><span class="p">.</span><span class="nx">y</span><span class="p">;</span></pre>
+<span class="c1">// Throws a TypeError, since Example.prototype is not an Example object.
+</span>Example<span class="p">.</span>prototype<span class="p">.</span>y<span class="p">;</span>
+</pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.10" data-lt="NamedConstructor" id="NamedConstructor"><span class="secno">3.3.10. </span><span class="content">[NamedConstructor]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-8">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-61">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-68">interface</a>,
@@ -8589,14 +8618,15 @@ are to be implemented.</p>
 </pre>
     <p>An ECMAScript implementation that supports this interface will
     allow the construction of <code class="idl">HTMLAudioElement</code> objects using the <code class="idl">Audio</code> constructor.</p>
-<pre class="highlight"><span></span><span class="k">typeof</span> <span class="nx">Audio</span><span class="p">;</span>                   <span class="c1">// Evaluates to 'function'.</span>
-
-<span class="kd">var</span> <span class="nx">a1</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Audio</span><span class="p">();</span>           <span class="c1">// Creates a new object that implements</span>
-                                <span class="c1">// HTMLAudioElement, using the zero-argument</span>
-                                <span class="c1">// constructor.</span>
-
-<span class="kd">var</span> <span class="nx">a2</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Audio</span><span class="p">(</span><span class="s1">'a.flac'</span><span class="p">);</span>   <span class="c1">// Creates an HTMLAudioElement using the</span>
-                                <span class="c1">// one-argument constructor.</span></pre>
+<pre class="highlight"><span class="k">typeof</span> Audio<span class="p">;</span>                   <span class="c1">// Evaluates to 'function'.
+</span>
+<span class="kd">var</span> a1 <span class="o">=</span> <span class="k">new</span> Audio<span class="p">(</span><span class="p">)</span><span class="p">;</span>           <span class="c1">// Creates a new object that implements
+</span>                                <span class="c1">// HTMLAudioElement, using the zero-argument
+</span>                                <span class="c1">// constructor.
+</span>
+<span class="kd">var</span> a2 <span class="o">=</span> <span class="k">new</span> Audio<span class="p">(</span><span class="s1">'a.flac'</span><span class="p">)</span><span class="p">;</span>   <span class="c1">// Creates an HTMLAudioElement using the
+</span>                                <span class="c1">// one-argument constructor.
+</span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.11" data-lt="NewObject" id="NewObject"><span class="secno">3.3.11. </span><span class="content">[NewObject]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#NewObject" id="ref-for-NewObject-2">NewObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-62">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-9">regular</a> or <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-7">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-54">operation</a>,
@@ -8663,17 +8693,18 @@ attribute specified.</p>
     <p>An ECMAScript implementation of the above IDL would allow
     manipulation of <code class="idl">Storage</code>’s
     prototype, but not <code class="idl">Query</code>’s.</p>
-<pre class="highlight"><span></span><span class="k">typeof</span> <span class="nx">Storage</span><span class="p">;</span>                        <span class="c1">// evaluates to "object"</span>
+<pre class="highlight"><span class="k">typeof</span> Storage<span class="p">;</span>                        <span class="c1">// evaluates to "object"
+</span>
+<span class="c1">// Add some tracing alert() call to Storage.addEntry.
+</span><span class="kd">var</span> fn <span class="o">=</span> Storage<span class="p">.</span>prototype<span class="p">.</span>addEntry<span class="p">;</span>
+Storage<span class="p">.</span>prototype<span class="p">.</span>addEntry <span class="o">=</span> <span class="kd">function</span><span class="p">(</span>key<span class="p">,</span> value<span class="p">)</span> <span class="p">{</span>
+  alert<span class="p">(</span><span class="s1">'Calling addEntry()'</span><span class="p">)</span><span class="p">;</span>
+  <span class="k">return</span> fn<span class="p">.</span>call<span class="p">(</span><span class="k">this</span><span class="p">,</span> key<span class="p">,</span> value<span class="p">)</span><span class="p">;</span>
+<span class="p">}</span><span class="p">;</span>
 
-<span class="c1">// Add some tracing alert() call to Storage.addEntry.</span>
-<span class="kd">var</span> <span class="nx">fn</span> <span class="o">=</span> <span class="nx">Storage</span><span class="p">.</span><span class="nx">prototype</span><span class="p">.</span><span class="nx">addEntry</span><span class="p">;</span>
-<span class="nx">Storage</span><span class="p">.</span><span class="nx">prototype</span><span class="p">.</span><span class="nx">addEntry</span> <span class="o">=</span> <span class="kd">function</span><span class="p">(</span><span class="nx">key</span><span class="p">,</span> <span class="nx">value</span><span class="p">)</span> <span class="p">{</span>
-  <span class="nx">alert</span><span class="p">(</span><span class="s1">'Calling addEntry()'</span><span class="p">);</span>
-  <span class="k">return</span> <span class="nx">fn</span><span class="p">.</span><span class="nx">call</span><span class="p">(</span><span class="k">this</span><span class="p">,</span> <span class="nx">key</span><span class="p">,</span> <span class="nx">value</span><span class="p">);</span>
-<span class="p">};</span>
-
-<span class="k">typeof</span> <span class="nx">Query</span><span class="p">;</span>                          <span class="c1">// evaluates to "undefined"</span>
-<span class="kd">var</span> <span class="nx">fn</span> <span class="o">=</span> <span class="nx">Query</span><span class="p">.</span><span class="nx">prototype</span><span class="p">.</span><span class="nx">lookupEntry</span><span class="p">;</span>  <span class="c1">// exception, Query isn’t defined</span></pre>
+<span class="k">typeof</span> Query<span class="p">;</span>                          <span class="c1">// evaluates to "undefined"
+</span><span class="kd">var</span> fn <span class="o">=</span> Query<span class="p">.</span>prototype<span class="p">.</span>lookupEntry<span class="p">;</span>  <span class="c1">// exception, Query isn’t defined
+</span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.13" data-lt="OverrideBuiltins" id="OverrideBuiltins"><span class="secno">3.3.13. </span><span class="content">[OverrideBuiltins]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-5">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-64">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-70">interface</a>,
@@ -8714,34 +8745,35 @@ the <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-na
     <p>In an ECMAScript implementation of these two interfaces,
     getting certain properties on objects implementing
     the interfaces will result in different values:</p>
-<pre class="highlight"><span></span><span class="c1">// Obtain an instance of StringMap.  Assume that it has "abc", "length" and</span>
-<span class="c1">// "toString" as supported property names.</span>
-<span class="kd">var</span> <span class="nx">map1</span> <span class="o">=</span> <span class="nx">getStringMap</span><span class="p">();</span>
+<pre class="highlight"><span class="c1">// Obtain an instance of StringMap.  Assume that it has "abc", "length" and
+</span><span class="c1">// "toString" as supported property names.
+</span><span class="kd">var</span> map1 <span class="o">=</span> getStringMap<span class="p">(</span><span class="p">)</span><span class="p">;</span>
 
-<span class="c1">// This invokes the named property getter.</span>
-<span class="nx">map1</span><span class="p">.</span><span class="nx">abc</span><span class="p">;</span>
+<span class="c1">// This invokes the named property getter.
+</span>map1<span class="p">.</span>abc<span class="p">;</span>
 
-<span class="c1">// This fetches the "length" property on the object that corresponds to the</span>
-<span class="c1">// length attribute.</span>
-<span class="nx">map1</span><span class="p">.</span><span class="nx">length</span><span class="p">;</span>
+<span class="c1">// This fetches the "length" property on the object that corresponds to the
+</span><span class="c1">// length attribute.
+</span>map1<span class="p">.</span>length<span class="p">;</span>
 
-<span class="c1">// This fetches the "toString" property from the object’s prototype chain.</span>
-<span class="nx">map1</span><span class="p">.</span><span class="nx">toString</span><span class="p">;</span>
+<span class="c1">// This fetches the "toString" property from the object’s prototype chain.
+</span>map1<span class="p">.</span>toString<span class="p">;</span>
 
-<span class="c1">// Obtain an instance of StringMap2.  Assume that it also has "abc", "length"</span>
-<span class="c1">// and "toString" as supported property names.</span>
-<span class="kd">var</span> <span class="nx">map2</span> <span class="o">=</span> <span class="nx">getStringMap2</span><span class="p">();</span>
+<span class="c1">// Obtain an instance of StringMap2.  Assume that it also has "abc", "length"
+</span><span class="c1">// and "toString" as supported property names.
+</span><span class="kd">var</span> map2 <span class="o">=</span> getStringMap2<span class="p">(</span><span class="p">)</span><span class="p">;</span>
 
-<span class="c1">// This invokes the named property getter.</span>
-<span class="nx">map2</span><span class="p">.</span><span class="nx">abc</span><span class="p">;</span>
+<span class="c1">// This invokes the named property getter.
+</span>map2<span class="p">.</span>abc<span class="p">;</span>
 
-<span class="c1">// This also invokes the named property getter, despite the fact that the "length"</span>
-<span class="c1">// property on the object corresponds to the length attribute.</span>
-<span class="nx">map2</span><span class="p">.</span><span class="nx">length</span><span class="p">;</span>
+<span class="c1">// This also invokes the named property getter, despite the fact that the "length"
+</span><span class="c1">// property on the object corresponds to the length attribute.
+</span>map2<span class="p">.</span>length<span class="p">;</span>
 
-<span class="c1">// This too invokes the named property getter, despite the fact that "toString" is</span>
-<span class="c1">// a property in map2’s prototype chain.</span>
-<span class="nx">map2</span><span class="p">.</span><span class="nx">toString</span><span class="p">;</span></pre>
+<span class="c1">// This too invokes the named property getter, despite the fact that "toString" is
+</span><span class="c1">// a property in map2’s prototype chain.
+</span>map2<span class="p">.</span>toString<span class="p">;</span>
+</pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.14" data-lt="PutForwards" id="PutForwards"><span class="secno">3.3.14. </span><span class="content">[PutForwards]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-3">PutForwards</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-65">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-8">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-8">regular attribute</a> declaration whose type is
@@ -8809,10 +8841,11 @@ is to be implemented.</p>
 </pre>
     <p>In the ECMAScript binding, this would allow assignments to the
     “name” property:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">p</span> <span class="o">=</span> <span class="nx">getPerson</span><span class="p">();</span>           <span class="c1">// Obtain an instance of Person.</span>
-
-<span class="nx">p</span><span class="p">.</span><span class="nx">name</span> <span class="o">=</span> <span class="s1">'John Citizen'</span><span class="p">;</span>       <span class="c1">// This statement...</span>
-<span class="nx">p</span><span class="p">.</span><span class="nx">name</span><span class="p">.</span><span class="nx">full</span> <span class="o">=</span> <span class="s1">'John Citizen'</span><span class="p">;</span>  <span class="c1">// ...has the same behavior as this one.</span></pre>
+<pre class="highlight"><span class="kd">var</span> p <span class="o">=</span> getPerson<span class="p">(</span><span class="p">)</span><span class="p">;</span>           <span class="c1">// Obtain an instance of Person.
+</span>
+p<span class="p">.</span>name <span class="o">=</span> <span class="s1">'John Citizen'</span><span class="p">;</span>       <span class="c1">// This statement...
+</span>p<span class="p">.</span>name<span class="p">.</span>full <span class="o">=</span> <span class="s1">'John Citizen'</span><span class="p">;</span>  <span class="c1">// ...has the same behavior as this one.
+</span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.15" data-lt="Replaceable" id="Replaceable"><span class="secno">3.3.15. </span><span class="content">[Replaceable]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-4">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-67">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-10">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-9">regular attribute</a>,
@@ -8848,26 +8881,27 @@ a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callbac
 </pre>
     <p>Assigning to the “value” property
     on a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-17">platform object</a> implementing <code class="idl">Counter</code> will shadow the property that corresponds to the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-54">attribute</a>:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">counter</span> <span class="o">=</span> <span class="nx">getCounter</span><span class="p">();</span>                              <span class="c1">// Obtain an instance of Counter.</span>
-<span class="nx">counter</span><span class="p">.</span><span class="nx">value</span><span class="p">;</span>                                           <span class="c1">// Evaluates to 0.</span>
-
-<span class="nx">counter</span><span class="p">.</span><span class="nx">hasOwnProperty</span><span class="p">(</span><span class="s2">"value"</span><span class="p">);</span>                         <span class="c1">// Evaluates to false.</span>
-<span class="nb">Object</span><span class="p">.</span><span class="nx">getPrototypeOf</span><span class="p">(</span><span class="nx">counter</span><span class="p">).</span><span class="nx">hasOwnProperty</span><span class="p">(</span><span class="s2">"value"</span><span class="p">);</span>  <span class="c1">// Evaluates to true.</span>
-
-<span class="nx">counter</span><span class="p">.</span><span class="nx">increment</span><span class="p">();</span>
-<span class="nx">counter</span><span class="p">.</span><span class="nx">increment</span><span class="p">();</span>
-<span class="nx">counter</span><span class="p">.</span><span class="nx">value</span><span class="p">;</span>                                           <span class="c1">// Evaluates to 2.</span>
-
-<span class="nx">counter</span><span class="p">.</span><span class="nx">value</span> <span class="o">=</span> <span class="s1">'a'</span><span class="p">;</span>                                     <span class="c1">// Shadows the property with one that is unrelated</span>
-                                                         <span class="c1">// to Counter::value.</span>
-
-<span class="nx">counter</span><span class="p">.</span><span class="nx">hasOwnProperty</span><span class="p">(</span><span class="s2">"value"</span><span class="p">);</span>                         <span class="c1">// Evaluates to true.</span>
-
-<span class="nx">counter</span><span class="p">.</span><span class="nx">increment</span><span class="p">();</span>
-<span class="nx">counter</span><span class="p">.</span><span class="nx">value</span><span class="p">;</span>                                           <span class="c1">// Evaluates to 'a'.</span>
-
-<span class="k">delete</span> <span class="nx">counter</span><span class="p">.</span><span class="nx">value</span><span class="p">;</span>                                    <span class="c1">// Reveals the original property.</span>
-<span class="nx">counter</span><span class="p">.</span><span class="nx">value</span><span class="p">;</span>                                           <span class="c1">// Evaluates to 3.</span></pre>
+<pre class="highlight"><span class="kd">var</span> counter <span class="o">=</span> getCounter<span class="p">(</span><span class="p">)</span><span class="p">;</span>                              <span class="c1">// Obtain an instance of Counter.
+</span>counter<span class="p">.</span>value<span class="p">;</span>                                           <span class="c1">// Evaluates to 0.
+</span>
+counter<span class="p">.</span>hasOwnProperty<span class="p">(</span><span class="s2">"value"</span><span class="p">)</span><span class="p">;</span>                         <span class="c1">// Evaluates to false.
+</span>Object<span class="p">.</span>getPrototypeOf<span class="p">(</span>counter<span class="p">)</span><span class="p">.</span>hasOwnProperty<span class="p">(</span><span class="s2">"value"</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// Evaluates to true.
+</span>
+counter<span class="p">.</span>increment<span class="p">(</span><span class="p">)</span><span class="p">;</span>
+counter<span class="p">.</span>increment<span class="p">(</span><span class="p">)</span><span class="p">;</span>
+counter<span class="p">.</span>value<span class="p">;</span>                                           <span class="c1">// Evaluates to 2.
+</span>
+counter<span class="p">.</span>value <span class="o">=</span> <span class="s1">'a'</span><span class="p">;</span>                                     <span class="c1">// Shadows the property with one that is unrelated
+</span>                                                         <span class="c1">// to Counter::value.
+</span>
+counter<span class="p">.</span>hasOwnProperty<span class="p">(</span><span class="s2">"value"</span><span class="p">)</span><span class="p">;</span>                         <span class="c1">// Evaluates to true.
+</span>
+counter<span class="p">.</span>increment<span class="p">(</span><span class="p">)</span><span class="p">;</span>
+counter<span class="p">.</span>value<span class="p">;</span>                                           <span class="c1">// Evaluates to 'a'.
+</span>
+<span class="k">delete</span> counter<span class="p">.</span>value<span class="p">;</span>                                    <span class="c1">// Reveals the original property.
+</span>counter<span class="p">.</span>value<span class="p">;</span>                                           <span class="c1">// Evaluates to 3.
+</span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.16" data-lt="SameObject" id="SameObject"><span class="secno">3.3.16. </span><span class="content">[SameObject]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-2">SameObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-68">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-12">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-55">attribute</a>, then it
@@ -8992,21 +9026,22 @@ the <emu-val>null</emu-val> value.</p>
     an object (such as a <emu-val>Number</emu-val> value)
     to handler1 will have different behavior from that when assigning
     to handler2:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">manager</span> <span class="o">=</span> <span class="nx">getManager</span><span class="p">();</span>  <span class="c1">// Get an instance of Manager.</span>
-
-<span class="nx">manager</span><span class="p">.</span><span class="nx">handler1</span> <span class="o">=</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span> <span class="p">};</span>
-<span class="nx">manager</span><span class="p">.</span><span class="nx">handler1</span><span class="p">;</span>            <span class="c1">// Evaluates to the function.</span>
-
+<pre class="highlight"><span class="kd">var</span> manager <span class="o">=</span> getManager<span class="p">(</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// Get an instance of Manager.
+</span>
+manager<span class="p">.</span>handler1 <span class="o">=</span> <span class="kd">function</span><span class="p">(</span><span class="p">)</span> <span class="p">{</span> <span class="p">}</span><span class="p">;</span>
+manager<span class="p">.</span>handler1<span class="p">;</span>            <span class="c1">// Evaluates to the function.
+</span>
 <span class="k">try</span> <span class="p">{</span>
-  <span class="nx">manager</span><span class="p">.</span><span class="nx">handler1</span> <span class="o">=</span> <span class="mi">123</span><span class="p">;</span>    <span class="c1">// Throws a TypeError.</span>
-<span class="p">}</span> <span class="k">catch</span> <span class="p">(</span><span class="nx">e</span><span class="p">)</span> <span class="p">{</span>
+  manager<span class="p">.</span>handler1 <span class="o">=</span> <span class="mi">123</span><span class="p">;</span>    <span class="c1">// Throws a TypeError.
+</span><span class="p">}</span> <span class="k">catch</span> <span class="p">(</span>e<span class="p">)</span> <span class="p">{</span>
 <span class="p">}</span>
 
-<span class="nx">manager</span><span class="p">.</span><span class="nx">handler2</span> <span class="o">=</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span> <span class="p">};</span>
-<span class="nx">manager</span><span class="p">.</span><span class="nx">handler2</span><span class="p">;</span>            <span class="c1">// Evaluates to the function.</span>
-
-<span class="nx">manager</span><span class="p">.</span><span class="nx">handler2</span> <span class="o">=</span> <span class="mi">123</span><span class="p">;</span>
-<span class="nx">manager</span><span class="p">.</span><span class="nx">handler2</span><span class="p">;</span>            <span class="c1">// Evaluates to null.</span></pre>
+manager<span class="p">.</span>handler2 <span class="o">=</span> <span class="kd">function</span><span class="p">(</span><span class="p">)</span> <span class="p">{</span> <span class="p">}</span><span class="p">;</span>
+manager<span class="p">.</span>handler2<span class="p">;</span>            <span class="c1">// Evaluates to the function.
+</span>
+manager<span class="p">.</span>handler2 <span class="o">=</span> <span class="mi">123</span><span class="p">;</span>
+manager<span class="p">.</span>handler2<span class="p">;</span>            <span class="c1">// Evaluates to null.
+</span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.19" data-lt="TreatNullAs" id="TreatNullAs"><span class="secno">3.3.19. </span><span class="content">[TreatNullAs]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#TreatNullAs" id="ref-for-TreatNullAs-8">TreatNullAs</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-75">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-58">attribute</a> or <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-59">operation</a> argument whose type is <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-52">DOMString</a></code>,
@@ -9049,16 +9084,17 @@ a non-callback interface.</p>
     assigned to the “owner” property or passed as the
     argument to the <code>isMemberOfBreed</code> function
     to the empty string rather than <code>"null"</code>:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">d</span> <span class="o">=</span> <span class="nx">getDog</span><span class="p">();</span>         <span class="c1">// Assume d is a platform object implementing the Dog</span>
-                          <span class="c1">// interface.</span>
-
-<span class="nx">d</span><span class="p">.</span><span class="nx">name</span> <span class="o">=</span> <span class="kc">null</span><span class="p">;</span>            <span class="c1">// This assigns the string "null" to the .name</span>
-                          <span class="c1">// property.</span>
-
-<span class="nx">d</span><span class="p">.</span><span class="nx">owner</span> <span class="o">=</span> <span class="kc">null</span><span class="p">;</span>           <span class="c1">// This assigns the string "" to the .owner property.</span>
-
-<span class="nx">d</span><span class="p">.</span><span class="nx">isMemberOfBreed</span><span class="p">(</span><span class="kc">null</span><span class="p">);</span>  <span class="c1">// This passes the string "" to the isMemberOfBreed</span>
-                          <span class="c1">// function.</span></pre>
+<pre class="highlight"><span class="kd">var</span> d <span class="o">=</span> getDog<span class="p">(</span><span class="p">)</span><span class="p">;</span>         <span class="c1">// Assume d is a platform object implementing the Dog
+</span>                          <span class="c1">// interface.
+</span>
+d<span class="p">.</span>name <span class="o">=</span> <span class="kc">null</span><span class="p">;</span>            <span class="c1">// This assigns the string "null" to the .name
+</span>                          <span class="c1">// property.
+</span>
+d<span class="p">.</span>owner <span class="o">=</span> <span class="kc">null</span><span class="p">;</span>           <span class="c1">// This assigns the string "" to the .owner property.
+</span>
+d<span class="p">.</span>isMemberOfBreed<span class="p">(</span><span class="kc">null</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// This passes the string "" to the isMemberOfBreed
+</span>                          <span class="c1">// function.
+</span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.20" data-lt="Unforgeable" id="Unforgeable"><span class="secno">3.3.20. </span><span class="content">[Unforgeable]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-5">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-76">extended attribute</a> appears on a non-<a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-10">static</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-59">attribute</a> or non-<a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-10">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-60">operations</a>, it indicates
@@ -9146,24 +9182,25 @@ the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifi
 </pre>
     <p>In an ECMAScript implementation of the interface, the username attribute will be exposed as a non-configurable property on the
     object itself:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">system</span> <span class="o">=</span> <span class="nx">getSystem</span><span class="p">();</span>                      <span class="c1">// Get an instance of System.</span>
-
-<span class="nx">system</span><span class="p">.</span><span class="nx">hasOwnProperty</span><span class="p">(</span><span class="s2">"username"</span><span class="p">);</span>             <span class="c1">// Evaluates to true.</span>
-<span class="nx">system</span><span class="p">.</span><span class="nx">hasOwnProperty</span><span class="p">(</span><span class="s2">"loginTime"</span><span class="p">);</span>            <span class="c1">// Evaluates to false.</span>
-<span class="nx">System</span><span class="p">.</span><span class="nx">prototype</span><span class="p">.</span><span class="nx">hasOwnProperty</span><span class="p">(</span><span class="s2">"username"</span><span class="p">);</span>   <span class="c1">// Evaluates to false.</span>
-<span class="nx">System</span><span class="p">.</span><span class="nx">prototype</span><span class="p">.</span><span class="nx">hasOwnProperty</span><span class="p">(</span><span class="s2">"loginTime"</span><span class="p">);</span>  <span class="c1">// Evaluates to true.</span>
-
+<pre class="highlight"><span class="kd">var</span> system <span class="o">=</span> getSystem<span class="p">(</span><span class="p">)</span><span class="p">;</span>                      <span class="c1">// Get an instance of System.
+</span>
+system<span class="p">.</span>hasOwnProperty<span class="p">(</span><span class="s2">"username"</span><span class="p">)</span><span class="p">;</span>             <span class="c1">// Evaluates to true.
+</span>system<span class="p">.</span>hasOwnProperty<span class="p">(</span><span class="s2">"loginTime"</span><span class="p">)</span><span class="p">;</span>            <span class="c1">// Evaluates to false.
+</span>System<span class="p">.</span>prototype<span class="p">.</span>hasOwnProperty<span class="p">(</span><span class="s2">"username"</span><span class="p">)</span><span class="p">;</span>   <span class="c1">// Evaluates to false.
+</span>System<span class="p">.</span>prototype<span class="p">.</span>hasOwnProperty<span class="p">(</span><span class="s2">"loginTime"</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// Evaluates to true.
+</span>
 <span class="k">try</span> <span class="p">{</span>
-  <span class="c1">// This call would fail, since the property is non-configurable.</span>
-  <span class="nb">Object</span><span class="p">.</span><span class="nx">defineProperty</span><span class="p">(</span><span class="nx">system</span><span class="p">,</span> <span class="s2">"username"</span><span class="p">,</span> <span class="p">{</span> <span class="nx">value</span><span class="o">:</span> <span class="s2">"administrator"</span> <span class="p">});</span>
-<span class="p">}</span> <span class="k">catch</span> <span class="p">(</span><span class="nx">e</span><span class="p">)</span> <span class="p">{</span> <span class="p">}</span>
+  <span class="c1">// This call would fail, since the property is non-configurable.
+</span>  Object<span class="p">.</span>defineProperty<span class="p">(</span>system<span class="p">,</span> <span class="s2">"username"</span><span class="p">,</span> <span class="p">{</span> value<span class="o">:</span> <span class="s2">"administrator"</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
+<span class="p">}</span> <span class="k">catch</span> <span class="p">(</span>e<span class="p">)</span> <span class="p">{</span> <span class="p">}</span>
 
-<span class="c1">// This defineProperty call would succeed, because System.prototype.loginTime</span>
-<span class="c1">// is configurable.</span>
-<span class="kd">var</span> <span class="nx">forgedLoginTime</span> <span class="o">=</span> <span class="mi">5</span><span class="p">;</span>
-<span class="nb">Object</span><span class="p">.</span><span class="nx">defineProperty</span><span class="p">(</span><span class="nx">System</span><span class="p">.</span><span class="nx">prototype</span><span class="p">,</span> <span class="s2">"loginTime"</span><span class="p">,</span> <span class="p">{</span> <span class="nx">value</span><span class="o">:</span> <span class="nx">forgedLoginTime</span> <span class="p">});</span>
+<span class="c1">// This defineProperty call would succeed, because System.prototype.loginTime
+</span><span class="c1">// is configurable.
+</span><span class="kd">var</span> forgedLoginTime <span class="o">=</span> <span class="mi">5</span><span class="p">;</span>
+Object<span class="p">.</span>defineProperty<span class="p">(</span>System<span class="p">.</span>prototype<span class="p">,</span> <span class="s2">"loginTime"</span><span class="p">,</span> <span class="p">{</span> value<span class="o">:</span> forgedLoginTime <span class="p">}</span><span class="p">)</span><span class="p">;</span>
 
-<span class="nx">system</span><span class="p">.</span><span class="nx">loginTime</span><span class="p">;</span>  <span class="c1">// So this now evaluates to forgedLoginTime.</span></pre>
+system<span class="p">.</span>loginTime<span class="p">;</span>  <span class="c1">// So this now evaluates to forgedLoginTime.
+</span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.21" data-lt="Unscopable" id="Unscopable"><span class="secno">3.3.21. </span><span class="content">[Unscopable]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-1">Unscopable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-81">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-10">regular attribute</a> or <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-12">regular operation</a>, it
@@ -9189,11 +9226,12 @@ anything other than a <a data-link-type="dfn" href="#dfn-regular-attribute" id="
 </pre>
     <p>the “f” property an be referenced with a bare identifier
     in a <code>with</code> statement but the “g” property cannot:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">thing</span> <span class="o">=</span> <span class="nx">getThing</span><span class="p">();</span>  <span class="c1">// An instance of Thing</span>
-<span class="kd">with</span> <span class="p">(</span><span class="nx">thing</span><span class="p">)</span> <span class="p">{</span>
-  <span class="nx">f</span><span class="p">;</span>                     <span class="c1">// Evaluates to a Function object.</span>
-  <span class="nx">g</span><span class="p">;</span>                     <span class="c1">// Throws a ReferenceError.</span>
-<span class="p">}</span></pre>
+<pre class="highlight"><span class="kd">var</span> thing <span class="o">=</span> getThing<span class="p">(</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// An instance of Thing
+</span><span class="kd">with</span> <span class="p">(</span>thing<span class="p">)</span> <span class="p">{</span>
+  f<span class="p">;</span>                     <span class="c1">// Evaluates to a Function object.
+</span>  g<span class="p">;</span>                     <span class="c1">// Throws a ReferenceError.
+</span><span class="p">}</span>
+</pre>
    </div>
    <h3 class="heading settled" data-level="3.4" id="es-security"><span class="secno">3.4. </span><span class="content">Security</span><a class="self-link" href="#es-security"></a></h3>
    <p>Certain algorithms in the sections below are defined to <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-perform-a-security-check">perform a security check</dfn> on a given
@@ -9677,7 +9715,7 @@ and is described in more detail in <a href="#interface-prototype-object">§3.6.3
 such an interface object.</p>
    <p>The internal [[Prototype]] property
 of an interface object for a callback interface must be
-the Object.prototype object.</p>
+the Function.prototype object.</p>
    <p class="note" role="note">Note: Remember that interface objects for callback interfaces only exist if they have <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-23">constants</a> declared on them;
 when they do exist, they are not <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-5">function objects</a>.</p>
    <h5 class="heading settled" data-level="3.6.1.1" id="es-interface-call"><span class="secno">3.6.1.1. </span><span class="content">Interface object [[Call]] method</span><a class="self-link" href="#es-interface-call"></a></h5>
@@ -12517,19 +12555,20 @@ optional user agent-defined message <var>M</var>.</p>
     <p>If we pass a <code class="idl">MathUtils</code> object from
     a different global environment to doComputation, then the exception
     thrown will be from that global environment:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="nx">getA</span><span class="p">();</span>                           <span class="c1">// An A object from this global environment.</span>
-<span class="kd">var</span> <span class="nx">m</span> <span class="o">=</span> <span class="nx">otherWindow</span><span class="p">.</span><span class="nx">getMathUtils</span><span class="p">();</span>       <span class="c1">// A MathUtils object from a different global environment.</span>
-
-<span class="nx">a</span> <span class="k">instanceof</span> <span class="nb">Object</span><span class="p">;</span>                      <span class="c1">// Evaluates to true.</span>
-<span class="nx">m</span> <span class="k">instanceof</span> <span class="nb">Object</span><span class="p">;</span>                      <span class="c1">// Evaluates to false.</span>
-<span class="nx">m</span> <span class="k">instanceof</span> <span class="nx">otherWindow</span><span class="p">.</span><span class="nb">Object</span><span class="p">;</span>          <span class="c1">// Evaluates to true.</span>
-
+<pre class="highlight"><span class="kd">var</span> a <span class="o">=</span> getA<span class="p">(</span><span class="p">)</span><span class="p">;</span>                           <span class="c1">// An A object from this global environment.
+</span><span class="kd">var</span> m <span class="o">=</span> otherWindow<span class="p">.</span>getMathUtils<span class="p">(</span><span class="p">)</span><span class="p">;</span>       <span class="c1">// A MathUtils object from a different global environment.
+</span>
+a <span class="k">instanceof</span> Object<span class="p">;</span>                      <span class="c1">// Evaluates to true.
+</span>m <span class="k">instanceof</span> Object<span class="p">;</span>                      <span class="c1">// Evaluates to false.
+</span>m <span class="k">instanceof</span> otherWindow<span class="p">.</span>Object<span class="p">;</span>          <span class="c1">// Evaluates to true.
+</span>
 <span class="k">try</span> <span class="p">{</span>
-  <span class="nx">a</span><span class="p">.</span><span class="nx">doComputation</span><span class="p">(</span><span class="nx">m</span><span class="p">,</span> <span class="o">-</span><span class="mi">1</span><span class="p">);</span>
-<span class="p">}</span> <span class="k">catch</span> <span class="p">(</span><span class="nx">e</span><span class="p">)</span> <span class="p">{</span>
-  <span class="nx">e</span> <span class="k">instanceof</span> <span class="nx">DOMException</span><span class="p">;</span>              <span class="c1">// Evaluates to false.</span>
-  <span class="nx">e</span> <span class="k">instanceof</span> <span class="nx">otherWindow</span><span class="p">.</span><span class="nx">DOMException</span><span class="p">;</span>  <span class="c1">// Evaluates to true.</span>
-<span class="p">}</span></pre>
+  a<span class="p">.</span>doComputation<span class="p">(</span>m<span class="p">,</span> <span class="o">-</span><span class="mi">1</span><span class="p">)</span><span class="p">;</span>
+<span class="p">}</span> <span class="k">catch</span> <span class="p">(</span>e<span class="p">)</span> <span class="p">{</span>
+  e <span class="k">instanceof</span> DOMException<span class="p">;</span>              <span class="c1">// Evaluates to false.
+</span>  e <span class="k">instanceof</span> otherWindow<span class="p">.</span>DOMException<span class="p">;</span>  <span class="c1">// Evaluates to true.
+</span><span class="p">}</span>
+</pre>
    </div>
    <p>Any requirements in this document to throw an instance of an ECMAScript built-in <emu-val>Error</emu-val> must use
 the built-in from the <a data-link-type="dfn" href="#dfn-current-global-environment" id="ref-for-dfn-current-global-environment-3">current global environment</a>.</p>
@@ -12556,31 +12595,32 @@ not caught there, to its caller, and so on.</p>
 </pre>
     <p>Assuming an ECMAScript implementation supporting this interface,
     the following code demonstrates how exceptions are handled:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">d</span> <span class="o">=</span> <span class="nx">getDahut</span><span class="p">();</span>              <span class="c1">// Obtain an instance of Dahut.</span>
-<span class="kd">var</span> <span class="nx">et</span> <span class="o">=</span> <span class="nx">getExceptionThrower</span><span class="p">();</span>  <span class="c1">// Obtain an instance of ExceptionThrower.</span>
+<pre class="highlight"><span class="kd">var</span> d <span class="o">=</span> getDahut<span class="p">(</span><span class="p">)</span><span class="p">;</span>              <span class="c1">// Obtain an instance of Dahut.
+</span><span class="kd">var</span> et <span class="o">=</span> getExceptionThrower<span class="p">(</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// Obtain an instance of ExceptionThrower.
+</span>
+<span class="k">try</span> <span class="p">{</span>
+  d<span class="p">.</span>type <span class="o">=</span> <span class="p">{</span> toString<span class="o">:</span> <span class="kd">function</span><span class="p">(</span><span class="p">)</span> <span class="p">{</span> <span class="k">throw</span> <span class="s2">"abc"</span><span class="p">;</span> <span class="p">}</span> <span class="p">}</span><span class="p">;</span>
+<span class="p">}</span> <span class="k">catch</span> <span class="p">(</span>e<span class="p">)</span> <span class="p">{</span>
+  <span class="c1">// The string "abc" is caught here, since as part of the conversion
+</span>  <span class="c1">// from the native object to a string, the anonymous function
+</span>  <span class="c1">// was invoked, and none of the [[DefaultValue]], ToPrimitive or
+</span>  <span class="c1">// ToString algorithms are defined to catch the exception.
+</span><span class="p">}</span>
 
 <span class="k">try</span> <span class="p">{</span>
-  <span class="nx">d</span><span class="p">.</span><span class="nx">type</span> <span class="o">=</span> <span class="p">{</span> <span class="nx">toString</span><span class="o">:</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span> <span class="k">throw</span> <span class="s2">"abc"</span><span class="p">;</span> <span class="p">}</span> <span class="p">};</span>
-<span class="p">}</span> <span class="k">catch</span> <span class="p">(</span><span class="nx">e</span><span class="p">)</span> <span class="p">{</span>
-  <span class="c1">// The string "abc" is caught here, since as part of the conversion</span>
-  <span class="c1">// from the native object to a string, the anonymous function</span>
-  <span class="c1">// was invoked, and none of the [[DefaultValue]], ToPrimitive or</span>
-  <span class="c1">// ToString algorithms are defined to catch the exception.</span>
-<span class="p">}</span>
+  d<span class="p">.</span>type <span class="o">=</span> <span class="p">{</span> toString<span class="o">:</span> <span class="p">{</span> <span class="p">}</span> <span class="p">}</span><span class="p">;</span>
+<span class="p">}</span> <span class="k">catch</span> <span class="p">(</span>e<span class="p">)</span> <span class="p">{</span>
+  <span class="c1">// An exception is caught here, since an attempt is made to invoke
+</span>  <span class="c1">// [[Call]] on the native object that is the value of toString
+</span>  <span class="c1">// property.
+</span><span class="p">}</span>
 
-<span class="k">try</span> <span class="p">{</span>
-  <span class="nx">d</span><span class="p">.</span><span class="nx">type</span> <span class="o">=</span> <span class="p">{</span> <span class="nx">toString</span><span class="o">:</span> <span class="p">{</span> <span class="p">}</span> <span class="p">};</span>
-<span class="p">}</span> <span class="k">catch</span> <span class="p">(</span><span class="nx">e</span><span class="p">)</span> <span class="p">{</span>
-  <span class="c1">// An exception is caught here, since an attempt is made to invoke</span>
-  <span class="c1">// [[Call]] on the native object that is the value of toString</span>
-  <span class="c1">// property.</span>
-<span class="p">}</span>
-
-<span class="nx">d</span><span class="p">.</span><span class="nx">type</span> <span class="o">=</span> <span class="nx">et</span><span class="p">;</span>
-<span class="c1">// An uncaught NotSupportedError DOMException is thrown here, since the</span>
-<span class="c1">// [[DefaultValue]] algorithm attempts to get the value of the</span>
-<span class="c1">// "valueOf" property on the ExceptionThrower object.  The exception</span>
-<span class="c1">// propagates out of this block of code.</span></pre>
+d<span class="p">.</span>type <span class="o">=</span> et<span class="p">;</span>
+<span class="c1">// An uncaught NotSupportedError DOMException is thrown here, since the
+</span><span class="c1">// [[DefaultValue]] algorithm attempts to get the value of the
+</span><span class="c1">// "valueOf" property on the ExceptionThrower object.  The exception
+</span><span class="c1">// propagates out of this block of code.
+</span></pre>
    </div>
    <h2 class="heading settled" data-level="4" id="common"><span class="secno">4. </span><span class="content">Common definitions</span><a class="self-link" href="#common"></a></h2>
    <p>This section specifies some common definitions that all <a data-link-type="dfn" href="#dfn-conforming-implementation" id="ref-for-dfn-conforming-implementation-1">conforming implementations</a> must support.</p>
@@ -12841,8 +12881,9 @@ including the ! and ? notation for unwrapping completion records.</p>
   <span class="kt">attribute</span> <span class="kt">long</span> <span class="nv">something</span>;
 };
 </pre>
-<pre class="highlight"><span></span><span class="c1">// This is an ECMAScript code block.</span>
-<span class="nb">window</span><span class="p">.</span><span class="nx">onload</span> <span class="o">=</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span> <span class="nb">window</span><span class="p">.</span><span class="nx">alert</span><span class="p">(</span><span class="s2">"loaded"</span><span class="p">);</span> <span class="p">};</span></pre>
+<pre class="highlight"><span class="c1">// This is an ECMAScript code block.
+</span>window<span class="p">.</span>onload <span class="o">=</span> <span class="kd">function</span><span class="p">(</span><span class="p">)</span> <span class="p">{</span> window<span class="p">.</span>alert<span class="p">(</span><span class="s2">"loaded"</span><span class="p">)</span><span class="p">;</span> <span class="p">}</span><span class="p">;</span>
+</pre>
    </ul>
    <h2 class="no-num heading settled" id="conformance"><span class="content">Conformance</span><span id="conformant-algorithms"></span><a class="self-link" href="#conformance"></a></h2>
    <p>Everything in this specification is normative except for diagrams,
@@ -13523,7 +13564,7 @@ language binding.</p>
    <dt id="biblio-rfc3629">[RFC3629]
    <dd>F. Yergeau. <a href="https://tools.ietf.org/html/rfc3629">UTF-8, a transformation format of ISO 10646</a>. November 2003. Internet Standard. URL: <a href="https://tools.ietf.org/html/rfc3629">https://tools.ietf.org/html/rfc3629</a>
    <dt id="biblio-secure-contexts">[SECURE-CONTEXTS]
-   <dd>Mike West. <a href="https://w3c.github.io/webappsec-secure-contexts/">Secure Contexts</a>. 19 July 2016. WD. URL: <a href="https://w3c.github.io/webappsec-secure-contexts/">https://w3c.github.io/webappsec-secure-contexts/</a>
+   <dd>Mike West. <a href="https://w3c.github.io/webappsec-secure-contexts/">Secure Contexts</a>. 15 September 2016. CR. URL: <a href="https://w3c.github.io/webappsec-secure-contexts/">https://w3c.github.io/webappsec-secure-contexts/</a>
    <dt id="biblio-unicode">[UNICODE]
    <dd><a href="http://www.unicode.org/versions/latest/">The Unicode Standard</a>. URL: <a href="http://www.unicode.org/versions/latest/">http://www.unicode.org/versions/latest/</a>
   </dl>


### PR DESCRIPTION
… not Object.prototype.

Fixes #96.  Recent versions of Chrome, Firefox, and Edge all say
Object.getPrototypeOf(NodeFilter) === Function.prototype, whereas the
spec says Object.prototype.  nox reports in #83 that Safari does not
return Function.prototype here, but doesn't say what it does return.  It
seems the spec should match the majority of browsers, unless there's
some good reason not to.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
    
    Don't remove this comment or modify anything below this line.
-->
<hr />
[Preview](https://rawgit.com/ayg/webidl/callback-prototype/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fheycam.github.io%2Fwebidl%2F&doc2=https%3A%2F%2Frawgit.com%2Fayg%2Fwebidl%2Fcallback-prototype%2Findex.html) 
