### PR TITLE
Change the named property visibility algorithm so that existing own props always make corresponding named props invisible.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12200,16 +12200,14 @@ depending on whether the [{{OverrideBuiltins}}]
 operates as follows, with property name |P| and object |O|:
 
 <ol class="algorithm">
-    1.  If |P| is an [=unforgeable property name=]
-        on |O|, then return false.
-    1.  If |O| implements an [=interface=] with
-        an [{{Unforgeable}}]-annotated [=attribute=]
-        whose [=identifier=] is |P|, then return false.
     1.  If |P| is not a [=supported property name=]
         of |O|, then return false.
+    1.  If |O| has an own property named |P|, then return false.
+
+          Note: This will include cases in which |O| has unforgeable properties, because in practice those are always set up before objects have any supported property names, and once set up will make the corresponding named properties invisible.
+
     1.  If |O| implements an interface that has the [{{OverrideBuiltins}}]
         [=extended attribute=], then return true.
-    1.  If |O| has an own property named |P|, then return false.
     1.  Initialize |prototype| to be the value of the internal \[[Prototype]] property of |O|.
     1.  While |prototype| is not null:
         1.  If |prototype| is not a [=named properties object=],
@@ -12223,16 +12221,12 @@ operates as follows, with property name |P| and object |O|:
     This should ensure that for objects with named properties, property resolution is done in the following order:
 
     1.  Indexed properties.
-    1.  Unforgeable attributes and operations.
+    1.  Own properties, including unforgeable attributes and operations.
     1.  Then, if [{{OverrideBuiltins}}]:
         1.  Named properties.
-        1.  Own properties.
         1.  Properties from the prototype chain.
     1.  Otherwise, if not [{{OverrideBuiltins}}]:
-        1.  Own properties.
-
         1.  Properties from the prototype chain.
-
         1.  Named properties.
 
 </div>

--- a/index.html
+++ b/index.html
@@ -1544,7 +1544,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web IDL</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-09-09">9 September 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-09-11">11 September 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1963,7 +1963,7 @@ including the ! and ? notation for unwrapping completion records.</p>
   <span class="kt">attribute</span> <span class="kt">long</span> <span class="nv">something</span>;
 };
 </pre>
-<pre class="highlight"><span></span><span class="c1">// This is an ECMAScript code block.</span>
+<pre class="highlight"><span class="c1">// This is an ECMAScript code block.</span>
 <span class="nb">window</span><span class="p">.</span><span class="nx">onload</span> <span class="o">=</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span> <span class="nb">window</span><span class="p">.</span><span class="nx">alert</span><span class="p">(</span><span class="s2">"loaded"</span><span class="p">);</span> <span class="p">};</span></pre>
    </ul>
    <h2 class="heading settled" data-level="2" id="conformance"><span class="secno">2. </span><span class="content">Conformance</span><a class="self-link" href="#conformance"></a></h2>
@@ -2397,7 +2397,7 @@ be defined on a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-f
 };
 </pre>
     <p>to be used like this:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="nx">getA</span><span class="p">();</span>  <span class="c1">// Get an instance of A.</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="nx">getA</span><span class="p">();</span>  <span class="c1">// Get an instance of A.</span>
 
 <span class="nx">a</span><span class="p">.</span><span class="nx">doTask</span><span class="p">(</span><span class="s2">"something"</span><span class="p">,</span> <span class="p">{</span> <span class="nx">option1</span><span class="o">:</span> <span class="s2">"banana"</span><span class="p">,</span> <span class="nx">option3</span><span class="o">:</span> <span class="mi">100</span> <span class="p">});</span></pre>
     <p>instead write the following:</p>
@@ -2538,7 +2538,7 @@ in the language.</p>
 </pre>
     <p>Since the <code class="idl">EventListener</code> interface is annotated
     callback interface, <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-3">user objects</a> can implement it:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">node</span> <span class="o">=</span> <span class="nx">getNode</span><span class="p">();</span>                                <span class="c1">// Obtain an instance of Node.</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">node</span> <span class="o">=</span> <span class="nx">getNode</span><span class="p">();</span>                                <span class="c1">// Obtain an instance of Node.</span>
 
 <span class="kd">var</span> <span class="nx">listener</span> <span class="o">=</span> <span class="p">{</span>
   <span class="nx">handleEvent</span><span class="o">:</span> <span class="kd">function</span><span class="p">(</span><span class="nx">event</span><span class="p">)</span> <span class="p">{</span>
@@ -2549,7 +2549,7 @@ in the language.</p>
 
 <span class="nx">node</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"click"</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span> <span class="p">...</span> <span class="p">});</span>  <span class="c1">// As does this.</span></pre>
     <p>It is not possible for a user object to implement <code class="idl">Node</code>, however:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">node</span> <span class="o">=</span> <span class="nx">getNode</span><span class="p">();</span>  <span class="c1">// Obtain an instance of Node.</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">node</span> <span class="o">=</span> <span class="nx">getNode</span><span class="p">();</span>  <span class="c1">// Obtain an instance of Node.</span>
 
 <span class="kd">var</span> <span class="nx">newNode</span> <span class="o">=</span> <span class="p">{</span>
   <span class="nx">nodeName</span><span class="o">:</span> <span class="s2">"span"</span><span class="p">,</span>
@@ -3010,7 +3010,7 @@ defined in this specification) and <a data-link-type="dfn" href="#dfn-callback-f
 </pre>
     <p>In the ECMAScript binding, variadic operations are implemented by
     functions that can accept the subsequent arguments:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">s</span> <span class="o">=</span> <span class="nx">getIntegerSet</span><span class="p">();</span>  <span class="c1">// Obtain an instance of IntegerSet.</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">s</span> <span class="o">=</span> <span class="nx">getIntegerSet</span><span class="p">();</span>  <span class="c1">// Obtain an instance of IntegerSet.</span>
 
 <span class="nx">s</span><span class="p">.</span><span class="nx">union</span><span class="p">();</span>                <span class="c1">// Passing no arguments corresponding to 'ints'.</span>
 <span class="nx">s</span><span class="p">.</span><span class="nx">union</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">4</span><span class="p">,</span> <span class="mi">7</span><span class="p">);</span>         <span class="c1">// Passing three arguments corresponding to 'ints'.</span></pre>
@@ -3325,7 +3325,7 @@ as if it were a function.</p>
 </pre>
     <p>An ECMAScript implementation supporting this interface would
     allow a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-2">platform object</a> that implements <code class="idl">NumberQuadrupler</code> to be called as a function:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">f</span> <span class="o">=</span> <span class="nx">getNumberQuadrupler</span><span class="p">();</span>  <span class="c1">// Obtain an instance of NumberQuadrupler.</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">f</span> <span class="o">=</span> <span class="nx">getNumberQuadrupler</span><span class="p">();</span>  <span class="c1">// Obtain an instance of NumberQuadrupler.</span>
 
 <span class="nx">f</span><span class="p">.</span><span class="nx">compute</span><span class="p">(</span><span class="mi">3</span><span class="p">);</span>                   <span class="c1">// This evaluates to 12.</span>
 <span class="nx">f</span><span class="p">(</span><span class="mi">3</span><span class="p">);</span>                           <span class="c1">// This also evaluates to 12.</span></pre>
@@ -3398,7 +3398,7 @@ a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-at
     <p>In the ECMAScript binding, using a <code class="idl">Student</code> object in a context where a string is expected will result in the
     value of the object’s “name” property being
     used:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">s</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Student</span><span class="p">();</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">s</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Student</span><span class="p">();</span>
 <span class="nx">s</span><span class="p">.</span><span class="nx">id</span> <span class="o">=</span> <span class="mi">12345678</span><span class="p">;</span>
 <span class="nx">s</span><span class="p">.</span><span class="nx">name</span> <span class="o">=</span> <span class="s1">'周杰倫'</span><span class="p">;</span>
 
@@ -3425,7 +3425,7 @@ a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-at
         the <code class="idl">familyName</code> attribute.</p>
     </blockquote>
     <p>An ECMAScript implementation of the IDL would behave as follows:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">s</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Student</span><span class="p">();</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">s</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Student</span><span class="p">();</span>
 <span class="nx">s</span><span class="p">.</span><span class="nx">id</span> <span class="o">=</span> <span class="mi">12345679</span><span class="p">;</span>
 <span class="nx">s</span><span class="p">.</span><span class="nx">familyName</span> <span class="o">=</span> <span class="s1">'Smithee'</span><span class="p">;</span>
 <span class="nx">s</span><span class="p">.</span><span class="nx">givenName</span> <span class="o">=</span> <span class="s1">'Alan'</span><span class="p">;</span>
@@ -3804,7 +3804,7 @@ and whose value is the <a data-link-type="dfn" href="#dfn-serialized-value" id="
 };
 </pre>
     <p>In the ECMAScript language binding, there would exist a <code>toJSON</code> method on <code class="idl">Transaction</code> objects:</p>
-<pre class="highlight"><span></span><span class="c1">// Get an instance of Transaction.</span>
+<pre class="highlight"><span class="c1">// Get an instance of Transaction.</span>
 <span class="kd">var</span> <span class="nx">txn</span> <span class="o">=</span> <span class="nx">getTransaction</span><span class="p">();</span>
 
 <span class="c1">// Evaluates to an object like this:</span>
@@ -3868,7 +3868,7 @@ by a description of how to <dfn class="dfn-paneled" data-dfn-type="dfn" data-exp
     <p>Assume that an object implementing <code class="idl">A</code> has <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-3">supported property indices</a> in the range 0 ≤ <var>index</var> &lt; 2.  Also assume that toWord is defined to return
     its argument converted into an English word.  The behavior when invoking the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-14">operation</a> with an out of range index
     is different from indexing the object directly:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="nx">getA</span><span class="p">();</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="nx">getA</span><span class="p">();</span>
 
 <span class="nx">a</span><span class="p">.</span><span class="nx">toWord</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span>  <span class="c1">// Evalautes to "zero".</span>
 <span class="nx">a</span><span class="p">[</span><span class="mi">0</span><span class="p">];</span>         <span class="c1">// Also evaluates to "zero".</span>
@@ -3910,7 +3910,7 @@ by a description of how to <dfn class="dfn-paneled" data-dfn-type="dfn" data-exp
     These properties can then be used to interact
     with the object in the same way as invoking the object’s
     methods, as demonstrated below:</p>
-<pre class="highlight"><span></span><span class="c1">// Assume map is a platform object implementing the OrderedMap interface.</span>
+<pre class="highlight"><span class="c1">// Assume map is a platform object implementing the OrderedMap interface.</span>
 <span class="kd">var</span> <span class="nx">map</span> <span class="o">=</span> <span class="nx">getOrderedMap</span><span class="p">();</span>
 <span class="kd">var</span> <span class="nx">x</span><span class="p">,</span> <span class="nx">y</span><span class="p">;</span>
 
@@ -4027,7 +4027,7 @@ declared on <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-d
 };
 </pre>
     <p>In the ECMAScript language binding, the <emu-val>Function</emu-val> object for <code>triangulate</code> and the accessor property for <code>triangulationCount</code> will exist on the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-1">interface object</a> for <code class="idl">Circle</code>:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">circles</span> <span class="o">=</span> <span class="nx">getCircles</span><span class="p">();</span>           <span class="c1">// an Array of Circle objects</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">circles</span> <span class="o">=</span> <span class="nx">getCircles</span><span class="p">();</span>           <span class="c1">// an Array of Circle objects</span>
 
 <span class="k">typeof</span> <span class="nx">Circle</span><span class="p">.</span><span class="nx">triangulate</span><span class="p">;</span>            <span class="c1">// Evaluates to "function"</span>
 <span class="k">typeof</span> <span class="nx">Circle</span><span class="p">.</span><span class="nx">triangulationCount</span><span class="p">;</span>     <span class="c1">// Evaluates to "number"</span>
@@ -4605,7 +4605,7 @@ or have any <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for
     next value to be iterated over.  It has <code>values</code> and <code>entries</code> methods that iterate over the indexes of the list of session objects
     and [index, session object] pairs, respectively.  It also has
     a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> method that allows a <code class="idl">SessionManager</code> to be used in a <code>for..of</code> loop:</p>
-<pre class="highlight"><span></span><span class="c1">// Get an instance of SessionManager.</span>
+<pre class="highlight"><span class="c1">// Get an instance of SessionManager.</span>
 <span class="c1">// Assume that it has sessions for two users, "anna" and "brian".</span>
 <span class="kd">var</span> <span class="nx">sm</span> <span class="o">=</span> <span class="nx">getSessionManager</span><span class="p">();</span>
 
@@ -4625,7 +4625,7 @@ or have any <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for
 <span class="p">}</span>
 
 <span class="c1">// This loop will also alert "anna" and then "brian".</span>
-<span class="k">for</span> <span class="p">(</span><span class="kd">let</span> <span class="nx">session</span> <span class="k">of</span> <span class="nx">sm</span><span class="p">)</span> <span class="p">{</span>
+<span class="k">for</span> <span class="p">(</span><span class="kd">let</span> <span class="nx">session</span> <span class="nx">of</span> <span class="nx">sm</span><span class="p">)</span> <span class="p">{</span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">alert</span><span class="p">(</span><span class="nx">session</span><span class="p">.</span><span class="nx">username</span><span class="p">);</span>
 <span class="p">}</span></pre>
    </div>
@@ -4786,7 +4786,7 @@ namespaces.</p>
 };
 </pre>
     <p>An ECMAScript implementation would then expose a global property named <code>VectorUtils</code> which was a simple object (with prototype <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a>) with enumerable data properties for each declared operation:</p>
