### PR TITLE
Remove "initializing objects from iterables"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11850,44 +11850,6 @@ The value of the <emu-val>Function</emu-val> object’s “length” property is
 The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “clear”.
 
 
-<h4 id="initializing-objects-from-iterables">Initializing objects from iterables</h4>
-
-Some objects, which are attempting to emulate map- and set-like interfaces, will want to accept iterables
-as constructor parameters and initialize themselves in this way. Here we provide some algorithms that can
-be invoked in order to do so in the same way as in the ECMAScript spec, so that those objects behave
-the same as the built-in <emu-val>Map</emu-val> and <emu-val>Set</emu-val> objects.
-
-To <dfn id="add-map-elements-from-iterable" export>add map elements from an iterable</dfn> |iterable| to
-an object |destination| with adder method name |adder|, perform the following steps:
-
-<ol class="algorithm">
-    1.  If [=Type=](|destination|) is not Object, then, <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
-    1.  If |iterable| is not present, let |iterable| be <emu-val>undefined</emu-val>.
-    1.  If |iterable| is either <emu-val>undefined</emu-val> or <emu-val>null</emu-val>, then let |iter| be <emu-val>undefined</emu-val>.
-    1.  Else,
-        1.  Let |adder| be the result of [=Get=](|destination|, |adder|).
-        1.  [=ReturnIfAbrupt=](|adder|).
-        1.  If [=IsCallable=](|adder|) is <emu-val>false</emu-val>, <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
-        1.  Let |iter| be the result of [=GetIterator=](|iterable|).
-        1.  [=ReturnIfAbrupt=](|iter|).
-    1.  If |iter| is <emu-val>undefined</emu-val>, then return.
-    1.  Repeat
-        1.  Let |next| be the result of [=IteratorStep=](|iter|).
-        1.  [=ReturnIfAbrupt=](|next|).
-        1.  If |next| is <emu-val>false</emu-val>, then return [=NormalCompletion=](|destination|).
-        1.  Let |nextItem| be [=IteratorValue=](|next|).
-        1.  [=ReturnIfAbrupt=](|nextItem|).
-        1.  If [=Type=](|nextItem|) is not Object, then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
-        1.  Let |k| be the result of [=Get=](|nextItem|, <code>"0"</code>).
-        1.  [=ReturnIfAbrupt=](|k|).
-        1.  Let |v| be the result of [=Get=](|nextItem|, <code>"1"</code>).
-        1.  [=ReturnIfAbrupt=](|v|).
-        1.  Let |status| be the result of calling the \[[Call]] internal method of |adder| with |destination| as
-            |thisArgument| and (|k|, |v|) as |argumentsList|.
-        1.  [=ReturnIfAbrupt=](|status|).
-</ol>
-
-
 <h3 id="es-implements-statements">Implements statements</h3>
 
 The [=interface prototype object=]

--- a/index.html
+++ b/index.html
@@ -1544,7 +1544,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web IDL</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-09-26">26 September 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-09-30">30 September 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1811,7 +1811,6 @@ are interoperable.</p>
           <li><a href="#es-add-delete"><span class="secno">3.6.11.5</span> <span class="content">add and delete</span></a>
           <li><a href="#es-set-clear"><span class="secno">3.6.11.6</span> <span class="content">clear</span></a>
          </ol>
-        <li><a href="#initializing-objects-from-iterables"><span class="secno">3.6.12</span> <span class="content">Initializing objects from iterables</span></a>
        </ol>
       <li><a href="#es-implements-statements"><span class="secno">3.7</span> <span class="content">Implements statements</span></a>
       <li>
@@ -2432,7 +2431,7 @@ in the language.</p>
 <span class="p">}</span><span class="p">;</span>
 node<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"click"</span><span class="p">,</span> listener<span class="p">)</span><span class="p">;</span>            <span class="c1">// This works.
 </span>
