### PR TITLE
Simplify the distinguishable table.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -203,6 +203,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         #distinguishable-table {
           font-size: 80%;
           border-collapse: collapse;
+          width: auto;
         }
 
         #distinguishable-table th {
@@ -3315,11 +3316,24 @@ the following algorithm returns <i>true</i>.
     with the non-union type,
     or <i>false</i> otherwise.
 1.  If the two types (taking their [=inner types=]
-    if they are [=nullable types=]) appear
+    if they are [=nullable types=]) appear or are in categories appearing
     in the following table and there is a “●” mark in the corresponding entry
     or there is a letter in the corresponding entry and the designated additional
     requirement below the table is satisfied, then return <i>true</i>.
     Otherwise return <i>false</i>.
+
+    Categories:
+    <dl>
+        <dt>interface-like</dt>
+        <dd>
+            * [=interfaces=]
+            * [=exception types=]
+            * [=buffer source types=]
+        <dt>sequence-like</dt>
+        <dd>
+            * <code>[=sequence=]&lt;T></code>
+            * <code>{{FrozenArray}}&lt;T></code>
+    </dl>
 
     <table id="distinguishable-table" class="matrix data complex">
         <tr>
@@ -3334,11 +3348,11 @@ the following algorithm returns <i>true</i>.
                     <span>string types</span>
             </div></th>
                 <th><div>
-                    <span>interface</span>
-            </div></th>
-                <th><div>
                     <span>object</span>
             </div></th>
+                <th><div>
+                    <span>interface-like</span>
+                </div></th>
                 <th><div>
                     <span>callback function</span>
             </div></th>
@@ -3346,24 +3360,12 @@ the following algorithm returns <i>true</i>.
                     <span>dictionary/record</span>
             </div></th>
                 <th><div>
-                    <span>sequence&lt;|T|&gt;</span>
-            </div></th>
-                <th><div>
-                    <span>FrozenArray&lt;|T|&gt;</span>
-            </div></th>
-                <th><div>
-                    <span>exception types</span>
-            </div></th>
-                <th><div>
-                    <span>buffer source types</span>
+                    <span>sequence-like</span>
             </div></th>
         </tr>
         <tr>
             <th>boolean</th>
             <td></td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
             <td>●</td>
             <td>●</td>
             <td>●</td>
@@ -3382,9 +3384,6 @@ the following algorithm returns <i>true</i>.
             <td>●</td>
             <td>●</td>
             <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
         </tr>
         <tr>
             <th>string types</th>
@@ -3396,37 +3395,28 @@ the following algorithm returns <i>true</i>.
             <td>●</td>
             <td>●</td>
             <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-        </tr>
-        <tr>
-            <th>interface</th>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td>(a)</td>
-            <td></td>
-            <td>(b)</td>
-            <td>(b)</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
         </tr>
         <tr>
             <th>object</th>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <th>interface-like</th>
             <td class="belowdiagonal"></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
+            <td class="belowdiagonal"></td>
+            <td class="belowdiagonal"></td>
+            <td class="belowdiagonal"></td>
+            <td>(a)</td>
+            <td>(b)</td>
+            <td>(b)</td>
+            <td>●</td>
         </tr>
         <tr>
             <th>callback function</th>
@@ -3437,9 +3427,6 @@ the following algorithm returns <i>true</i>.
             <td class="belowdiagonal"></td>
             <td></td>
             <td></td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
             <td>●</td>
         </tr>
         <tr>
@@ -3452,57 +3439,9 @@ the following algorithm returns <i>true</i>.
             <td class="belowdiagonal"></td>
             <td></td>
             <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
         </tr>
         <tr>
-            <th>sequence&lt;|T|&gt;</th>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td></td>
-            <td></td>
-            <td>●</td>
-            <td>●</td>
-        </tr>
-        <tr>
-            <th>FrozenArray&lt;|T|&gt;</th>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td></td>
-            <td>●</td>
-            <td>●</td>
-        </tr>
-        <tr>
-            <th>exception types</th>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td></td>
-            <td>●</td>
-        </tr>
-        <tr>
-            <th>buffer source types</th>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
+            <th>sequence-like</th>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
@@ -3515,9 +3454,9 @@ the following algorithm returns <i>true</i>.
     </table>
 
     <ol type="a">
-        1.  The two identified [=interfaces=] are
-            not the same, it is not possible for a single [=platform object=]
-            to implement both [=interfaces=],
+        1.  The two identified interface-like types are
+            not the same, no single [=platform object=] implements both
+            interface-like types,
             and it is not the case that both are [=callback interfaces=].
         1.  The interface type is not a [=callback interface=].
     </ol>

--- a/index.bs
+++ b/index.bs
@@ -3326,9 +3326,14 @@ the following algorithm returns <i>true</i>.
     <dl>
         <dt>interface-like</dt>
         <dd>
-            * [=interfaces=]
+            * non-[=callback interfaces|callback=] [=interfaces=]
             * [=exception types=]
             * [=buffer source types=]
+        <dt>dictionary-like</dt>
+        <dd>
+            * [=dictionaries=]
+            * [=record types=]
+            * [=callback interfaces=]
         <dt>sequence-like</dt>
         <dd>
             * <code>[=sequence=]&lt;T></code>
@@ -3357,7 +3362,7 @@ the following algorithm returns <i>true</i>.
                     <span>callback function</span>
             </div></th>
                 <th><div>
-                    <span>dictionary/record</span>
+                    <span>dictionary-like</span>
             </div></th>
                 <th><div>
                     <span>sequence-like</span>
@@ -3414,8 +3419,8 @@ the following algorithm returns <i>true</i>.
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td>(a)</td>
-            <td>(b)</td>
-            <td>(b)</td>
+            <td>●</td>
+            <td>●</td>
             <td>●</td>
         </tr>
         <tr>
@@ -3430,7 +3435,7 @@ the following algorithm returns <i>true</i>.
             <td>●</td>
         </tr>
         <tr>
-            <th>dictionary/record</th>
+            <th>dictionary-like</th>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
@@ -3455,10 +3460,8 @@ the following algorithm returns <i>true</i>.
 
     <ol type="a">
         1.  The two identified interface-like types are
-            not the same, no single [=platform object=] implements both
-            interface-like types,
-            and it is not the case that both are [=callback interfaces=].
-        1.  The interface type is not a [=callback interface=].
+            not the same, and no single [=platform object=] implements both
+            interface-like types.
     </ol>
 
     <div class="example" id="example-distinguishability-diff-types">
@@ -3489,9 +3492,9 @@ the following algorithm returns <i>true</i>.
         </pre>
 
         <code>CBIface</code> is distinguishable from <code>Iface</code>
-        because the pair satisfies note (a),
+        because there's a ● at the intersection of dictionary-like and interface-like,
         but it is not distinguishable from <code>Dict</code>
-        because that pair does not satisfy note (b).
+        because there's no ● at the intersection of dictionary-like and itself.
     </div>
 
     <div class="example" id="example-distinguishability-promises">

--- a/index.html
+++ b/index.html
@@ -1246,6 +1246,7 @@ Possible extra rowspan handling
         #distinguishable-table {
           font-size: 80%;
           border-collapse: collapse;
+          width: auto;
         }
 
         #distinguishable-table th {
@@ -4250,11 +4251,32 @@ return <i>true</i> if each <a data-link-type="dfn" href="#dfn-union-member-type"
 with the non-union type,
 or <i>false</i> otherwise.</p>
     <li data-md="">