-<pre class="highlight"><span></span><span class="nb">Object</span><span class="p">.</span><span class="nx">getPrototypeOf</span><span class="p">(</span><span class="nx">VectorUtils</span><span class="p">);</span>                         <span class="c1">// Evaluates to Object.prototype.</span>
+<pre class="highlight"><span class="nb">Object</span><span class="p">.</span><span class="nx">getPrototypeOf</span><span class="p">(</span><span class="nx">VectorUtils</span><span class="p">);</span>                         <span class="c1">// Evaluates to Object.prototype.</span>
 <span class="nb">Object</span><span class="p">.</span><span class="nx">keys</span><span class="p">(</span><span class="nx">VectorUtils</span><span class="p">);</span>                                   <span class="c1">// Evaluates to ["dotProduct", "crossProduct"].</span>
 <span class="nb">Object</span><span class="p">.</span><span class="nx">getOwnPropertyDescriptor</span><span class="p">(</span><span class="nx">VectorUtils</span><span class="p">,</span> <span class="s2">"dotProduct"</span><span class="p">);</span> <span class="c1">// Evaluates to { value: &lt;a function>, enumerable: true, configurable: true, writable: true }.</span></pre>
    </div>
@@ -4942,7 +4942,7 @@ identifiers.</p>
 };
 </pre>
     <p>and this ECMAScript code:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">something</span> <span class="o">=</span> <span class="nx">getSomething</span><span class="p">();</span>  <span class="c1">// Get an instance of Something.</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">something</span> <span class="o">=</span> <span class="nx">getSomething</span><span class="p">();</span>  <span class="c1">// Get an instance of Something.</span>
 <span class="kd">var</span> <span class="nx">x</span> <span class="o">=</span> <span class="mi">0</span><span class="p">;</span>
 
 <span class="kd">var</span> <span class="nx">dict</span> <span class="o">=</span> <span class="p">{</span> <span class="p">};</span>
@@ -5013,7 +5013,7 @@ on that dictionary’s <a data-link-type="dfn" href="#dfn-inherited-dictionaries
 };
 </pre>
     <p>In an ECMAScript implementation of the IDL, an <emu-val>Object</emu-val> can be passed in for the optional <code class="idl">PaintOptions</code> dictionary:</p>
-<pre class="highlight"><span></span><span class="c1">// Get an instance of GraphicsContext.</span>
+<pre class="highlight"><span class="c1">// Get an instance of GraphicsContext.</span>
 <span class="kd">var</span> <span class="nx">ctx</span> <span class="o">=</span> <span class="nx">getGraphicsContext</span><span class="p">();</span>
 
 <span class="c1">// Draw a rectangle.</span>
@@ -5282,7 +5282,7 @@ results in an exception being thrown.</p>
     <p>An ECMAScript implementation would restrict the strings that can be
     assigned to the type property or passed to the initializeMeal function
     to those identified in the <a data-link-type="dfn" href="#dfn-enumeration" id="ref-for-dfn-enumeration-14">enumeration</a>.</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">meal</span> <span class="o">=</span> <span class="nx">getMeal</span><span class="p">();</span>                <span class="c1">// Get an instance of Meal.</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">meal</span> <span class="o">=</span> <span class="nx">getMeal</span><span class="p">();</span>                <span class="c1">// Get an instance of Meal.</span>
 
 <span class="nx">meal</span><span class="p">.</span><span class="nx">initialize</span><span class="p">(</span><span class="s2">"rice"</span><span class="p">,</span> <span class="mi">200</span><span class="p">);</span>        <span class="c1">// Operation invoked as normal.</span>
 
@@ -5327,7 +5327,7 @@ be used as the type of a <a data-link-type="dfn" href="#dfn-constant" id="ref-fo
 </pre>
     <p>In the ECMAScript language binding, a <emu-val>Function</emu-val> object is
     passed as the operation argument.</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">ops</span> <span class="o">=</span> <span class="nx">getAsyncOperations</span><span class="p">();</span>  <span class="c1">// Get an instance of AsyncOperations.</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">ops</span> <span class="o">=</span> <span class="nx">getAsyncOperations</span><span class="p">();</span>  <span class="c1">// Get an instance of AsyncOperations.</span>
 
 <span class="nx">ops</span><span class="p">.</span><span class="nx">performOperation</span><span class="p">(</span><span class="kd">function</span><span class="p">(</span><span class="nx">status</span><span class="p">)</span> <span class="p">{</span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">alert</span><span class="p">(</span><span class="s2">"Operation finished, status is "</span> <span class="o">+</span> <span class="nx">status</span> <span class="o">+</span> <span class="s2">"."</span><span class="p">);</span>
@@ -5467,7 +5467,7 @@ of those consequential interfaces or on the original interface itself.</p>
 </pre>
     <p>An ECMAScript implementation would thus have an “addEventListener”
     property in the prototype chain of every <code class="idl">Entry</code>:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">e</span> <span class="o">=</span> <span class="nx">getEntry</span><span class="p">();</span>          <span class="c1">// Obtain an instance of Entry.</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">e</span> <span class="o">=</span> <span class="nx">getEntry</span><span class="p">();</span>          <span class="c1">// Obtain an instance of Entry.</span>
 <span class="k">typeof</span> <span class="nx">e</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">;</span>  <span class="c1">// Evaluates to "function".</span></pre>
     <p>Note that it is not the case that all <code class="idl">Observable</code> objects implement <code class="idl">Entry</code>.</p>
    </div>
@@ -6362,10 +6362,10 @@ that same global environment.</p>
     multiple frames or windows are created.  Each frame or window will have
     its own set of <a data-link-type="dfn" href="#dfn-initial-object" id="ref-for-dfn-initial-object-2">initial objects</a>,
     which the following HTML document demonstrates:</p>
-<pre class="highlight"><span></span><span class="cp">&lt;!DOCTYPE html></span>
-<span class="p">&lt;</span><span class="nt">title</span><span class="p">></span>Different global environments<span class="p">&lt;/</span><span class="nt">title</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">id</span><span class="o">=</span><span class="s">a</span><span class="p">>&lt;/</span><span class="nt">iframe</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+<pre class="highlight"><span class="cp">&lt;!DOCTYPE html></span>
+<span class="nt">&lt;title></span>Different global environments<span class="nt">&lt;/title></span>
+<span class="nt">&lt;iframe</span> <span class="na">id=</span><span class="s">a</span><span class="nt">>&lt;/iframe></span>
+<span class="nt">&lt;script></span>
 <span class="kd">var</span> <span class="nx">iframe</span> <span class="o">=</span> <span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"a"</span><span class="p">);</span>
 <span class="kd">var</span> <span class="nx">w</span> <span class="o">=</span> <span class="nx">iframe</span><span class="p">.</span><span class="nx">contentWindow</span><span class="p">;</span>              <span class="c1">// The global object in the frame</span>
 
@@ -6375,7 +6375,7 @@ that same global environment.</p>
 <span class="nx">iframe</span> <span class="k">instanceof</span> <span class="nx">w</span><span class="p">.</span><span class="nb">Object</span><span class="p">;</span>                <span class="c1">// Evaluates to false</span>
 <span class="nx">iframe</span><span class="p">.</span><span class="nx">appendChild</span> <span class="k">instanceof</span> <span class="nb">Function</span><span class="p">;</span>    <span class="c1">// Evaluates to true</span>
 <span class="nx">iframe</span><span class="p">.</span><span class="nx">appendChild</span> <span class="k">instanceof</span> <span class="nx">w</span><span class="p">.</span><span class="nb">Function</span><span class="p">;</span>  <span class="c1">// Evaluates to false</span>
-<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span></pre>
+<span class="nt">&lt;/script></span></pre>
    </div>
    <p>Unless otherwise specified, each ECMAScript global environment <dfn class="dfn-paneled" data-dfn-for="ECMAScript global environment" data-dfn-type="dfn" data-export="" id="dfn-expose">exposes</dfn> all <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-53">interfaces</a> that the implementation supports.  If a given ECMAScript global environment does not
 expose an interface, then the requirements given in <a href="#es-interfaces">§4.6 Interfaces</a> are
@@ -7368,7 +7368,7 @@ at index <var>j</var> is <var>S</var><sub><var>j</var></sub>.</p>
     returned, and whenever an <emu-val>Array</emu-val> is
     passed to <code>drawPolygon</code> no reference
     will be kept after the call completes.</p>
-<pre class="highlight"><span></span><span class="c1">// Obtain an instance of Canvas.  Assume that getSupportedImageCodecs()</span>
+<pre class="highlight"><span class="c1">// Obtain an instance of Canvas.  Assume that getSupportedImageCodecs()</span>
 <span class="c1">// returns a sequence with two DOMString values: "image/png" and "image/svg+xml".</span>
 <span class="kd">var</span> <span class="nx">canvas</span> <span class="o">=</span> <span class="nx">getCanvas</span><span class="p">();</span>
 
@@ -7825,7 +7825,7 @@ types in <a href="#es-type-mapping">§4.2 ECMAScript type mapping</a> for the sp
 };
 </pre>
     <p>In an ECMAScript implementation of the IDL, a call to setColorClamped with <emu-val>Number</emu-val> values that are out of range for an <code class="idl"><a data-link-type="idl" href="#idl-octet" id="ref-for-idl-octet-14">octet</a></code> are clamped to the range [0, 255].</p>
-<pre class="highlight"><span></span><span class="c1">// Get an instance of GraphicsContext.</span>
+<pre class="highlight"><span class="c1">// Get an instance of GraphicsContext.</span>
 <span class="kd">var</span> <span class="nx">context</span> <span class="o">=</span> <span class="nx">getGraphicsContext</span><span class="p">();</span>
 
 <span class="c1">// Calling the non-[Clamp] version uses ToUint8 to coerce the Numbers to octets.</span>
@@ -7885,7 +7885,7 @@ for an interface is to be implemented.</p>
     return a new object that implements the interface.  It would take
     either zero or one argument.  The <code class="idl">NodeList</code> interface object would not
     have a [[Construct]] property.</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">x</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Circle</span><span class="p">();</span>      <span class="c1">// The uses the zero-argument constructor to create a</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">x</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Circle</span><span class="p">();</span>      <span class="c1">// The uses the zero-argument constructor to create a</span>
                            <span class="c1">// reference to a platform object that implements the</span>
                            <span class="c1">// Circle interface.</span>
 
@@ -7926,7 +7926,7 @@ types in <a href="#es-type-mapping">§4.2 ECMAScript type mapping</a> for the sp
 </pre>
     <p>In an ECMAScript implementation of the IDL, a call to setColorEnforcedRange with <emu-val>Number</emu-val> values that are out of range for an <code class="idl"><a data-link-type="idl" href="#idl-octet" id="ref-for-idl-octet-16">octet</a></code> will result in an exception being
     thrown.</p>
-<pre class="highlight"><span></span><span class="c1">// Get an instance of GraphicsContext.</span>
+<pre class="highlight"><span class="c1">// Get an instance of GraphicsContext.</span>
 <span class="kd">var</span> <span class="nx">context</span> <span class="o">=</span> <span class="nx">getGraphicsContext</span><span class="p">();</span>
 
 <span class="c1">// Calling the non-[EnforceRange] version uses ToUint8 to coerce the Numbers to octets.</span>
@@ -8107,7 +8107,7 @@ will correspond to properties on the object itself rather than on <a data-link-t
     <p>Placing properties corresponding to interface members on
     the object itself will mean that common feature detection
     methods like the following will work:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">indexedDB</span> <span class="o">=</span> <span class="nb">window</span><span class="p">.</span><span class="nx">indexedDB</span> <span class="o">||</span> <span class="nb">window</span><span class="p">.</span><span class="nx">webkitIndexedDB</span> <span class="o">||</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">indexedDB</span> <span class="o">=</span> <span class="nb">window</span><span class="p">.</span><span class="nx">indexedDB</span> <span class="o">||</span> <span class="nb">window</span><span class="p">.</span><span class="nx">webkitIndexedDB</span> <span class="o">||</span>
                 <span class="nb">window</span><span class="p">.</span><span class="nx">mozIndexedDB</span> <span class="o">||</span> <span class="nb">window</span><span class="p">.</span><span class="nx">msIndexedDB</span><span class="p">;</span>
 
 <span class="kd">var</span> <span class="nx">requestAnimationFrame</span> <span class="o">=</span> <span class="nb">window</span><span class="p">.</span><span class="nx">requestAnimationFrame</span> <span class="o">||</span>
@@ -8196,29 +8196,29 @@ corresponding to <a data-link-type="dfn" href="#dfn-interface-member" id="ref-fo
     <p>The following HTML document illustrates how the named properties on the <code class="idl">Window</code> object can be shadowed, and how
     the property for an attribute will not be replaced when declaring
     a variable of the same name:</p>
-<pre class="highlight"><span></span><span class="cp">&lt;!DOCTYPE html></span>
-<span class="p">&lt;</span><span class="nt">title</span><span class="p">></span>Variable declarations and assignments on Window<span class="p">&lt;/</span><span class="nt">title</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">name</span><span class="o">=</span><span class="s">abc</span><span class="p">>&lt;/</span><span class="nt">iframe</span><span class="p">></span>
+<pre class="highlight"><span class="cp">&lt;!DOCTYPE html></span>
+<span class="nt">&lt;title></span>Variable declarations and assignments on Window<span class="nt">&lt;/title></span>
+<span class="nt">&lt;iframe</span> <span class="na">name=</span><span class="s">abc</span><span class="nt">>&lt;/iframe></span>
 <span class="c">&lt;!-- Shadowing named properties --></span>
-<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+<span class="nt">&lt;script></span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">abc</span><span class="p">;</span>    <span class="c1">// Evaluates to the iframe’s Window object.</span>
   <span class="nx">abc</span> <span class="o">=</span> <span class="mi">1</span><span class="p">;</span>       <span class="c1">// Shadows the named property.</span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">abc</span><span class="p">;</span>    <span class="c1">// Evaluates to 1.</span>
-<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
+<span class="nt">&lt;/script></span>
 
 <span class="c">&lt;!-- Preserving properties for IDL attributes --></span>