-node<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"click"</span><span class="p">,</span> <span class="kd">function</span><span class="p">(</span><span class="p">)</span> <span class="p">{</span> <span class="p">.</span><span class="p">.</span><span class="p">.</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// As does this.
+node<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"click"</span><span class="p">,</span> <span class="kd">function</span><span class="p">(</span><span class="p">)</span> <span class="p">{</span> <span class="p">...</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// As does this.
 </span></pre>
     <p>It is not possible for a user object to implement <code class="idl">Node</code>, however:</p>
 <pre class="highlight"><span class="kd">var</span> node <span class="o">=</span> getNode<span class="p">(</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// Obtain an instance of Node.
@@ -4520,7 +4519,7 @@ or have any <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for
 <span class="p">}</span>
 
 <span class="c1">// This loop will also alert "anna" and then "brian".
-</span><span class="k">for</span> <span class="p">(</span><span class="kd">let</span> session of sm<span class="p">)</span> <span class="p">{</span>
+</span><span class="k">for</span> <span class="p">(</span><span class="kd">let</span> session <span class="k">of</span> sm<span class="p">)</span> <span class="p">{</span>
   window<span class="p">.</span>alert<span class="p">(</span>session<span class="p">.</span>username<span class="p">)</span><span class="p">;</span>
 <span class="p">}</span>
 </pre>
@@ -6265,9 +6264,9 @@ that same global environment.</p>
     its own set of <a data-link-type="dfn" href="#dfn-initial-object" id="ref-for-dfn-initial-object-2">initial objects</a>,
     which the following HTML document demonstrates:</p>
 <pre class="highlight"><span class="cp">&lt;!DOCTYPE html></span>
-<span class="nt">&lt;title</span><span class="nt">></span>Different global environments<span class="nt">&lt;/title></span>
-<span class="nt">&lt;iframe</span> <span class="na">id=</span><span class="s">a</span><span class="nt">></span><span class="nt">&lt;/iframe></span>
-<span class="nt">&lt;script</span><span class="nt">></span>
+<span class="p">&lt;</span><span class="nt">title</span><span class="p">></span>Different global environments<span class="p">&lt;</span><span class="p">/</span><span class="nt">title</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">id</span><span class="o">=</span><span class="s">a</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">iframe</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
 <span class="kd">var</span> iframe <span class="o">=</span> document<span class="p">.</span>getElementById<span class="p">(</span><span class="s2">"a"</span><span class="p">)</span><span class="p">;</span>
 <span class="kd">var</span> w <span class="o">=</span> iframe<span class="p">.</span>contentWindow<span class="p">;</span>              <span class="c1">// The global object in the frame
 </span>
@@ -6277,7 +6276,7 @@ Object <span class="o">==</span> w<span class="p">.</span>Object<span class="p">
 </span>iframe <span class="k">instanceof</span> w<span class="p">.</span>Object<span class="p">;</span>                <span class="c1">// Evaluates to false
 </span>iframe<span class="p">.</span>appendChild <span class="k">instanceof</span> Function<span class="p">;</span>    <span class="c1">// Evaluates to true
 </span>iframe<span class="p">.</span>appendChild <span class="k">instanceof</span> w<span class="p">.</span>Function<span class="p">;</span>  <span class="c1">// Evaluates to false
-</span><span class="nt">&lt;/script></span>
+</span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
 </pre>
    </div>
    <p>Unless otherwise specified, each ECMAScript global environment <dfn class="dfn-paneled" data-dfn-for="ECMAScript global environment" data-dfn-type="dfn" data-export="" id="dfn-expose">exposes</dfn> all <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-53">interfaces</a> that the implementation supports.  If a given ECMAScript global environment does not
@@ -8018,7 +8017,7 @@ will correspond to properties on the object itself rather than on <a data-link-t
                 window<span class="p">.</span>mozIndexedDB <span class="o">||</span> window<span class="p">.</span>msIndexedDB<span class="p">;</span>
 
 <span class="kd">var</span> requestAnimationFrame <span class="o">=</span> window<span class="p">.</span>requestAnimationFrame <span class="o">||</span>
-                            window<span class="p">.</span>mozRequestAnimationFrame <span class="o">||</span> <span class="p">.</span><span class="p">.</span><span class="p">.</span><span class="p">;</span>
+                            window<span class="p">.</span>mozRequestAnimationFrame <span class="o">||</span> <span class="p">...</span><span class="p">;</span>
 </pre>
     <p>Because of the way variable declarations are handled in
     ECMAScript, the code above would result in the <code>window.indexedDB</code> and <code>window.requestAnimationFrame</code> evaluating
@@ -8105,28 +8104,28 @@ corresponding to <a data-link-type="dfn" href="#dfn-interface-member" id="ref-fo
     the property for an attribute will not be replaced when declaring
     a variable of the same name:</p>
 <pre class="highlight"><span class="cp">&lt;!DOCTYPE html></span>
-<span class="nt">&lt;title</span><span class="nt">></span>Variable declarations and assignments on Window<span class="nt">&lt;/title></span>
-<span class="nt">&lt;iframe</span> <span class="na">name=</span><span class="s">abc</span><span class="nt">></span><span class="nt">&lt;/iframe></span>
+<span class="p">&lt;</span><span class="nt">title</span><span class="p">></span>Variable declarations and assignments on Window<span class="p">&lt;</span><span class="p">/</span><span class="nt">title</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">name</span><span class="o">=</span><span class="s">abc</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">iframe</span><span class="p">></span>
 <span class="c">&lt;!--</span><span class="c"> Shadowing named properties </span><span class="c">--></span>
-<span class="nt">&lt;script</span><span class="nt">></span>
+<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
   window<span class="p">.</span>abc<span class="p">;</span>    <span class="c1">// Evaluates to the iframe’s Window object.
 </span>  abc <span class="o">=</span> <span class="mi">1</span><span class="p">;</span>       <span class="c1">// Shadows the named property.
 </span>  window<span class="p">.</span>abc<span class="p">;</span>    <span class="c1">// Evaluates to 1.
-</span><span class="nt">&lt;/script></span>
+</span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
 
 <span class="c">&lt;!--</span><span class="c"> Preserving properties for IDL attributes </span><span class="c">--></span>
-<span class="nt">&lt;script</span><span class="nt">></span>
+<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
   Window<span class="p">.</span>prototype<span class="p">.</span>def <span class="o">=</span> <span class="mi">2</span><span class="p">;</span>         <span class="c1">// Places a property on the prototype.
 </span>  window<span class="p">.</span>hasOwnProperty<span class="p">(</span><span class="s2">"length"</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// Evaluates to true.
 </span>  length<span class="p">;</span>                           <span class="c1">// Evaluates to 1.
 </span>  def<span class="p">;</span>                              <span class="c1">// Evaluates to 2.
-</span><span class="nt">&lt;/script></span>
-<span class="nt">&lt;script</span><span class="nt">></span>
+</span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
   <span class="kd">var</span> length<span class="p">;</span>                       <span class="c1">// Variable declaration leaves existing property.
 </span>  length<span class="p">;</span>                           <span class="c1">// Evaluates to 1.
 </span>  <span class="kd">var</span> def<span class="p">;</span>                          <span class="c1">// Variable declaration creates shadowing property.
 </span>  def<span class="p">;</span>                              <span class="c1">// Evaluates to undefined.
-</span><span class="nt">&lt;/script></span>
+</span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.6" data-lt="LegacyArrayClass" id="LegacyArrayClass"><span class="secno">3.3.6. </span><span class="content">[LegacyArrayClass]</span></h4>
@@ -11143,65 +11142,6 @@ must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prot
    </ul>
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “clear”.</p>
-   <h4 class="heading settled" data-level="3.6.12" id="initializing-objects-from-iterables"><span class="secno">3.6.12. </span><span class="content">Initializing objects from iterables</span><a class="self-link" href="#initializing-objects-from-iterables"></a></h4>
-   <p>Some objects, which are attempting to emulate map- and set-like interfaces, will want to accept iterables
-as constructor parameters and initialize themselves in this way. Here we provide some algorithms that can
-be invoked in order to do so in the same way as in the ECMAScript spec, so that those objects behave
-the same as the built-in <emu-val>Map</emu-val> and <emu-val>Set</emu-val> objects.</p>
-   <p>To <dfn data-dfn-type="dfn" data-export="" id="add-map-elements-from-iterable">add map elements from an iterable<a class="self-link" href="#add-map-elements-from-iterable"></a></dfn> <var>iterable</var> to
-an object <var>destination</var> with adder method name <var>adder</var>, perform the following steps:</p>
-   <ol class="algorithm">
-    <li data-md="">
-     <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>destination</var>) is not Object, then, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-70">throw a <emu-val>TypeError</emu-val></a>.</p>
-    <li data-md="">
-     <p>If <var>iterable</var> is not present, let <var>iterable</var> be <emu-val>undefined</emu-val>.</p>
-    <li data-md="">
-     <p>If <var>iterable</var> is either <emu-val>undefined</emu-val> or <emu-val>null</emu-val>, then let <var>iter</var> be <emu-val>undefined</emu-val>.</p>
-    <li data-md="">
-     <p>Else,</p>
-     <ol>
-      <li data-md="">
-       <p>Let <var>adder</var> be the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>destination</var>, <var>adder</var>).</p>
-      <li data-md="">
-       <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>adder</var>).</p>
-      <li data-md="">
-       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>adder</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-71">throw a <emu-val>TypeError</emu-val></a>.</p>
-      <li data-md="">
-       <p>Let <var>iter</var> be the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-getiterator">GetIterator</a>(<var>iterable</var>).</p>
-      <li data-md="">
-       <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>iter</var>).</p>
-     </ol>
-    <li data-md="">
-     <p>If <var>iter</var> is <emu-val>undefined</emu-val>, then return.</p>
-    <li data-md="">
-     <p>Repeat</p>
-     <ol>
-      <li data-md="">
-       <p>Let <var>next</var> be the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iteratorstep">IteratorStep</a>(<var>iter</var>).</p>
-      <li data-md="">
-       <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>next</var>).</p>
-      <li data-md="">
-       <p>If <var>next</var> is <emu-val>false</emu-val>, then return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-normalcompletion">NormalCompletion</a>(<var>destination</var>).</p>
-      <li data-md="">
-       <p>Let <var>nextItem</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iteratorvalue">IteratorValue</a>(<var>next</var>).</p>
-      <li data-md="">
-       <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>nextItem</var>).</p>
-      <li data-md="">
-       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>nextItem</var>) is not Object, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-72">throw a <emu-val>TypeError</emu-val></a>.</p>
-      <li data-md="">
-       <p>Let <var>k</var> be the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>nextItem</var>, <code>"0"</code>).</p>
-      <li data-md="">
-       <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>k</var>).</p>
-      <li data-md="">
-       <p>Let <var>v</var> be the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>nextItem</var>, <code>"1"</code>).</p>
-      <li data-md="">
-       <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>v</var>).</p>
-      <li data-md="">
-       <p>Let <var>status</var> be the result of calling the [[Call]] internal method of <var>adder</var> with <var>destination</var> as <var>thisArgument</var> and (<var>k</var>, <var>v</var>) as <var>argumentsList</var>.</p>
-      <li data-md="">
-       <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>status</var>).</p>
-     </ol>
-   </ol>
    <h3 class="heading settled" data-level="3.7" id="es-implements-statements"><span class="secno">3.7. </span><span class="content">Implements statements</span><a class="self-link" href="#es-implements-statements"></a></h3>
    <p>The <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-53">interface prototype object</a> of an interface <var>A</var> must have a copy of
 each property that corresponds to one of the <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-27">constants</a>, <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-74">attributes</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-74">operations</a>, <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-18">iterable declarations</a>, <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-21">maplike declarations</a> and <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-18">setlike declarations</a> that exist on all of the interface prototype objects of <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-37">consequential interfaces</a>.
