### PR TITLE
Mute escape backslashes of terminal symbol regexes.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12984,7 +12984,7 @@ expression syntax [[!PERLRE]]) as follows:
     <tr>
         <td id="prod-comment"><emu-t class="regex">comment</emu-t></td>
         <td><code>=</code></td>
-        <td><code class="regex"><span class="mute">/</span>\/\/.*|\/\*(.|\n)*?\*\/<span class="mute">/</span></code></td>
+        <td><code class="regex"><span class="mute">/</span><span class="mute">\</span>/<span class="mute">\</span>/.*|<span class="mute">\</span>/\*(.|\n)*?\*<span class="mute">\</span>/<span class="mute">/</span></code></td>
     </tr>
     <tr>
         <td id="prod-other"><emu-t class="regex">other</emu-t></td>

--- a/index.html
+++ b/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 176d39d5a285c04f57d2f0e078fa69273028eb45" name="generator">
+  <meta content="Bikeshed version 0feafaae1a97b66d9da46b325858f9805ac01fb2" name="generator">
 <style>
         pre.set {
           font-size: 80%;
@@ -1557,7 +1557,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web IDL</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-19">19 January 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-20">20 January 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -12375,7 +12375,7 @@ expression syntax <a data-link-type="biblio" href="#biblio-perlre">[PERLRE]</a>)
      <tr>
       <td id="prod-comment"><emu-t class="regex">comment</emu-t>
       <td><code>=</code>
-      <td><code class="regex"><span class="mute">/</span>\/\/.*|\/\*(.|\n)*?\*\/<span class="mute">/</span></code>
+      <td><code class="regex"><span class="mute">/</span><span class="mute">\</span>/<span class="mute">\</span>/.*|<span class="mute">\</span>/\*(.|\n)*?\*<span class="mute">\</span>/<span class="mute">/</span></code>
      <tr>
       <td id="prod-other"><emu-t class="regex">other</emu-t>
       <td><code>=</code>


### PR DESCRIPTION
This mutes the escape backslashes of the comment terminal symbol regex.

It's more correct and makes it easier to programatically extract the regexes for a lexer.

/cc @heycam


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
    
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://cdn.rawgit.com/tobie/webidl/15e54a3/index.html) | [Diff w/ current ED](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fheycam.github.io%2Fwebidl%2F&doc2=https%3A%2F%2Fcdn.rawgit.com%2Ftobie%2Fwebidl%2F15e54a3%2Findex.html) | [Diff w/ base](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2F4c9c298%2Findex.html&doc2=https%3A%2F%2Fcdn.rawgit.com%2Ftobie%2Fwebidl%2F15e54a3%2Findex.html)