-<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+<span class="nt">&lt;script></span>
   <span class="nx">Window</span><span class="p">.</span><span class="nx">prototype</span><span class="p">.</span><span class="nx">def</span> <span class="o">=</span> <span class="mi">2</span><span class="p">;</span>         <span class="c1">// Places a property on the prototype.</span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">hasOwnProperty</span><span class="p">(</span><span class="s2">"length"</span><span class="p">);</span>  <span class="c1">// Evaluates to true.</span>
   <span class="nx">length</span><span class="p">;</span>                           <span class="c1">// Evaluates to 1.</span>
   <span class="nx">def</span><span class="p">;</span>                              <span class="c1">// Evaluates to 2.</span>
-<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+<span class="nt">&lt;/script></span>
+<span class="nt">&lt;script></span>
   <span class="kd">var</span> <span class="nx">length</span><span class="p">;</span>                       <span class="c1">// Variable declaration leaves existing property.</span>
   <span class="nx">length</span><span class="p">;</span>                           <span class="c1">// Evaluates to 1.</span>
   <span class="kd">var</span> <span class="nx">def</span><span class="p">;</span>                          <span class="c1">// Variable declaration creates shadowing property.</span>
   <span class="nx">def</span><span class="p">;</span>                              <span class="c1">// Evaluates to undefined.</span>
-<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span></pre>
+<span class="nt">&lt;/script></span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.6" data-lt="LegacyArrayClass" id="LegacyArrayClass"><span class="secno">4.3.6. </span><span class="content">[LegacyArrayClass]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-3">LegacyArrayClass</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-57">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-64">interface</a> that is not defined to <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-12">inherit</a> from another, it indicates that the internal [[Prototype]]
@@ -8255,7 +8255,7 @@ entails.</p>
     <p>In an ECMAScript implementation of the above two interfaces,
     with appropriate definitions for getItem, setItem and removeItem, <emu-val>Array</emu-val> methods to inspect and
     modify the array-like object can be used.</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">list</span> <span class="o">=</span> <span class="nx">getItemList</span><span class="p">();</span>  <span class="c1">// Obtain an instance of ItemList.</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">list</span> <span class="o">=</span> <span class="nx">getItemList</span><span class="p">();</span>  <span class="c1">// Obtain an instance of ItemList.</span>
 
 <span class="nx">list</span><span class="p">.</span><span class="nx">concat</span><span class="p">();</span>             <span class="c1">// Clone the ItemList into an Array.</span>
 <span class="nx">list</span><span class="p">.</span><span class="nx">pop</span><span class="p">();</span>                <span class="c1">// Remove an item from the ItemList.</span>
@@ -8318,7 +8318,7 @@ is to be implemented.</p>
     <p>An ECMAScript implementation that supports this interface will
     have a setter on the accessor property that correspond to x,
     which allows any assignment to be ignored in strict mode.</p>
-<pre class="highlight"><span></span><span class="s2">"use strict"</span><span class="p">;</span>
+<pre class="highlight"><span class="s2">"use strict"</span><span class="p">;</span>
 
 <span class="kd">var</span> <span class="nx">example</span> <span class="o">=</span> <span class="nx">getExample</span><span class="p">();</span>  <span class="c1">// Get an instance of Example.</span>
 
@@ -8355,7 +8355,7 @@ is to be implemented.</p>
     <p>An ECMAScript implementation that supports this interface will
     allow the getter and setter of the accessor property that corresponds
     to x to be invoked with something other than an <code class="idl">Example</code> object.</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">example</span> <span class="o">=</span> <span class="nx">getExample</span><span class="p">();</span>  <span class="c1">// Get an instance of Example.</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">example</span> <span class="o">=</span> <span class="nx">getExample</span><span class="p">();</span>  <span class="c1">// Get an instance of Example.</span>
 <span class="kd">var</span> <span class="nx">obj</span> <span class="o">=</span> <span class="p">{</span> <span class="p">};</span>
 
 <span class="c1">// Fine.</span>
@@ -8408,7 +8408,7 @@ are to be implemented.</p>
 </pre>
     <p>An ECMAScript implementation that supports this interface will
     allow the construction of <code class="idl">HTMLAudioElement</code> objects using the <code class="idl">Audio</code> constructor.</p>
-<pre class="highlight"><span></span><span class="k">typeof</span> <span class="nx">Audio</span><span class="p">;</span>                   <span class="c1">// Evaluates to 'function'.</span>
+<pre class="highlight"><span class="k">typeof</span> <span class="nx">Audio</span><span class="p">;</span>                   <span class="c1">// Evaluates to 'function'.</span>
 
 <span class="kd">var</span> <span class="nx">a1</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Audio</span><span class="p">();</span>           <span class="c1">// Creates a new object that implements</span>
                                 <span class="c1">// HTMLAudioElement, using the zero-argument</span>
@@ -8482,7 +8482,7 @@ attribute specified.</p>
     <p>An ECMAScript implementation of the above IDL would allow
     manipulation of <code class="idl">Storage</code>’s
     prototype, but not <code class="idl">Query</code>’s.</p>
-<pre class="highlight"><span></span><span class="k">typeof</span> <span class="nx">Storage</span><span class="p">;</span>                        <span class="c1">// evaluates to "object"</span>
+<pre class="highlight"><span class="k">typeof</span> <span class="nx">Storage</span><span class="p">;</span>                        <span class="c1">// evaluates to "object"</span>
 
 <span class="c1">// Add some tracing alert() call to Storage.addEntry.</span>
 <span class="kd">var</span> <span class="nx">fn</span> <span class="o">=</span> <span class="nx">Storage</span><span class="p">.</span><span class="nx">prototype</span><span class="p">.</span><span class="nx">addEntry</span><span class="p">;</span>
@@ -8533,7 +8533,7 @@ the <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-na
     <p>In an ECMAScript implementation of these two interfaces,
     getting certain properties on objects implementing
     the interfaces will result in different values:</p>
-<pre class="highlight"><span></span><span class="c1">// Obtain an instance of StringMap.  Assume that it has "abc", "length" and</span>
+<pre class="highlight"><span class="c1">// Obtain an instance of StringMap.  Assume that it has "abc", "length" and</span>
 <span class="c1">// "toString" as supported property names.</span>
 <span class="kd">var</span> <span class="nx">map1</span> <span class="o">=</span> <span class="nx">getStringMap</span><span class="p">();</span>
 
@@ -8628,7 +8628,7 @@ is to be implemented.</p>
 </pre>
     <p>In the ECMAScript binding, this would allow assignments to the
     “name” property:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">p</span> <span class="o">=</span> <span class="nx">getPerson</span><span class="p">();</span>           <span class="c1">// Obtain an instance of Person.</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">p</span> <span class="o">=</span> <span class="nx">getPerson</span><span class="p">();</span>           <span class="c1">// Obtain an instance of Person.</span>
 
 <span class="nx">p</span><span class="p">.</span><span class="nx">name</span> <span class="o">=</span> <span class="s1">'John Citizen'</span><span class="p">;</span>       <span class="c1">// This statement...</span>
 <span class="nx">p</span><span class="p">.</span><span class="nx">name</span><span class="p">.</span><span class="nx">full</span> <span class="o">=</span> <span class="s1">'John Citizen'</span><span class="p">;</span>  <span class="c1">// ...has the same behavior as this one.</span></pre>
@@ -8667,7 +8667,7 @@ a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callbac
 </pre>
     <p>Assigning to the “value” property
     on a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-16">platform object</a> implementing <code class="idl">Counter</code> will shadow the property that corresponds to the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-53">attribute</a>:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">counter</span> <span class="o">=</span> <span class="nx">getCounter</span><span class="p">();</span>                              <span class="c1">// Obtain an instance of Counter.</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">counter</span> <span class="o">=</span> <span class="nx">getCounter</span><span class="p">();</span>                              <span class="c1">// Obtain an instance of Counter.</span>
 <span class="nx">counter</span><span class="p">.</span><span class="nx">value</span><span class="p">;</span>                                           <span class="c1">// Evaluates to 0.</span>
 
 <span class="nx">counter</span><span class="p">.</span><span class="nx">hasOwnProperty</span><span class="p">(</span><span class="s2">"value"</span><span class="p">);</span>                         <span class="c1">// Evaluates to false.</span>
@@ -8811,7 +8811,7 @@ the <emu-val>null</emu-val> value.</p>
     an object (such as a <emu-val>Number</emu-val> value)
     to handler1 will have different behavior from that when assigning
     to handler2:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">manager</span> <span class="o">=</span> <span class="nx">getManager</span><span class="p">();</span>  <span class="c1">// Get an instance of Manager.</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">manager</span> <span class="o">=</span> <span class="nx">getManager</span><span class="p">();</span>  <span class="c1">// Get an instance of Manager.</span>
 
 <span class="nx">manager</span><span class="p">.</span><span class="nx">handler1</span> <span class="o">=</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span> <span class="p">};</span>
 <span class="nx">manager</span><span class="p">.</span><span class="nx">handler1</span><span class="p">;</span>            <span class="c1">// Evaluates to the function.</span>
@@ -8868,7 +8868,7 @@ a non-callback interface.</p>
     assigned to the “owner” property or passed as the
     argument to the <code>isMemberOfBreed</code> function
     to the empty string rather than <code>"null"</code>:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">d</span> <span class="o">=</span> <span class="nx">getDog</span><span class="p">();</span>         <span class="c1">// Assume d is a platform object implementing the Dog</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">d</span> <span class="o">=</span> <span class="nx">getDog</span><span class="p">();</span>         <span class="c1">// Assume d is a platform object implementing the Dog</span>
                           <span class="c1">// interface.</span>
 
 <span class="nx">d</span><span class="p">.</span><span class="nx">name</span> <span class="o">=</span> <span class="kc">null</span><span class="p">;</span>            <span class="c1">// This assigns the string "null" to the .name</span>
@@ -8965,7 +8965,7 @@ the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifi
 </pre>
     <p>In an ECMAScript implementation of the interface, the username attribute will be exposed as a non-configurable property on the
     object itself:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">system</span> <span class="o">=</span> <span class="nx">getSystem</span><span class="p">();</span>                      <span class="c1">// Get an instance of System.</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">system</span> <span class="o">=</span> <span class="nx">getSystem</span><span class="p">();</span>                      <span class="c1">// Get an instance of System.</span>
 
 <span class="nx">system</span><span class="p">.</span><span class="nx">hasOwnProperty</span><span class="p">(</span><span class="s2">"username"</span><span class="p">);</span>             <span class="c1">// Evaluates to true.</span>
 <span class="nx">system</span><span class="p">.</span><span class="nx">hasOwnProperty</span><span class="p">(</span><span class="s2">"loginTime"</span><span class="p">);</span>            <span class="c1">// Evaluates to false.</span>
@@ -9008,7 +9008,7 @@ anything other than a <a data-link-type="dfn" href="#dfn-regular-attribute" id="
 </pre>
     <p>the “f” property an be referenced with a bare identifier
     in a <code>with</code> statement but the “g” property cannot:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">thing</span> <span class="o">=</span> <span class="nx">getThing</span><span class="p">();</span>  <span class="c1">// An instance of Thing</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">thing</span> <span class="o">=</span> <span class="nx">getThing</span><span class="p">();</span>  <span class="c1">// An instance of Thing</span>
 <span class="kd">with</span> <span class="p">(</span><span class="nx">thing</span><span class="p">)</span> <span class="p">{</span>
   <span class="nx">f</span><span class="p">;</span>                     <span class="c1">// Evaluates to a Function object.</span>
   <span class="nx">g</span><span class="p">;</span>                     <span class="c1">// Throws a ReferenceError.</span>
@@ -12295,7 +12295,7 @@ optional user agent-defined message <var>M</var>.</p>
     <p>If we pass a <code class="idl">MathUtils</code> object from
     a different global environment to doComputation, then the exception
     thrown will be from that global environment:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="nx">getA</span><span class="p">();</span>                           <span class="c1">// An A object from this global environment.</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="nx">getA</span><span class="p">();</span>                           <span class="c1">// An A object from this global environment.</span>
 <span class="kd">var</span> <span class="nx">m</span> <span class="o">=</span> <span class="nx">otherWindow</span><span class="p">.</span><span class="nx">getMathUtils</span><span class="p">();</span>       <span class="c1">// A MathUtils object from a different global environment.</span>
 
 <span class="nx">a</span> <span class="k">instanceof</span> <span class="nb">Object</span><span class="p">;</span>                      <span class="c1">// Evaluates to true.</span>
@@ -12334,7 +12334,7 @@ not caught there, to its caller, and so on.</p>
 </pre>
     <p>Assuming an ECMAScript implementation supporting this interface,
     the following code demonstrates how exceptions are handled:</p>
-<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">d</span> <span class="o">=</span> <span class="nx">getDahut</span><span class="p">();</span>              <span class="c1">// Obtain an instance of Dahut.</span>
+<pre class="highlight"><span class="kd">var</span> <span class="nx">d</span> <span class="o">=</span> <span class="nx">getDahut</span><span class="p">();</span>              <span class="c1">// Obtain an instance of Dahut.</span>
 <span class="kd">var</span> <span class="nx">et</span> <span class="o">=</span> <span class="nx">getExceptionThrower</span><span class="p">();</span>  <span class="c1">// Obtain an instance of ExceptionThrower.</span>
 
 <span class="k">try</span> <span class="p">{</span>

--- a/index.html
+++ b/index.html
@@ -1963,7 +1963,7 @@ including the ! and ? notation for unwrapping completion records.</p>
   <span class="kt">attribute</span> <span class="kt">long</span> <span class="nv">something</span>;
 };
 </pre>
-<pre class="highlight"><span class="c1">// This is an ECMAScript code block.</span>
+<pre class="highlight"><span></span><span class="c1">// This is an ECMAScript code block.</span>
 <span class="nb">window</span><span class="p">.</span><span class="nx">onload</span> <span class="o">=</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span> <span class="nb">window</span><span class="p">.</span><span class="nx">alert</span><span class="p">(</span><span class="s2">"loaded"</span><span class="p">);</span> <span class="p">};</span></pre>
    </ul>
    <h2 class="heading settled" data-level="2" id="conformance"><span class="secno">2. </span><span class="content">Conformance</span><a class="self-link" href="#conformance"></a></h2>