@@ -11317,10 +11257,10 @@ when indexing the object with an array index.  Similarly for <a data-link-type="
 This way, the definitions of these special operations from
 ancestor interfaces can be overridden.</p>
    <p>Platform objects implementing an interface that supports indexed or named properties cannot be fixed; if <code>Object.freeze</code>, <code>Object.seal</code> or <code>Object.preventExtensions</code> is called on one of these objects, the function
-must <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-73">throw a <emu-val>TypeError</emu-val></a>.
+must <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-70">throw a <emu-val>TypeError</emu-val></a>.
 Similarly, an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-57">interface prototype object</a> that exposes named properties due to the use of [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-95">Global</a></code>] or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-96">PrimaryGlobal</a></code>]
-also must <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-74">throw a <emu-val>TypeError</emu-val></a> if one of the three functions above is called on it.</p>
+also must <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-71">throw a <emu-val>TypeError</emu-val></a> if one of the three functions above is called on it.</p>
    <p>The name of each property that appears to exist due to an object supporting indexed properties
 is an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-array-index-property-name">array index property name</dfn>, which is a property
 name <var>P</var> such that <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>P</var>) is String
@@ -12637,7 +12577,6 @@ language binding.</p>
   <ul class="index">
    <li><a href="#dom-domexception-abort_err">ABORT_ERR</a><span>, in §2.5.1</span>
    <li><a href="#aborterror">AbortError</a><span>, in §2.5.1</span>
