### PR TITLE
Consolidate issue tracking links in the header under "Feedback"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7,18 +7,8 @@ Group: webplatform
 Mailing list: public-script-coord@w3.org
 Mailing List Archives: https://lists.w3.org/Archives/Public/public-script-coord/
 Repository: heycam/webidl
-!Participate: <a href="https://github.com/heycam/webidl">GitHub</a> (<a href="https://github.com/heycam/webidl/issues/new">new issue</a>, <a href="https://github.com/heycam/webidl/issues">open issues</a>, <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=WebIDL&amp;resolution=---">legacy bug tracker</a>)
+!Feedback: <a href="https://github.com/heycam/webidl">GitHub</a> (<a href="https://github.com/heycam/webidl/issues/new">new issue</a>, <a href="https://github.com/heycam/webidl/issues">open issues</a>, <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=WebIDL&amp;resolution=---">legacy bug tracker</a>)
 ED: https://heycam.github.io/webidl/
-<!--TR: http://www.w3.org/TR/WebIDL/
-Previous Version: http://www.w3.org/TR/2012/CR-WebIDL-20120419/
-Previous Version: http://www.w3.org/TR/2012/WD-WebIDL-20120207/
-Previous Version: http://www.w3.org/TR/2011/WD-WebIDL-20110927/
-Previous Version: http://www.w3.org/TR/2011/WD-WebIDL-20110712/
-Previous Version: http://www.w3.org/TR/2010/WD-WebIDL-20101021/
-Previous Version: http://www.w3.org/TR/2008/WD-WebIDL-20081219/
-Previous Version: http://www.w3.org/TR/2008/WD-WebIDL-20080829/
-Previous Version: http://www.w3.org/TR/2008/WD-DOM-Bindings-20080410/
-Previous Version: http://www.w3.org/TR/2007/WD-DOM-Bindings-20071017/ -->
 Editor: Cameron McCormack, Mozilla Corporation, http://mcc.id.au/, cam@mcc.id.au
 Editor: Boris Zbarsky, Mozilla Corporation, bzbarsky@mit.edu
 Abstract: This document defines an interface definition language, Web IDL,
@@ -34,7 +24,7 @@ Abstract: and that newly published specifications reference this
 Abstract: document to ensure conforming implementations of interfaces
 Abstract: are interoperable.
 Ignored Vars: callback, op, ownDesc, exampleVariableName, target, f, g
-Boilerplate: omit issues-index, omit conformance
+Boilerplate: omit issues-index, omit conformance, omit feedback-header
 </pre>
 
 <pre class="anchors">

--- a/index.html
+++ b/index.html
@@ -1551,13 +1551,10 @@ pre.idl.highlight { color: #708090; }
      <dd><a class="u-url" href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
      <dt>Feedback:
      <dd><span><a href="mailto:public-script-coord@w3.org?subject=%5BWebIDL%5D%20YOUR%20TOPIC%20HERE">public-script-coord@w3.org</a> with subject line “<kbd>[WebIDL] <i data-lt="">… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-script-coord/" rel="discussion">archives</a>)</span>
-     <dt>Issue Tracking:
-     <dd><a href="https://github.com/heycam/webidl/issues/">GitHub</a>
+     <dd><span><a href="https://github.com/heycam/webidl">GitHub</a> (<a href="https://github.com/heycam/webidl/issues/new">new issue</a>, <a href="https://github.com/heycam/webidl/issues">open issues</a>, <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=WebIDL&amp;resolution=---">legacy bug tracker</a>)</span>
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-url url" href="http://mcc.id.au/">Cameron McCormack</a> (<span class="p-org org">Mozilla Corporation</span>) <a class="u-email email" href="mailto:cam@mcc.id.au">cam@mcc.id.au</a>
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:bzbarsky@mit.edu">Boris Zbarsky</a> (<span class="p-org org">Mozilla Corporation</span>)
-     <dt>Participate:
-     <dd><span><a href="https://github.com/heycam/webidl">GitHub</a> (<a href="https://github.com/heycam/webidl/issues/new">new issue</a>, <a href="https://github.com/heycam/webidl/issues">open issues</a>, <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=WebIDL&amp;resolution=---">legacy bug tracker</a>)</span>
     </dl>
    </div>
    <div data-fill-with="warning"></div>


### PR DESCRIPTION
I would have liked to get rid of the always-redundant "This version:" but Bikeshed won't let you do that for anything that's marked as an ED (instead of a LS).