@@ -2397,7 +2397,7 @@ be defined on a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-f
 };
 </pre>
     <p>to be used like this:</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="nx">getA</span><span class="p">();</span>  <span class="c1">// Get an instance of A.</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="nx">getA</span><span class="p">();</span>  <span class="c1">// Get an instance of A.</span>
 
 <span class="nx">a</span><span class="p">.</span><span class="nx">doTask</span><span class="p">(</span><span class="s2">"something"</span><span class="p">,</span> <span class="p">{</span> <span class="nx">option1</span><span class="o">:</span> <span class="s2">"banana"</span><span class="p">,</span> <span class="nx">option3</span><span class="o">:</span> <span class="mi">100</span> <span class="p">});</span></pre>
     <p>instead write the following:</p>
@@ -2538,7 +2538,7 @@ in the language.</p>
 </pre>
     <p>Since the <code class="idl">EventListener</code> interface is annotated
     callback interface, <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-3">user objects</a> can implement it:</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">node</span> <span class="o">=</span> <span class="nx">getNode</span><span class="p">();</span>                                <span class="c1">// Obtain an instance of Node.</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">node</span> <span class="o">=</span> <span class="nx">getNode</span><span class="p">();</span>                                <span class="c1">// Obtain an instance of Node.</span>
 
 <span class="kd">var</span> <span class="nx">listener</span> <span class="o">=</span> <span class="p">{</span>
   <span class="nx">handleEvent</span><span class="o">:</span> <span class="kd">function</span><span class="p">(</span><span class="nx">event</span><span class="p">)</span> <span class="p">{</span>
@@ -2549,7 +2549,7 @@ in the language.</p>
 
 <span class="nx">node</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"click"</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span> <span class="p">...</span> <span class="p">});</span>  <span class="c1">// As does this.</span></pre>
     <p>It is not possible for a user object to implement <code class="idl">Node</code>, however:</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">node</span> <span class="o">=</span> <span class="nx">getNode</span><span class="p">();</span>  <span class="c1">// Obtain an instance of Node.</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">node</span> <span class="o">=</span> <span class="nx">getNode</span><span class="p">();</span>  <span class="c1">// Obtain an instance of Node.</span>
 
 <span class="kd">var</span> <span class="nx">newNode</span> <span class="o">=</span> <span class="p">{</span>
   <span class="nx">nodeName</span><span class="o">:</span> <span class="s2">"span"</span><span class="p">,</span>
@@ -3010,7 +3010,7 @@ defined in this specification) and <a data-link-type="dfn" href="#dfn-callback-f
 </pre>
     <p>In the ECMAScript binding, variadic operations are implemented by
     functions that can accept the subsequent arguments:</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">s</span> <span class="o">=</span> <span class="nx">getIntegerSet</span><span class="p">();</span>  <span class="c1">// Obtain an instance of IntegerSet.</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">s</span> <span class="o">=</span> <span class="nx">getIntegerSet</span><span class="p">();</span>  <span class="c1">// Obtain an instance of IntegerSet.</span>
 
 <span class="nx">s</span><span class="p">.</span><span class="nx">union</span><span class="p">();</span>                <span class="c1">// Passing no arguments corresponding to 'ints'.</span>
 <span class="nx">s</span><span class="p">.</span><span class="nx">union</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">4</span><span class="p">,</span> <span class="mi">7</span><span class="p">);</span>         <span class="c1">// Passing three arguments corresponding to 'ints'.</span></pre>
@@ -3325,7 +3325,7 @@ as if it were a function.</p>
 </pre>
     <p>An ECMAScript implementation supporting this interface would
     allow a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-2">platform object</a> that implements <code class="idl">NumberQuadrupler</code> to be called as a function:</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">f</span> <span class="o">=</span> <span class="nx">getNumberQuadrupler</span><span class="p">();</span>  <span class="c1">// Obtain an instance of NumberQuadrupler.</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">f</span> <span class="o">=</span> <span class="nx">getNumberQuadrupler</span><span class="p">();</span>  <span class="c1">// Obtain an instance of NumberQuadrupler.</span>
 
 <span class="nx">f</span><span class="p">.</span><span class="nx">compute</span><span class="p">(</span><span class="mi">3</span><span class="p">);</span>                   <span class="c1">// This evaluates to 12.</span>
 <span class="nx">f</span><span class="p">(</span><span class="mi">3</span><span class="p">);</span>                           <span class="c1">// This also evaluates to 12.</span></pre>
@@ -3398,7 +3398,7 @@ a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-at
     <p>In the ECMAScript binding, using a <code class="idl">Student</code> object in a context where a string is expected will result in the
     value of the object’s “name” property being
     used:</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">s</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Student</span><span class="p">();</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">s</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Student</span><span class="p">();</span>
 <span class="nx">s</span><span class="p">.</span><span class="nx">id</span> <span class="o">=</span> <span class="mi">12345678</span><span class="p">;</span>
 <span class="nx">s</span><span class="p">.</span><span class="nx">name</span> <span class="o">=</span> <span class="s1">'周杰倫'</span><span class="p">;</span>
 
@@ -3425,7 +3425,7 @@ a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-at
         the <code class="idl">familyName</code> attribute.</p>
     </blockquote>
     <p>An ECMAScript implementation of the IDL would behave as follows:</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">s</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Student</span><span class="p">();</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">s</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Student</span><span class="p">();</span>
 <span class="nx">s</span><span class="p">.</span><span class="nx">id</span> <span class="o">=</span> <span class="mi">12345679</span><span class="p">;</span>
 <span class="nx">s</span><span class="p">.</span><span class="nx">familyName</span> <span class="o">=</span> <span class="s1">'Smithee'</span><span class="p">;</span>
 <span class="nx">s</span><span class="p">.</span><span class="nx">givenName</span> <span class="o">=</span> <span class="s1">'Alan'</span><span class="p">;</span>
@@ -3804,7 +3804,7 @@ and whose value is the <a data-link-type="dfn" href="#dfn-serialized-value" id="
 };
 </pre>
     <p>In the ECMAScript language binding, there would exist a <code>toJSON</code> method on <code class="idl">Transaction</code> objects:</p>
-<pre class="highlight"><span class="c1">// Get an instance of Transaction.</span>
+<pre class="highlight"><span></span><span class="c1">// Get an instance of Transaction.</span>
 <span class="kd">var</span> <span class="nx">txn</span> <span class="o">=</span> <span class="nx">getTransaction</span><span class="p">();</span>
 
 <span class="c1">// Evaluates to an object like this:</span>
@@ -3868,7 +3868,7 @@ by a description of how to <dfn class="dfn-paneled" data-dfn-type="dfn" data-exp
     <p>Assume that an object implementing <code class="idl">A</code> has <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-3">supported property indices</a> in the range 0 ≤ <var>index</var> &lt; 2.  Also assume that toWord is defined to return
     its argument converted into an English word.  The behavior when invoking the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-14">operation</a> with an out of range index
     is different from indexing the object directly:</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="nx">getA</span><span class="p">();</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="nx">getA</span><span class="p">();</span>
 
 <span class="nx">a</span><span class="p">.</span><span class="nx">toWord</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span>  <span class="c1">// Evalautes to "zero".</span>
 <span class="nx">a</span><span class="p">[</span><span class="mi">0</span><span class="p">];</span>         <span class="c1">// Also evaluates to "zero".</span>
@@ -3910,7 +3910,7 @@ by a description of how to <dfn class="dfn-paneled" data-dfn-type="dfn" data-exp
     These properties can then be used to interact
     with the object in the same way as invoking the object’s
     methods, as demonstrated below:</p>
-<pre class="highlight"><span class="c1">// Assume map is a platform object implementing the OrderedMap interface.</span>
+<pre class="highlight"><span></span><span class="c1">// Assume map is a platform object implementing the OrderedMap interface.</span>
 <span class="kd">var</span> <span class="nx">map</span> <span class="o">=</span> <span class="nx">getOrderedMap</span><span class="p">();</span>
 <span class="kd">var</span> <span class="nx">x</span><span class="p">,</span> <span class="nx">y</span><span class="p">;</span>
 
@@ -4027,7 +4027,7 @@ declared on <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-d
 };
 </pre>
     <p>In the ECMAScript language binding, the <emu-val>Function</emu-val> object for <code>triangulate</code> and the accessor property for <code>triangulationCount</code> will exist on the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-1">interface object</a> for <code class="idl">Circle</code>:</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">circles</span> <span class="o">=</span> <span class="nx">getCircles</span><span class="p">();</span>           <span class="c1">// an Array of Circle objects</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">circles</span> <span class="o">=</span> <span class="nx">getCircles</span><span class="p">();</span>           <span class="c1">// an Array of Circle objects</span>
 
 <span class="k">typeof</span> <span class="nx">Circle</span><span class="p">.</span><span class="nx">triangulate</span><span class="p">;</span>            <span class="c1">// Evaluates to "function"</span>
 <span class="k">typeof</span> <span class="nx">Circle</span><span class="p">.</span><span class="nx">triangulationCount</span><span class="p">;</span>     <span class="c1">// Evaluates to "number"</span>
@@ -4605,7 +4605,7 @@ or have any <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for
     next value to be iterated over.  It has <code>values</code> and <code>entries</code> methods that iterate over the indexes of the list of session objects
     and [index, session object] pairs, respectively.  It also has
     a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> method that allows a <code class="idl">SessionManager</code> to be used in a <code>for..of</code> loop:</p>
-<pre class="highlight"><span class="c1">// Get an instance of SessionManager.</span>
+<pre class="highlight"><span></span><span class="c1">// Get an instance of SessionManager.</span>
 <span class="c1">// Assume that it has sessions for two users, "anna" and "brian".</span>
 <span class="kd">var</span> <span class="nx">sm</span> <span class="o">=</span> <span class="nx">getSessionManager</span><span class="p">();</span>
 
@@ -4625,7 +4625,7 @@ or have any <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for
 <span class="p">}</span>
 
 <span class="c1">// This loop will also alert "anna" and then "brian".</span>
-<span class="k">for</span> <span class="p">(</span><span class="kd">let</span> <span class="nx">session</span> <span class="nx">of</span> <span class="nx">sm</span><span class="p">)</span> <span class="p">{</span>
+<span class="k">for</span> <span class="p">(</span><span class="kd">let</span> <span class="nx">session</span> <span class="k">of</span> <span class="nx">sm</span><span class="p">)</span> <span class="p">{</span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">alert</span><span class="p">(</span><span class="nx">session</span><span class="p">.</span><span class="nx">username</span><span class="p">);</span>
 <span class="p">}</span></pre>
    </div>
@@ -4786,7 +4786,7 @@ namespaces.</p>
 };
 </pre>
     <p>An ECMAScript implementation would then expose a global property named <code>VectorUtils</code> which was a simple object (with prototype <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a>) with enumerable data properties for each declared operation:</p>
-<pre class="highlight"><span class="nb">Object</span><span class="p">.</span><span class="nx">getPrototypeOf</span><span class="p">(</span><span class="nx">VectorUtils</span><span class="p">);</span>                         <span class="c1">// Evaluates to Object.prototype.</span>
+<pre class="highlight"><span></span><span class="nb">Object</span><span class="p">.</span><span class="nx">getPrototypeOf</span><span class="p">(</span><span class="nx">VectorUtils</span><span class="p">);</span>                         <span class="c1">// Evaluates to Object.prototype.</span>
 <span class="nb">Object</span><span class="p">.</span><span class="nx">keys</span><span class="p">(</span><span class="nx">VectorUtils</span><span class="p">);</span>                                   <span class="c1">// Evaluates to ["dotProduct", "crossProduct"].</span>
 <span class="nb">Object</span><span class="p">.</span><span class="nx">getOwnPropertyDescriptor</span><span class="p">(</span><span class="nx">VectorUtils</span><span class="p">,</span> <span class="s2">"dotProduct"</span><span class="p">);</span> <span class="c1">// Evaluates to { value: &lt;a function>, enumerable: true, configurable: true, writable: true }.</span></pre>
    </div>
@@ -4942,7 +4942,7 @@ identifiers.</p>
 };
 </pre>
     <p>and this ECMAScript code:</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">something</span> <span class="o">=</span> <span class="nx">getSomething</span><span class="p">();</span>  <span class="c1">// Get an instance of Something.</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">something</span> <span class="o">=</span> <span class="nx">getSomething</span><span class="p">();</span>  <span class="c1">// Get an instance of Something.</span>
 <span class="kd">var</span> <span class="nx">x</span> <span class="o">=</span> <span class="mi">0</span><span class="p">;</span>
 
 <span class="kd">var</span> <span class="nx">dict</span> <span class="o">=</span> <span class="p">{</span> <span class="p">};</span>
@@ -5013,7 +5013,7 @@ on that dictionary’s <a data-link-type="dfn" href="#dfn-inherited-dictionaries
 };
 </pre>
     <p>In an ECMAScript implementation of the IDL, an <emu-val>Object</emu-val> can be passed in for the optional <code class="idl">PaintOptions</code> dictionary:</p>
-<pre class="highlight"><span class="c1">// Get an instance of GraphicsContext.</span>
+<pre class="highlight"><span></span><span class="c1">// Get an instance of GraphicsContext.</span>
 <span class="kd">var</span> <span class="nx">ctx</span> <span class="o">=</span> <span class="nx">getGraphicsContext</span><span class="p">();</span>
 
 <span class="c1">// Draw a rectangle.</span>