-     <p>If the two types (taking their <a data-link-type="dfn" href="#dfn-inner-type" id="ref-for-dfn-inner-type-3">inner types</a> if they are <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-7">nullable types</a>) appear
+     <p>If the two types (taking their <a data-link-type="dfn" href="#dfn-inner-type" id="ref-for-dfn-inner-type-3">inner types</a> if they are <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-7">nullable types</a>) appear or are in categories appearing
 in the following table and there is a “●” mark in the corresponding entry
 or there is a letter in the corresponding entry and the designated additional
 requirement below the table is satisfied, then return <i>true</i>.
 Otherwise return <i>false</i>.</p>
+     <p>Categories:</p>
+     <dl>
+      <dt>interface-like
+      <dd>
+       <ul>
+        <li data-md="">
+         <p><a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-41">interfaces</a></p>
+        <li data-md="">
+         <p><a data-link-type="dfn" href="#dfn-exception-type" id="ref-for-dfn-exception-type-1">exception types</a></p>
+        <li data-md="">
+         <p><a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-1">buffer source types</a></p>
+       </ul>
+      <dt>sequence-like
+      <dd>
+       <ul>
+        <li data-md="">
+         <p><code><a data-link-type="dfn" href="#idl-sequence" id="ref-for-idl-sequence-1">sequence</a>&lt;T></code></p>
+        <li data-md="">
+         <p><code><code class="idl"><a data-link-type="idl" href="#idl-frozen-array" id="ref-for-idl-frozen-array-1">FrozenArray</a></code>&lt;T></code></p>
+       </ul>
+     </dl>
      <table class="matrix data complex" id="distinguishable-table">
       <tbody>
        <tr>
@@ -4266,27 +4288,18 @@ Otherwise return <i>false</i>.</p>
         <th>
          <div> <span>string types</span> </div>
         <th>
-         <div> <span>interface</span> </div>
-        <th>
          <div> <span>object</span> </div>
+        <th>
+         <div> <span>interface-like</span> </div>
         <th>
          <div> <span>callback function</span> </div>
         <th>
          <div> <span>dictionary/record</span> </div>
         <th>
-         <div> <span>sequence&lt;<var>T</var>></span> </div>
-        <th>
-         <div> <span>FrozenArray&lt;<var>T</var>></span> </div>
-        <th>
-         <div> <span>exception types</span> </div>
-        <th>
-         <div> <span>buffer source types</span> </div>
+         <div> <span>sequence-like</span> </div>
        <tr>
         <th>boolean
         <td>
-        <td>●
-        <td>●
-        <td>●
         <td>●
         <td>●
         <td>●
@@ -4304,9 +4317,6 @@ Otherwise return <i>false</i>.</p>
         <td>●
         <td>●
         <td>●
-        <td>●
-        <td>●
-        <td>●
        <tr>
         <th>string types
         <td class="belowdiagonal">
@@ -4317,35 +4327,26 @@ Otherwise return <i>false</i>.</p>
         <td>●
         <td>●
         <td>●
-        <td>●
-        <td>●
-        <td>●
-       <tr>
-        <th>interface
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td>(a)
-        <td>
-        <td>(b)
-        <td>(b)
-        <td>●
-        <td>●
-        <td>●
-        <td>●
        <tr>
         <th>object
         <td class="belowdiagonal">
         <td class="belowdiagonal">
         <td class="belowdiagonal">
+        <td>
+        <td>
+        <td>
+        <td>
+        <td>
+       <tr>
+        <th>interface-like
         <td class="belowdiagonal">
-        <td>
-        <td>
-        <td>
-        <td>
-        <td>
-        <td>
-        <td>
+        <td class="belowdiagonal">
+        <td class="belowdiagonal">
+        <td class="belowdiagonal">
+        <td>(a)
+        <td>(b)
+        <td>(b)
+        <td>●
        <tr>
         <th>callback function
         <td class="belowdiagonal">
@@ -4355,9 +4356,6 @@ Otherwise return <i>false</i>.</p>
         <td class="belowdiagonal">
         <td>
         <td>
-        <td>●
-        <td>●
-        <td>●
         <td>●
        <tr>
         <th>dictionary/record
@@ -4369,53 +4367,8 @@ Otherwise return <i>false</i>.</p>
         <td class="belowdiagonal">
         <td>
         <td>●
-        <td>●
-        <td>●
-        <td>●
        <tr>
-        <th>sequence&lt;<var>T</var>>
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td>
-        <td>
-        <td>●
-        <td>●
-       <tr>
-        <th>FrozenArray&lt;<var>T</var>>
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td>
-        <td>●
-        <td>●
-       <tr>
-        <th>exception types
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td>
-        <td>●
-       <tr>
-        <th>buffer source types
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
-        <td class="belowdiagonal">
+        <th>sequence-like
         <td class="belowdiagonal">
         <td class="belowdiagonal">
         <td class="belowdiagonal">
@@ -4427,8 +4380,9 @@ Otherwise return <i>false</i>.</p>
      </table>
      <ol type="a">
       <li data-md="">
-       <p>The two identified <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-41">interfaces</a> are
-not the same, it is not possible for a single <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-4">platform object</a> to implement both <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-42">interfaces</a>,
+       <p>The two identified interface-like types are
+not the same, no single <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-4">platform object</a> implements both
+interface-like types,
 and it is not the case that both are <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-9">callback interfaces</a>.</p>
       <li data-md="">
        <p>The interface type is not a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-10">callback interface</a>.</p>
@@ -4497,7 +4451,7 @@ be the same.</p>
     the overloading is invalid.</p>
    </div>
    <h4 class="heading settled" data-level="2.2.7" id="idl-iterable"><span class="secno">2.2.7. </span><span class="content">Iterable declarations</span><a class="self-link" href="#idl-iterable"></a></h4>
-   <p>An <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-43">interface</a> can be declared to be <dfn data-dfn-type="dfn" data-export="" id="dfn-iterable">iterable<a class="self-link" href="#dfn-iterable"></a></dfn> by using an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-iterable-declaration">iterable declaration</dfn> (matching <emu-nt><a href="#prod-Iterable">Iterable</a></emu-nt>) in the body of the interface.</p>
+   <p>An <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-42">interface</a> can be declared to be <dfn data-dfn-type="dfn" data-export="" id="dfn-iterable">iterable<a class="self-link" href="#dfn-iterable"></a></dfn> by using an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-iterable-declaration">iterable declaration</dfn> (matching <emu-nt><a href="#prod-Iterable">Iterable</a></emu-nt>) in the body of the interface.</p>
 <pre class="syntax highlight"><span class="kt">interface</span> <span class="nv">interface_identifier</span> {
   <span class="kt">iterable</span>&lt;<span class="n">value_type</span>>;
   <span class="kt">iterable</span>&lt;<span class="n">key_type</span>, <span class="n">value_type</span>>;
@@ -4560,7 +4514,7 @@ or have any <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for
         on the <code class="idl">SessionManager</code> sorted by username.</p>
      <p class="issue" id="issue-d0d15dea"><a class="self-link" href="#issue-d0d15dea"></a> Fix reference to removed definition for "values to iterate over". </p>
     </blockquote>
-    <p>In the ECMAScript language binding, the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-2">interface prototype object</a> for the <code class="idl">SessionManager</code> <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-44">interface</a> has a <code>values</code> method that is a function, which, when invoked,
+    <p>In the ECMAScript language binding, the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-2">interface prototype object</a> for the <code class="idl">SessionManager</code> <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-43">interface</a> has a <code>values</code> method that is a function, which, when invoked,
     returns an iterator object that itself has a <code>next</code> method that returns the
     next value to be iterated over.  It has <code>values</code> and <code>entries</code> methods that iterate over the indexes of the list of session objects
     and [index, session object] pairs, respectively.  It also has
@@ -4604,7 +4558,7 @@ An interface with an <a data-link-type="dfn" href="#dfn-iterable-declaration" id
     ε
 </pre>
    <h4 class="heading settled" data-level="2.2.8" id="idl-maplike"><span class="secno">2.2.8. </span><span class="content">Maplike declarations</span><a class="self-link" href="#idl-maplike"></a></h4>
-   <p>An <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-45">interface</a> can be declared to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-maplike">maplike</dfn> by using a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-maplike-declaration">maplike declaration</dfn> (matching <emu-nt><a href="#prod-ReadWriteMaplike">ReadWriteMaplike</a></emu-nt> or <emu-t>readonly</emu-t> <emu-nt><a href="#prod-MaplikeRest">MaplikeRest</a></emu-nt>) in the body of the interface.</p>
+   <p>An <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-44">interface</a> can be declared to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-maplike">maplike</dfn> by using a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-maplike-declaration">maplike declaration</dfn> (matching <emu-nt><a href="#prod-ReadWriteMaplike">ReadWriteMaplike</a></emu-nt> or <emu-t>readonly</emu-t> <emu-nt><a href="#prod-MaplikeRest">MaplikeRest</a></emu-nt>) in the body of the interface.</p>
 <pre class="syntax highlight"><span class="kt">interface</span> <span class="nv">interface_identifier</span> {
   <span class="kt">readonly</span> <span class="kt">maplike</span>&lt;<span class="n">key_type</span>, <span class="n">value_type</span>>;
   <span class="kt">maplike</span>&lt;<span class="n">key_type</span>, <span class="n">value_type</span>>;
@@ -4651,7 +4605,7 @@ A maplike interface and its <a data-link-type="dfn" href="#dfn-inherited-interfa
    <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-17">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-4">maplike declarations</a>.</p>
    <p class="issue" id="issue-dbe4d1af"><a class="self-link" href="#issue-dbe4d1af"></a> Add example. </p>
    <h4 class="heading settled" data-level="2.2.9" id="idl-setlike"><span class="secno">2.2.9. </span><span class="content">Setlike declarations</span><a class="self-link" href="#idl-setlike"></a></h4>
-   <p>An <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-46">interface</a> can be declared to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-setlike">setlike</dfn> by using a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-setlike-declaration">setlike declaration</dfn> (matching <emu-nt><a href="#prod-ReadWriteSetlike">ReadWriteSetlike</a></emu-nt> or <emu-t>readonly</emu-t> <emu-nt><a href="#prod-SetlikeRest">SetlikeRest</a></emu-nt>) in the body of the interface.</p>
+   <p>An <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-45">interface</a> can be declared to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-setlike">setlike</dfn> by using a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-setlike-declaration">setlike declaration</dfn> (matching <emu-nt><a href="#prod-ReadWriteSetlike">ReadWriteSetlike</a></emu-nt> or <emu-t>readonly</emu-t> <emu-nt><a href="#prod-SetlikeRest">SetlikeRest</a></emu-nt>) in the body of the interface.</p>
 <pre class="syntax highlight"><span class="kt">interface</span> <span class="nv">interface_identifier</span> {
   <span class="kt">readonly</span> <span class="kt">setlike</span>&lt;<span class="n">type</span>>;
   <span class="kt">setlike</span>&lt;<span class="n">type</span>>;
@@ -5365,7 +5319,7 @@ An interface <var>A</var> is considered to be a <a data-link-type="dfn" href="#d
      <p><var>O</var> implements a different <a data-link-type="dfn" href="#dfn-supplemental-interface" id="ref-for-dfn-supplemental-interface-2">supplemental interface</a> <var>C</var>, and <var>C</var> <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-8">inherits</a> from <var>A</var>.</p>
    </ul>
    <div class="note" role="note">
-    <p>Specification authors are discouraged from writing <a data-link-type="dfn" href="#dfn-implements-statement" id="ref-for-dfn-implements-statement-5">implements statements</a> where the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-47">interface</a> on the left-hand side
+    <p>Specification authors are discouraged from writing <a data-link-type="dfn" href="#dfn-implements-statement" id="ref-for-dfn-implements-statement-5">implements statements</a> where the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-46">interface</a> on the left-hand side
     is a <a data-link-type="dfn" href="#dfn-supplemental-interface" id="ref-for-dfn-supplemental-interface-3">supplemental interface</a>.
     For example, if author 1 writes:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Window</span> { /* ... */ };
@@ -5426,7 +5380,7 @@ of those consequential interfaces or on the original interface itself.</p>
 </pre>
    <div class="example" id="example-4ec12a2d">
     <a class="self-link" href="#example-4ec12a2d"></a> 
-    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-29">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-48">interfaces</a>, stating
+    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-29">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-47">interfaces</a>, stating
     that one interface is always implemented on objects implementing the other.</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Entry</span> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">short</span> <span class="nv">entryType</span>;
@@ -5455,11 +5409,11 @@ an object can be described as being a <dfn class="dfn-paneled" data-dfn-type="df
 object that are considered to be platform objects:</p>
    <ul>
     <li data-md="">
-     <p>objects that implement a non-<a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-13">callback</a> <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-49">interface</a>;</p>
+     <p>objects that implement a non-<a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-13">callback</a> <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-48">interface</a>;</p>
     <li data-md="">
      <p>objects representing IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-16">DOMExceptions</a></code>.</p>
    </ul>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-legacy-platform-object">Legacy platform objects</dfn> are <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-7">platform objects</a> that implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-50">interface</a> which
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-legacy-platform-object">Legacy platform objects</dfn> are <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-7">platform objects</a> that implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-49">interface</a> which
 does not have a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-5">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-6">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-22">extended attribute</a>, <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-9">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-4">named properties</a>,
 and may have one or multiple <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-10">legacy callers</a>.</p>
    <p>In a browser, for example,
@@ -5496,7 +5450,7 @@ the <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-typ
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-buffer-source-type">buffer source types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-ArrayBuffer" id="ref-for-idl-ArrayBuffer-1">ArrayBuffer</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-DataView" id="ref-for-idl-DataView-1">DataView</a></code>,
 and the <a data-link-type="dfn" href="#dfn-typed-array-type" id="ref-for-dfn-typed-array-type-1">typed array types</a>.</p>
    <p>The <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-1">object</a></code> type,
-all <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-2">interface types</a> and the <a data-link-type="dfn" href="#dfn-exception-type" id="ref-for-dfn-exception-type-1">exception types</a> are known as <dfn data-dfn-type="dfn" data-export="" id="dfn-object-type">object types<a class="self-link" href="#dfn-object-type"></a></dfn>.</p>
+all <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-2">interface types</a> and the <a data-link-type="dfn" href="#dfn-exception-type" id="ref-for-dfn-exception-type-2">exception types</a> are known as <dfn data-dfn-type="dfn" data-export="" id="dfn-object-type">object types<a class="self-link" href="#dfn-object-type"></a></dfn>.</p>
    <p>Every type has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-type-name">type name</dfn>, which
 is a string, not necessarily unique, that identifies the type.
 Each sub-section below defines what the type name is for each
@@ -5799,7 +5753,7 @@ all possible non-null object references.</p>
    <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-18">type name</a> of the <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-4">object</a></code> type is “Object”.</p>
    <h4 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="2.11.19" data-lt="Interface types" data-noexport="" id="idl-interface"><span class="secno">2.11.19. </span><span class="content">Interface types</span></h4>
    <p>An <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-41">identifier</a> that
-identifies an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-51">interface</a> is used to refer to
+identifies an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-50">interface</a> is used to refer to
 a type that corresponds to the set of all possible non-null references to objects that
 implement that interface.</p>
    <p>For non-callback interfaces, an IDL value of the interface type is represented just
@@ -5874,7 +5828,7 @@ the string “OrNull”.</p>
   <span class="kt">const</span> <span class="kt">boolean</span>? <span class="nv">ARE_WE_THERE_YET</span> = <span class="kt">false</span>;
 };
 </pre>
-    <p>The following <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-52">interface</a> has two <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-21">attributes</a>: one whose value can
+    <p>The following <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-51">interface</a> has two <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-21">attributes</a>: one whose value can
     be a <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-43">DOMString</a></code> or the <emu-val>null</emu-val> value, and another whose value can be a reference to a <code class="idl">Node</code> object or the <emu-val>null</emu-val> value:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Node</span> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span>? <span class="nv">namespaceURI</span>;
@@ -5883,7 +5837,7 @@ the string “OrNull”.</p>
 };
 </pre>
    </div>
-   <h4 class="heading settled" data-dfn-type="dfn" data-export="" data-level="2.11.24" data-lt="sequence" id="idl-sequence"><span class="secno">2.11.24. </span><span class="content">Sequence types — sequence&lt;<var>T</var>></span><span id="dom-sequence"></span><a class="self-link" href="#idl-sequence"></a></h4>
+   <h4 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="2.11.24" data-lt="sequence" id="idl-sequence"><span class="secno">2.11.24. </span><span class="content">Sequence types — sequence&lt;<var>T</var>></span><span id="dom-sequence"></span></h4>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="sequence type" id="sequence-type">sequence&lt;<var>T</var>></dfn> type is a parameterized type whose values are (possibly zero-length) sequences of
 values of type <var>T</var>.</p>
    <p>Sequences are always passed by value.  In
@@ -6071,7 +6025,7 @@ data.  The table below lists these types and the kind of buffer or view they rep
    <p>There is no way to represent a constant value of any of these types in IDL.</p>
    <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-30">type name</a> of all
 of these types is the name of the type itself.</p>
-   <p>At the specification prose level, IDL <a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-1">buffer source types</a> are simply references to objects.  To inspect or manipulate the bytes inside the buffer,
+   <p>At the specification prose level, IDL <a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-2">buffer source types</a> are simply references to objects.  To inspect or manipulate the bytes inside the buffer,
 specification prose must first either <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="get a reference to the buffer source" id="dfn-get-buffer-source-reference">get a reference to the bytes held by the buffer source</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="get a copy of the buffer source" id="dfn-get-buffer-source-copy">get a copy of the bytes held by the buffer source</dfn>.
 With a reference to the buffer source’s bytes, specification prose can get or set individual
 byte values using that reference.</p>
@@ -6111,7 +6065,7 @@ how interacting with buffer source types works in the ECMAScript language bindin
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-frozen-array-type">frozen array type</dfn> is a parameterized
 type whose values are references to objects that hold a fixed length array
 of unmodifiable values.  The values in the array are of type <var>T</var>.</p>
-   <p>Since <a class="idl-code" data-link-type="interface" href="#idl-frozen-array" id="ref-for-idl-frozen-array-1">FrozenArray&lt;<var>T</var>></a> values
+   <p>Since <a class="idl-code" data-link-type="interface" href="#idl-frozen-array" id="ref-for-idl-frozen-array-2">FrozenArray&lt;<var>T</var>></a> values
 are references, they are unlike <a data-link-type="dfn" href="#sequence-type" id="ref-for-sequence-type-9">sequence types</a>,
 which are lists of values that are passed by value.</p>
    <p>There is no way to represent a constant frozen array value in IDL.</p>
@@ -6264,7 +6218,7 @@ more of the following are redefined in accordance with the rules for exotic obje
 [[Delete]] and
 [[HasInstance]].</p>
    <p>Other specifications may override the definitions
-of any internal method of a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-10">platform object</a> that is an instance of an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-53">interface</a>.</p>
+of any internal method of a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-10">platform object</a> that is an instance of an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-52">interface</a>.</p>
    <p class="advisement"> As overriding internal ECMAScript object methods is a low level operation and
     can result in objects that behave differently from ordinary objects,
     this facility should not be used unless necessary
@@ -6387,7 +6341,7 @@ Object <span class="o">==</span> w<span class="p">.</span>Object<span class="p">
 </span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
 </pre>
    </div>
-   <p>Unless otherwise specified, each ECMAScript global environment <dfn class="dfn-paneled" data-dfn-for="ECMAScript global environment" data-dfn-type="dfn" data-export="" id="dfn-expose">exposes</dfn> all <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-54">interfaces</a> that the implementation supports.  If a given ECMAScript global environment does not
+   <p>Unless otherwise specified, each ECMAScript global environment <dfn class="dfn-paneled" data-dfn-for="ECMAScript global environment" data-dfn-type="dfn" data-export="" id="dfn-expose">exposes</dfn> all <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-53">interfaces</a> that the implementation supports.  If a given ECMAScript global environment does not
 expose an interface, then the requirements given in <a href="#es-interfaces">§3.6 Interfaces</a> are
 not followed for that interface.</p>
    <p class="note" role="note">Note: This allows, for example, ECMAScript global environments for Web Workers to <a data-link-type="dfn" href="#dfn-expose" id="ref-for-dfn-expose-1">expose</a> different sets of supported interfaces from those exposed in environments
@@ -6880,7 +6834,7 @@ the value of the corresponding element of <var>x</var>.</p>
    <h4 class="heading settled" data-level="3.2.13" id="es-interface"><span class="secno">3.2.13. </span><span class="content">Interface types</span><a class="self-link" href="#es-interface"></a></h4>
    <p>IDL <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-4">interface type</a> values are represented by ECMAScript <emu-val>Object</emu-val> or <emu-val>Function</emu-val> values.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to interface" id="es-to-interface">
-    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-20">converted</a> to an IDL <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-5">interface type</a> value by running the following algorithm (where <var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-55">interface</a>):</p>
+    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-20">converted</a> to an IDL <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-5">interface type</a> value by running the following algorithm (where <var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-54">interface</a>):</p>
     <ol>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-8">throw</a> a <emu-val>TypeError</emu-val>.</p>
@@ -7136,7 +7090,7 @@ at index <var>j</var> is <var>S</var><sub><var>j</var></sub>.</p>
    </div>
    <div class="example" id="example-520e0ef6">
     <a class="self-link" href="#example-520e0ef6"></a> 
-    <p>The following <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-56">interface</a> defines
+    <p>The following <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-55">interface</a> defines
     an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-30">attribute</a> of a sequence
     type as well as an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-34">operation</a> with an argument of a sequence type.</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Canvas</span> {
@@ -7572,7 +7526,7 @@ to the same object as <var>V</var>.</p>
     value is the <emu-val>Object</emu-val> value that represents a reference to the same object that the
     IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-32">DOMException</a></code> represents. </p>
    <h4 class="heading settled" data-level="3.2.24" id="es-buffer-source-types"><span class="secno">3.2.24. </span><span class="content">Buffer source types</span><a class="self-link" href="#es-buffer-source-types"></a></h4>
-   <p>Values of the IDL <a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-2">buffer source types</a> are represented by objects of the corresponding ECMAScript class.</p>
+   <p>Values of the IDL <a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-3">buffer source types</a> are represented by objects of the corresponding ECMAScript class.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to buffer source" id="es-to-buffer-source">
     <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-54">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#idl-ArrayBuffer" id="ref-for-idl-ArrayBuffer-12">ArrayBuffer</a></code> value by running the following algorithm:</p>
     <ol>
@@ -7612,7 +7566,7 @@ then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-thr
       <p>Return the IDL value of type <var>T</var> that is a reference to the same object as <var>V</var>.</p>
     </ol>
    </div>
-   <p>The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-35">converting</a> an IDL value of any <a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-3">buffer source type</a> to an ECMAScript value is the <emu-val>Object</emu-val> value that represents
+   <p>The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-35">converting</a> an IDL value of any <a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-4">buffer source type</a> to an ECMAScript value is the <emu-val>Object</emu-val> value that represents
 a reference to the same object that the IDL value represents.</p>
    <div class="algorithm" data-algorithm="get a reference to a buffer source">
     <p>When <a data-link-type="dfn" href="#dfn-get-buffer-source-reference" id="ref-for-dfn-get-buffer-source-reference-2">getting a reference to</a> or <a data-link-type="dfn" href="#dfn-get-buffer-source-copy" id="ref-for-dfn-get-buffer-source-copy-2">getting a copy of the bytes held by a buffer source</a> that is an ECMAScript <emu-val>ArrayBuffer</emu-val>, <emu-val>DataView</emu-val> or typed array object, these steps must be followed:</p>
@@ -7659,7 +7613,7 @@ a reference to the same object that the IDL value represents.</p>
    <h4 class="heading settled" data-level="3.2.25" id="es-frozen-array"><span class="secno">3.2.25. </span><span class="content">Frozen arrays — FrozenArray&lt;<var>T</var>></span><a class="self-link" href="#es-frozen-array"></a></h4>
    <p>Values of frozen array types are represented by frozen ECMAScript <emu-val>Array</emu-val> object references.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to frozen array">
-    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-57">converted</a> to an IDL <a class="idl-code" data-link-type="interface" href="#idl-frozen-array" id="ref-for-idl-frozen-array-2">FrozenArray&lt;<var>T</var>></a> value
+    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-57">converted</a> to an IDL <a class="idl-code" data-link-type="interface" href="#idl-frozen-array" id="ref-for-idl-frozen-array-3">FrozenArray&lt;<var>T</var>></a> value
     by running the following algorithm:</p>
     <ol>
      <li data-md="">
@@ -7679,12 +7633,12 @@ a reference to the same object that the IDL value represents.</p>
       <p>Return <var>array</var>.</p>
     </ol>
    </div>
-   <p>The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-37">converting</a> an IDL <a class="idl-code" data-link-type="interface" href="#idl-frozen-array" id="ref-for-idl-frozen-array-3">FrozenArray&lt;<var>T</var>></a> value to an ECMAScript
+   <p>The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-37">converting</a> an IDL <a class="idl-code" data-link-type="interface" href="#idl-frozen-array" id="ref-for-idl-frozen-array-4">FrozenArray&lt;<var>T</var>></a> value to an ECMAScript
 value is the <emu-val>Object</emu-val> value that represents a reference
-to the same object that the IDL <a class="idl-code" data-link-type="interface" href="#idl-frozen-array" id="ref-for-idl-frozen-array-4">FrozenArray&lt;<var>T</var>></a> represents.</p>
+to the same object that the IDL <a class="idl-code" data-link-type="interface" href="#idl-frozen-array" id="ref-for-idl-frozen-array-5">FrozenArray&lt;<var>T</var>></a> represents.</p>
    <h5 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="3.2.25.1" data-lt="Creating a frozen array from an iterable" data-noexport="" id="create-frozen-array-from-iterable"><span class="secno">3.2.25.1. </span><span class="content">Creating a frozen array from an iterable</span></h5>
    <div class="algorithm" data-algorithm="create frozen array from iterable">
-    <p>To create an IDL value of type <a class="idl-code" data-link-type="interface" href="#idl-frozen-array" id="ref-for-idl-frozen-array-5">FrozenArray&lt;<var>T</var>></a> given an
+    <p>To create an IDL value of type <a class="idl-code" data-link-type="interface" href="#idl-frozen-array" id="ref-for-idl-frozen-array-6">FrozenArray&lt;<var>T</var>></a> given an
     iterable <var>iterable</var> and an iterator getter <var>method</var>, perform the following steps:</p>
     <ol>
      <li data-md="">
@@ -7737,7 +7691,7 @@ types in <a href="#es-type-mapping">§3.2 ECMAScript type mapping</a> for the sp
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.2" data-lt="Constructor" id="Constructor"><span class="secno">3.3.2. </span><span class="content">[Constructor]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-11">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-30">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-57">interface</a>, it indicates that
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-11">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-30">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-56">interface</a>, it indicates that
 the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-3">interface object</a> for this interface
 will have an [[Construct]] internal method,
 allowing objects implementing the interface to be constructed.</p>
@@ -7844,7 +7798,7 @@ types in <a href="#es-type-mapping">§3.2 ECMAScript type mapping</a> for the sp
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.4" data-lt="Exposed" id="Exposed"><span class="secno">3.3.4. </span><span class="content">[Exposed]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-9">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-33">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-58">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-8">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-6">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-3">partial namespace</a>, or
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-9">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-33">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-57">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-8">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-6">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-3">partial namespace</a>, or
 an individual <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-11">interface member</a> or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-3">namespace member</a>,
 it indicates that the construct is exposed
 on a particular set of global interfaces, rather than the default of
@@ -7853,7 +7807,7 @@ being exposed only on the <a data-link-type="dfn" href="#dfn-primary-global-inte
 Each of the identifiers mentioned must be
 a <a data-link-type="dfn" href="#dfn-global-name" id="ref-for-dfn-global-name-1">global name</a>.</p>
    <p>Every construct that the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-11">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-35">extended attribute</a> can be specified on has an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exposure-set">exposure set</dfn>,
-which is a set of <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-59">interfaces</a> defining which global environments the construct can be used in.
+which is a set of <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-58">interfaces</a> defining which global environments the construct can be used in.
 The <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-1">exposure set</a> for a given construct is defined as follows:</p>
    <ul>
     <li data-md="">
@@ -7906,7 +7860,7 @@ namespace or partial namespace it’s a member of.</p>
    <p>An interface’s <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-15">exposure set</a> must be a subset of the <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-16">exposure set</a> of all
 of the interface’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-13">consequential interfaces</a>.</p>
    <p>If an interface <var>X</var> <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-9">inherits</a> from another interface <var>Y</var> then the <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-17">exposure set</a> of <var>X</var> must be a subset of the <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-18">exposure set</a> of <var>Y</var>.</p>
-   <p>An <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-60">interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-7">namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-12">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-4">namespace member</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exposed">exposed</dfn> in a given ECMAScript global environment if the
+   <p>An <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-59">interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-7">namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-12">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-4">namespace member</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exposed">exposed</dfn> in a given ECMAScript global environment if the
 ECMAScript global object implements an interface that is in the construct’s <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-19">exposure set</a>, and either:</p>
    <ul>
     <li data-md="">
@@ -7987,7 +7941,7 @@ can be made once, at the time the <a data-link-type="dfn" href="#dfn-initial-obj
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.5" data-lt="Global|PrimaryGlobal" dfn="" id="Global"><span class="secno">3.3.5. </span><span class="content">[Global] and [PrimaryGlobal]</span><span id="PrimaryGlobal"></span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-7">Global</a></code>]
-or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-8">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-38">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-61">interface</a>,
+or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-8">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-38">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-60">interface</a>,
 it indicates that objects implementing this interface can
 be used as the global object in an ECMAScript environment,
 and that the structure of the prototype chain and how
@@ -7998,7 +7952,7 @@ interfaces. Specifically:</p>
      <p>Any <a data-link-type="dfn" href="#idl-named-properties" id="ref-for-idl-named-properties-2">named properties</a> will be exposed on an object in the prototype chain – the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-2">named properties object</a> –
 rather than on the object itself.</p>
     <li data-md="">
-     <p><a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-14">Interface members</a> from the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-62">interface</a> (or <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-14">consequential interfaces</a>)
+     <p><a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-14">Interface members</a> from the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-61">interface</a> (or <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-14">consequential interfaces</a>)
 will correspond to properties on the object itself rather than on <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-4">interface prototype objects</a>.</p>
    </ol>
    <div class="note" role="note">
@@ -8022,7 +7976,7 @@ will correspond to properties on the object itself rather than on <a data-link-t
     assignment is evaluated.</p>
    </div>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-9">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-10">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-39">extended attributes</a> is
-used on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-63">interface</a>, then:</p>
+used on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-62">interface</a>, then:</p>
    <ul>
     <li data-md="">
      <p>The interface must not define a <a data-link-type="dfn" href="#dfn-named-property-setter" id="ref-for-dfn-named-property-setter-3">named property setter</a>.</p>
@@ -8042,7 +7996,7 @@ a <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-
 be the part of the interface definition that defines
 the <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-named-property-getter-5">named property getter</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-13">Global</a></code>] and [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-14">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-40">extended attribute</a> must not
-be used on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-64">interface</a> that can have more
+be used on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-63">interface</a> that can have more
 than one object implementing it in the same ECMAScript global environment.</p>
    <p class="note" role="note">Note: This is because the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-3">named properties object</a>,
 which exposes the named properties, is in the prototype chain, and it would not make
@@ -8127,7 +8081,7 @@ corresponding to <a data-link-type="dfn" href="#dfn-interface-member" id="ref-fo
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.6" data-lt="LegacyArrayClass" id="LegacyArrayClass"><span class="secno">3.3.6. </span><span class="content">[LegacyArrayClass]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-3">LegacyArrayClass</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-46">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-65">interface</a> that is not defined to <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-12">inherit</a> from another, it indicates that the internal [[Prototype]]
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-3">LegacyArrayClass</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-46">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-64">interface</a> that is not defined to <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-12">inherit</a> from another, it indicates that the internal [[Prototype]]
 property of its <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-5">interface prototype object</a> will be the <emu-val>Array</emu-val> prototype object rather than
 the <emu-val>Object</emu-val> prototype object.  This allows <emu-val>Array</emu-val> methods to be used more easily
 with objects implementing the interface.</p>
@@ -8144,7 +8098,7 @@ specific requirements that the use of [<code class="idl"><a data-link-type="idl"
 entails.</p>
    <div class="example" id="example-2664cf61">
     <a class="self-link" href="#example-2664cf61"></a> 
-    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-36">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-66">interfaces</a> that use [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-7">LegacyArrayClass</a></code>].</p>
+    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-36">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-65">interfaces</a> that use [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-7">LegacyArrayClass</a></code>].</p>
 <pre class="highlight">[<span class="nv">LegacyArrayClass</span>]
 <span class="kt">interface</span> <span class="nv">ItemList</span> {
   <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <span class="nv">length</span>;
@@ -8174,7 +8128,7 @@ list<span class="p">.</span>concat<span class="p">(</span><span class="p">)</spa
     The exact behavior depends on the definition of the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-array-prototype-object">Array methods</a> themselves.</p>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.7" data-lt="LegacyUnenumerableNamedProperties" id="LegacyUnenumerableNamedProperties"><span class="secno">3.3.7. </span><span class="content">[LegacyUnenumerableNamedProperties]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-1">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-47">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-67">interface</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-5">supports named properties</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-1">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-47">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-66">interface</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-5">supports named properties</a>,
 it indicates that all the interface’s named properties are unenumerable.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-2">LegacyUnenumerableNamedProperties</a></code>]
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-6">take no arguments</a> and must not appear on an interface
@@ -8239,7 +8193,7 @@ or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Re
    <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-3">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-49">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-7">regular attribute</a>,
 it indicates that invocations of the attribute’s getter or setter
 with a <emu-val>this</emu-val> value that is not an
-object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-68">interface</a> on which the attribute appears will be ignored.</p>
+object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-67">interface</a> on which the attribute appears will be ignored.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-4">LenientThis</a></code>] extended attribute
 must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-8">take no arguments</a>.
 It must not be used on a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-7">static attribute</a>.</p>
@@ -8279,7 +8233,7 @@ is to be implemented.</p>
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.10" data-lt="NamedConstructor" id="NamedConstructor"><span class="secno">3.3.10. </span><span class="content">[NamedConstructor]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-8">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-50">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-69">interface</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-8">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-50">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-68">interface</a>,
 it indicates that the ECMAScript global object will have a property with the
 specified name whose value is a constructor function that can
 create objects that implement the interface.
@@ -8350,7 +8304,7 @@ a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.12" data-lt="NoInterfaceObject" id="NoInterfaceObject"><span class="secno">3.3.12. </span><span class="content">[NoInterfaceObject]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-4">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-52">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-70">interface</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-4">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-52">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-69">interface</a>,
 it indicates that an <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-5">interface object</a> will not exist for the interface in the ECMAScript binding.</p>
    <p class="advisement"> The [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-5">NoInterfaceObject</a></code>] extended attribute
     should not be used on interfaces that are not
@@ -8405,7 +8359,7 @@ Storage<span class="p">.</span>prototype<span class="p">.</span>addEntry <span c
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.13" data-lt="OverrideBuiltins" id="OverrideBuiltins"><span class="secno">3.3.13. </span><span class="content">[OverrideBuiltins]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-5">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-53">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-71">interface</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-5">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-53">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-70">interface</a>,
 it indicates that for a <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-3">legacy platform object</a> implementing the interface,
 properties corresponding to all of
 the object’s <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-3">supported property names</a> will appear to be on the object,
@@ -8427,7 +8381,7 @@ the <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-na
 [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-7">OverrideBuiltins</a></code>] entails.</p>
    <div class="example" id="example-1f93745b">
     <a class="self-link" href="#example-1f93745b"></a> 
-    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-38">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-72">interfaces</a>,
+    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-38">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-71">interfaces</a>,
     one that has a <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-named-property-getter-9">named property getter</a> and one that does not.</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">StringMap</span> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <span class="nv">length</span>;
@@ -8488,7 +8442,7 @@ Assuming that:</p>
      <p><var>A</var> is the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-34">attribute</a> on which the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-6">PutForwards</a></code>]
 extended attribute appears,</p>
     <li data-md="">
-     <p><var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-73">interface</a> on which <var>A</var> is declared,</p>
+     <p><var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-72">interface</a> on which <var>A</var> is declared,</p>
     <li data-md="">
      <p><var>J</var> is the <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-13">interface type</a> that <var>A</var> is declared to be of, and</p>
     <li data-md="">
@@ -8501,7 +8455,7 @@ chained.  That is, an attribute with the [<code class="idl"><a data-link-type="i
 There must not exist a cycle in a
 chain of forwarded assignments.  A cycle exists if, when following
 the chain of forwarded assignments, a particular attribute on
-an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-74">interface</a> is
+an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-73">interface</a> is
 encountered more than once.</p>
    <p>An attribute with the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-9">PutForwards</a></code>]
 extended attribute must not also be declared
@@ -8571,7 +8525,7 @@ a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callbac
 [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-11">Replaceable</a></code>] entails.</p>
    <div class="example" id="example-8ded6a51">
     <a class="self-link" href="#example-8ded6a51"></a> 
-    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-40">IDL fragment</a> defines an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-75">interface</a> with an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-42">operation</a> that increments a counter, and an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-39">attribute</a> that exposes the counter’s value, which is initially 0:</p>
+    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-40">IDL fragment</a> defines an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-74">interface</a> with an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-42">operation</a> that increments a counter, and an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-39">attribute</a> that exposes the counter’s value, which is initially 0:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Counter</span> {
   [<span class="nv">Replaceable</span>] <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <span class="nv">value</span>;
   <span class="kt">void</span> <span class="nv">increment</span>();
@@ -8623,14 +8577,14 @@ be used on anything other than a <a data-link-type="dfn" href="#dfn-read-only" i
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.17" data-lt="SecureContext" id="SecureContext"><span class="secno">3.3.17. </span><span class="content">[SecureContext]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-9">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-58">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-76">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-11">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-8">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-4">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-17">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-5">namespace member</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-9">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-58">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-75">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-11">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-8">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-4">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-17">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-5">namespace member</a>,
 it indicates that the construct is exposed
 only within a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-10">SecureContext</a></code>]
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-14">take no arguments</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-11">SecureContext</a></code>]
 extended attribute must not
-be used on anything other than an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-77">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-12">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-9">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-5">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-18">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-6">namespace member</a>.</p>
+be used on anything other than an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-76">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-12">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-9">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-5">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-18">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-6">namespace member</a>.</p>
    <p>Whether a construct that the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-12">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-59">extended attribute</a> can be specified on is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-available-only-in-secure-contexts">available only in secure contexts</dfn> is defined as follows:</p>
    <ul>
     <li data-md="">
@@ -9309,14 +9263,14 @@ If there are none, then a <emu-val>TypeError</emu-val> is thrown.</p>
     of variadic argument as would be done for a non-optional argument.</p>
    </div>
    <h3 class="heading settled" data-level="3.6" id="es-interfaces"><span class="secno">3.6. </span><span class="content">Interfaces</span><a class="self-link" href="#es-interfaces"></a></h3>
-   <p>For every <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-78">interface</a> that
+   <p>For every <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-77">interface</a> that
 is <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-2">exposed</a> in a given
 ECMAScript global environment and:</p>
    <ul>
     <li data-md="">
      <p>is a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-25">callback interface</a> that has <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-21">constants</a> declared on it, or</p>
     <li data-md="">
-     <p>is a non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-79">interface</a> that is not declared with the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-13">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-70">extended attribute</a>,</p>
+     <p>is a non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-78">interface</a> that is not declared with the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-13">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-70">extended attribute</a>,</p>
    </ul>
    <p>a corresponding property must exist on the
 ECMAScript environment’s global object.
@@ -9332,7 +9286,7 @@ construction of objects that implement the interface.  The property has the
 attributes { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }.
 The characteristics of a named constructor are described in <a href="#named-constructors">§3.6.2 Named constructors</a>.</p>
    <h4 class="heading settled" data-level="3.6.1" id="interface-object"><span class="secno">3.6.1. </span><span class="content">Interface object</span><a class="self-link" href="#interface-object"></a></h4>
-   <p>The interface object for a given non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-80">interface</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-3">function object</a>.
+   <p>The interface object for a given non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-79">interface</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-3">function object</a>.
 It has properties that correspond to
 the <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-22">constants</a> and <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-12">static operations</a> defined on that interface, as described in sections <a href="#es-constants">§3.6.5 Constants</a> and <a href="#es-operations">§3.6.7 Operations</a>.</p>
    <p>The [[Prototype]] internal property of
@@ -9362,7 +9316,7 @@ the Function.prototype object.</p>
    <p class="note" role="note">Note: Remember that interface objects for callback interfaces only exist if they have <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-23">constants</a> declared on them;
 when they do exist, they are not <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-5">function objects</a>.</p>
    <h5 class="heading settled" data-level="3.6.1.1" id="es-constructible-interfaces"><span class="secno">3.6.1.1. </span><span class="content">Constructible Interfaces</span><span id="es-interface-call"></span><a class="self-link" href="#es-constructible-interfaces"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-81">interface</a> is declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-20">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-71">extended attribute</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-80">interface</a> is declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-20">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-71">extended attribute</a>,
 then the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-7">interface object</a> can be called as a constructor
 to create an object that implements that interface.
 Calling that interface as a function will throw an exception.</p>
@@ -9370,7 +9324,7 @@ Calling that interface as a function will throw an exception.</p>
 both as a function and as a constructor.</p>
    <div class="algorithm" data-algorithm="to construct an object implementing an interface">
     <p>When evaluating the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-6">function object</a> <var>F</var>,
-    which is the interface object for a given non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-82">interface</a> <var>I</var>,
+    which is the interface object for a given non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-81">interface</a> <var>I</var>,
     assuming <var>arg</var><sub>0..<var>n</var>−1</sub> as the list of argument values passed <var>F</var>,
     the following steps must be taken:</p>
     <ol>
@@ -9381,7 +9335,7 @@ both as a function and as a constructor.</p>
      <li data-md="">
       <p>Let <var>id</var> be the identifier of interface <var>I</var>.</p>
      <li data-md="">
-      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-5">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-58">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-83">interface</a> <var>I</var> and with argument count <var>n</var>.</p>
+      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-5">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-58">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-82">interface</a> <var>I</var> and with argument count <var>n</var>.</p>
      <li data-md="">
       <p>Let &lt;<var>constructor</var>, <var>values</var>> be the result of passing <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to the <a data-link-type="dfn" href="#dfn-overload-resolution-algorithm" id="ref-for-dfn-overload-resolution-algorithm-1">overload resolution algorithm</a>.</p>
      <li data-md="">
@@ -9406,7 +9360,7 @@ both as a function and as a constructor.</p>
      <li data-md="">
       <p>Let <var>id</var> be the identifier of interface <var>I</var>.</p>
      <li data-md="">
-      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-6">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-59">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-84">interface</a> <var>I</var> and with argument count 0.</p>
+      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-6">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-59">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-83">interface</a> <var>I</var> and with argument count 0.</p>
      <li data-md="">
       <p>Return the length of the shortest argument list of the entries in <var>S</var>.</p>
     </ol>
@@ -9454,11 +9408,11 @@ implement the interface on which the
     <p>It behaves as follows, assuming <var>arg</var><sub>0..<var>n</var>−1</sub> is the list
     of argument values passed to the constructor, <var>id</var> is the identifier of the constructor specified in the
     extended attribute <a data-link-type="dfn" href="#dfn-xattr-named-argument-list" id="ref-for-dfn-xattr-named-argument-list-4">named argument list</a>,
-    and <var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-85">interface</a> on which the
+    and <var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-84">interface</a> on which the
     [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-19">NamedConstructor</a></code>] extended attribute appears:</p>
     <ol>
      <li data-md="">
-      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-7">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-61">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-86">interface</a> <var>I</var> and with argument count <var>n</var>.</p>
+      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-7">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-61">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-85">interface</a> <var>I</var> and with argument count <var>n</var>.</p>
      <li data-md="">
       <p>Let &lt;<var>constructor</var>, <var>values</var>> be the result of passing <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to the <a data-link-type="dfn" href="#dfn-overload-resolution-algorithm" id="ref-for-dfn-overload-resolution-algorithm-2">overload resolution algorithm</a>.</p>
      <li data-md="">
@@ -9479,7 +9433,7 @@ with the <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-n
     whose value is a <emu-val>Number</emu-val> determined as follows:</p>
     <ol>
      <li data-md="">
-      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-8">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-62">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-87">interface</a> <var>I</var> and with argument count 0.</p>
+      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-8">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-62">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-86">interface</a> <var>I</var> and with argument count 0.</p>
      <li data-md="">
       <p>Return the length of the shortest argument list of the entries in <var>S</var>.</p>
     </ol>
@@ -9490,10 +9444,10 @@ whose value is the identifier used for the named constructor.</p>
    <p>A named constructor must also have a property named
 “prototype” with attributes
 { [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }
-whose value is the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-9">interface prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-88">interface</a> on which the
+whose value is the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-9">interface prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-87">interface</a> on which the
 [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-20">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-76">extended attribute</a> appears.</p>
    <h4 class="heading settled" data-level="3.6.3" id="interface-prototype-object"><span class="secno">3.6.3. </span><span class="content">Interface prototype object</span><a class="self-link" href="#interface-prototype-object"></a></h4>
-   <p>There must exist an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-10">interface prototype object</a> for every non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-89">interface</a> defined, regardless of whether the interface was declared with the
+   <p>There must exist an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-10">interface prototype object</a> for every non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-88">interface</a> defined, regardless of whether the interface was declared with the
 [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-14">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-77">extended attribute</a>.
 The interface prototype object for a particular interface has
 properties that correspond to the <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-13">regular attributes</a> and <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-15">regular operations</a> defined on that interface.  These properties are described in more detail in
@@ -9527,7 +9481,7 @@ extended attribute, then return <a data-link-type="dfn" href="https://tc39.githu
     </ol>
    </div>
    <div class="note" role="note">
-    <p>The <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-13">interface prototype object</a> of an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-90">interface</a> that is defined with
+    <p>The <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-13">interface prototype object</a> of an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-89">interface</a> that is defined with
     the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-16">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-79">extended attribute</a> will be accessible if the interface is used as a <a data-link-type="dfn" href="#dfn-supplemental-interface" id="ref-for-dfn-supplemental-interface-5">non-supplemental interface</a>.
     For example, with the following IDL:</p>
 <pre class="highlight">[<span class="nv">NoInterfaceObject</span>]
@@ -9572,10 +9526,10 @@ interface member, <emu-val>true</emu-val>).</p>
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-36">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-80">extended attribute</a>, or the interface is in the set
 of <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces-16">inherited interfaces</a> for any
 other interface that is declared with one of these attributes, then the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-14">interface prototype object</a> must be an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">immutable prototype exotic object</a>.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-1">class string</a> of an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-15">interface prototype object</a> is the concatenation of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-91">interface</a>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-64">identifier</a> and the string
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-1">class string</a> of an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-15">interface prototype object</a> is the concatenation of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-90">interface</a>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-64">identifier</a> and the string
 “Prototype”.</p>
    <h4 class="heading settled" data-level="3.6.4" id="named-properties-object"><span class="secno">3.6.4. </span><span class="content">Named properties object</span><a class="self-link" href="#named-properties-object"></a></h4>
-   <p>For every <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-92">interface</a> declared with the
+   <p>For every <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-91">interface</a> declared with the
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-37">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-38">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-81">extended attribute</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-7">supports named properties</a>,
 there must exist an object known as the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-named-properties-object">named properties object</dfn> for that interface on which named properties are exposed.</p>
    <div class="algorithm" data-algorithm="value of [[Prototype]] property of named properties objects">
@@ -9592,16 +9546,16 @@ extended attribute, then return <a data-link-type="dfn" href="https://tc39.githu
       <p>Otherwise, return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a>.</p>
     </ol>
    </div>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-2">class string</a> of a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-6">named properties object</a> is the concatenation of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-93">interface</a>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-65">identifier</a> and the string “Properties”.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-2">class string</a> of a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-6">named properties object</a> is the concatenation of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-92">interface</a>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-65">identifier</a> and the string “Properties”.</p>
    <h5 class="heading settled" data-level="3.6.4.1" id="named-properties-object-getownproperty"><span class="secno">3.6.4.1. </span><span class="content">[[GetOwnProperty]]</span><a class="self-link" href="#named-properties-object-getownproperty"></a></h5>
    <div class="algorithm" data-algorithm="to invoke the internal [[GetOwnProperty]] method of named properties object">
     <p>When the [[GetOwnProperty]] internal method of a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-7">named properties object</a> <var>O</var> is called with property key <var>P</var>, the following steps are taken:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>A</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-94">interface</a> for the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-8">named properties object</a> <var>O</var>.</p>
+      <p>Let <var>A</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-93">interface</a> for the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-8">named properties object</a> <var>O</var>.</p>
      <li data-md="">
       <p>Let <var>object</var> be the sole object from <var>O</var>’s ECMAScript global environment that implements <var>A</var>.</p>
-      <p class="note" role="note">Note: For example, if the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-95">interface</a> is the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> interface,
+      <p class="note" role="note">Note: For example, if the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-94">interface</a> is the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> interface,
 then the sole object will be this global environment’s window object.</p>
      <li data-md="">
       <p>If the result of running the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-1">named property visibility algorithm</a> with
@@ -9668,7 +9622,7 @@ called, the same algorithm must be executed as is defined for the [[SetPrototype
     making [[PreventExtensions]] fail.</p>
    </div>
    <h4 class="heading settled" data-level="3.6.5" id="es-constants"><span class="secno">3.6.5. </span><span class="content">Constants</span><a class="self-link" href="#es-constants"></a></h4>
-   <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-4">exposed</a> <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-25">constant</a> defined on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-96">interface</a> <var>A</var>,
+   <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-4">exposed</a> <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-25">constant</a> defined on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-95">interface</a> <var>A</var>,
 there must be a corresponding property.
 The property has the following characteristics:</p>
    <ul>
@@ -9696,7 +9650,7 @@ the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-pro
    <p>In addition, a property with the same characteristics must
 exist on the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-11">interface object</a>, if that object exists.</p>
    <h4 class="heading settled" data-level="3.6.6" id="es-attributes"><span class="secno">3.6.6. </span><span class="content">Attributes</span><a class="self-link" href="#es-attributes"></a></h4>
-   <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-5">exposed</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-49">attribute</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-97">interface</a>, whether it
+   <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-5">exposed</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-49">attribute</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-96">interface</a>, whether it
 was declared on the interface itself or one of its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-20">consequential interfaces</a>,
 there must exist a corresponding property.
 The characteristics of this property are as follows:</p>
@@ -9739,7 +9693,7 @@ the object that is the location of the property.</p>
      </ul>
    </ul>
    <div class="algorithm" data-algorithm="attribute getter">
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-attribute-getter">attribute getter</dfn> is created as follows, given an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-51">attribute</a> <var>attribute</var>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-98">interface</a> <var>target</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>:</p>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-attribute-getter">attribute getter</dfn> is created as follows, given an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-51">attribute</a> <var>attribute</var>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-97">interface</a> <var>target</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>:</p>
     <ol>
      <li data-md="">
       <p>Let <var>steps</var> be the following series of steps:</p>
@@ -9807,7 +9761,7 @@ PropertyDescriptor{[[Value]]: 0, [[Writable]]: <emu-val>false</emu-val>, [[Enume
     </ol>
    </div>
    <div class="algorithm" data-algorithm="attribute setter">
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-attribute-setter">attribute setter</dfn> is created as follows, given an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-52">attribute</a> <var>attribute</var>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-99">interface</a> <var>target</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>:</p>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-attribute-setter">attribute setter</dfn> is created as follows, given an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-52">attribute</a> <var>attribute</var>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-98">interface</a> <var>target</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>:</p>
     <ol>
      <li data-md="">
       <p>If <var>attribute</var> is <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-15">read only</a> and does not have a
@@ -9913,7 +9867,7 @@ accessed, they are able to expose instance-specific data.</p>
    <p class="note" role="note">Note: Attempting to assign to a property corresponding to a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-16">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-53">attribute</a> results in different behavior depending on whether the script doing so is in strict mode.
 When in strict mode, such an assignment will result in a <emu-val>TypeError</emu-val> being thrown.  When not in strict mode, the assignment attempt will be ignored.</p>
    <h4 class="heading settled" data-level="3.6.7" id="es-operations"><span class="secno">3.6.7. </span><span class="content">Operations</span><a class="self-link" href="#es-operations"></a></h4>
-   <p>For each unique <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-72">identifier</a> of an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-6">exposed</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-52">operation</a> defined on the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-100">interface</a>, there
+   <p>For each unique <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-72">identifier</a> of an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-6">exposed</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-52">operation</a> defined on the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-99">interface</a>, there
 must exist a corresponding property,
 unless the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-9">effective overload set</a> for that <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-73">identifier</a> and <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-53">operation</a> and with an argument count of 0 has no entries.</p>
    <p>The characteristics of this property are as follows:</p>
@@ -9956,7 +9910,7 @@ where the operation was originally declared.</p>
 property-installation style as namespaces.)</p>
    <div class="algorithm" data-algorithm="create an operation function">
      To <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="creating an operation function" data-noexport="" id="dfn-create-operation-function">create an operation function</dfn>,
-    given an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-54">operation</a> <var>op</var>, a <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-11">namespace</a> or <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-101">interface</a> <var>target</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>: 
+    given an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-54">operation</a> <var>op</var>, a <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-11">namespace</a> or <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-100">interface</a> <var>target</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>: 
     <ol>
      <li data-md="">
       <p>Let <var>id</var> be <var>op</var>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-75">identifier</a>.</p>
@@ -9970,7 +9924,7 @@ values <var>arg</var><sub>0..<var>n</var>−1</sub>:</p>
          <li data-md="">
           <p>Let <var>O</var> be <emu-val>null</emu-val>.</p>
          <li data-md="">
-          <p>If <var>target</var> is an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-102">interface</a>, and <var>op</var> is not a <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-14">static operation</a>:</p>
+          <p>If <var>target</var> is an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-101">interface</a>, and <var>op</var> is not a <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-14">static operation</a>:</p>
           <ol>
            <li data-md="">
             <p>If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, set <var>O</var> to <var>realm</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global">global object</a>. (This
@@ -10027,7 +9981,7 @@ PropertyDescriptor{[[Value]]: <var>length</var>, [[Writable]]: <emu-val>false</e
     </ol>
    </div>
    <h5 class="heading settled" data-level="3.6.7.1" id="es-stringifier"><span class="secno">3.6.7.1. </span><span class="content">Stringifiers</span><a class="self-link" href="#es-stringifier"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-103">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-7">exposed</a> <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-3">stringifier</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-102">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-7">exposed</a> <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-3">stringifier</a>,
 then there must exist a property with the following characteristics:</p>
    <ul>
     <li data-md="">
@@ -10060,7 +10014,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-104">interface</a> on which the stringifier was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-35">throw</a> a <emu-val>TypeError</emu-val>.</p>
+        <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-103">interface</a> on which the stringifier was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-35">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>V</var> be an uninitialized variable.</p>
        <li data-md="">
@@ -10095,7 +10049,7 @@ property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
 property is the <emu-val>String</emu-val> value “toString”.</p>
    </ul>
    <h5 class="heading settled" data-level="3.6.7.2" id="es-serializer"><span class="secno">3.6.7.2. </span><span class="content">Serializers</span><a class="self-link" href="#es-serializer"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-105">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-8">exposed</a> <a data-link-type="dfn" href="#dfn-serializer" id="ref-for-dfn-serializer-5">serializer</a>, then
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-104">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-8">exposed</a> <a data-link-type="dfn" href="#dfn-serializer" id="ref-for-dfn-serializer-5">serializer</a>, then
 a property must exist whose name is “toJSON”, with attributes
 { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
 and whose value is a <emu-val>Function</emu-val> object.</p>
@@ -10130,7 +10084,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-106">interface</a> on which the serializer was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-36">throw</a> a <emu-val>TypeError</emu-val>.</p>
+      <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-105">interface</a> on which the serializer was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-36">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Depending on how <code>serializer</code> was specified:</p>
       <dl class="switch">
@@ -10147,7 +10101,7 @@ using <var>O</var> as the <emu-val>this</emu-val> value and passing no arguments
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-serialized-value" id="ref-for-dfn-serialized-value-8">serialized value</a> that is the result of invoking the <a data-link-type="dfn" href="#dfn-serialization-behavior" id="ref-for-dfn-serialization-behavior-15">serialization behavior</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-107">interface</a> for object <var>O</var>.</p>
+          <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-serialized-value" id="ref-for-dfn-serialized-value-8">serialized value</a> that is the result of invoking the <a data-link-type="dfn" href="#dfn-serialization-behavior" id="ref-for-dfn-serialization-behavior-15">serialization behavior</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-106">interface</a> for object <var>O</var>.</p>
          <li data-md="">
           <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-serialized-value-to-ecmascript-value" id="ref-for-dfn-convert-serialized-value-to-ecmascript-value-1">converting</a> <var>S</var> to an ECMAScript value.</p>
         </ol>
@@ -10220,7 +10174,7 @@ property is the <emu-val>String</emu-val> value “toJSON”.</p>
    </div>
    <h4 class="heading settled" data-level="3.6.8" id="es-iterators"><span class="secno">3.6.8. </span><span class="content">Common iterator behavior</span><a class="self-link" href="#es-iterators"></a></h4>
    <h5 class="heading settled" data-level="3.6.8.1" id="es-iterator"><span class="secno">3.6.8.1. </span><span class="content">@@iterator</span><a class="self-link" href="#es-iterator"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-108">interface</a> has any of the following:</p>
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-107">interface</a> has any of the following:</p>
    <ul>
     <li data-md="">
      <p>an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-9">iterable declaration</a></p>
@@ -10269,7 +10223,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-109">interface</a> the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-10">iterable declaration</a> is on.</p>
+      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-108">interface</a> the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-10">iterable declaration</a> is on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-29">platform object</a> that implements <var>interface</var>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-37">throw</a> a <emu-val>TypeError</emu-val>.</p>
@@ -10298,7 +10252,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-31">platform object</a> that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-110">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-9">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-9">setlike declaration</a> is defined,
+      <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-31">platform object</a> that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-109">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-9">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-9">setlike declaration</a> is defined,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-38">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>If the interface has a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-10">maplike declaration</a>, then:</p>
@@ -10325,7 +10279,7 @@ is the <emu-val>String</emu-val> value “entries”
 if the interface has a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-5">pair iterator</a> or a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-11">maplike declaration</a> and the <emu-val>String</emu-val> “values”
 if the interface has a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-10">setlike declaration</a>.</p>
    <h5 class="heading settled" data-level="3.6.8.2" id="es-forEach"><span class="secno">3.6.8.2. </span><span class="content">forEach</span><a class="self-link" href="#es-forEach"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-111">interface</a> has any of the following:</p>
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-110">interface</a> has any of the following:</p>
    <ul>
     <li data-md="">
      <p>an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-11">iterable declaration</a></p>
@@ -10407,7 +10361,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-112">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-14">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-13">setlike declaration</a> is declared.</p>
+      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-111">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-14">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-13">setlike declaration</a> is declared.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-33">platform object</a> that implements <var>interface</var>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-39">throw</a> a <emu-val>TypeError</emu-val>.</p>
@@ -10451,7 +10405,7 @@ property is the <emu-val>Number</emu-val> value <emu-val>1</emu-val>.</p>
 property is the <emu-val>String</emu-val> value “forEach”.</p>
    <h4 class="heading settled" data-level="3.6.9" id="es-iterable"><span class="secno">3.6.9. </span><span class="content">Iterable declarations</span><a class="self-link" href="#es-iterable"></a></h4>
    <h5 class="heading settled" data-level="3.6.9.1" id="es-iterable-entries"><span class="secno">3.6.9.1. </span><span class="content">entries</span><a class="self-link" href="#es-iterable-entries"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-113">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-13">iterable declaration</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-112">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-13">iterable declaration</a>,
 then a property named “entries” must exist with attributes
 { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
 and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-10">function object</a>.</p>
@@ -10475,7 +10429,7 @@ the initial value of the “entries” data property of <a data-link-type="dfn" 
 then the <emu-val>Function</emu-val> object is
 the value of the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> property.</p>
    <h5 class="heading settled" data-level="3.6.9.2" id="es-iterable-keys"><span class="secno">3.6.9.2. </span><span class="content">keys</span><a class="self-link" href="#es-iterable-keys"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-114">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-14">iterable declaration</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-113">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-14">iterable declaration</a>,
 then a property named “keys” must exist with attributes
 { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
 and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-11">function object</a>.</p>
@@ -10513,7 +10467,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-115">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-15">iterable declaration</a> is declared on.</p>
+      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-114">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-15">iterable declaration</a> is declared on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-35">platform object</a> that implements <var>interface</var>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-42">throw</a> a <emu-val>TypeError</emu-val>.</p>
@@ -10526,7 +10480,7 @@ then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-thr
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “keys”.</p>
    <h5 class="heading settled" data-level="3.6.9.3" id="es-iterable-values"><span class="secno">3.6.9.3. </span><span class="content">values</span><a class="self-link" href="#es-iterable-values"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-116">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-16">iterable declaration</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-115">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-16">iterable declaration</a>,
 then a property named “values” must exist
 with attributes { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
 and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-12">function object</a>.</p>
@@ -10564,7 +10518,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-117">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-17">iterable declaration</a> is declared on.</p>
+      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-116">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-17">iterable declaration</a> is declared on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-37">platform object</a> that implements <var>interface</var>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-43">throw</a> a <emu-val>TypeError</emu-val>.</p>
@@ -10577,8 +10531,8 @@ then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-thr
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “values”.</p>
    <h5 class="heading settled" data-level="3.6.9.4" id="es-default-iterator-object"><span class="secno">3.6.9.4. </span><span class="content">Default iterator objects</span><a class="self-link" href="#es-default-iterator-object"></a></h5>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-default-iterator-object">default iterator object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-118">interface</a>, target and iteration kind
-is an object whose internal [[Prototype]] property is the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-2">iterator prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-119">interface</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-default-iterator-object">default iterator object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-117">interface</a>, target and iteration kind
+is an object whose internal [[Prototype]] property is the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-2">iterator prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-118">interface</a>.</p>
    <p>A <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-4">default iterator object</a> has three internal values:</p>
    <ol>
     <li data-md="">
@@ -10593,9 +10547,9 @@ restricted to iterating over an object’s <a data-link-type="dfn" href="#dfn-su
 use standard ECMAScript Array iterator objects.</p>
    <p>When a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-5">default iterator object</a> is first created,
 its index is set to 0.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-3">class string</a> of a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-6">default iterator object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-120">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-80">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-121">interface</a> and the string “Iterator”.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-3">class string</a> of a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-6">default iterator object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-119">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-80">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-120">interface</a> and the string “Iterator”.</p>
    <h5 class="heading settled" data-level="3.6.9.5" id="es-iterator-prototype-object"><span class="secno">3.6.9.5. </span><span class="content">Iterator prototype object</span><a class="self-link" href="#es-iterator-prototype-object"></a></h5>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-iterator-prototype-object">iterator prototype object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-122">interface</a> is an object that exists for every interface that has a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-11">pair iterator</a>.  It serves as the
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-iterator-prototype-object">iterator prototype object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-121">interface</a> is an object that exists for every interface that has a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-11">pair iterator</a>.  It serves as the
 prototype for <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-7">default iterator objects</a> for the interface.</p>
    <p>The internal [[Prototype]] property of an <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-3">iterator prototype object</a> must be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%IteratorPrototype%</a>.</p>
    <div class="algorithm" data-algorithm="to invoke the next property of iterators">
@@ -10604,7 +10558,7 @@ prototype for <a data-link-type="dfn" href="#dfn-default-iterator-object" id="re
     and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-13">function object</a> that behaves as follows:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-123">interface</a> for which the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-5">iterator prototype object</a> exists.</p>
+      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-122">interface</a> for which the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-5">iterator prototype object</a> exists.</p>
      <li data-md="">
       <p>Let <var>object</var> be the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-toobject">ToObject</a> on the <emu-val>this</emu-val> value.</p>
      <li data-md="">
@@ -10687,13 +10641,13 @@ return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createi
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createiterresultobject">CreateIterResultObject</a>(<var>result</var>, <emu-val>false</emu-val>).</p>
     </ol>
    </div>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-4">class string</a> of an <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-6">iterator prototype object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-124">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-81">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-125">interface</a> and the string “Iterator”.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-4">class string</a> of an <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-6">iterator prototype object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-123">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-81">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-124">interface</a> and the string “Iterator”.</p>
    <h4 class="heading settled" data-level="3.6.10" id="es-maplike"><span class="secno">3.6.10. </span><span class="content">Maplike declarations</span><a class="self-link" href="#es-maplike"></a></h4>
-   <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-126">interface</a> that has a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-16">maplike declaration</a> must have a [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
+   <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-125">interface</a> that has a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-16">maplike declaration</a> must have a [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
 initially set to a newly created <emu-val>Map</emu-val> object.
 This <emu-val>Map</emu-val> object’s [[MapData]] internal slot is
 the object’s <a data-link-type="dfn" href="#dfn-map-entries" id="ref-for-dfn-map-entries-3">map entries</a>.</p>
-   <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-127">interface</a> <var>A</var> is declared with
+   <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-126">interface</a> <var>A</var> is declared with
 a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-17">maplike declaration</a>, then
 there exists a number of additional properties on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-36">interface prototype object</a>.
 These additional properties are described in the sub-sections below.</p>
@@ -10940,11 +10894,11 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>2</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “set”.</p>
    <h4 class="heading settled" data-level="3.6.11" id="es-setlike"><span class="secno">3.6.11. </span><span class="content">Setlike declarations</span><a class="self-link" href="#es-setlike"></a></h4>
-   <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-128">interface</a> that has a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-14">setlike declaration</a> must have a [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
+   <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-127">interface</a> that has a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-14">setlike declaration</a> must have a [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
 initially set to a newly created <emu-val>Set</emu-val> object.
 This <emu-val>Set</emu-val> object’s [[SetData]] internal slot is
 the object’s <a data-link-type="dfn" href="#dfn-set-entries" id="ref-for-dfn-set-entries-3">set entries</a>.</p>
-   <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-129">interface</a> <var>A</var> is declared with a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-15">setlike declaration</a>, then
+   <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-128">interface</a> <var>A</var> is declared with a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-15">setlike declaration</a>, then
 there exists a number of additional properties
 on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-44">interface prototype object</a>.
 These additional properties are described in the sub-sections below.</p>
@@ -11161,7 +11115,7 @@ and similarly with their setters.</p>
     <p>When invoking an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-60">operation</a> by calling
     a <emu-val>Function</emu-val> object that is the value of one of the copies that exists
     due to an implements statement, the <emu-val>this</emu-val> value is
-    checked to ensure that it is an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-130">interface</a> corresponding to the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-52">interface prototype object</a> that the property is on.</p>
+    checked to ensure that it is an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-129">interface</a> corresponding to the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-52">interface prototype object</a> that the property is on.</p>
     <p>For example, consider the following IDL:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">A</span> {
   <span class="kt">void</span> <span class="nv">f</span>();
@@ -11197,7 +11151,7 @@ a platform object that implements one or more interfaces
 must be the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-82">identifier</a> of
 the <a data-link-type="dfn" href="#dfn-primary-interface" id="ref-for-dfn-primary-interface-3">primary interface</a> of the platform object.</p>
    <h4 class="heading settled" data-level="3.8.1" id="platform-object-setprototypeof"><span class="secno">3.8.1. </span><span class="content">[[SetPrototypeOf]]</span><span id="platformobjectsetprototypeof"></span><a class="self-link" href="#platform-object-setprototypeof"></a></h4>
-   <p>The internal [[SetPrototypeOf]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-52">platform object</a> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-131">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-95">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-96">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-86">extended attribute</a> must execute the same algorithm as is defined for the
+   <p>The internal [[SetPrototypeOf]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-52">platform object</a> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-130">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-95">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-96">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-86">extended attribute</a> must execute the same algorithm as is defined for the
 [[SetPrototypeOf]] internal method of an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">immutable prototype exotic object</a>.</p>
    <p class="note" role="note">Note: For <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> objects, it is unobservable whether this is implemented, since the presence of
 the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#windowproxy">WindowProxy</a></code> object ensures that [[SetPrototypeOf]] is never called on a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> object
@@ -11218,7 +11172,7 @@ when indexing the object with an array index.  Similarly for <a data-link-type="
 This way, the definitions of these special operations from
 ancestor interfaces can be overridden.</p>
    <p>A property name is an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-unforgeable-property-name">unforgeable property name</dfn> on a
-given platform object if the object implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-132">interface</a> that
+given platform object if the object implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-131">interface</a> that
 has an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-26">interface member</a> with that identifier
 and that interface member is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-7">unforgeable</a> on any of
 the interfaces that <var>O</var> implements.</p>
@@ -11282,7 +11236,7 @@ and <var>O</var> implements an interface with a <a data-link-type="dfn" href="#d
         <p>Return <emu-val>true</emu-val>.</p>
       </ol>
      <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-9">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-133">interface</a> with the
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-9">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-132">interface</a> with the
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-97">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-98">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-87">extended attribute</a> and <var>P</var> is not an <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-dfn-unforgeable-property-name-1">unforgeable property name</a> of <var>O</var>, then:</p>
       <ol>
        <li data-md="">
@@ -11307,7 +11261,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
         </ol>
       </ol>
      <li data-md="">
-      <p>If <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-134">interface</a> with the
+      <p>If <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-133">interface</a> with the
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-99">Global</a></code>] or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-100">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-89">extended attribute</a>, then set <var>Desc</var>.[[Configurable]] to <emu-val>true</emu-val>.</p>
      <li data-md="">
@@ -11329,7 +11283,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
         <p>Return <emu-val>false</emu-val>.</p>
       </ol>
      <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-10">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-135">interface</a> with the
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-10">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-134">interface</a> with the
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-101">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-102">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-90">extended attribute</a> and the result of calling the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-2">named property visibility algorithm</a> with property name <var>P</var> and object <var>O</var> is true, then:</p>
       <ol>
        <li data-md="">
@@ -11370,7 +11324,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
    <h4 class="heading settled" data-level="3.9.5" id="legacy-platform-object-call"><span class="secno">3.9.5. </span><span class="content">[[Call]]</span><span id="call"></span><a class="self-link" href="#legacy-platform-object-call"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[Call]] method of legacy platform objects">
     <p>The internal [[Call]] method of <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-9">legacy platform object</a> that implements
-    an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-136">interface</a> <var>I</var> must behave as follows,
+    an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-135">interface</a> <var>I</var> must behave as follows,
     assuming <var>arg</var><sub>0..<var>n</var>−1</sub> is the list of argument values passed to [[Call]]:</p>
     <ol>
      <li data-md="">
@@ -11398,7 +11352,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
    </div>
    <h4 class="heading settled" data-level="3.9.7" id="legacy-platform-object-property-enumeration"><span class="secno">3.9.7. </span><span class="content">Property enumeration</span><span id="property-enumeration"></span><a class="self-link" href="#legacy-platform-object-property-enumeration"></a></h4>
    <p>This document does not define a complete property enumeration order
-for <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-53">platform objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-137">interfaces</a> (or for <a href="#es-exception-objects" id="ref-for-es-exception-objects-1">platform objects representing exceptions</a>).
+for <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-53">platform objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-136">interfaces</a> (or for <a href="#es-exception-objects" id="ref-for-es-exception-objects-1">platform objects representing exceptions</a>).
 However, for <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-12">legacy platform objects</a>,
 properties on the object must be
 enumerated in the following order:</p>
@@ -11408,7 +11362,7 @@ enumerated in the following order:</p>
 the object’s <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-6">supported property indices</a> are
 enumerated first, in numerical order.</p>
     <li data-md="">
-     <p>If the object <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-11">supports named properties</a> and doesn’t implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-138">interface</a> with the
+     <p>If the object <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-11">supports named properties</a> and doesn’t implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-137">interface</a> with the
 [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-6">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-91">extended attribute</a>, then
 the object’s <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-5">supported property names</a> that
 are visible according to the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-3">named property visibility algorithm</a> are enumerated next, in the order given in the definition of the set of supported property names.</p>
@@ -11638,7 +11592,7 @@ is the result of invoking [[Get]] on the object with a
 property name that is that identifier.</p>
    </ul>
    <p>Note that ECMAScript objects need not have
-properties corresponding to <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-29">constants</a> on them to be considered as <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-9">user objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-139">interfaces</a> that happen
+properties corresponding to <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-29">constants</a> on them to be considered as <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-9">user objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-138">interfaces</a> that happen
 to have constants declared on them.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-single-operation-callback-interface">single operation callback interface</dfn> is
 a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-27">callback interface</a> that:</p>
@@ -12068,7 +12022,7 @@ as the <emu-val>this</emu-val> value in the top-most call
 on the ECMAScript call stack where <var>F</var> corresponds to an IDL <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-59">attribute</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-62">operation</a>, <a data-link-type="dfn" href="#idl-indexed-properties" id="ref-for-idl-indexed-properties-4">indexed property</a>, <a data-link-type="dfn" href="#idl-named-properties" id="ref-for-idl-named-properties-4">named property</a>, <a href="#Constructor" id="ref-for-Constructor-24">constructor</a>, <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-5">named constructor</a> or <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-6">stringifier</a>.</p>
      <li data-md="">
       <p>If <var>F</var> corresponds to an attribute, operation or stringifier, then return
-the global environment associated with the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-140">interface</a> that definition appears on.</p>
+the global environment associated with the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-139">interface</a> that definition appears on.</p>
      <li data-md="">
       <p>Otherwise, if <var>F</var> corresponds to an indexed or named property, then return
 the global environment associated with the interface that
@@ -12189,7 +12143,7 @@ must propagate to the caller, and if
 not caught there, to its caller, and so on.</p>
    <div class="example" id="example-1432e05c">
     <a class="self-link" href="#example-1432e05c"></a> 
-    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-45">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-141">interfaces</a> and an <a data-link-type="dfn" href="#dfn-exception" id="ref-for-dfn-exception-1">exception</a>.
+    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-45">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-140">interfaces</a> and an <a data-link-type="dfn" href="#dfn-exception" id="ref-for-dfn-exception-1">exception</a>.
     The <code>valueOf</code> attribute on <code class="idl">ExceptionThrower</code> is defined to throw an exception whenever an attempt is made
     to get its value.</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Dahut</span> {
@@ -12420,7 +12374,7 @@ and “<span class="input">.</span>” is tokenized as the quoted terminal symbo
 used in the grammar and the values used for <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> terminals.  Thus, for
 example, the input text “<span class="input">Const</span>” is tokenized as
 an <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> rather than the
-terminal symbol <emu-t>const</emu-t>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-142">interface</a> with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-93">identifier</a> “A” is distinct from one named “a”, and an <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-96">extended attribute</a> [<code class="idl">constructor</code>] will not be recognized as
+terminal symbol <emu-t>const</emu-t>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-141">interface</a> with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-93">identifier</a> “A” is distinct from one named “a”, and an <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-96">extended attribute</a> [<code class="idl">constructor</code>] will not be recognized as
 the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-25">Constructor</a></code>]
 extended attribute.</p>
    <p>Implicitly, any number of <emu-t class="regex"><a href="#prod-whitespace">whitespace</a></emu-t> and <emu-t class="regex"><a href="#prod-comment">comment</a></emu-t> terminals are allowed between every other terminal
@@ -13331,62 +13285,62 @@ language binding.</p>
     <li><a href="#ref-for-dfn-interface-32">2.2.4.4. Indexed properties</a>
     <li><a href="#ref-for-dfn-interface-33">2.2.4.5. Named properties</a>
     <li><a href="#ref-for-dfn-interface-34">2.2.5. Static attributes and operations</a>
-    <li><a href="#ref-for-dfn-interface-35">2.2.6. Overloading</a> <a href="#ref-for-dfn-interface-36">(2)</a> <a href="#ref-for-dfn-interface-37">(3)</a> <a href="#ref-for-dfn-interface-38">(4)</a> <a href="#ref-for-dfn-interface-39">(5)</a> <a href="#ref-for-dfn-interface-40">(6)</a> <a href="#ref-for-dfn-interface-41">(7)</a> <a href="#ref-for-dfn-interface-42">(8)</a>
-    <li><a href="#ref-for-dfn-interface-43">2.2.7. Iterable declarations</a> <a href="#ref-for-dfn-interface-44">(2)</a>
-    <li><a href="#ref-for-dfn-interface-45">2.2.8. Maplike declarations</a>
-    <li><a href="#ref-for-dfn-interface-46">2.2.9. Setlike declarations</a>
-    <li><a href="#ref-for-dfn-interface-47">2.9. Implements statements</a> <a href="#ref-for-dfn-interface-48">(2)</a>
-    <li><a href="#ref-for-dfn-interface-49">2.10. Objects implementing interfaces</a> <a href="#ref-for-dfn-interface-50">(2)</a>
-    <li><a href="#ref-for-dfn-interface-51">2.11.19. Interface types</a>
-    <li><a href="#ref-for-dfn-interface-52">2.11.23. Nullable types — T?</a>
-    <li><a href="#ref-for-dfn-interface-53">3. ECMAScript binding</a>
-    <li><a href="#ref-for-dfn-interface-54">3.1. ECMAScript environment</a>
-    <li><a href="#ref-for-dfn-interface-55">3.2.13. Interface types</a>
-    <li><a href="#ref-for-dfn-interface-56">3.2.18.1. Creating a sequence from an iterable</a>
-    <li><a href="#ref-for-dfn-interface-57">3.3.2. [Constructor]</a>
-    <li><a href="#ref-for-dfn-interface-58">3.3.4. [Exposed]</a> <a href="#ref-for-dfn-interface-59">(2)</a> <a href="#ref-for-dfn-interface-60">(3)</a>
-    <li><a href="#ref-for-dfn-interface-61">3.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-interface-62">(2)</a> <a href="#ref-for-dfn-interface-63">(3)</a> <a href="#ref-for-dfn-interface-64">(4)</a>
-    <li><a href="#ref-for-dfn-interface-65">3.3.6. [LegacyArrayClass]</a> <a href="#ref-for-dfn-interface-66">(2)</a>
-    <li><a href="#ref-for-dfn-interface-67">3.3.7. [LegacyUnenumerableNamedProperties]</a>
-    <li><a href="#ref-for-dfn-interface-68">3.3.9. [LenientThis]</a>
-    <li><a href="#ref-for-dfn-interface-69">3.3.10. [NamedConstructor]</a>
-    <li><a href="#ref-for-dfn-interface-70">3.3.12. [NoInterfaceObject]</a>
-    <li><a href="#ref-for-dfn-interface-71">3.3.13. [OverrideBuiltins]</a> <a href="#ref-for-dfn-interface-72">(2)</a>
-    <li><a href="#ref-for-dfn-interface-73">3.3.14. [PutForwards]</a> <a href="#ref-for-dfn-interface-74">(2)</a>
-    <li><a href="#ref-for-dfn-interface-75">3.3.15. [Replaceable]</a>
-    <li><a href="#ref-for-dfn-interface-76">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-interface-77">(2)</a>
-    <li><a href="#ref-for-dfn-interface-78">3.6. Interfaces</a> <a href="#ref-for-dfn-interface-79">(2)</a>
-    <li><a href="#ref-for-dfn-interface-80">3.6.1. Interface object</a>
-    <li><a href="#ref-for-dfn-interface-81">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-dfn-interface-82">(2)</a> <a href="#ref-for-dfn-interface-83">(3)</a> <a href="#ref-for-dfn-interface-84">(4)</a>
-    <li><a href="#ref-for-dfn-interface-85">3.6.2. Named constructors</a> <a href="#ref-for-dfn-interface-86">(2)</a> <a href="#ref-for-dfn-interface-87">(3)</a> <a href="#ref-for-dfn-interface-88">(4)</a>
-    <li><a href="#ref-for-dfn-interface-89">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-interface-90">(2)</a> <a href="#ref-for-dfn-interface-91">(3)</a>
-    <li><a href="#ref-for-dfn-interface-92">3.6.4. Named properties object</a> <a href="#ref-for-dfn-interface-93">(2)</a>
-    <li><a href="#ref-for-dfn-interface-94">3.6.4.1. [[GetOwnProperty]]</a> <a href="#ref-for-dfn-interface-95">(2)</a>
-    <li><a href="#ref-for-dfn-interface-96">3.6.5. Constants</a>
-    <li><a href="#ref-for-dfn-interface-97">3.6.6. Attributes</a> <a href="#ref-for-dfn-interface-98">(2)</a> <a href="#ref-for-dfn-interface-99">(3)</a>
-    <li><a href="#ref-for-dfn-interface-100">3.6.7. Operations</a> <a href="#ref-for-dfn-interface-101">(2)</a> <a href="#ref-for-dfn-interface-102">(3)</a>
-    <li><a href="#ref-for-dfn-interface-103">3.6.7.1. Stringifiers</a> <a href="#ref-for-dfn-interface-104">(2)</a>
-    <li><a href="#ref-for-dfn-interface-105">3.6.7.2. Serializers</a> <a href="#ref-for-dfn-interface-106">(2)</a> <a href="#ref-for-dfn-interface-107">(3)</a>
-    <li><a href="#ref-for-dfn-interface-108">3.6.8.1. @@iterator</a> <a href="#ref-for-dfn-interface-109">(2)</a> <a href="#ref-for-dfn-interface-110">(3)</a>
-    <li><a href="#ref-for-dfn-interface-111">3.6.8.2. forEach</a> <a href="#ref-for-dfn-interface-112">(2)</a>
-    <li><a href="#ref-for-dfn-interface-113">3.6.9.1. entries</a>
-    <li><a href="#ref-for-dfn-interface-114">3.6.9.2. keys</a> <a href="#ref-for-dfn-interface-115">(2)</a>
-    <li><a href="#ref-for-dfn-interface-116">3.6.9.3. values</a> <a href="#ref-for-dfn-interface-117">(2)</a>
-    <li><a href="#ref-for-dfn-interface-118">3.6.9.4. Default iterator objects</a> <a href="#ref-for-dfn-interface-119">(2)</a> <a href="#ref-for-dfn-interface-120">(3)</a> <a href="#ref-for-dfn-interface-121">(4)</a>
-    <li><a href="#ref-for-dfn-interface-122">3.6.9.5. Iterator prototype object</a> <a href="#ref-for-dfn-interface-123">(2)</a> <a href="#ref-for-dfn-interface-124">(3)</a> <a href="#ref-for-dfn-interface-125">(4)</a>
-    <li><a href="#ref-for-dfn-interface-126">3.6.10. Maplike declarations</a> <a href="#ref-for-dfn-interface-127">(2)</a>
-    <li><a href="#ref-for-dfn-interface-128">3.6.11. Setlike declarations</a> <a href="#ref-for-dfn-interface-129">(2)</a>
-    <li><a href="#ref-for-dfn-interface-130">3.7. Implements statements</a>
-    <li><a href="#ref-for-dfn-interface-131">3.8.1. [[SetPrototypeOf]]</a>
-    <li><a href="#ref-for-dfn-interface-132">3.9. Legacy platform objects</a>
-    <li><a href="#ref-for-dfn-interface-133">3.9.3. [[DefineOwnProperty]]</a> <a href="#ref-for-dfn-interface-134">(2)</a>
-    <li><a href="#ref-for-dfn-interface-135">3.9.4. [[Delete]]</a>
-    <li><a href="#ref-for-dfn-interface-136">3.9.5. [[Call]]</a>
-    <li><a href="#ref-for-dfn-interface-137">3.9.7. Property enumeration</a> <a href="#ref-for-dfn-interface-138">(2)</a>
-    <li><a href="#ref-for-dfn-interface-139">3.10. User objects implementing callback interfaces</a>
-    <li><a href="#ref-for-dfn-interface-140">3.15. Creating and throwing exceptions</a>
-    <li><a href="#ref-for-dfn-interface-141">3.16. Handling exceptions</a>
-    <li><a href="#ref-for-dfn-interface-142">IDL grammar</a>
+    <li><a href="#ref-for-dfn-interface-35">2.2.6. Overloading</a> <a href="#ref-for-dfn-interface-36">(2)</a> <a href="#ref-for-dfn-interface-37">(3)</a> <a href="#ref-for-dfn-interface-38">(4)</a> <a href="#ref-for-dfn-interface-39">(5)</a> <a href="#ref-for-dfn-interface-40">(6)</a> <a href="#ref-for-dfn-interface-41">(7)</a>
+    <li><a href="#ref-for-dfn-interface-42">2.2.7. Iterable declarations</a> <a href="#ref-for-dfn-interface-43">(2)</a>
+    <li><a href="#ref-for-dfn-interface-44">2.2.8. Maplike declarations</a>
+    <li><a href="#ref-for-dfn-interface-45">2.2.9. Setlike declarations</a>
+    <li><a href="#ref-for-dfn-interface-46">2.9. Implements statements</a> <a href="#ref-for-dfn-interface-47">(2)</a>
+    <li><a href="#ref-for-dfn-interface-48">2.10. Objects implementing interfaces</a> <a href="#ref-for-dfn-interface-49">(2)</a>
+    <li><a href="#ref-for-dfn-interface-50">2.11.19. Interface types</a>
+    <li><a href="#ref-for-dfn-interface-51">2.11.23. Nullable types — T?</a>
+    <li><a href="#ref-for-dfn-interface-52">3. ECMAScript binding</a>
+    <li><a href="#ref-for-dfn-interface-53">3.1. ECMAScript environment</a>
+    <li><a href="#ref-for-dfn-interface-54">3.2.13. Interface types</a>
+    <li><a href="#ref-for-dfn-interface-55">3.2.18.1. Creating a sequence from an iterable</a>
+    <li><a href="#ref-for-dfn-interface-56">3.3.2. [Constructor]</a>
+    <li><a href="#ref-for-dfn-interface-57">3.3.4. [Exposed]</a> <a href="#ref-for-dfn-interface-58">(2)</a> <a href="#ref-for-dfn-interface-59">(3)</a>
+    <li><a href="#ref-for-dfn-interface-60">3.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-interface-61">(2)</a> <a href="#ref-for-dfn-interface-62">(3)</a> <a href="#ref-for-dfn-interface-63">(4)</a>
+    <li><a href="#ref-for-dfn-interface-64">3.3.6. [LegacyArrayClass]</a> <a href="#ref-for-dfn-interface-65">(2)</a>
+    <li><a href="#ref-for-dfn-interface-66">3.3.7. [LegacyUnenumerableNamedProperties]</a>
+    <li><a href="#ref-for-dfn-interface-67">3.3.9. [LenientThis]</a>
+    <li><a href="#ref-for-dfn-interface-68">3.3.10. [NamedConstructor]</a>
+    <li><a href="#ref-for-dfn-interface-69">3.3.12. [NoInterfaceObject]</a>
+    <li><a href="#ref-for-dfn-interface-70">3.3.13. [OverrideBuiltins]</a> <a href="#ref-for-dfn-interface-71">(2)</a>
+    <li><a href="#ref-for-dfn-interface-72">3.3.14. [PutForwards]</a> <a href="#ref-for-dfn-interface-73">(2)</a>
+    <li><a href="#ref-for-dfn-interface-74">3.3.15. [Replaceable]</a>
+    <li><a href="#ref-for-dfn-interface-75">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-interface-76">(2)</a>
+    <li><a href="#ref-for-dfn-interface-77">3.6. Interfaces</a> <a href="#ref-for-dfn-interface-78">(2)</a>
+    <li><a href="#ref-for-dfn-interface-79">3.6.1. Interface object</a>
+    <li><a href="#ref-for-dfn-interface-80">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-dfn-interface-81">(2)</a> <a href="#ref-for-dfn-interface-82">(3)</a> <a href="#ref-for-dfn-interface-83">(4)</a>
+    <li><a href="#ref-for-dfn-interface-84">3.6.2. Named constructors</a> <a href="#ref-for-dfn-interface-85">(2)</a> <a href="#ref-for-dfn-interface-86">(3)</a> <a href="#ref-for-dfn-interface-87">(4)</a>
+    <li><a href="#ref-for-dfn-interface-88">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-interface-89">(2)</a> <a href="#ref-for-dfn-interface-90">(3)</a>
+    <li><a href="#ref-for-dfn-interface-91">3.6.4. Named properties object</a> <a href="#ref-for-dfn-interface-92">(2)</a>
+    <li><a href="#ref-for-dfn-interface-93">3.6.4.1. [[GetOwnProperty]]</a> <a href="#ref-for-dfn-interface-94">(2)</a>
+    <li><a href="#ref-for-dfn-interface-95">3.6.5. Constants</a>
+    <li><a href="#ref-for-dfn-interface-96">3.6.6. Attributes</a> <a href="#ref-for-dfn-interface-97">(2)</a> <a href="#ref-for-dfn-interface-98">(3)</a>
+    <li><a href="#ref-for-dfn-interface-99">3.6.7. Operations</a> <a href="#ref-for-dfn-interface-100">(2)</a> <a href="#ref-for-dfn-interface-101">(3)</a>
+    <li><a href="#ref-for-dfn-interface-102">3.6.7.1. Stringifiers</a> <a href="#ref-for-dfn-interface-103">(2)</a>
+    <li><a href="#ref-for-dfn-interface-104">3.6.7.2. Serializers</a> <a href="#ref-for-dfn-interface-105">(2)</a> <a href="#ref-for-dfn-interface-106">(3)</a>
+    <li><a href="#ref-for-dfn-interface-107">3.6.8.1. @@iterator</a> <a href="#ref-for-dfn-interface-108">(2)</a> <a href="#ref-for-dfn-interface-109">(3)</a>
+    <li><a href="#ref-for-dfn-interface-110">3.6.8.2. forEach</a> <a href="#ref-for-dfn-interface-111">(2)</a>
+    <li><a href="#ref-for-dfn-interface-112">3.6.9.1. entries</a>
+    <li><a href="#ref-for-dfn-interface-113">3.6.9.2. keys</a> <a href="#ref-for-dfn-interface-114">(2)</a>
+    <li><a href="#ref-for-dfn-interface-115">3.6.9.3. values</a> <a href="#ref-for-dfn-interface-116">(2)</a>
+    <li><a href="#ref-for-dfn-interface-117">3.6.9.4. Default iterator objects</a> <a href="#ref-for-dfn-interface-118">(2)</a> <a href="#ref-for-dfn-interface-119">(3)</a> <a href="#ref-for-dfn-interface-120">(4)</a>
+    <li><a href="#ref-for-dfn-interface-121">3.6.9.5. Iterator prototype object</a> <a href="#ref-for-dfn-interface-122">(2)</a> <a href="#ref-for-dfn-interface-123">(3)</a> <a href="#ref-for-dfn-interface-124">(4)</a>
+    <li><a href="#ref-for-dfn-interface-125">3.6.10. Maplike declarations</a> <a href="#ref-for-dfn-interface-126">(2)</a>
+    <li><a href="#ref-for-dfn-interface-127">3.6.11. Setlike declarations</a> <a href="#ref-for-dfn-interface-128">(2)</a>
+    <li><a href="#ref-for-dfn-interface-129">3.7. Implements statements</a>
+    <li><a href="#ref-for-dfn-interface-130">3.8.1. [[SetPrototypeOf]]</a>
+    <li><a href="#ref-for-dfn-interface-131">3.9. Legacy platform objects</a>
+    <li><a href="#ref-for-dfn-interface-132">3.9.3. [[DefineOwnProperty]]</a> <a href="#ref-for-dfn-interface-133">(2)</a>
+    <li><a href="#ref-for-dfn-interface-134">3.9.4. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-interface-135">3.9.5. [[Call]]</a>
+    <li><a href="#ref-for-dfn-interface-136">3.9.7. Property enumeration</a> <a href="#ref-for-dfn-interface-137">(2)</a>
+    <li><a href="#ref-for-dfn-interface-138">3.10. User objects implementing callback interfaces</a>
+    <li><a href="#ref-for-dfn-interface-139">3.15. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-interface-140">3.16. Handling exceptions</a>
+    <li><a href="#ref-for-dfn-interface-141">IDL grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-interface-member">
@@ -14539,7 +14493,8 @@ language binding.</p>
   <aside class="dfn-panel" data-for="dfn-exception-type">
    <b><a href="#dfn-exception-type">#dfn-exception-type</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-exception-type-1">2.11. Types</a>
+    <li><a href="#ref-for-dfn-exception-type-1">2.2.6. Overloading</a>
+    <li><a href="#ref-for-dfn-exception-type-2">2.11. Types</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-typed-array-type">
@@ -14553,8 +14508,9 @@ language binding.</p>
   <aside class="dfn-panel" data-for="dfn-buffer-source-type">
    <b><a href="#dfn-buffer-source-type">#dfn-buffer-source-type</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-buffer-source-type-1">2.11.30. Buffer source types</a>
-    <li><a href="#ref-for-dfn-buffer-source-type-2">3.2.24. Buffer source types</a> <a href="#ref-for-dfn-buffer-source-type-3">(2)</a>
+    <li><a href="#ref-for-dfn-buffer-source-type-1">2.2.6. Overloading</a>
+    <li><a href="#ref-for-dfn-buffer-source-type-2">2.11.30. Buffer source types</a>
+    <li><a href="#ref-for-dfn-buffer-source-type-3">3.2.24. Buffer source types</a> <a href="#ref-for-dfn-buffer-source-type-4">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-type-name">
@@ -14906,6 +14862,12 @@ language binding.</p>
     <li><a href="#ref-for-dfn-inner-type-8">3.2.17. Nullable types — T?</a> <a href="#ref-for-dfn-inner-type-9">(2)</a> <a href="#ref-for-dfn-inner-type-10">(3)</a> <a href="#ref-for-dfn-inner-type-11">(4)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="idl-sequence">
+   <b><a href="#idl-sequence">#idl-sequence</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-sequence-1">2.2.6. Overloading</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="sequence-type">
    <b><a href="#sequence-type">#sequence-type</a></b><b>Referenced in:</b>
    <ul>
@@ -15136,9 +15098,10 @@ language binding.</p>
   <aside class="dfn-panel" data-for="idl-frozen-array">
    <b><a href="#idl-frozen-array">#idl-frozen-array</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-frozen-array-1">2.11.31. Frozen array types — FrozenArray&lt;T></a>
-    <li><a href="#ref-for-idl-frozen-array-2">3.2.25. Frozen arrays — FrozenArray&lt;T></a> <a href="#ref-for-idl-frozen-array-3">(2)</a> <a href="#ref-for-idl-frozen-array-4">(3)</a>
-    <li><a href="#ref-for-idl-frozen-array-5">3.2.25.1. Creating a frozen array from an iterable</a>
+    <li><a href="#ref-for-idl-frozen-array-1">2.2.6. Overloading</a>
+    <li><a href="#ref-for-idl-frozen-array-2">2.11.31. Frozen array types — FrozenArray&lt;T></a>
+    <li><a href="#ref-for-idl-frozen-array-3">3.2.25. Frozen arrays — FrozenArray&lt;T></a> <a href="#ref-for-idl-frozen-array-4">(2)</a> <a href="#ref-for-idl-frozen-array-5">(3)</a>
+    <li><a href="#ref-for-idl-frozen-array-6">3.2.25.1. Creating a frozen array from an iterable</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-frozen-array-type">

--- a/index.html
+++ b/index.html
@@ -4262,11 +4262,21 @@ Otherwise return <i>false</i>.</p>
       <dd>
        <ul>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-41">interfaces</a></p>
+         <p>non-<a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-9">callback</a> <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-41">interfaces</a></p>
         <li data-md="">
          <p><a data-link-type="dfn" href="#dfn-exception-type" id="ref-for-dfn-exception-type-1">exception types</a></p>
         <li data-md="">
          <p><a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-1">buffer source types</a></p>
+       </ul>
+      <dt>dictionary-like
+      <dd>
+       <ul>
+        <li data-md="">
+         <p><a data-link-type="dfn" href="#dfn-dictionary" id="ref-for-dfn-dictionary-9">dictionaries</a></p>
+        <li data-md="">
+         <p><a data-link-type="dfn" href="#record-type" id="ref-for-record-type-5">record types</a></p>
+        <li data-md="">
+         <p><a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-10">callback interfaces</a></p>
        </ul>
       <dt>sequence-like
       <dd>
@@ -4294,7 +4304,7 @@ Otherwise return <i>false</i>.</p>
         <th>
          <div> <span>callback function</span> </div>
         <th>
-         <div> <span>dictionary/record</span> </div>
+         <div> <span>dictionary-like</span> </div>
         <th>
          <div> <span>sequence-like</span> </div>
        <tr>
@@ -4344,8 +4354,8 @@ Otherwise return <i>false</i>.</p>
         <td class="belowdiagonal">
         <td class="belowdiagonal">
         <td>(a)
-        <td>(b)
-        <td>(b)
+        <td>●
+        <td>●
         <td>●
        <tr>
         <th>callback function
@@ -4358,7 +4368,7 @@ Otherwise return <i>false</i>.</p>
         <td>
         <td>●
        <tr>
-        <th>dictionary/record
+        <th>dictionary-like
         <td class="belowdiagonal">
         <td class="belowdiagonal">
         <td class="belowdiagonal">
@@ -4381,11 +4391,8 @@ Otherwise return <i>false</i>.</p>
      <ol type="a">
       <li data-md="">
        <p>The two identified interface-like types are
-not the same, no single <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-4">platform object</a> implements both
-interface-like types,
-and it is not the case that both are <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-9">callback interfaces</a>.</p>
-      <li data-md="">
-       <p>The interface type is not a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-10">callback interface</a>.</p>
+not the same, and no single <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-4">platform object</a> implements both
+interface-like types.</p>
      </ol>
      <div class="example" id="example-distinguishability-diff-types"><a class="self-link" href="#example-distinguishability-diff-types"></a> <code class="idl"><a data-link-type="idl" href="#idl-double" id="ref-for-idl-double-8">double</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-21">DOMString</a></code> are distinguishable because
     there is a ● at the intersection of <a data-link-type="dfn" href="#dfn-numeric-type" id="ref-for-dfn-numeric-type-1">numeric types</a> with <a data-link-type="dfn" href="#dfn-string-type" id="ref-for-dfn-string-type-2">string types</a>. </div>
@@ -4405,8 +4412,8 @@ and it is not the case that both are <a data-link-type="dfn" href="#dfn-callback
     <span class="kt">DOMString</span> <span class="nv">field1</span>;
 };
 </pre>
-      <p><code>CBIface</code> is distinguishable from <code>Iface</code> because the pair satisfies note (a),
-    but it is not distinguishable from <code>Dict</code> because that pair does not satisfy note (b).</p>
+      <p><code>CBIface</code> is distinguishable from <code>Iface</code> because there’s a ● at the intersection of dictionary-like and interface-like,
+    but it is not distinguishable from <code>Dict</code> because there’s no ● at the intersection of dictionary-like and itself.</p>
      </div>
      <div class="example" id="example-distinguishability-promises"><a class="self-link" href="#example-distinguishability-promises"></a> <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-3">Promise types</a> do not appear in the above table, and as a consequence are
     not distinguishable with any other type. </div>
@@ -4757,7 +4764,7 @@ must identify an
 interface, <a data-link-type="dfn" href="#dfn-enumeration" id="ref-for-dfn-enumeration-10">enumeration</a>, <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-13">callback function</a> or <a data-link-type="dfn" href="#dfn-typedef" id="ref-for-dfn-typedef-10">typedef</a>.
 If the dictionary member type is an identifier
 not followed by <emu-t>?</emu-t>, then the identifier must
-identify any one of those definitions or a <a data-link-type="dfn" href="#dfn-dictionary" id="ref-for-dfn-dictionary-9">dictionary</a>.</p>
+identify any one of those definitions or a <a data-link-type="dfn" href="#dfn-dictionary" id="ref-for-dfn-dictionary-10">dictionary</a>.</p>
 <pre class="syntax highlight"><span class="kt">dictionary</span> <span class="nv">identifier</span> {
   <span class="n">type</span> <span class="nv">identifier</span>;
 };
@@ -5773,7 +5780,7 @@ use a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable
 is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-42">identifier</a> of the interface.</p>
    <h4 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="2.11.20" data-lt="Dictionary types" data-noexport="" id="idl-dictionary"><span class="secno">2.11.20. </span><span class="content">Dictionary types</span></h4>
    <p>An <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-43">identifier</a> that
-identifies a <a data-link-type="dfn" href="#dfn-dictionary" id="ref-for-dfn-dictionary-10">dictionary</a> is used to refer to
+identifies a <a data-link-type="dfn" href="#dfn-dictionary" id="ref-for-dfn-dictionary-11">dictionary</a> is used to refer to
 a type that corresponds to the set of all dictionaries that adhere to
 the dictionary definition.</p>
    <p>There is no way to represent a constant dictionary value in IDL.</p>
@@ -5962,7 +5969,7 @@ Add <var>U</var> to <var>S</var>.</p>
 be used as a <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-dfn-union-member-type-8">union member type</a>.</p>
    <p>The <a data-link-type="dfn" href="#dfn-number-of-nullable-member-types" id="ref-for-dfn-number-of-nullable-member-types-2">number of nullable member types</a> of a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-21">union type</a> must
 be 0 or 1, and if it is 1 then the union type must also not have
-a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-5">dictionary type</a> or <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-5">record type</a> in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-8">flattened member types</a>.</p>
+a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-5">dictionary type</a> or <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-6">record type</a> in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-8">flattened member types</a>.</p>
    <p>A type <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-includes-a-nullable-type">includes a nullable type</dfn> if:</p>
    <ul>
     <li data-md="">
@@ -6914,7 +6921,7 @@ in order from least to most derived.</p>
 up on the ECMAScript object are not necessarily the same as the object’s property enumeration order.</p>
    <div class="algorithm" data-algorithm="convert a dictionary to an ECMAScript value" id="dictionary-to-es">
     <p>An IDL dictionary value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-20">converted</a> to an ECMAScript <emu-val>Object</emu-val> value by
-    running the following algorithm (where <var>D</var> is the <a data-link-type="dfn" href="#dfn-dictionary" id="ref-for-dfn-dictionary-11">dictionary</a>):</p>
+    running the following algorithm (where <var>D</var> is the <a data-link-type="dfn" href="#dfn-dictionary" id="ref-for-dfn-dictionary-12">dictionary</a>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>O</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-objectcreate">ObjectCreate</a>(<a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a>).</p>
@@ -7351,7 +7358,7 @@ then return the IDL value <emu-val>null</emu-val>.</p>
         <p>If <var>types</var> includes a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-9">dictionary type</a>, then return the
 result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-36">converting</a> <var>V</var> to that dictionary type.</p>
        <li data-md="">
-        <p>If <var>types</var> includes a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-6">record type</a>, then return the
+        <p>If <var>types</var> includes a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-7">record type</a>, then return the
 result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-37">converting</a> <var>V</var> to that record type.</p>
       </ol>
      <li data-md="">
@@ -7451,7 +7458,7 @@ return the result of <a data-link-type="dfn" href="#create-frozen-array-from-ite
         <p>If <var>types</var> includes a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-10">dictionary type</a>, then return the
 result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-44">converting</a> <var>V</var> to that dictionary type.</p>
        <li data-md="">
-        <p>If <var>types</var> includes a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-7">record type</a>, then return the
+        <p>If <var>types</var> includes a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-8">record type</a>, then return the
 result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-45">converting</a> <var>V</var> to that record type.</p>
        <li data-md="">
         <p>If <var>types</var> includes a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-17">callback interface</a> type, then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-46">converting</a> <var>V</var> to that interface type.</p>
@@ -8933,10 +8940,10 @@ and there is an entry in <var>S</var> that has one of the following types at pos
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-11">dictionary type</a></p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-8">record type</a></p>
+          <p>a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-9">record type</a></p>
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-29">union type</a> that <a data-link-type="dfn" href="#dfn-includes-a-nullable-type" id="ref-for-dfn-includes-a-nullable-type-5">includes a nullable type</a> or that
-has a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-12">dictionary type</a> or a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-9">record type</a> in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-11">flattened members</a></p>
+has a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-12">dictionary type</a> or a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-10">record type</a> in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-11">flattened members</a></p>
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
        <li data-md="">
@@ -9080,7 +9087,7 @@ there is an entry in <var>S</var> that has one of the following types at positio
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-13">dictionary type</a></p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-10">record type</a></p>
+          <p>a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-11">record type</a></p>
          <li data-md="">
           <p><code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-31">object</a></code></p>
          <li data-md="">
@@ -14113,9 +14120,10 @@ language binding.</p>
     <li><a href="#ref-for-dfn-dictionary-6">2.2.3. Operations</a>
     <li><a href="#ref-for-dfn-dictionary-7">2.2.4. Special operations</a>
     <li><a href="#ref-for-dfn-dictionary-8">2.2.4.3. Serializers</a>
-    <li><a href="#ref-for-dfn-dictionary-9">2.4. Dictionaries</a>
-    <li><a href="#ref-for-dfn-dictionary-10">2.11.20. Dictionary types</a>
-    <li><a href="#ref-for-dfn-dictionary-11">3.2.14. Dictionary types</a>
+    <li><a href="#ref-for-dfn-dictionary-9">2.2.6. Overloading</a>
+    <li><a href="#ref-for-dfn-dictionary-10">2.4. Dictionaries</a>
+    <li><a href="#ref-for-dfn-dictionary-11">2.11.20. Dictionary types</a>
+    <li><a href="#ref-for-dfn-dictionary-12">3.2.14. Dictionary types</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-dictionary-member">
@@ -14900,10 +14908,10 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-record-type-1">2.2.2. Attributes</a>
     <li><a href="#ref-for-record-type-2">2.2.3. Operations</a>
-    <li><a href="#ref-for-record-type-3">2.2.6. Overloading</a> <a href="#ref-for-record-type-4">(2)</a>
-    <li><a href="#ref-for-record-type-5">2.11.27. Union types</a>
-    <li><a href="#ref-for-record-type-6">3.2.21. Union types</a> <a href="#ref-for-record-type-7">(2)</a>
-    <li><a href="#ref-for-record-type-8">3.5. Overload resolution algorithm</a> <a href="#ref-for-record-type-9">(2)</a> <a href="#ref-for-record-type-10">(3)</a>
+    <li><a href="#ref-for-record-type-3">2.2.6. Overloading</a> <a href="#ref-for-record-type-4">(2)</a> <a href="#ref-for-record-type-5">(3)</a>
+    <li><a href="#ref-for-record-type-6">2.11.27. Union types</a>
+    <li><a href="#ref-for-record-type-7">3.2.21. Union types</a> <a href="#ref-for-record-type-8">(2)</a>
+    <li><a href="#ref-for-record-type-9">3.5. Overload resolution algorithm</a> <a href="#ref-for-record-type-10">(2)</a> <a href="#ref-for-record-type-11">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="record-mappings">


### PR DESCRIPTION
Primarily by grouping types into larger categories, but also by recategorizing callback interfaces as more like dictionaries than normal interfaces.

Fixes #50 and #59.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
    
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://cdn.rawgit.com/jyasskin/webidl/6a5406a/index.html) | [Diff w/ current ED](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fheycam.github.io%2Fwebidl%2F&doc2=https%3A%2F%2Fcdn.rawgit.com%2Fjyasskin%2Fwebidl%2F6a5406a%2Findex.html) | [Diff w/ base](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2Ffef2cda%2Findex.html&doc2=https%3A%2F%2Fcdn.rawgit.com%2Fjyasskin%2Fwebidl%2F6a5406a%2Findex.html)