-   <li><a href="#add-map-elements-from-iterable">add map elements from an iterable</a><span>, in §3.6.12</span>
    <li><a href="#idl-any">any</a><span>, in §2.11</span>
    <li><a href="#idl-ArrayBuffer">ArrayBuffer</a><span>, in §2.11.30</span>
    <li><a href="#ArrayBufferView">ArrayBufferView</a><span>, in §4</span>
@@ -13097,7 +13036,7 @@ language binding.</p>
    <dt id="biblio-rfc3629">[RFC3629]
    <dd>F. Yergeau. <a href="https://tools.ietf.org/html/rfc3629">UTF-8, a transformation format of ISO 10646</a>. November 2003. Internet Standard. URL: <a href="https://tools.ietf.org/html/rfc3629">https://tools.ietf.org/html/rfc3629</a>
    <dt id="biblio-secure-contexts">[SECURE-CONTEXTS]
-   <dd>Mike West. <a href="https://w3c.github.io/webappsec-secure-contexts/">Secure Contexts</a>. 15 September 2016. CR. URL: <a href="https://w3c.github.io/webappsec-secure-contexts/">https://w3c.github.io/webappsec-secure-contexts/</a>
+   <dd>Mike West. <a href="https://w3c.github.io/webappsec-secure-contexts/">Secure Contexts</a>. 19 July 2016. WD. URL: <a href="https://w3c.github.io/webappsec-secure-contexts/">https://w3c.github.io/webappsec-secure-contexts/</a>
    <dt id="biblio-unicode">[UNICODE]
    <dd><a href="http://www.unicode.org/versions/latest/">The Unicode Standard</a>. URL: <a href="http://www.unicode.org/versions/latest/">http://www.unicode.org/versions/latest/</a>
   </dl>
@@ -15231,8 +15170,7 @@ language binding.</p>
     <li><a href="#ref-for-ecmascript-throw-67">3.6.11.1. size</a>
     <li><a href="#ref-for-ecmascript-throw-68">3.6.11.4. has</a>
     <li><a href="#ref-for-ecmascript-throw-69">3.6.11.5. add and delete</a>
-    <li><a href="#ref-for-ecmascript-throw-70">3.6.12. Initializing objects from iterables</a> <a href="#ref-for-ecmascript-throw-71">(2)</a> <a href="#ref-for-ecmascript-throw-72">(3)</a>
-    <li><a href="#ref-for-ecmascript-throw-73">3.8.1. Indexed and named properties</a> <a href="#ref-for-ecmascript-throw-74">(2)</a>
+    <li><a href="#ref-for-ecmascript-throw-70">3.8.1. Indexed and named properties</a> <a href="#ref-for-ecmascript-throw-71">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-initial-object">


### PR DESCRIPTION
This feature was introduced by #13, but the main thing we actually
needed for Headers et al was open dictionaries (see #180). As such this
feature has not seen any use.