@@ -5282,7 +5282,7 @@ results in an exception being thrown.</p>
     <p>An ECMAScript implementation would restrict the strings that can be
     assigned to the type property or passed to the initializeMeal function
     to those identified in the <a data-link-type="dfn" href="#dfn-enumeration" id="ref-for-dfn-enumeration-14">enumeration</a>.</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">meal</span> <span class="o">=</span> <span class="nx">getMeal</span><span class="p">();</span>                <span class="c1">// Get an instance of Meal.</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">meal</span> <span class="o">=</span> <span class="nx">getMeal</span><span class="p">();</span>                <span class="c1">// Get an instance of Meal.</span>
 
 <span class="nx">meal</span><span class="p">.</span><span class="nx">initialize</span><span class="p">(</span><span class="s2">"rice"</span><span class="p">,</span> <span class="mi">200</span><span class="p">);</span>        <span class="c1">// Operation invoked as normal.</span>
 
@@ -5327,7 +5327,7 @@ be used as the type of a <a data-link-type="dfn" href="#dfn-constant" id="ref-fo
 </pre>
     <p>In the ECMAScript language binding, a <emu-val>Function</emu-val> object is
     passed as the operation argument.</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">ops</span> <span class="o">=</span> <span class="nx">getAsyncOperations</span><span class="p">();</span>  <span class="c1">// Get an instance of AsyncOperations.</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">ops</span> <span class="o">=</span> <span class="nx">getAsyncOperations</span><span class="p">();</span>  <span class="c1">// Get an instance of AsyncOperations.</span>
 
 <span class="nx">ops</span><span class="p">.</span><span class="nx">performOperation</span><span class="p">(</span><span class="kd">function</span><span class="p">(</span><span class="nx">status</span><span class="p">)</span> <span class="p">{</span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">alert</span><span class="p">(</span><span class="s2">"Operation finished, status is "</span> <span class="o">+</span> <span class="nx">status</span> <span class="o">+</span> <span class="s2">"."</span><span class="p">);</span>
@@ -5467,7 +5467,7 @@ of those consequential interfaces or on the original interface itself.</p>
 </pre>
     <p>An ECMAScript implementation would thus have an “addEventListener”
     property in the prototype chain of every <code class="idl">Entry</code>:</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">e</span> <span class="o">=</span> <span class="nx">getEntry</span><span class="p">();</span>          <span class="c1">// Obtain an instance of Entry.</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">e</span> <span class="o">=</span> <span class="nx">getEntry</span><span class="p">();</span>          <span class="c1">// Obtain an instance of Entry.</span>
 <span class="k">typeof</span> <span class="nx">e</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">;</span>  <span class="c1">// Evaluates to "function".</span></pre>
     <p>Note that it is not the case that all <code class="idl">Observable</code> objects implement <code class="idl">Entry</code>.</p>
    </div>
@@ -6362,10 +6362,10 @@ that same global environment.</p>
     multiple frames or windows are created.  Each frame or window will have
     its own set of <a data-link-type="dfn" href="#dfn-initial-object" id="ref-for-dfn-initial-object-2">initial objects</a>,
     which the following HTML document demonstrates:</p>
-<pre class="highlight"><span class="cp">&lt;!DOCTYPE html></span>
-<span class="nt">&lt;title></span>Different global environments<span class="nt">&lt;/title></span>
-<span class="nt">&lt;iframe</span> <span class="na">id=</span><span class="s">a</span><span class="nt">>&lt;/iframe></span>
-<span class="nt">&lt;script></span>
+<pre class="highlight"><span></span><span class="cp">&lt;!DOCTYPE html></span>
+<span class="p">&lt;</span><span class="nt">title</span><span class="p">></span>Different global environments<span class="p">&lt;/</span><span class="nt">title</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">id</span><span class="o">=</span><span class="s">a</span><span class="p">>&lt;/</span><span class="nt">iframe</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
 <span class="kd">var</span> <span class="nx">iframe</span> <span class="o">=</span> <span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"a"</span><span class="p">);</span>
 <span class="kd">var</span> <span class="nx">w</span> <span class="o">=</span> <span class="nx">iframe</span><span class="p">.</span><span class="nx">contentWindow</span><span class="p">;</span>              <span class="c1">// The global object in the frame</span>
 
@@ -6375,7 +6375,7 @@ that same global environment.</p>
 <span class="nx">iframe</span> <span class="k">instanceof</span> <span class="nx">w</span><span class="p">.</span><span class="nb">Object</span><span class="p">;</span>                <span class="c1">// Evaluates to false</span>
 <span class="nx">iframe</span><span class="p">.</span><span class="nx">appendChild</span> <span class="k">instanceof</span> <span class="nb">Function</span><span class="p">;</span>    <span class="c1">// Evaluates to true</span>
 <span class="nx">iframe</span><span class="p">.</span><span class="nx">appendChild</span> <span class="k">instanceof</span> <span class="nx">w</span><span class="p">.</span><span class="nb">Function</span><span class="p">;</span>  <span class="c1">// Evaluates to false</span>
-<span class="nt">&lt;/script></span></pre>
+<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span></pre>
    </div>
    <p>Unless otherwise specified, each ECMAScript global environment <dfn class="dfn-paneled" data-dfn-for="ECMAScript global environment" data-dfn-type="dfn" data-export="" id="dfn-expose">exposes</dfn> all <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-53">interfaces</a> that the implementation supports.  If a given ECMAScript global environment does not
 expose an interface, then the requirements given in <a href="#es-interfaces">§4.6 Interfaces</a> are
@@ -7368,7 +7368,7 @@ at index <var>j</var> is <var>S</var><sub><var>j</var></sub>.</p>
     returned, and whenever an <emu-val>Array</emu-val> is
     passed to <code>drawPolygon</code> no reference
     will be kept after the call completes.</p>
-<pre class="highlight"><span class="c1">// Obtain an instance of Canvas.  Assume that getSupportedImageCodecs()</span>
+<pre class="highlight"><span></span><span class="c1">// Obtain an instance of Canvas.  Assume that getSupportedImageCodecs()</span>
 <span class="c1">// returns a sequence with two DOMString values: "image/png" and "image/svg+xml".</span>
 <span class="kd">var</span> <span class="nx">canvas</span> <span class="o">=</span> <span class="nx">getCanvas</span><span class="p">();</span>
 
@@ -7825,7 +7825,7 @@ types in <a href="#es-type-mapping">§4.2 ECMAScript type mapping</a> for the sp
 };
 </pre>
     <p>In an ECMAScript implementation of the IDL, a call to setColorClamped with <emu-val>Number</emu-val> values that are out of range for an <code class="idl"><a data-link-type="idl" href="#idl-octet" id="ref-for-idl-octet-14">octet</a></code> are clamped to the range [0, 255].</p>
-<pre class="highlight"><span class="c1">// Get an instance of GraphicsContext.</span>
+<pre class="highlight"><span></span><span class="c1">// Get an instance of GraphicsContext.</span>
 <span class="kd">var</span> <span class="nx">context</span> <span class="o">=</span> <span class="nx">getGraphicsContext</span><span class="p">();</span>
 
 <span class="c1">// Calling the non-[Clamp] version uses ToUint8 to coerce the Numbers to octets.</span>
@@ -7885,7 +7885,7 @@ for an interface is to be implemented.</p>
     return a new object that implements the interface.  It would take
     either zero or one argument.  The <code class="idl">NodeList</code> interface object would not
     have a [[Construct]] property.</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">x</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Circle</span><span class="p">();</span>      <span class="c1">// The uses the zero-argument constructor to create a</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">x</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Circle</span><span class="p">();</span>      <span class="c1">// The uses the zero-argument constructor to create a</span>
                            <span class="c1">// reference to a platform object that implements the</span>
                            <span class="c1">// Circle interface.</span>
 
@@ -7926,7 +7926,7 @@ types in <a href="#es-type-mapping">§4.2 ECMAScript type mapping</a> for the sp
 </pre>
     <p>In an ECMAScript implementation of the IDL, a call to setColorEnforcedRange with <emu-val>Number</emu-val> values that are out of range for an <code class="idl"><a data-link-type="idl" href="#idl-octet" id="ref-for-idl-octet-16">octet</a></code> will result in an exception being
     thrown.</p>
-<pre class="highlight"><span class="c1">// Get an instance of GraphicsContext.</span>
+<pre class="highlight"><span></span><span class="c1">// Get an instance of GraphicsContext.</span>
 <span class="kd">var</span> <span class="nx">context</span> <span class="o">=</span> <span class="nx">getGraphicsContext</span><span class="p">();</span>
 
 <span class="c1">// Calling the non-[EnforceRange] version uses ToUint8 to coerce the Numbers to octets.</span>
@@ -8107,7 +8107,7 @@ will correspond to properties on the object itself rather than on <a data-link-t
     <p>Placing properties corresponding to interface members on
     the object itself will mean that common feature detection
     methods like the following will work:</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">indexedDB</span> <span class="o">=</span> <span class="nb">window</span><span class="p">.</span><span class="nx">indexedDB</span> <span class="o">||</span> <span class="nb">window</span><span class="p">.</span><span class="nx">webkitIndexedDB</span> <span class="o">||</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">indexedDB</span> <span class="o">=</span> <span class="nb">window</span><span class="p">.</span><span class="nx">indexedDB</span> <span class="o">||</span> <span class="nb">window</span><span class="p">.</span><span class="nx">webkitIndexedDB</span> <span class="o">||</span>
                 <span class="nb">window</span><span class="p">.</span><span class="nx">mozIndexedDB</span> <span class="o">||</span> <span class="nb">window</span><span class="p">.</span><span class="nx">msIndexedDB</span><span class="p">;</span>
 
 <span class="kd">var</span> <span class="nx">requestAnimationFrame</span> <span class="o">=</span> <span class="nb">window</span><span class="p">.</span><span class="nx">requestAnimationFrame</span> <span class="o">||</span>
@@ -8196,29 +8196,29 @@ corresponding to <a data-link-type="dfn" href="#dfn-interface-member" id="ref-fo
     <p>The following HTML document illustrates how the named properties on the <code class="idl">Window</code> object can be shadowed, and how
     the property for an attribute will not be replaced when declaring
     a variable of the same name:</p>
-<pre class="highlight"><span class="cp">&lt;!DOCTYPE html></span>
-<span class="nt">&lt;title></span>Variable declarations and assignments on Window<span class="nt">&lt;/title></span>
-<span class="nt">&lt;iframe</span> <span class="na">name=</span><span class="s">abc</span><span class="nt">>&lt;/iframe></span>
+<pre class="highlight"><span></span><span class="cp">&lt;!DOCTYPE html></span>
+<span class="p">&lt;</span><span class="nt">title</span><span class="p">></span>Variable declarations and assignments on Window<span class="p">&lt;/</span><span class="nt">title</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">name</span><span class="o">=</span><span class="s">abc</span><span class="p">>&lt;/</span><span class="nt">iframe</span><span class="p">></span>
 <span class="c">&lt;!-- Shadowing named properties --></span>
-<span class="nt">&lt;script></span>
+<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">abc</span><span class="p">;</span>    <span class="c1">// Evaluates to the iframe’s Window object.</span>
   <span class="nx">abc</span> <span class="o">=</span> <span class="mi">1</span><span class="p">;</span>       <span class="c1">// Shadows the named property.</span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">abc</span><span class="p">;</span>    <span class="c1">// Evaluates to 1.</span>
-<span class="nt">&lt;/script></span>
+<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
 
 <span class="c">&lt;!-- Preserving properties for IDL attributes --></span>
-<span class="nt">&lt;script></span>
+<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
   <span class="nx">Window</span><span class="p">.</span><span class="nx">prototype</span><span class="p">.</span><span class="nx">def</span> <span class="o">=</span> <span class="mi">2</span><span class="p">;</span>         <span class="c1">// Places a property on the prototype.</span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">hasOwnProperty</span><span class="p">(</span><span class="s2">"length"</span><span class="p">);</span>  <span class="c1">// Evaluates to true.</span>
   <span class="nx">length</span><span class="p">;</span>                           <span class="c1">// Evaluates to 1.</span>
   <span class="nx">def</span><span class="p">;</span>                              <span class="c1">// Evaluates to 2.</span>
-<span class="nt">&lt;/script></span>
-<span class="nt">&lt;script></span>
+<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
   <span class="kd">var</span> <span class="nx">length</span><span class="p">;</span>                       <span class="c1">// Variable declaration leaves existing property.</span>
   <span class="nx">length</span><span class="p">;</span>                           <span class="c1">// Evaluates to 1.</span>
   <span class="kd">var</span> <span class="nx">def</span><span class="p">;</span>                          <span class="c1">// Variable declaration creates shadowing property.</span>
   <span class="nx">def</span><span class="p">;</span>                              <span class="c1">// Evaluates to undefined.</span>
-<span class="nt">&lt;/script></span></pre>
+<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="4.3.6" data-lt="LegacyArrayClass" id="LegacyArrayClass"><span class="secno">4.3.6. </span><span class="content">[LegacyArrayClass]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-3">LegacyArrayClass</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-57">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-64">interface</a> that is not defined to <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-12">inherit</a> from another, it indicates that the internal [[Prototype]]
@@ -8255,7 +8255,7 @@ entails.</p>
     <p>In an ECMAScript implementation of the above two interfaces,
     with appropriate definitions for getItem, setItem and removeItem, <emu-val>Array</emu-val> methods to inspect and
     modify the array-like object can be used.</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">list</span> <span class="o">=</span> <span class="nx">getItemList</span><span class="p">();</span>  <span class="c1">// Obtain an instance of ItemList.</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">list</span> <span class="o">=</span> <span class="nx">getItemList</span><span class="p">();</span>  <span class="c1">// Obtain an instance of ItemList.</span>
 
 <span class="nx">list</span><span class="p">.</span><span class="nx">concat</span><span class="p">();</span>             <span class="c1">// Clone the ItemList into an Array.</span>
 <span class="nx">list</span><span class="p">.</span><span class="nx">pop</span><span class="p">();</span>                <span class="c1">// Remove an item from the ItemList.</span>
@@ -8318,7 +8318,7 @@ is to be implemented.</p>
     <p>An ECMAScript implementation that supports this interface will
     have a setter on the accessor property that correspond to x,
     which allows any assignment to be ignored in strict mode.</p>
-<pre class="highlight"><span class="s2">"use strict"</span><span class="p">;</span>
+<pre class="highlight"><span></span><span class="s2">"use strict"</span><span class="p">;</span>
 
 <span class="kd">var</span> <span class="nx">example</span> <span class="o">=</span> <span class="nx">getExample</span><span class="p">();</span>  <span class="c1">// Get an instance of Example.</span>
 
@@ -8355,7 +8355,7 @@ is to be implemented.</p>
     <p>An ECMAScript implementation that supports this interface will
     allow the getter and setter of the accessor property that corresponds
     to x to be invoked with something other than an <code class="idl">Example</code> object.</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">example</span> <span class="o">=</span> <span class="nx">getExample</span><span class="p">();</span>  <span class="c1">// Get an instance of Example.</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">example</span> <span class="o">=</span> <span class="nx">getExample</span><span class="p">();</span>  <span class="c1">// Get an instance of Example.</span>
 <span class="kd">var</span> <span class="nx">obj</span> <span class="o">=</span> <span class="p">{</span> <span class="p">};</span>
 
 <span class="c1">// Fine.</span>
@@ -8408,7 +8408,7 @@ are to be implemented.</p>
 </pre>
     <p>An ECMAScript implementation that supports this interface will
     allow the construction of <code class="idl">HTMLAudioElement</code> objects using the <code class="idl">Audio</code> constructor.</p>
-<pre class="highlight"><span class="k">typeof</span> <span class="nx">Audio</span><span class="p">;</span>                   <span class="c1">// Evaluates to 'function'.</span>
+<pre class="highlight"><span></span><span class="k">typeof</span> <span class="nx">Audio</span><span class="p">;</span>                   <span class="c1">// Evaluates to 'function'.</span>
 
 <span class="kd">var</span> <span class="nx">a1</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Audio</span><span class="p">();</span>           <span class="c1">// Creates a new object that implements</span>
                                 <span class="c1">// HTMLAudioElement, using the zero-argument</span>
@@ -8482,7 +8482,7 @@ attribute specified.</p>
     <p>An ECMAScript implementation of the above IDL would allow
     manipulation of <code class="idl">Storage</code>’s
     prototype, but not <code class="idl">Query</code>’s.</p>
-<pre class="highlight"><span class="k">typeof</span> <span class="nx">Storage</span><span class="p">;</span>                        <span class="c1">// evaluates to "object"</span>
+<pre class="highlight"><span></span><span class="k">typeof</span> <span class="nx">Storage</span><span class="p">;</span>                        <span class="c1">// evaluates to "object"</span>
 
 <span class="c1">// Add some tracing alert() call to Storage.addEntry.</span>
 <span class="kd">var</span> <span class="nx">fn</span> <span class="o">=</span> <span class="nx">Storage</span><span class="p">.</span><span class="nx">prototype</span><span class="p">.</span><span class="nx">addEntry</span><span class="p">;</span>
@@ -8533,7 +8533,7 @@ the <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-na
     <p>In an ECMAScript implementation of these two interfaces,
     getting certain properties on objects implementing
     the interfaces will result in different values:</p>
-<pre class="highlight"><span class="c1">// Obtain an instance of StringMap.  Assume that it has "abc", "length" and</span>
+<pre class="highlight"><span></span><span class="c1">// Obtain an instance of StringMap.  Assume that it has "abc", "length" and</span>
 <span class="c1">// "toString" as supported property names.</span>
 <span class="kd">var</span> <span class="nx">map1</span> <span class="o">=</span> <span class="nx">getStringMap</span><span class="p">();</span>
 
@@ -8628,7 +8628,7 @@ is to be implemented.</p>
 </pre>
     <p>In the ECMAScript binding, this would allow assignments to the
     “name” property:</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">p</span> <span class="o">=</span> <span class="nx">getPerson</span><span class="p">();</span>           <span class="c1">// Obtain an instance of Person.</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">p</span> <span class="o">=</span> <span class="nx">getPerson</span><span class="p">();</span>           <span class="c1">// Obtain an instance of Person.</span>
 
 <span class="nx">p</span><span class="p">.</span><span class="nx">name</span> <span class="o">=</span> <span class="s1">'John Citizen'</span><span class="p">;</span>       <span class="c1">// This statement...</span>
 <span class="nx">p</span><span class="p">.</span><span class="nx">name</span><span class="p">.</span><span class="nx">full</span> <span class="o">=</span> <span class="s1">'John Citizen'</span><span class="p">;</span>  <span class="c1">// ...has the same behavior as this one.</span></pre>
@@ -8667,7 +8667,7 @@ a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callbac
 </pre>
     <p>Assigning to the “value” property
     on a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-16">platform object</a> implementing <code class="idl">Counter</code> will shadow the property that corresponds to the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-53">attribute</a>:</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">counter</span> <span class="o">=</span> <span class="nx">getCounter</span><span class="p">();</span>                              <span class="c1">// Obtain an instance of Counter.</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">counter</span> <span class="o">=</span> <span class="nx">getCounter</span><span class="p">();</span>                              <span class="c1">// Obtain an instance of Counter.</span>
 <span class="nx">counter</span><span class="p">.</span><span class="nx">value</span><span class="p">;</span>                                           <span class="c1">// Evaluates to 0.</span>
 
 <span class="nx">counter</span><span class="p">.</span><span class="nx">hasOwnProperty</span><span class="p">(</span><span class="s2">"value"</span><span class="p">);</span>                         <span class="c1">// Evaluates to false.</span>
@@ -8811,7 +8811,7 @@ the <emu-val>null</emu-val> value.</p>
     an object (such as a <emu-val>Number</emu-val> value)
     to handler1 will have different behavior from that when assigning
     to handler2:</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">manager</span> <span class="o">=</span> <span class="nx">getManager</span><span class="p">();</span>  <span class="c1">// Get an instance of Manager.</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">manager</span> <span class="o">=</span> <span class="nx">getManager</span><span class="p">();</span>  <span class="c1">// Get an instance of Manager.</span>
 
 <span class="nx">manager</span><span class="p">.</span><span class="nx">handler1</span> <span class="o">=</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span> <span class="p">};</span>
 <span class="nx">manager</span><span class="p">.</span><span class="nx">handler1</span><span class="p">;</span>            <span class="c1">// Evaluates to the function.</span>
@@ -8868,7 +8868,7 @@ a non-callback interface.</p>
     assigned to the “owner” property or passed as the
     argument to the <code>isMemberOfBreed</code> function
     to the empty string rather than <code>"null"</code>:</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">d</span> <span class="o">=</span> <span class="nx">getDog</span><span class="p">();</span>         <span class="c1">// Assume d is a platform object implementing the Dog</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">d</span> <span class="o">=</span> <span class="nx">getDog</span><span class="p">();</span>         <span class="c1">// Assume d is a platform object implementing the Dog</span>
                           <span class="c1">// interface.</span>
 
 <span class="nx">d</span><span class="p">.</span><span class="nx">name</span> <span class="o">=</span> <span class="kc">null</span><span class="p">;</span>            <span class="c1">// This assigns the string "null" to the .name</span>
@@ -8965,7 +8965,7 @@ the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifi
 </pre>
     <p>In an ECMAScript implementation of the interface, the username attribute will be exposed as a non-configurable property on the
     object itself:</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">system</span> <span class="o">=</span> <span class="nx">getSystem</span><span class="p">();</span>                      <span class="c1">// Get an instance of System.</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">system</span> <span class="o">=</span> <span class="nx">getSystem</span><span class="p">();</span>                      <span class="c1">// Get an instance of System.</span>
 
 <span class="nx">system</span><span class="p">.</span><span class="nx">hasOwnProperty</span><span class="p">(</span><span class="s2">"username"</span><span class="p">);</span>             <span class="c1">// Evaluates to true.</span>
 <span class="nx">system</span><span class="p">.</span><span class="nx">hasOwnProperty</span><span class="p">(</span><span class="s2">"loginTime"</span><span class="p">);</span>            <span class="c1">// Evaluates to false.</span>
@@ -9008,7 +9008,7 @@ anything other than a <a data-link-type="dfn" href="#dfn-regular-attribute" id="
 </pre>
     <p>the “f” property an be referenced with a bare identifier
     in a <code>with</code> statement but the “g” property cannot:</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">thing</span> <span class="o">=</span> <span class="nx">getThing</span><span class="p">();</span>  <span class="c1">// An instance of Thing</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">thing</span> <span class="o">=</span> <span class="nx">getThing</span><span class="p">();</span>  <span class="c1">// An instance of Thing</span>
 <span class="kd">with</span> <span class="p">(</span><span class="nx">thing</span><span class="p">)</span> <span class="p">{</span>
   <span class="nx">f</span><span class="p">;</span>                     <span class="c1">// Evaluates to a Function object.</span>
   <span class="nx">g</span><span class="p">;</span>                     <span class="c1">// Throws a ReferenceError.</span>
@@ -11427,16 +11427,12 @@ depending on whether the [<code class="idl"><a data-link-type="idl" href="#Overr
 operates as follows, with property name <var>P</var> and object <var>O</var>:</p>
    <ol class="algorithm">
     <li data-md="">
-     <p>If <var>P</var> is an <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-dfn-unforgeable-property-name-2">unforgeable property name</a> on <var>O</var>, then return false.</p>
-    <li data-md="">
-     <p>If <var>O</var> implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-135">interface</a> with
-an [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-19">Unforgeable</a></code>]-annotated <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-76">attribute</a> whose <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-82">identifier</a> is <var>P</var>, then return false.</p>
-    <li data-md="">
      <p>If <var>P</var> is not a <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-4">supported property name</a> of <var>O</var>, then return false.</p>
     <li data-md="">
-     <p>If <var>O</var> implements an interface that has the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-9">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-101">extended attribute</a>, then return true.</p>
-    <li data-md="">
      <p>If <var>O</var> has an own property named <var>P</var>, then return false.</p>
+     <p class="note" role="note">Note: This will include cases in which <var>O</var> has unforgeable properties, because in practice those are always set up before objects have any supported property names, and once set up will make the corresponding named properties invisible.</p>
+    <li data-md="">
+     <p>If <var>O</var> implements an interface that has the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-9">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-101">extended attribute</a>, then return true.</p>
     <li data-md="">
      <p>Initialize <var>prototype</var> to be the value of the internal [[Prototype]] property of <var>O</var>.</p>
     <li data-md="">
@@ -11457,22 +11453,18 @@ and <var>prototype</var> has an own property named <var>P</var>, then return fal
      <li data-md="">
       <p>Indexed properties.</p>
      <li data-md="">
-      <p>Unforgeable attributes and operations.</p>
+      <p>Own properties, including unforgeable attributes and operations.</p>
      <li data-md="">
       <p>Then, if [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-10">OverrideBuiltins</a></code>]:</p>
       <ol>
        <li data-md="">
         <p>Named properties.</p>
        <li data-md="">
-        <p>Own properties.</p>
-       <li data-md="">
         <p>Properties from the prototype chain.</p>
       </ol>
      <li data-md="">
       <p>Otherwise, if not [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-11">OverrideBuiltins</a></code>]:</p>
       <ol>
-       <li data-md="">
-        <p>Own properties.</p>
        <li data-md="">
         <p>Properties from the prototype chain.</p>
        <li data-md="">
@@ -11501,7 +11493,7 @@ object <var>O</var>, a property name <var>P</var>, and a boolean <var>ignoreName
         <li data-md="">
          <p>Let <var>value</var> be an uninitialized variable.</p>
         <li data-md="">
-         <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-83">identifier</a>, then
+         <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-82">identifier</a>, then
 set <var>value</var> to the result of performing the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-determine-the-value-of-an-indexed-property" id="ref-for-dfn-determine-the-value-of-an-indexed-property-1">determine the value of an indexed property</a> with <var>index</var> as the index.</p>
         <li data-md="">
          <p>Otherwise, <var>operation</var> was defined with an identifier.  Set <var>value</var> to the result
@@ -11522,7 +11514,7 @@ of performing the steps listed in the description of <var>operation</var> with <
      </ol>
     <li data-md="">
      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-6">supports named properties</a>, <var>O</var> does not
-implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-136">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-97">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-98">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-102">extended attribute</a>, the result of running the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-2">named property visibility algorithm</a> with
+implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-135">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-97">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-98">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-102">extended attribute</a>, the result of running the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-2">named property visibility algorithm</a> with
 property name <var>P</var> and object <var>O</var> is true, and <var>ignoreNamedProps</var> is false, then:</p>
      <ol>
       <li data-md="">
@@ -11530,7 +11522,7 @@ property name <var>P</var> and object <var>O</var> is true, and <var>ignoreNamed
       <li data-md="">
        <p>Let <var>value</var> be an uninitialized variable.</p>
       <li data-md="">
-       <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-84">identifier</a>, then
+       <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-83">identifier</a>, then
 set <var>value</var> to the result of performing the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-determine-the-value-of-a-named-property" id="ref-for-dfn-determine-the-value-of-a-named-property-2">determine the value of a named property</a> with <var>P</var> as the name.</p>
       <li data-md="">
        <p>Otherwise, <var>operation</var> was defined with an identifier.  Set <var>value</var> to the result
@@ -11555,7 +11547,7 @@ otherwise set it to <emu-val>true</emu-val>.</p>
      <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinarygetownproperty">OrdinaryGetOwnProperty</a>(<var>O</var>, <var>P</var>).</p>
    </ol>
    <h4 class="heading settled" data-level="4.8.3" id="getownproperty"><span class="secno">4.8.3. </span><span class="content">Platform object [[GetOwnProperty]] method</span><a class="self-link" href="#getownproperty"></a></h4>
-   <p>The internal [[GetOwnProperty]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-52">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-137">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-11">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-7">named properties</a> must behave as follows when called with property name <var>P</var>:</p>
+   <p>The internal [[GetOwnProperty]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-52">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-136">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-11">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-7">named properties</a> must behave as follows when called with property name <var>P</var>:</p>
    <ol class="algorithm">
     <li data-md="">
      <p>Return the result of invoking the <a data-link-type="dfn" href="#getownproperty-guts" id="ref-for-getownproperty-guts-1">PlatformObjectGetOwnProperty</a> abstract operation with <var>O</var>, <var>P</var>, and <emu-val>false</emu-val> as
@@ -11575,7 +11567,7 @@ arguments.</p>
     <li data-md="">
      <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-65">converting</a> <var>V</var> to an IDL value of type <var>T</var>.</p>
     <li data-md="">
-     <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-85">identifier</a>, then:</p>
+     <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-84">identifier</a>, then:</p>
      <ol>
       <li data-md="">
        <p>If <var>creating</var> is true, then perform the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-set-the-value-of-a-new-indexed-property" id="ref-for-dfn-set-the-value-of-a-new-indexed-property-1">set the value of a new indexed property</a> with <var>index</var> as the index and <var>value</var> as the value.</p>
@@ -11597,7 +11589,7 @@ arguments.</p>
     <li data-md="">
      <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-66">converting</a> <var>V</var> to an IDL value of type <var>T</var>.</p>
     <li data-md="">
-     <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-86">identifier</a>, then:</p>
+     <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-85">identifier</a>, then:</p>
      <ol>
       <li data-md="">
        <p>If <var>creating</var> is true, then perform the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-set-the-value-of-a-new-named-property" id="ref-for-dfn-set-the-value-of-a-new-named-property-1">set the value of a new named property</a> with <var>P</var> as the name and <var>value</var> as the value.</p>
@@ -11608,7 +11600,7 @@ arguments.</p>
      <p>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</p>
    </ol>
    <h4 class="heading settled" data-level="4.8.6" id="platformobjectset"><span class="secno">4.8.6. </span><span class="content">Platform object [[Set]] method</span><a class="self-link" href="#platformobjectset"></a></h4>
-   <p>The internal [[Set]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-53">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-138">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-12">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-8">named properties</a> must behave as follows when called
+   <p>The internal [[Set]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-53">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-137">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-12">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-8">named properties</a> must behave as follows when called
 with property name <var>P</var>, value <var>V</var>, and
 ECMAScript language value <var>Receiver</var>:</p>
    <ol class="algorithm">
@@ -11643,7 +11635,7 @@ arguments.</p>
    </ol>
    <h4 class="heading settled" data-level="4.8.7" id="defineownproperty"><span class="secno">4.8.7. </span><span class="content">Platform object [[DefineOwnProperty]] method</span><a class="self-link" href="#defineownproperty"></a></h4>
    <p>When the internal [[DefineOwnProperty]] method of a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-54">platform object</a> <var>O</var> that
-implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-139">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-14">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-10">named properties</a> is
+implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-138">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-14">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-10">named properties</a> is
 called with property key <var>P</var> and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">Property Descriptor</a> <var>Desc</var>, the following steps must be taken:</p>
    <ol class="algorithm">
     <li data-md="">
@@ -11659,8 +11651,8 @@ called with property key <var>P</var> and <a data-link-type="dfn" href="https://
        <p>Return <emu-val>true</emu-val>.</p>
      </ol>
     <li data-md="">
-     <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-11">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-140">interface</a> with the
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-99">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-100">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-104">extended attribute</a> and <var>P</var> is not an <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-dfn-unforgeable-property-name-3">unforgeable property name</a> of <var>O</var>, then:</p>
+     <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-11">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-139">interface</a> with the
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-99">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-100">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-104">extended attribute</a> and <var>P</var> is not an <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-dfn-unforgeable-property-name-2">unforgeable property name</a> of <var>O</var>, then:</p>
      <ol>
       <li data-md="">
        <p>Let <var>creating</var> be true if <var>P</var> is not a <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-6">supported property name</a>, and false otherwise.</p>
@@ -11684,14 +11676,14 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
        </ol>
      </ol>
     <li data-md="">
-     <p>If <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-141">interface</a> with the
+     <p>If <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-140">interface</a> with the
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-101">Global</a></code>] or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-102">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-106">extended attribute</a>, then set <var>Desc</var>.[[Configurable]] to <emu-val>true</emu-val>.</p>
     <li data-md="">
      <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinarydefineownproperty">OrdinaryDefineOwnProperty</a>(<var>O</var>, <var>P</var>, <var>Desc</var>).</p>
    </ol>
    <h4 class="heading settled" data-level="4.8.8" id="delete"><span class="secno">4.8.8. </span><span class="content">Platform object [[Delete]] method</span><a class="self-link" href="#delete"></a></h4>
-   <p>The internal [[Delete]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-55">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-142">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-16">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-12">named properties</a> must behave as follows when called with property name <var>P</var>.</p>
+   <p>The internal [[Delete]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-55">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-141">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-16">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-12">named properties</a> must behave as follows when called with property name <var>P</var>.</p>
    <ol class="algorithm">
     <li data-md="">
      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-17">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-5">array index property name</a>, then:</p>
@@ -11704,7 +11696,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
        <p>Return <emu-val>false</emu-val>.</p>
      </ol>
     <li data-md="">
-     <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-13">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-143">interface</a> with the
+     <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-13">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-142">interface</a> with the
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-103">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-104">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-107">extended attribute</a> and the result of calling the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-3">named property visibility algorithm</a> with property name <var>P</var> and object <var>O</var> is true, then:</p>
      <ol>
       <li data-md="">
@@ -11712,7 +11704,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
       <li data-md="">
        <p>Let <var>operation</var> be the operation used to declare the named property deleter.</p>
       <li data-md="">
-       <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-87">identifier</a>, then:</p>
+       <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-86">identifier</a>, then:</p>
        <ol>
         <li data-md="">
          <p>Perform the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-delete-an-existing-named-property" id="ref-for-dfn-delete-an-existing-named-property-1">delete an existing named property</a> with <var>P</var> as the name.</p>
@@ -11742,7 +11734,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
      <p>Return <emu-val>true</emu-val>.</p>
    </ol>
    <h4 class="heading settled" data-level="4.8.9" id="call"><span class="secno">4.8.9. </span><span class="content">Platform object [[Call]] method</span><a class="self-link" href="#call"></a></h4>
-   <p>The internal [[Call]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-56">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-144">interface</a> <var>I</var> with at least one <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-8">legacy caller</a> must behave as follows, assuming <var>arg</var><sub>0..<var>n</var>−1</sub> is the list of argument
+   <p>The internal [[Call]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-56">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-143">interface</a> <var>I</var> with at least one <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-8">legacy caller</a> must behave as follows, assuming <var>arg</var><sub>0..<var>n</var>−1</sub> is the list of argument
 values passed to [[Call]]:</p>
    <ol class="algorithm">
     <li data-md="">
@@ -11756,7 +11748,7 @@ values passed to [[Call]]:</p>
    </ol>
    <h4 class="heading settled" data-level="4.8.10" id="property-enumeration"><span class="secno">4.8.10. </span><span class="content">Property enumeration</span><a class="self-link" href="#property-enumeration"></a></h4>
    <p>This document does not define a complete property enumeration order
-for all <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-57">platform objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-145">interfaces</a> (or for <a href="#es-exception-objects" id="ref-for-es-exception-objects-1">platform objects representing exceptions</a>).
+for all <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-57">platform objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-144">interfaces</a> (or for <a href="#es-exception-objects" id="ref-for-es-exception-objects-1">platform objects representing exceptions</a>).
 However, if a platform object implements an interface that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-18">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-14">named properties</a>, then
 properties on the object must be
 enumerated in the following order:</p>
@@ -11766,7 +11758,7 @@ enumerated in the following order:</p>
 the object’s <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-8">supported property indices</a> are
 enumerated first, in numerical order.</p>
     <li data-md="">
-     <p>If the object <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-15">supports named properties</a> and doesn’t implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-146">interface</a> with the
+     <p>If the object <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-15">supports named properties</a> and doesn’t implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-145">interface</a> with the
 [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-7">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-108">extended attribute</a>, then
 the object’s <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-7">supported property names</a> that
 are visible according to the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-4">named property visibility algorithm</a> are enumerated next, in the order given in the definition of the set of supported property names.</p>
@@ -11794,17 +11786,17 @@ the callable object itself.</p>
        <p>Otherwise, the object is not <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">callable</a>.
 The implementation of the operation (or set of overloaded operations) is
 the result of invoking the internal [[Get]] method
-on the object with a property name that is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-88">identifier</a> of the operation.</p>
+on the object with a property name that is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-87">identifier</a> of the operation.</p>
      </ul>
     <li data-md="">
      <p>Otherwise, the interface is not a <a data-link-type="dfn" href="#dfn-single-operation-callback-interface" id="ref-for-dfn-single-operation-callback-interface-2">single operation callback interface</a>.
 Any object that is not a native <emu-val>RegExp</emu-val> object is considered to implement the interface.
-For each operation declared on the interface with a given <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-89">identifier</a>, the implementation
+For each operation declared on the interface with a given <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-88">identifier</a>, the implementation
 is the result of invoking [[Get]] on the object with a
 property name that is that identifier.</p>
    </ul>
    <p>Note that ECMAScript objects need not have
-properties corresponding to <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-28">constants</a> on them to be considered as <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-9">user objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-147">interfaces</a> that happen
+properties corresponding to <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-28">constants</a> on them to be considered as <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-9">user objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-146">interfaces</a> that happen
 to have constants declared on them.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-single-operation-callback-interface">single operation callback interface</dfn> is
 a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-27">callback interface</a> that:</p>
@@ -11812,9 +11804,9 @@ a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callbac
     <li data-md="">
      <p>is not declared to <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-14">inherit</a> from another interface,</p>
     <li data-md="">
-     <p>has no <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-77">attributes</a>, and</p>
+     <p>has no <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-76">attributes</a>, and</p>
     <li data-md="">
-     <p>has one or more <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-18">regular operations</a> that all have the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-90">identifier</a>,
+     <p>has one or more <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-18">regular operations</a> that all have the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-89">identifier</a>,
 and no others.</p>
    </ul>
    <p>To <dfn data-dfn-type="dfn" data-export="" id="call-a-user-objects-operation">call a user object’s operation<a class="self-link" href="#call-a-user-objects-operation"></a></dfn>, given a <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-18">callback interface type</a> value <var>value</var>, sometimes-optional operation name <var>opName</var>,
@@ -12102,7 +12094,7 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
    <h3 class="heading settled" data-level="4.11" id="es-namespaces"><span class="secno">4.11. </span><span class="content">Namespaces</span><a class="self-link" href="#es-namespaces"></a></h3>
    <p>For every <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-12">namespace</a> that is <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-9">exposed</a> in a given ECMAScript global environment,
 a corresponding property must exist on the ECMAScript
-environment’s global object. The name of the property is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-91">identifier</a> of the namespace, and its value is an object
+environment’s global object. The name of the property is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-90">identifier</a> of the namespace, and its value is an object
 called the <dfn data-dfn-type="dfn" data-export="" id="dfn-namespace-object">namespace object<a class="self-link" href="#dfn-namespace-object"></a></dfn>.</p>
    <p>The property has the attributes <span class="descriptor">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>,
 [[Configurable]]: <emu-val>true</emu-val> }</span>. The characteristics of a
@@ -12119,7 +12111,7 @@ follows:</p>
       <li data-md="">
        <p>Let <var>F</var> be the result of <a data-link-type="dfn" href="#dfn-create-operation-function" id="ref-for-dfn-create-operation-function-2">creating an operation function</a> given <var>op</var>, <var>namespace</var>,  and <var>realm</var>.</p>
       <li data-md="">
-       <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createdataproperty">CreateDataProperty</a>(<var>namespaceObject</var>, <var>op</var>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-92">identifier</a>, <var>F</var>).</p>
+       <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createdataproperty">CreateDataProperty</a>(<var>namespaceObject</var>, <var>op</var>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-91">identifier</a>, <var>F</var>).</p>
      </ol>
    </ol>
    <h3 class="heading settled" data-level="4.12" id="es-exceptions"><span class="secno">4.12. </span><span class="content">Exceptions</span><a class="self-link" href="#es-exceptions"></a></h3>
@@ -12208,10 +12200,10 @@ on exception objects too.</p>
     <li data-md="">
      <p>Let <var>F</var> be the <emu-val>Function</emu-val> object used
 as the <emu-val>this</emu-val> value in the top-most call
-on the ECMAScript call stack where <var>F</var> corresponds to an IDL <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-78">attribute</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-77">operation</a>, <a data-link-type="dfn" href="#idl-indexed-properties" id="ref-for-idl-indexed-properties-3">indexed property</a>, <a data-link-type="dfn" href="#idl-named-properties" id="ref-for-idl-named-properties-3">named property</a>, <a href="#Constructor" id="ref-for-Constructor-23">constructor</a>, <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-5">named constructor</a> or <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-8">stringifier</a>.</p>
+on the ECMAScript call stack where <var>F</var> corresponds to an IDL <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-77">attribute</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-77">operation</a>, <a data-link-type="dfn" href="#idl-indexed-properties" id="ref-for-idl-indexed-properties-3">indexed property</a>, <a data-link-type="dfn" href="#idl-named-properties" id="ref-for-idl-named-properties-3">named property</a>, <a href="#Constructor" id="ref-for-Constructor-23">constructor</a>, <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-5">named constructor</a> or <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-8">stringifier</a>.</p>
     <li data-md="">
      <p>If <var>F</var> corresponds to an attribute, operation or stringifier, then return
-the global environment associated with the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-148">interface</a> that definition appears on.</p>
+the global environment associated with the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-147">interface</a> that definition appears on.</p>
     <li data-md="">
      <p>Otherwise, if <var>F</var> corresponds to an indexed or named property, then return
 the global environment associated with the interface that
@@ -12303,7 +12295,7 @@ optional user agent-defined message <var>M</var>.</p>
     <p>If we pass a <code class="idl">MathUtils</code> object from
     a different global environment to doComputation, then the exception
     thrown will be from that global environment:</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="nx">getA</span><span class="p">();</span>                           <span class="c1">// An A object from this global environment.</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="nx">getA</span><span class="p">();</span>                           <span class="c1">// An A object from this global environment.</span>
 <span class="kd">var</span> <span class="nx">m</span> <span class="o">=</span> <span class="nx">otherWindow</span><span class="p">.</span><span class="nx">getMathUtils</span><span class="p">();</span>       <span class="c1">// A MathUtils object from a different global environment.</span>
 
 <span class="nx">a</span> <span class="k">instanceof</span> <span class="nb">Object</span><span class="p">;</span>                      <span class="c1">// Evaluates to true.</span>
@@ -12328,7 +12320,7 @@ must propagate to the caller, and if
 not caught there, to its caller, and so on.</p>
    <div class="example" id="example-1432e05c">
     <a class="self-link" href="#example-1432e05c"></a> 
-    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-46">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-149">interfaces</a> and an <a data-link-type="dfn" href="#dfn-exception" id="ref-for-dfn-exception-1">exception</a>.
+    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-46">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-148">interfaces</a> and an <a data-link-type="dfn" href="#dfn-exception" id="ref-for-dfn-exception-1">exception</a>.
     The <code>valueOf</code> attribute on <code class="idl">ExceptionThrower</code> is defined to throw an exception whenever an attempt is made
     to get its value.</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Dahut</span> {
@@ -12342,7 +12334,7 @@ not caught there, to its caller, and so on.</p>
 </pre>
     <p>Assuming an ECMAScript implementation supporting this interface,
     the following code demonstrates how exceptions are handled:</p>
-<pre class="highlight"><span class="kd">var</span> <span class="nx">d</span> <span class="o">=</span> <span class="nx">getDahut</span><span class="p">();</span>              <span class="c1">// Obtain an instance of Dahut.</span>
+<pre class="highlight"><span></span><span class="kd">var</span> <span class="nx">d</span> <span class="o">=</span> <span class="nx">getDahut</span><span class="p">();</span>              <span class="c1">// Obtain an instance of Dahut.</span>
 <span class="kd">var</span> <span class="nx">et</span> <span class="o">=</span> <span class="nx">getExceptionThrower</span><span class="p">();</span>  <span class="c1">// Obtain an instance of ExceptionThrower.</span>
 
 <span class="k">try</span> <span class="p">{</span>
@@ -12558,7 +12550,7 @@ and “<span class="input">.</span>” is tokenized as the quoted terminal symbo
 used in the grammar and the values used for <emu-t><a href="#prod-identifier">identifier</a></emu-t> terminals.  Thus, for
 example, the input text “<span class="input">Const</span>” is tokenized as
 an <emu-t><a href="#prod-identifier">identifier</a></emu-t> rather than the
-terminal symbol <emu-t>const</emu-t>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-150">interface</a> with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-93">identifier</a> “A” is distinct from one named “a”, and an <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-110">extended attribute</a> [<code class="idl">constructor</code>] will not be recognized as
+terminal symbol <emu-t>const</emu-t>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-149">interface</a> with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-92">identifier</a> “A” is distinct from one named “a”, and an <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-110">extended attribute</a> [<code class="idl">constructor</code>] will not be recognized as
 the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-24">Constructor</a></code>]
 extended attribute.</p>
    <p>Implicitly, any number of <emu-t><a href="#prod-whitespace">whitespace</a></emu-t> and <emu-t><a href="#prod-comment">comment</a></emu-t> terminals are allowed between every other terminal
@@ -13032,6 +13024,7 @@ possible sequences are used by the <a data-link-type="dfn" href="#dfn-extended-a
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-a-callback">clean up after running a callback</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script">clean up after running script</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-attributes">event handler idl attributes</a>
@@ -13044,19 +13037,14 @@ possible sequences are used by the <a data-link-type="dfn" href="#dfn-extended-a
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-settings-object">settings object</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[UNICODE]</a> defines the following terms:
-    <ul>
-     <li><a href="http://www.unicode.org/glossary/#unicode_scalar_value">unicode scalar value</a>
-    </ul>
-   <li>
-    <a data-link-type="biblio">[HTML]</a> defines the following terms:
-    <ul>
-     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>
-    </ul>
-   <li>
     <a data-link-type="biblio">[secure-contexts]</a> defines the following terms:
     <ul>
      <li><a href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[UNICODE]</a> defines the following terms:
+    <ul>
+     <li><a href="http://www.unicode.org/glossary/#unicode_scalar_value">unicode scalar value</a>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -13222,15 +13210,14 @@ possible sequences are used by the <a data-link-type="dfn" href="#dfn-extended-a
     <li><a href="#ref-for-dfn-identifier-79">4.6.9.4. Default iterator objects</a>
     <li><a href="#ref-for-dfn-identifier-80">4.6.9.5. Iterator prototype object</a>
     <li><a href="#ref-for-dfn-identifier-81">4.8. Platform objects implementing interfaces</a>
-    <li><a href="#ref-for-dfn-identifier-82">4.8.1. Indexed and named properties</a>
-    <li><a href="#ref-for-dfn-identifier-83">4.8.2. The PlatformObjectGetOwnProperty abstract operation</a> <a href="#ref-for-dfn-identifier-84">(2)</a>
-    <li><a href="#ref-for-dfn-identifier-85">4.8.4. Invoking a platform object indexed property setter</a>
-    <li><a href="#ref-for-dfn-identifier-86">4.8.5. Invoking a platform object named property setter</a>
-    <li><a href="#ref-for-dfn-identifier-87">4.8.8. Platform object [[Delete]] method</a>
-    <li><a href="#ref-for-dfn-identifier-88">4.9. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-identifier-89">(2)</a> <a href="#ref-for-dfn-identifier-90">(3)</a>
-    <li><a href="#ref-for-dfn-identifier-91">4.11. Namespaces</a>
-    <li><a href="#ref-for-dfn-identifier-92">4.11.1. Namespace object</a>
-    <li><a href="#ref-for-dfn-identifier-93">IDL grammar</a>
+    <li><a href="#ref-for-dfn-identifier-82">4.8.2. The PlatformObjectGetOwnProperty abstract operation</a> <a href="#ref-for-dfn-identifier-83">(2)</a>
+    <li><a href="#ref-for-dfn-identifier-84">4.8.4. Invoking a platform object indexed property setter</a>
+    <li><a href="#ref-for-dfn-identifier-85">4.8.5. Invoking a platform object named property setter</a>
+    <li><a href="#ref-for-dfn-identifier-86">4.8.8. Platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-identifier-87">4.9. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-identifier-88">(2)</a> <a href="#ref-for-dfn-identifier-89">(3)</a>
+    <li><a href="#ref-for-dfn-identifier-90">4.11. Namespaces</a>
+    <li><a href="#ref-for-dfn-identifier-91">4.11.1. Namespace object</a>
+    <li><a href="#ref-for-dfn-identifier-92">IDL grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-reserved-identifier">
@@ -13302,18 +13289,18 @@ possible sequences are used by the <a data-link-type="dfn" href="#dfn-extended-a
     <li><a href="#ref-for-dfn-interface-127">4.6.10. Maplike declarations</a> <a href="#ref-for-dfn-interface-128">(2)</a>
     <li><a href="#ref-for-dfn-interface-129">4.6.11. Setlike declarations</a> <a href="#ref-for-dfn-interface-130">(2)</a>
     <li><a href="#ref-for-dfn-interface-131">4.7. Implements statements</a>
-    <li><a href="#ref-for-dfn-interface-132">4.8.1. Indexed and named properties</a> <a href="#ref-for-dfn-interface-133">(2)</a> <a href="#ref-for-dfn-interface-134">(3)</a> <a href="#ref-for-dfn-interface-135">(4)</a>
-    <li><a href="#ref-for-dfn-interface-136">4.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-dfn-interface-137">4.8.3. Platform object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-interface-138">4.8.6. Platform object [[Set]] method</a>
-    <li><a href="#ref-for-dfn-interface-139">4.8.7. Platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-interface-140">(2)</a> <a href="#ref-for-dfn-interface-141">(3)</a>
-    <li><a href="#ref-for-dfn-interface-142">4.8.8. Platform object [[Delete]] method</a> <a href="#ref-for-dfn-interface-143">(2)</a>
-    <li><a href="#ref-for-dfn-interface-144">4.8.9. Platform object [[Call]] method</a>
-    <li><a href="#ref-for-dfn-interface-145">4.8.10. Property enumeration</a> <a href="#ref-for-dfn-interface-146">(2)</a>
-    <li><a href="#ref-for-dfn-interface-147">4.9. User objects implementing callback interfaces</a>
-    <li><a href="#ref-for-dfn-interface-148">4.14. Creating and throwing exceptions</a>
-    <li><a href="#ref-for-dfn-interface-149">4.15. Handling exceptions</a>
-    <li><a href="#ref-for-dfn-interface-150">IDL grammar</a>
+    <li><a href="#ref-for-dfn-interface-132">4.8.1. Indexed and named properties</a> <a href="#ref-for-dfn-interface-133">(2)</a> <a href="#ref-for-dfn-interface-134">(3)</a>
+    <li><a href="#ref-for-dfn-interface-135">4.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
+    <li><a href="#ref-for-dfn-interface-136">4.8.3. Platform object [[GetOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-interface-137">4.8.6. Platform object [[Set]] method</a>
+    <li><a href="#ref-for-dfn-interface-138">4.8.7. Platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-interface-139">(2)</a> <a href="#ref-for-dfn-interface-140">(3)</a>
+    <li><a href="#ref-for-dfn-interface-141">4.8.8. Platform object [[Delete]] method</a> <a href="#ref-for-dfn-interface-142">(2)</a>
+    <li><a href="#ref-for-dfn-interface-143">4.8.9. Platform object [[Call]] method</a>
+    <li><a href="#ref-for-dfn-interface-144">4.8.10. Property enumeration</a> <a href="#ref-for-dfn-interface-145">(2)</a>
+    <li><a href="#ref-for-dfn-interface-146">4.9. User objects implementing callback interfaces</a>
+    <li><a href="#ref-for-dfn-interface-147">4.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-interface-148">4.15. Handling exceptions</a>
+    <li><a href="#ref-for-dfn-interface-149">IDL grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-interface-member">
@@ -13465,9 +13452,8 @@ possible sequences are used by the <a data-link-type="dfn" href="#dfn-extended-a
     <li><a href="#ref-for-dfn-attribute-72">4.6.7.1. Stringifiers</a>
     <li><a href="#ref-for-dfn-attribute-73">4.6.8.1. @@iterator</a>
     <li><a href="#ref-for-dfn-attribute-74">4.7. Implements statements</a> <a href="#ref-for-dfn-attribute-75">(2)</a>
-    <li><a href="#ref-for-dfn-attribute-76">4.8.1. Indexed and named properties</a>
-    <li><a href="#ref-for-dfn-attribute-77">4.9. User objects implementing callback interfaces</a>
-    <li><a href="#ref-for-dfn-attribute-78">4.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-attribute-76">4.9. User objects implementing callback interfaces</a>
+    <li><a href="#ref-for-dfn-attribute-77">4.14. Creating and throwing exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-regular-attribute">
@@ -15663,7 +15649,7 @@ possible sequences are used by the <a data-link-type="dfn" href="#dfn-extended-a
     <li><a href="#ref-for-Unforgeable-5">4.3.20. [Unforgeable]</a> <a href="#ref-for-Unforgeable-6">(2)</a> <a href="#ref-for-Unforgeable-7">(3)</a> <a href="#ref-for-Unforgeable-8">(4)</a> <a href="#ref-for-Unforgeable-9">(5)</a> <a href="#ref-for-Unforgeable-10">(6)</a> <a href="#ref-for-Unforgeable-11">(7)</a> <a href="#ref-for-Unforgeable-12">(8)</a> <a href="#ref-for-Unforgeable-13">(9)</a>
     <li><a href="#ref-for-Unforgeable-14">4.6.6. Attributes</a>
     <li><a href="#ref-for-Unforgeable-15">4.8. Platform objects implementing interfaces</a> <a href="#ref-for-Unforgeable-16">(2)</a> <a href="#ref-for-Unforgeable-17">(3)</a>
-    <li><a href="#ref-for-Unforgeable-18">4.8.1. Indexed and named properties</a> <a href="#ref-for-Unforgeable-19">(2)</a>
+    <li><a href="#ref-for-Unforgeable-18">4.8.1. Indexed and named properties</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-unforgeable-on-an-interface">
@@ -15894,8 +15880,8 @@ possible sequences are used by the <a data-link-type="dfn" href="#dfn-extended-a
   <aside class="dfn-panel" data-for="dfn-unforgeable-property-name">
    <b><a href="#dfn-unforgeable-property-name">#dfn-unforgeable-property-name</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-unforgeable-property-name-1">4.8.1. Indexed and named properties</a> <a href="#ref-for-dfn-unforgeable-property-name-2">(2)</a>
-    <li><a href="#ref-for-dfn-unforgeable-property-name-3">4.8.7. Platform object [[DefineOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-unforgeable-property-name-1">4.8.1. Indexed and named properties</a>
+    <li><a href="#ref-for-dfn-unforgeable-property-name-2">4.8.7. Platform object [[DefineOwnProperty]] method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-named-property-visibility">


### PR DESCRIPTION
Fixes <https://github.com/heycam/webidl/issues/152>.