### PR TITLE
Throw when not calling interfaces as constructors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -129,6 +129,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: typed arrays; url: sec-typedarray-objects
         text: GetMethod; url: sec-getmethod
         text: @@unscopables; url: sec-well-known-symbols
+        text: NewTarget; url: sec-built-in-function-objects
 </pre>
 
 <style>
@@ -8214,7 +8215,7 @@ extended attributes must not be specified on the same interface.
 The [{{Constructor}}] extended attribute
 must not be used on a [=callback interface=].
 
-See [[#es-interface-call]] for details on how a constructor
+See [[#es-constructible-interfaces]] for details on how a constructor
 for an interface is to be implemented.
 
 <div class="example">
@@ -10273,25 +10274,27 @@ Note: Remember that interface objects for callback interfaces only exist if they
 when they do exist, they are not [=function objects=].
 
 
-<h5 id="es-interface-call">Interface object \[[Call]] method</h5>
+<h5 id="es-constructible-interfaces" oldids="es-interface-call">Constructible Interfaces</h5>
 
-If the [=interface=] is declared with a
-[{{Constructor}}] [=extended attribute=],
-then the [=interface object=]
-can be called as a function to create an object that implements that
-interface.  Interfaces that do not have a constructor will throw
-an exception when called as a function.
+If the [=interface=] is declared with a [{{Constructor}}] [=extended attribute=],
+then the [=interface object=] can be called as a constructor
+to create an object that implements that interface.
+Calling that interface as a function will throw an exception.
 
-<div algorithm="to invoke the internal [[Call]] method of interface objects">
+Interfaces that are not declared with a [{{Constructor}}] [=extended attribute=] will throw when called,
+both as a function and as a constructor.
 
-    The internal \[[Call]] method
-    of the interface object behaves as follows, assuming
-    |arg|<sub>0..|n|−1</sub> is the list
-    of argument values passed to the constructor, and |I|
-    is the [=interface=]:
+<div algorithm="to construct an object implementing an interface">
+
+    When evaluating the [=function object=] |F|,
+    which is the interface object for a given non-callback [=interface=] |I|,
+    assuming |arg|<sub>0..|n|−1</sub> as the list of argument values passed |F|,
+    the following steps must be taken:
 
     1.  If |I| was not declared with a [{{Constructor}}]
         [=extended attribute=], then
+        <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+    1.  If [=NewTarget=] is <emu-val>undefined</emu-val>, then
         <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
     1.  Let |id| be the identifier of interface |I|.
     1.  Initialize |S| to the
@@ -10303,18 +10306,13 @@ an exception when called as a function.
         |arg|<sub>0..|n|−1</sub> to the
         [=overload resolution algorithm=].
     1.  Let |R| be the result of performing the actions listed in the description of
-        |constructor| with |values| as the argument values.
-    1.  Return the result of [=converted to an ECMAScript value|converting=]
+        |constructor| with |values| as the argument values. Rethrow any exceptions.
+    1.  Let |O| be the result of [=converted to an ECMAScript value|converting=]
         |R| to an ECMAScript [=interface type=] value |I|.
+    1.  Assert: |O| is an object that implements |I|.
+    1.  Assert: |O|.\[[Realm]] is equal to |F|.\[[Realm]].
+    1.  Return |O|.
 </div>
-
-If the internal \[[Call]] method
-of the [=interface object=]
-returns normally, then it must
-return an object that implements interface |I|.
-This object also must be
-associated with the ECMAScript global environment associated
-with the interface object.
 
 <div algorithm="determine value of length property of non-callback interfaces">
 

--- a/index.html
+++ b/index.html
@@ -1768,7 +1768,7 @@ are interoperable.</p>
         <li>
          <a href="#interface-object"><span class="secno">3.6.1</span> <span class="content">Interface object</span></a>
          <ol class="toc">
-          <li><a href="#es-interface-call"><span class="secno">3.6.1.1</span> <span class="content">Interface object [[Call]] method</span></a>
+          <li><a href="#es-constructible-interfaces"><span class="secno">3.6.1.1</span> <span class="content">Constructible Interfaces</span></a>
           <li><a href="#es-interface-hasinstance"><span class="secno">3.6.1.2</span> <span class="content">Interface object [[HasInstance]] method</span></a>
          </ol>
         <li><a href="#named-constructors"><span class="secno">3.6.2</span> <span class="content">Named constructors</span></a>
@@ -8060,7 +8060,7 @@ extended attribute appears on, or throw an exception.</p>
 extended attributes must not be specified on the same interface.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-17">Constructor</a></code>] extended attribute
 must not be used on a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-18">callback interface</a>.</p>
-   <p>See <a href="#es-interface-call">§3.6.1.1 Interface object [[Call]] method</a> for details on how a constructor
+   <p>See <a href="#es-constructible-interfaces">§3.6.1.1 Constructible Interfaces</a> for details on how a constructor
 for an interface is to be implemented.</p>
    <div class="example" id="example-595d0762">
     <a class="self-link" href="#example-595d0762"></a> 
@@ -9675,19 +9675,23 @@ of an interface object for a callback interface must be
 the Function.prototype object.</p>
    <p class="note" role="note">Note: Remember that interface objects for callback interfaces only exist if they have <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-23">constants</a> declared on them;
 when they do exist, they are not <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-5">function objects</a>.</p>
-   <h5 class="heading settled" data-level="3.6.1.1" id="es-interface-call"><span class="secno">3.6.1.1. </span><span class="content">Interface object [[Call]] method</span><a class="self-link" href="#es-interface-call"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-80">interface</a> is declared with a
-[<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-20">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-82">extended attribute</a>,
-then the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-7">interface object</a> can be called as a function to create an object that implements that
-interface.  Interfaces that do not have a constructor will throw
-an exception when called as a function.</p>
-   <div class="algorithm" data-algorithm="to invoke the internal [[Call]] method of interface objects">
-    <p>The internal [[Call]] method
-    of the interface object behaves as follows, assuming <var>arg</var><sub>0..<var>n</var>−1</sub> is the list
-    of argument values passed to the constructor, and <var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-81">interface</a>:</p>
+   <h5 class="heading settled" data-level="3.6.1.1" id="es-constructible-interfaces"><span class="secno">3.6.1.1. </span><span class="content">Constructible Interfaces</span><span id="es-interface-call"></span><a class="self-link" href="#es-constructible-interfaces"></a></h5>
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-80">interface</a> is declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-20">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-82">extended attribute</a>,
+then the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-7">interface object</a> can be called as a constructor
+to create an object that implements that interface.
+Calling that interface as a function will throw an exception.</p>
+   <p>Interfaces that are not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-21">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-83">extended attribute</a> will throw when called,
+both as a function and as a constructor.</p>
+   <div class="algorithm" data-algorithm="to construct an object implementing an interface">
+    <p>When evaluating the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-6">function object</a> <var>F</var>,
+    which is the interface object for a given non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-81">interface</a> <var>I</var>,
+    assuming <var>arg</var><sub>0..<var>n</var>−1</sub> as the list of argument values passed <var>F</var>,
+    the following steps must be taken:</p>
     <ol>
      <li data-md="">
-      <p>If <var>I</var> was not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-21">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-83">extended attribute</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-43">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <var>I</var> was not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-22">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-84">extended attribute</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-43">throw a <emu-val>TypeError</emu-val></a>.</p>
+     <li data-md="">
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-built-in-function-objects">NewTarget</a> is <emu-val>undefined</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-44">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>Let <var>id</var> be the identifier of interface <var>I</var>.</p>
      <li data-md="">
@@ -9695,20 +9699,20 @@ an exception when called as a function.</p>
      <li data-md="">
       <p>Let &lt;<var>constructor</var>, <var>values</var>> be the result of passing <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to the <a data-link-type="dfn" href="#dfn-overload-resolution-algorithm" id="ref-for-dfn-overload-resolution-algorithm-1">overload resolution algorithm</a>.</p>
      <li data-md="">
-      <p>Let <var>R</var> be the result of performing the actions listed in the description of <var>constructor</var> with <var>values</var> as the argument values.</p>
+      <p>Let <var>R</var> be the result of performing the actions listed in the description of <var>constructor</var> with <var>values</var> as the argument values. Rethrow any exceptions.</p>
      <li data-md="">
-      <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-39">converting</a> <var>R</var> to an ECMAScript <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-16">interface type</a> value <var>I</var>.</p>
+      <p>Let <var>O</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-39">converting</a> <var>R</var> to an ECMAScript <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-16">interface type</a> value <var>I</var>.</p>
+     <li data-md="">
+      <p class="assertion">Assert: <var>O</var> is an object that implements <var>I</var>.</p>
+     <li data-md="">
+      <p class="assertion">Assert: <var>O</var>.[[Realm]] is equal to <var>F</var>.[[Realm]].</p>
+     <li data-md="">
+      <p>Return <var>O</var>.</p>
     </ol>
    </div>
-   <p>If the internal [[Call]] method
-of the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-8">interface object</a> returns normally, then it must
-return an object that implements interface <var>I</var>.
-This object also must be
-associated with the ECMAScript global environment associated
-with the interface object.</p>
    <div class="algorithm" data-algorithm="determine value of length property of non-callback interfaces">
     <p>Interface objects for non-callback interfaces must have a property named “length” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> whose value is a <emu-val>Number</emu-val>.
-    If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-22">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-84">extended attribute</a> does not appear on the interface definition, then the value is 0.
+    If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-23">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-85">extended attribute</a> does not appear on the interface definition, then the value is 0.
     Otherwise, the value is determined as follows:</p>
     <ol>
      <li data-md="">
@@ -9724,7 +9728,7 @@ property named “name” with attributes <span class="prop-desc">{ [[Writable]]
    <h5 class="heading settled" data-level="3.6.1.2" id="es-interface-hasinstance"><span class="secno">3.6.1.2. </span><span class="content">Interface object [[HasInstance]] method</span><a class="self-link" href="#es-interface-hasinstance"></a></h5>
    <div class="algorithm" data-algorithm="to invoke the internal [[HasInstance]] method of interface objects">
     <p>The internal [[HasInstance]] method of
-    every <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-9">interface object</a> <var>A</var> must behave as follows,
+    every <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-8">interface object</a> <var>A</var> must behave as follows,
     assuming <var>V</var> is the object argument passed to [[HasInstance]]:</p>
     <ol>
      <li data-md="">
@@ -9732,7 +9736,7 @@ property named “name” with attributes <span class="prop-desc">{ [[Writable]]
      <li data-md="">
       <p>Let <var>O</var> be the result of calling the [[Get]] method of <var>A</var> with property name “prototype”.</p>
      <li data-md="">
-      <p>If <var>O</var> is not an object, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-44">throw a <emu-val>TypeError</emu-val></a> exception.</p>
+      <p>If <var>O</var> is not an object, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-45">throw a <emu-val>TypeError</emu-val></a> exception.</p>
      <li data-md="">
       <p>If <var>V</var> is a platform object that implements the
 interface for which <var>O</var> is the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-8">interface prototype object</a>,
@@ -9752,7 +9756,7 @@ return <emu-val>true</emu-val>.</p>
    </div>
    <h4 class="heading settled" data-level="3.6.2" id="named-constructors"><span class="secno">3.6.2. </span><span class="content">Named constructors</span><a class="self-link" href="#named-constructors"></a></h4>
    <p>A <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-2">named constructor</a> that exists due to one or more
-[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-17">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-85">extended attributes</a> with a given <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-60">identifier</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-6">function object</a>.
+[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-17">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-86">extended attributes</a> with a given <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-60">identifier</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-7">function object</a>.
 It must have a [[Call]] internal property,
 which allows construction of objects that
 implement the interface on which the
@@ -9793,14 +9797,14 @@ with the <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-n
 with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> whose value is the identifier used for the named constructor.</p>
    <p>A named constructor must also have a property named
 “prototype” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span> whose value is the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-9">interface prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-87">interface</a> on which the
-[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-20">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-86">extended attribute</a> appears.</p>
+[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-20">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-87">extended attribute</a> appears.</p>
    <h4 class="heading settled" data-level="3.6.3" id="interface-prototype-object"><span class="secno">3.6.3. </span><span class="content">Interface prototype object</span><a class="self-link" href="#interface-prototype-object"></a></h4>
    <p>There must exist an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-10">interface prototype object</a> for every non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-88">interface</a> defined, regardless of whether the interface was declared with the
-[<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-14">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-87">extended attribute</a>.
+[<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-14">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-88">extended attribute</a>.
 The interface prototype object for a particular interface has
 properties that correspond to the <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-13">regular attributes</a> and <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-15">regular operations</a> defined on that interface.  These properties are described in more detail in
 sections <a href="#es-attributes">§3.6.6 Attributes</a> and <a href="#es-operations">§3.6.7 Operations</a>.</p>
-   <p>As with the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-10">interface object</a>,
+   <p>As with the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-9">interface object</a>,
 the interface prototype object also has properties that correspond to the <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-24">constants</a> defined on that
 interface, described in <a href="#es-operations">§3.6.7 Operations</a>.</p>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-15">NoInterfaceObject</a></code>]
@@ -9815,7 +9819,7 @@ is a reference to the interface object for the interface.</p>
     <ol>
      <li data-md="">
       <p>If <var>A</var> is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-31">Global</a></code>]
-or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-32">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-88">extended attribute</a>, and <var>A</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-3">supports named properties</a>, then
+or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-32">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-89">extended attribute</a>, and <var>A</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-3">supports named properties</a>, then
 return the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-4">named properties object</a> for <var>A</var>, as defined in <a href="#named-properties-object">§3.6.4 Named properties object</a>.</p>
      <li data-md="">
       <p>Otherwise, if <var>A</var> is declared to inherit from another
@@ -9829,7 +9833,7 @@ extended attribute, then return <a data-link-type="dfn" href="https://tc39.githu
    </div>
    <div class="note" role="note">
     <p>The <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-13">interface prototype object</a> of an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-89">interface</a> that is defined with
-    the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-16">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-89">extended attribute</a> will be accessible if the interface is used as a <a data-link-type="dfn" href="#dfn-supplemental-interface" id="ref-for-dfn-supplemental-interface-5">non-supplemental interface</a>.
+    the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-16">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-90">extended attribute</a> will be accessible if the interface is used as a <a data-link-type="dfn" href="#dfn-supplemental-interface" id="ref-for-dfn-supplemental-interface-5">non-supplemental interface</a>.
     For example, with the following IDL:</p>
 <pre class="highlight">[<span class="nv">NoInterfaceObject</span>]
 <span class="kt">interface</span> <span class="nv">Foo</span> {
@@ -9840,7 +9844,7 @@ extended attribute, then return <a data-link-type="dfn" href="https://tc39.githu
 };
 </pre>
     <p>it is not possible to access the interface prototype object through
-    the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-11">interface object</a> (since it does not exist as <code>window.Foo</code>).  However, an instance
+    the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-10">interface object</a> (since it does not exist as <code>window.Foo</code>).  However, an instance
     of <code class="idl">Foo</code> can expose the interface prototype
     object by gettings its internal [[Prototype]]
     property value – <code>Object.getPrototypeOf(window.foo)</code> in
@@ -9870,14 +9874,14 @@ interface member, <emu-val>true</emu-val>).</p>
     </ol>
    </div>
    <p>If the interface is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-33">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-34">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-90">extended attribute</a>, or the interface is in the set
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-34">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-91">extended attribute</a>, or the interface is in the set
 of <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces-16">inherited interfaces</a> for any
 other interface that is declared with one of these attributes, then the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-14">interface prototype object</a> must be an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">immutable prototype exotic object</a>.</p>
    <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-1">class string</a> of an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-15">interface prototype object</a> is the concatenation of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-90">interface</a>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-64">identifier</a> and the string
 “Prototype”.</p>
    <h4 class="heading settled" data-level="3.6.4" id="named-properties-object"><span class="secno">3.6.4. </span><span class="content">Named properties object</span><a class="self-link" href="#named-properties-object"></a></h4>
    <p>For every <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-91">interface</a> declared with the
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-35">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-36">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-91">extended attribute</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-4">supports named properties</a>,
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-35">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-36">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-92">extended attribute</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-4">supports named properties</a>,
 there must exist an object known as the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-named-properties-object">named properties object</dfn> for that interface.</p>
    <div class="algorithm" data-algorithm="value of [[Prototype]] property of named properties objects">
     <p>The <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-5">named properties object</a> for a given interface <var>A</var> must have an internal
@@ -9924,7 +9928,7 @@ of performing the steps listed in the description of <var>operation</var> with <
         <p>Set <var>desc</var>.[[Value]] to the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-41">converting</a> <var>value</var> to an ECMAScript value.</p>
        <li data-md="">
         <p>If <var>A</var> implements an interface with the
-[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-5">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-92">extended attribute</a>,
+[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-5">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-93">extended attribute</a>,
 then set <var>desc</var>.[[Enumerable]] to <emu-val>false</emu-val>,
 otherwise set it to <emu-val>true</emu-val>.</p>
        <li data-md="">
@@ -9995,7 +9999,7 @@ the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-pro
      <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span>.</p>
    </ul>
    <p>In addition, a property with the same characteristics must
-exist on the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-12">interface object</a>, if that object exists.</p>
+exist on the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-11">interface object</a>, if that object exists.</p>
    <h4 class="heading settled" data-level="3.6.6" id="es-attributes"><span class="secno">3.6.6. </span><span class="content">Attributes</span><a class="self-link" href="#es-attributes"></a></h4>
    <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-5">exposed</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-63">attribute</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-96">interface</a>, whether it
 was declared on the interface itself or one of its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-20">consequential interfaces</a>,
@@ -10009,7 +10013,7 @@ The characteristics of this property are as follows:</p>
      <ul>
       <li data-md="">
        <p>If the attribute is a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-11">static attribute</a>,
-then there is a single corresponding property and it exists on the interface’s <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-13">interface object</a>.</p>
+then there is a single corresponding property and it exists on the interface’s <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-12">interface object</a>.</p>
       <li data-md="">
        <p>Otherwise, if the attribute is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-2">unforgeable</a> on
 the interface or if the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-43">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-44">PrimaryGlobal</a></code>] extended attribute,
@@ -10067,10 +10071,10 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <ol>
            <li data-md="">
             <p>If the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-67">attribute</a> was specified with the
-[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-8">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-93">extended attribute</a>,
+[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-8">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-94">extended attribute</a>,
 then return <emu-val>undefined</emu-val>.</p>
            <li data-md="">
-            <p>Otherwise, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-45">throw a <emu-val>TypeError</emu-val></a>.</p>
+            <p>Otherwise, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-46">throw a <emu-val>TypeError</emu-val></a>.</p>
           </ol>
          <li data-md="">
           <p>Set <var>idlValue</var> to be the result of performing the actions listed in the description of the attribute that occur when getting
@@ -10094,11 +10098,11 @@ concatenation of “get ” and the identifier of the attribute.</p>
     <li data-md="">
      <div class="algorithm" data-algorithm="attribute setter">
       <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-attribute-setter">attribute setter</dfn> is <emu-val>undefined</emu-val> if the attribute is declared <code>readonly</code> and does not have a
-    [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-9">LenientThis</a></code>], [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-15">PutForwards</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-11">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-94">extended attribute</a> declared on it.
+    [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-9">LenientThis</a></code>], [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-15">PutForwards</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-11">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-95">extended attribute</a> declared on it.
     Otherwise, it is a <emu-val>Function</emu-val> object whose behavior when invoked is as follows:</p>
       <ol>
        <li data-md="">
-        <p>If no arguments were passed to the <emu-val>Function</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-46">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If no arguments were passed to the <emu-val>Function</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-47">throw a <emu-val>TypeError</emu-val></a>.</p>
        <li data-md="">
         <p>Let <var>V</var> be the value of the first argument passed to the <emu-val>Function</emu-val>.</p>
        <li data-md="">
@@ -10123,8 +10127,8 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>Let <var>validThis</var> be <emu-val>true</emu-val> if <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-23">platform object</a> that implements <var>I</var>, or <emu-val>false</emu-val> otherwise.</p>
          <li data-md="">
           <p>If <var>validThis</var> is <emu-val>false</emu-val> and the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-70">attribute</a> was not specified with the
-[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-10">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-95">extended attribute</a>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-47">throw a <emu-val>TypeError</emu-val></a>.</p>
+[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-10">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-96">extended attribute</a>,
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-48">throw a <emu-val>TypeError</emu-val></a>.</p>
          <li data-md="">
           <p>If the attribute is declared with a [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-12">Replaceable</a></code>]
 extended attribute, then:</p>
@@ -10149,7 +10153,7 @@ extended attribute, then:</p>
             <p>Let <var>Q</var> be the result of calling the [[Get]] method
 on <var>O</var> using the identifier of the attribute as the property name.</p>
            <li data-md="">
-            <p>If <var>Q</var> is not an object, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-48">throw a <emu-val>TypeError</emu-val></a>.</p>
+            <p>If <var>Q</var> is not an object, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-49">throw a <emu-val>TypeError</emu-val></a>.</p>
            <li data-md="">
             <p>Let <var>A</var> be the attribute identified by the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-17">PutForwards</a></code>] extended attribute.</p>
            <li data-md="">
@@ -10209,7 +10213,7 @@ unless the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-fo
      <ul>
       <li data-md="">
        <p>If the operation is <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-13">static</a>, then
-the property exists on the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-14">interface object</a>.</p>
+the property exists on the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-13">interface object</a>.</p>
       <li data-md="">
        <p>Otherwise, if the operation is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-3">unforgeable</a> on
 the interface or if the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-49">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-50">PrimaryGlobal</a></code>] extended attribute,
@@ -10263,7 +10267,7 @@ object does not implement <var>target</var>.)</p>
           <li data-md="">
            <p>If <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-24">platform object</a>, then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-dfn-perform-a-security-check-3">perform a security check</a>, passing <var>O</var>, <var>id</var>, and "method".</p>
           <li data-md="">
-           <p>If <var>O</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-25">platform object</a> that implements the interface <var>target</var>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-49">throw a <emu-val>TypeError</emu-val></a>.</p>
+           <p>If <var>O</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-25">platform object</a> that implements the interface <var>target</var>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-50">throw a <emu-val>TypeError</emu-val></a>.</p>
          </ol>
         <li data-md="">
          <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-10">effective overload set</a> for <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-16">regular operations</a> (if <var>op</var> is a
@@ -10338,7 +10342,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-103">interface</a> on which the stringifier was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-50">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-103">interface</a> on which the stringifier was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-51">throw a <emu-val>TypeError</emu-val></a>.</p>
        <li data-md="">
         <p>Let <var>V</var> be an uninitialized variable.</p>
        <li data-md="">
@@ -10406,7 +10410,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-105">interface</a> on which the serializer was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-51">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-105">interface</a> on which the serializer was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-52">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>Depending on how <code>serializer</code> was specified:</p>
       <dl class="switch">
@@ -10509,7 +10513,7 @@ an <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type
      <p>a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-7">setlike declaration</a></p>
    </ul>
    <p>then a property must exist
-whose name is the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> symbol, with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-7">function object</a>.</p>
+whose name is the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> symbol, with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-8">function object</a>.</p>
    <p>The location of the property is determined as follows:</p>
    <ul>
     <li data-md="">
@@ -10546,7 +10550,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-108">interface</a> the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-10">iterable declaration</a> is on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-29">platform object</a> that implements <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-52">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-53">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>Let <var>iterator</var> be a newly created <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-1">default iterator object</a> for <var>interface</var> with <var>object</var> as its target and iterator kind “key+value”.</p>
      <li data-md="">
@@ -10573,7 +10577,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       </ul>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-31">platform object</a> that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-109">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-9">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-9">setlike declaration</a> is defined,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-53">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-54">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>If the interface has a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-10">maplike declaration</a>, then:</p>
       <ol>
@@ -10608,7 +10612,7 @@ if the interface has a <a data-link-type="dfn" href="#dfn-setlike-declaration" i
     <li data-md="">
      <p>a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-11">setlike declaration</a></p>
    </ul>
-   <p>then a property named “forEach” must exist with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-8">function object</a>.</p>
+   <p>then a property named “forEach” must exist with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-9">function object</a>.</p>
    <p>The location of the property is determined as follows:</p>
    <ul>
     <li data-md="">
@@ -10682,11 +10686,11 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-111">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-14">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-13">setlike declaration</a> is declared.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-33">platform object</a> that implements <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-54">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-55">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>Let <var>callbackFn</var> be the value of the first argument passed to the function, or <emu-val>undefined</emu-val> if the argument was not supplied.</p>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>callbackFn</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-55">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>callbackFn</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-56">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>Let <var>thisArg</var> be the value of the second argument passed to the function, or <emu-val>undefined</emu-val> if the argument was not supplied.</p>
      <li data-md="">
@@ -10710,7 +10714,7 @@ or the [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma2
      <li data-md="">
       <p>Let <var>forEach</var> be the result of calling the [[Get]] internal method of <var>backing</var> with “forEach” and <var>backing</var> as arguments.</p>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>forEach</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-56">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>forEach</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-57">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-call">Call</a>(<var>forEach</var>, <var>backing</var>, «<var>callbackWrapper</var>, <var>thisArg</var>»).</p>
      <li data-md="">
@@ -10724,7 +10728,7 @@ property is the <emu-val>String</emu-val> value “forEach”.</p>
    <h4 class="heading settled" data-level="3.6.9" id="es-iterable"><span class="secno">3.6.9. </span><span class="content">Iterable declarations</span><a class="self-link" href="#es-iterable"></a></h4>
    <h5 class="heading settled" data-level="3.6.9.1" id="es-iterable-entries"><span class="secno">3.6.9.1. </span><span class="content">entries</span><a class="self-link" href="#es-iterable-entries"></a></h5>
    <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-112">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-13">iterable declaration</a>,
-then a property named “entries” must exist with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-9">function object</a>.</p>
+then a property named “entries” must exist with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-10">function object</a>.</p>
    <p>The location of the property is determined as follows:</p>
    <ul>
     <li data-md="">
@@ -10746,7 +10750,7 @@ then the <emu-val>Function</emu-val> object is
 the value of the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> property.</p>
    <h5 class="heading settled" data-level="3.6.9.2" id="es-iterable-keys"><span class="secno">3.6.9.2. </span><span class="content">keys</span><a class="self-link" href="#es-iterable-keys"></a></h5>
    <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-113">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-14">iterable declaration</a>,
-then a property named “keys” must exist with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-10">function object</a>.</p>
+then a property named “keys” must exist with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-11">function object</a>.</p>
    <p>The location of the property is determined as follows:</p>
    <ul>
     <li data-md="">
@@ -10784,7 +10788,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-114">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-15">iterable declaration</a> is declared on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-35">platform object</a> that implements <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-57">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-58">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>Let <var>iterator</var> be a newly created <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-2">default iterator object</a> for <var>interface</var> with <var>object</var> as its target and iterator kind “key”.</p>
      <li data-md="">
@@ -10796,7 +10800,7 @@ then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-thr
    <h5 class="heading settled" data-level="3.6.9.3" id="es-iterable-values"><span class="secno">3.6.9.3. </span><span class="content">values</span><a class="self-link" href="#es-iterable-values"></a></h5>
    <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-115">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-16">iterable declaration</a>,
 then a property named “values” must exist
-with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-11">function object</a>.</p>
+with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-12">function object</a>.</p>
    <p>The location of the property is determined as follows:</p>
    <ul>
     <li data-md="">
@@ -10834,7 +10838,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-116">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-17">iterable declaration</a> is declared on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-37">platform object</a> that implements <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-58">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-59">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>Let <var>iterator</var> be a newly created <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-3">default iterator object</a> for <var>interface</var> with <var>object</var> as its target and iterator kind “value”.</p>
      <li data-md="">
@@ -10866,7 +10870,7 @@ its index is set to 0.</p>
 prototype for <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-7">default iterator objects</a> for the interface.</p>
    <p>The internal [[Prototype]] property of an <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-3">iterator prototype object</a> must be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%IteratorPrototype%</a>.</p>
    <div class="algorithm" data-algorithm="to invoke the next property of iterators">
-    <p>An <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-4">iterator prototype object</a> must have a property named “next” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-12">function object</a> that behaves as follows:</p>
+    <p>An <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-4">iterator prototype object</a> must have a property named “next” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-13">function object</a> that behaves as follows:</p>
     <ol>
      <li data-md="">
       <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-122">interface</a> for which the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-5">iterator prototype object</a> exists.</p>
@@ -10885,7 +10889,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       </ul>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-8">default iterator object</a> for <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-59">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-60">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>Let <var>target</var> be <var>object</var>’s target.</p>
      <li data-md="">
@@ -10963,7 +10967,7 @@ a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplik
 there exists a number of additional properties on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-38">interface prototype object</a>.
 These additional properties are described in the sub-sections below.</p>
    <div class="algorithm" data-algorithm="forwards to the internal map object">
-    <p>Some of the properties below are defined to have a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-13">function object</a> value that <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-forwards-to-the-internal-map-object">forwards to the internal map object</dfn> for a given function name.  Such functions behave as follows when invoked:</p>
+    <p>Some of the properties below are defined to have a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-14">function object</a> value that <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-forwards-to-the-internal-map-object">forwards to the internal map object</dfn> for a given function name.  Such functions behave as follows when invoked:</p>
     <ol>
      <li data-md="">
       <p>Let <var>O</var> be the <emu-val>this</emu-val> value.</p>
@@ -10983,13 +10987,13 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-60">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-61">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
      <li data-md="">
       <p>Let <var>function</var> be the result of calling the [[Get]] internal method of <var>map</var> passing <var>name</var> and <var>map</var> as arguments.</p>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>function</var>) is <emu-val>false</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-61">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>function</var>) is <emu-val>false</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-62">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-call">Call</a>(<var>function</var>, <var>map</var>, <var>arguments</var>).</p>
     </ol>
@@ -11020,7 +11024,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “getter”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-62">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-63">throw a <emu-val>TypeError</emu-val></a>.</p>
        <li data-md="">
         <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -11031,7 +11035,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
      <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “size”.</p>
    </ul>
    <h5 class="heading settled" data-level="3.6.10.2" id="es-map-entries"><span class="secno">3.6.10.2. </span><span class="content">entries</span><a class="self-link" href="#es-map-entries"></a></h5>
-   <p>A property named “entries” must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-40">interface prototype object</a> with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-14">function object</a> that is the value of
+   <p>A property named “entries” must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-40">interface prototype object</a> with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-15">function object</a> that is the value of
 the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> property.</p>
    <h5 class="heading settled" data-level="3.6.10.3" id="es-map-keys-values"><span class="secno">3.6.10.3. </span><span class="content">keys and values</span><a class="self-link" href="#es-map-keys-values"></a></h5>
    <p>For both of “keys” and “values”, there must exist a property with that name on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-41">interface prototype object</a> with the following characteristics:</p>
@@ -11069,7 +11073,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-63">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-64">throw a <emu-val>TypeError</emu-val></a>.</p>
        <li data-md="">
         <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -11126,7 +11130,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-64">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-65">throw a <emu-val>TypeError</emu-val></a>.</p>
        <li data-md="">
         <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -11172,7 +11176,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-65">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-66">throw a <emu-val>TypeError</emu-val></a>.</p>
        <li data-md="">
         <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -11210,7 +11214,7 @@ there exists a number of additional properties
 on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-46">interface prototype object</a>.
 These additional properties are described in the sub-sections below.</p>
    <div class="algorithm" data-algorithm="forwards to the internal set object">
-    <p>Some of the properties below are defined to have a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-15">function object</a> value that <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-forwards-to-the-internal-set-object">forwards to the internal set object</dfn> for a given function name. Such functions behave as follows when invoked:</p>
+    <p>Some of the properties below are defined to have a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-16">function object</a> value that <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-forwards-to-the-internal-set-object">forwards to the internal set object</dfn> for a given function name. Such functions behave as follows when invoked:</p>
     <ol>
      <li data-md="">
       <p>Let <var>O</var> be the <emu-val>this</emu-val> value.</p>
@@ -11231,7 +11235,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       </ul>
      <li data-md="">
       <p>If <var>O</var> is not an object that implements <var>A</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-66">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-67">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>Let <var>set</var> be the <emu-val>Set</emu-val> object that is
 the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
@@ -11239,7 +11243,7 @@ the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https
       <p>Let <var>function</var> be the result of calling the [[Get]] internal method of <var>set</var> passing <var>name</var> and <var>set</var> as arguments.</p>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>function</var>) is <emu-val>false</emu-val>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-67">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-68">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-call">Call</a>(<var>function</var>, <var>set</var>, <var>arguments</var>).</p>
     </ol>
@@ -11270,7 +11274,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “getter”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-68">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-69">throw a <emu-val>TypeError</emu-val></a>.</p>
        <li data-md="">
         <p>Let <var>set</var> be the <emu-val>Set</emu-val> object that is the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -11281,7 +11285,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
      <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “size”.</p>
    </ul>
    <h5 class="heading settled" data-level="3.6.11.2" id="es-set-values"><span class="secno">3.6.11.2. </span><span class="content">values</span><a class="self-link" href="#es-set-values"></a></h5>
-   <p>A property named “values” must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-48">interface prototype object</a> with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-16">function object</a> that is the value of
+   <p>A property named “values” must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-48">interface prototype object</a> with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-17">function object</a> that is the value of
 the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> property.</p>
    <h5 class="heading settled" data-level="3.6.11.3" id="es-set-entries-keys"><span class="secno">3.6.11.3. </span><span class="content">entries and keys</span><a class="self-link" href="#es-set-entries-keys"></a></h5>
    <p>For both of “entries” and “keys”, there must exist a property with that name on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-49">interface prototype object</a> with the following characteristics:</p>
@@ -11318,7 +11322,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-69">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-70">throw a <emu-val>TypeError</emu-val></a>.</p>
        <li data-md="">
         <p>Let <var>set</var> be the <emu-val>Set</emu-val> object that is the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -11371,7 +11375,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-70">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-71">throw a <emu-val>TypeError</emu-val></a>.</p>
        <li data-md="">
         <p>Let <var>set</var> be the <emu-val>Set</emu-val> object that is the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -11461,7 +11465,7 @@ object’s indexed and named properties.  These properties are not “real” ow
 properties on the object, but are made to look like they are by being exposed
 by the [[GetOwnProperty]] internal method.</p>
    <p>However, when the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-93">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-94">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-96">extended attribute</a> has been used,
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-94">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-97">extended attribute</a> has been used,
 named properties are not exposed on the object but on another object
 in the prototype chain, the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-14">named properties object</a>.</p>
    <p>It is permissible for an object to implement multiple interfaces that support indexed properties.
@@ -11499,7 +11503,7 @@ the interfaces that <var>O</var> implements.</p>
    <div class="algorithm" data-algorithm="named property visibility algorithm">
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-named-property-visibility">named property visibility algorithm</dfn> is used to determine if a given named property is exposed on an object.
     Some named properties are not exposed on an object depending on whether
-    the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-8">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-97">extended attribute</a> was used.
+    the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-8">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-98">extended attribute</a> was used.
     The algorithm operates as follows, with property name <var>P</var> and object <var>O</var>:</p>
     <ol>
      <li data-md="">
@@ -11508,7 +11512,7 @@ the interfaces that <var>O</var> implements.</p>
       <p>If <var>O</var> has an own property named <var>P</var>, then return false.</p>
       <p class="note" role="note">Note: This will include cases in which <var>O</var> has unforgeable properties, because in practice those are always set up before objects have any supported property names, and once set up will make the corresponding named properties invisible.</p>
      <li data-md="">
-      <p>If <var>O</var> implements an interface that has the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-9">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-98">extended attribute</a>, then return true.</p>
+      <p>If <var>O</var> implements an interface that has the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-9">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-99">extended attribute</a>, then return true.</p>
      <li data-md="">
       <p>Initialize <var>prototype</var> to be the value of the internal [[Prototype]] property of <var>O</var>.</p>
      <li data-md="">
@@ -11591,7 +11595,7 @@ of performing the steps listed in the description of <var>operation</var> with <
       </ol>
      <li data-md="">
       <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-6">supports named properties</a>, <var>O</var> does not
-implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-132">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-95">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-96">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-99">extended attribute</a>, the result of running the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-2">named property visibility algorithm</a> with
+implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-132">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-95">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-96">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-100">extended attribute</a>, the result of running the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-2">named property visibility algorithm</a> with
 property name <var>P</var> and object <var>O</var> is true, and <var>ignoreNamedProps</var> is false, then:</p>
       <ol>
        <li data-md="">
@@ -11612,7 +11616,7 @@ of performing the steps listed in the description of <var>operation</var> with <
         <p>If <var>O</var> implements an interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="ref-for-dfn-named-property-setter-4">named property setter</a>, then set <var>desc</var>.[[Writable]] to <emu-val>true</emu-val>, otherwise set it to <emu-val>false</emu-val>.</p>
        <li data-md="">
         <p>If <var>O</var> implements an interface with the
-[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-6">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-100">extended attribute</a>,
+[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-6">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-101">extended attribute</a>,
 then set <var>desc</var>.[[Enumerable]] to <emu-val>false</emu-val>,
 otherwise set it to <emu-val>true</emu-val>.</p>
        <li data-md="">
@@ -11717,7 +11721,7 @@ and <var>O</var> implements an interface with a <a data-link-type="dfn" href="#d
    </div>
    <h4 class="heading settled" data-level="3.8.7" id="platformobjectsetprototypeof"><span class="secno">3.8.7. </span><span class="content">Platform object [[SetPrototypeOf]] method</span><a class="self-link" href="#platformobjectsetprototypeof"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[SetPrototypeOf]] method of platform objects">
-    <p>The internal [[SetPrototypeOf]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-55">platform object</a> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-135">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-97">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-98">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-101">extended attribute</a> must execute the same algorithm as is defined for the
+    <p>The internal [[SetPrototypeOf]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-55">platform object</a> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-135">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-97">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-98">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-102">extended attribute</a> must execute the same algorithm as is defined for the
     [[SetPrototypeOf]] internal method of an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">immutable prototype exotic object</a>.</p>
    </div>
    <p class="note" role="note">Note: For <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> objects, it is unobservable whether this is implemented, since the presence of
@@ -11743,12 +11747,12 @@ directly. For other global objects, however, this is necessary.</p>
       </ol>
      <li data-md="">
       <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-11">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-137">interface</a> with the
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-99">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-100">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-102">extended attribute</a> and <var>P</var> is not an <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-dfn-unforgeable-property-name-1">unforgeable property name</a> of <var>O</var>, then:</p>
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-99">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-100">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-103">extended attribute</a> and <var>P</var> is not an <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-dfn-unforgeable-property-name-1">unforgeable property name</a> of <var>O</var>, then:</p>
       <ol>
        <li data-md="">
         <p>Let <var>creating</var> be true if <var>P</var> is not a <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-6">supported property name</a>, and false otherwise.</p>
        <li data-md="">
-        <p>If <var>O</var> implements an interface with the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-12">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-103">extended attribute</a> or <var>O</var> does not have an own property
+        <p>If <var>O</var> implements an interface with the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-12">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-104">extended attribute</a> or <var>O</var> does not have an own property
 named <var>P</var>, then:</p>
         <ol>
          <li data-md="">
@@ -11769,7 +11773,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
      <li data-md="">
       <p>If <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-138">interface</a> with the
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-101">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-102">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-104">extended attribute</a>, then set <var>Desc</var>.[[Configurable]] to <emu-val>true</emu-val>.</p>
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-102">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-105">extended attribute</a>, then set <var>Desc</var>.[[Configurable]] to <emu-val>true</emu-val>.</p>
      <li data-md="">
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinarydefineownproperty">OrdinaryDefineOwnProperty</a>(<var>O</var>, <var>P</var>, <var>Desc</var>).</p>
     </ol>
@@ -11790,7 +11794,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
       </ol>
      <li data-md="">
       <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-13">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-140">interface</a> with the
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-103">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-104">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-105">extended attribute</a> and the result of calling the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-3">named property visibility algorithm</a> with property name <var>P</var> and object <var>O</var> is true, then:</p>
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-103">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-104">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-106">extended attribute</a> and the result of calling the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-3">named property visibility algorithm</a> with property name <var>P</var> and object <var>O</var> is true, then:</p>
       <ol>
        <li data-md="">
         <p>If <var>O</var> does not implement an interface with a <a data-link-type="dfn" href="#dfn-named-property-deleter" id="ref-for-dfn-named-property-deleter-5">named property deleter</a>, then return <emu-val>false</emu-val>.</p>
@@ -11870,7 +11874,7 @@ the object’s <a data-link-type="dfn" href="#dfn-supported-property-indices" id
 enumerated first, in numerical order.</p>
     <li data-md="">
      <p>If the object <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-17">supports named properties</a> and doesn’t implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-143">interface</a> with the
-[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-7">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-106">extended attribute</a>, then
+[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-7">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-107">extended attribute</a>, then
 the object’s <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-7">supported property names</a> that
 are visible according to the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-4">named property visibility algorithm</a> are enumerated next, in the order given in the definition of the set of supported property names.</p>
     <li data-md="">
@@ -12247,7 +12251,7 @@ which provides access to legacy DOMException code constants and allows construct
 DOMException instances.
 The property has the attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
    <h4 class="heading settled" data-level="3.12.1" id="es-DOMException-constructor-object"><span class="secno">3.12.1. </span><span class="content">DOMException constructor object</span><a class="self-link" href="#es-DOMException-constructor-object"></a></h4>
-   <p>The DOMException constructor object must be a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-17">function object</a> but with a [[Prototype]] value of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Error%</a>.</p>
+   <p>The DOMException constructor object must be a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-18">function object</a> but with a [[Prototype]] value of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Error%</a>.</p>
    <p>For every legacy code listed in the <a href="#dfn-error-names-table" id="ref-for-dfn-error-names-table-2">error names table</a>,
 there must be a property on the DOMException constructor object
 whose name and value are as indicated in the table.  The property has
@@ -12330,7 +12334,7 @@ on exception objects too.</p>
      <li data-md="">
       <p>Let <var>F</var> be the <emu-val>Function</emu-val> object used
 as the <emu-val>this</emu-val> value in the top-most call
-on the ECMAScript call stack where <var>F</var> corresponds to an IDL <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-77">attribute</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-76">operation</a>, <a data-link-type="dfn" href="#idl-indexed-properties" id="ref-for-idl-indexed-properties-3">indexed property</a>, <a data-link-type="dfn" href="#idl-named-properties" id="ref-for-idl-named-properties-3">named property</a>, <a href="#Constructor" id="ref-for-Constructor-23">constructor</a>, <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-5">named constructor</a> or <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-6">stringifier</a>.</p>
+on the ECMAScript call stack where <var>F</var> corresponds to an IDL <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-77">attribute</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-76">operation</a>, <a data-link-type="dfn" href="#idl-indexed-properties" id="ref-for-idl-indexed-properties-3">indexed property</a>, <a data-link-type="dfn" href="#idl-named-properties" id="ref-for-idl-named-properties-3">named property</a>, <a href="#Constructor" id="ref-for-Constructor-24">constructor</a>, <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-5">named constructor</a> or <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-6">stringifier</a>.</p>
      <li data-md="">
       <p>If <var>F</var> corresponds to an attribute, operation or stringifier, then return
 the global environment associated with the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-145">interface</a> that definition appears on.</p>
@@ -12340,7 +12344,7 @@ the global environment associated with the interface that
 the indexed or named property getter, setter or deleter was defined on.</p>
      <li data-md="">
       <p>Otherwise, if <var>F</var> is a named constructor for an interface, or is
-an <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-15">interface object</a> for an
+an <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-14">interface object</a> for an
 interface that is a constructor, then return the global environment
 associated with that interface.</p>
      <li data-md="">
@@ -12526,7 +12530,7 @@ return any value.</p>
    <h2 class="heading settled" data-level="5" id="extensibility"><span class="secno">5. </span><span class="content">Extensibility</span><a class="self-link" href="#extensibility"></a></h2>
    <p><i>This section is informative.</i></p>
    <p>Extensions to language binding requirements can be specified
-using <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-107">extended attributes</a> that do not conflict with those defined in this document.  Extensions for
+using <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-108">extended attributes</a> that do not conflict with those defined in this document.  Extensions for
 private, project-specific use should not be included in <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-46">IDL fragments</a> appearing in other specifications.  It is recommended that extensions
 that are required for use in other specifications be coordinated
 with the group responsible for work on <cite>Web IDL</cite>, which
@@ -12685,8 +12689,8 @@ and “<span class="input">.</span>” is tokenized as the quoted terminal symbo
 used in the grammar and the values used for <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> terminals.  Thus, for
 example, the input text “<span class="input">Const</span>” is tokenized as
 an <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> rather than the
-terminal symbol <emu-t>const</emu-t>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-147">interface</a> with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-92">identifier</a> “A” is distinct from one named “a”, and an <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-108">extended attribute</a> [<code class="idl">constructor</code>] will not be recognized as
-the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-24">Constructor</a></code>]
+terminal symbol <emu-t>const</emu-t>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-147">interface</a> with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-92">identifier</a> “A” is distinct from one named “a”, and an <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-109">extended attribute</a> [<code class="idl">constructor</code>] will not be recognized as
+the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-25">Constructor</a></code>]
 extended attribute.</p>
    <p>Implicitly, any number of <emu-t class="regex"><a href="#prod-whitespace">whitespace</a></emu-t> and <emu-t class="regex"><a href="#prod-comment">comment</a></emu-t> terminals are allowed between every other terminal
 in the input text being parsed.  Such <emu-t class="regex"><a href="#prod-whitespace">whitespace</a></emu-t> and <emu-t class="regex"><a href="#prod-comment">comment</a></emu-t> terminals are ignored while parsing.</p>
@@ -12697,7 +12701,7 @@ matches an <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-
    <p>While the <emu-nt><a href="#prod-ExtendedAttribute">ExtendedAttribute</a></emu-nt> non-terminal matches any non-empty sequence of terminal symbols (as long as any
 parentheses, square brackets or braces are balanced, and the <emu-t>,</emu-t> token appears only within those balanced brackets),
 only a subset of those
-possible sequences are used by the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-109">extended attributes</a> defined in this specification — see <a href="#idl-extended-attributes">§2.12 Extended attributes</a> for the syntaxes that are used by these extended attributes.</p>
+possible sequences are used by the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-110">extended attributes</a> defined in this specification — see <a href="#idl-extended-attributes">§2.12 Extended attributes</a> for the syntaxes that are used by these extended attributes.</p>
    <h2 class="no-num heading settled" id="conventions"><span class="content">Document conventions</span><a class="self-link" href="#conventions"></a></h2>
    <p>The following typographic conventions are used in this document:</p>
    <ul>
@@ -13366,6 +13370,7 @@ language binding.</p>
      <li><a href="https://tc39.github.io/ecma262/#sec-iteratorvalue">iteratorvalue</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">list</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">modulo</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-built-in-function-objects">newtarget</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-normalcompletion">normalcompletion</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-literals-numeric-literals">numericliteral</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-objectcreate">objectcreate</a>
@@ -13542,7 +13547,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-identifier-54">3.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-identifier-55">(2)</a>
     <li><a href="#ref-for-dfn-identifier-56">3.4. Security</a>
     <li><a href="#ref-for-dfn-identifier-57">3.6. Interfaces</a>
-    <li><a href="#ref-for-dfn-identifier-58">3.6.1.1. Interface object [[Call]] method</a> <a href="#ref-for-dfn-identifier-59">(2)</a>
+    <li><a href="#ref-for-dfn-identifier-58">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-dfn-identifier-59">(2)</a>
     <li><a href="#ref-for-dfn-identifier-60">3.6.2. Named constructors</a> <a href="#ref-for-dfn-identifier-61">(2)</a> <a href="#ref-for-dfn-identifier-62">(3)</a>
     <li><a href="#ref-for-dfn-identifier-63">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-identifier-64">(2)</a>
     <li><a href="#ref-for-dfn-identifier-65">3.6.4. Named properties object</a>
@@ -13613,7 +13618,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-interface-75">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-interface-76">(2)</a>
     <li><a href="#ref-for-dfn-interface-77">3.6. Interfaces</a> <a href="#ref-for-dfn-interface-78">(2)</a>
     <li><a href="#ref-for-dfn-interface-79">3.6.1. Interface object</a>
-    <li><a href="#ref-for-dfn-interface-80">3.6.1.1. Interface object [[Call]] method</a> <a href="#ref-for-dfn-interface-81">(2)</a> <a href="#ref-for-dfn-interface-82">(3)</a> <a href="#ref-for-dfn-interface-83">(4)</a>
+    <li><a href="#ref-for-dfn-interface-80">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-dfn-interface-81">(2)</a> <a href="#ref-for-dfn-interface-82">(3)</a> <a href="#ref-for-dfn-interface-83">(4)</a>
     <li><a href="#ref-for-dfn-interface-84">3.6.2. Named constructors</a> <a href="#ref-for-dfn-interface-85">(2)</a> <a href="#ref-for-dfn-interface-86">(3)</a> <a href="#ref-for-dfn-interface-87">(4)</a>
     <li><a href="#ref-for-dfn-interface-88">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-interface-89">(2)</a> <a href="#ref-for-dfn-interface-90">(3)</a>
     <li><a href="#ref-for-dfn-interface-91">3.6.4. Named properties object</a> <a href="#ref-for-dfn-interface-92">(2)</a>
@@ -14261,7 +14266,7 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-dfn-effective-overload-set-1">2.2.6. Overloading</a> <a href="#ref-for-dfn-effective-overload-set-2">(2)</a> <a href="#ref-for-dfn-effective-overload-set-3">(3)</a>
     <li><a href="#ref-for-dfn-effective-overload-set-4">3.5. Overload resolution algorithm</a>
-    <li><a href="#ref-for-dfn-effective-overload-set-5">3.6.1.1. Interface object [[Call]] method</a> <a href="#ref-for-dfn-effective-overload-set-6">(2)</a>
+    <li><a href="#ref-for-dfn-effective-overload-set-5">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-dfn-effective-overload-set-6">(2)</a>
     <li><a href="#ref-for-dfn-effective-overload-set-7">3.6.2. Named constructors</a> <a href="#ref-for-dfn-effective-overload-set-8">(2)</a>
     <li><a href="#ref-for-dfn-effective-overload-set-9">3.6.7. Operations</a> <a href="#ref-for-dfn-effective-overload-set-10">(2)</a> <a href="#ref-for-dfn-effective-overload-set-11">(3)</a>
     <li><a href="#ref-for-dfn-effective-overload-set-12">3.8.10. Platform object [[Call]] method</a>
@@ -15086,7 +15091,7 @@ language binding.</p>
     <li><a href="#ref-for-idl-interface-12">3.3.14. [PutForwards]</a> <a href="#ref-for-idl-interface-13">(2)</a>
     <li><a href="#ref-for-idl-interface-14">3.3.16. [SameObject]</a>
     <li><a href="#ref-for-idl-interface-15">3.5. Overload resolution algorithm</a>
-    <li><a href="#ref-for-idl-interface-16">3.6.1.1. Interface object [[Call]] method</a>
+    <li><a href="#ref-for-idl-interface-16">3.6.1.1. Constructible Interfaces</a>
     <li><a href="#ref-for-idl-interface-17">3.6.2. Named constructors</a>
     <li><a href="#ref-for-idl-interface-18">3.9. User objects implementing callback interfaces</a> <a href="#ref-for-idl-interface-19">(2)</a> <a href="#ref-for-idl-interface-20">(3)</a>
    </ul>
@@ -15456,20 +15461,20 @@ language binding.</p>
     <li><a href="#ref-for-dfn-extended-attribute-78">3.3.21. [Unscopable]</a>
     <li><a href="#ref-for-dfn-extended-attribute-79">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-extended-attribute-80">(2)</a>
     <li><a href="#ref-for-dfn-extended-attribute-81">3.6. Interfaces</a>
-    <li><a href="#ref-for-dfn-extended-attribute-82">3.6.1.1. Interface object [[Call]] method</a> <a href="#ref-for-dfn-extended-attribute-83">(2)</a> <a href="#ref-for-dfn-extended-attribute-84">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-85">3.6.2. Named constructors</a> <a href="#ref-for-dfn-extended-attribute-86">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-87">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-extended-attribute-88">(2)</a> <a href="#ref-for-dfn-extended-attribute-89">(3)</a> <a href="#ref-for-dfn-extended-attribute-90">(4)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-91">3.6.4. Named properties object</a>
-    <li><a href="#ref-for-dfn-extended-attribute-92">3.6.4.1. Named properties object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-extended-attribute-93">3.6.6. Attributes</a> <a href="#ref-for-dfn-extended-attribute-94">(2)</a> <a href="#ref-for-dfn-extended-attribute-95">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-96">3.8.1. Indexed and named properties</a> <a href="#ref-for-dfn-extended-attribute-97">(2)</a> <a href="#ref-for-dfn-extended-attribute-98">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-99">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a> <a href="#ref-for-dfn-extended-attribute-100">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-101">3.8.7. Platform object [[SetPrototypeOf]] method</a>
-    <li><a href="#ref-for-dfn-extended-attribute-102">3.8.8. Platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-extended-attribute-103">(2)</a> <a href="#ref-for-dfn-extended-attribute-104">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-105">3.8.9. Platform object [[Delete]] method</a>
-    <li><a href="#ref-for-dfn-extended-attribute-106">3.8.12. Property enumeration</a>
-    <li><a href="#ref-for-dfn-extended-attribute-107">5. Extensibility</a>
-    <li><a href="#ref-for-dfn-extended-attribute-108">IDL grammar</a> <a href="#ref-for-dfn-extended-attribute-109">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-82">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-dfn-extended-attribute-83">(2)</a> <a href="#ref-for-dfn-extended-attribute-84">(3)</a> <a href="#ref-for-dfn-extended-attribute-85">(4)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-86">3.6.2. Named constructors</a> <a href="#ref-for-dfn-extended-attribute-87">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-88">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-extended-attribute-89">(2)</a> <a href="#ref-for-dfn-extended-attribute-90">(3)</a> <a href="#ref-for-dfn-extended-attribute-91">(4)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-92">3.6.4. Named properties object</a>
+    <li><a href="#ref-for-dfn-extended-attribute-93">3.6.4.1. Named properties object [[GetOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-extended-attribute-94">3.6.6. Attributes</a> <a href="#ref-for-dfn-extended-attribute-95">(2)</a> <a href="#ref-for-dfn-extended-attribute-96">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-97">3.8.1. Indexed and named properties</a> <a href="#ref-for-dfn-extended-attribute-98">(2)</a> <a href="#ref-for-dfn-extended-attribute-99">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-100">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a> <a href="#ref-for-dfn-extended-attribute-101">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-102">3.8.7. Platform object [[SetPrototypeOf]] method</a>
+    <li><a href="#ref-for-dfn-extended-attribute-103">3.8.8. Platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-extended-attribute-104">(2)</a> <a href="#ref-for-dfn-extended-attribute-105">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-106">3.8.9. Platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-extended-attribute-107">3.8.12. Property enumeration</a>
+    <li><a href="#ref-for-dfn-extended-attribute-108">5. Extensibility</a>
+    <li><a href="#ref-for-dfn-extended-attribute-109">IDL grammar</a> <a href="#ref-for-dfn-extended-attribute-110">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-xattr-no-arguments">
@@ -15541,18 +15546,19 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-dfn-function-object-1">3.2.27. Promise types — Promise&lt;T></a> <a href="#ref-for-dfn-function-object-2">(2)</a>
     <li><a href="#ref-for-dfn-function-object-3">3.6.1. Interface object</a> <a href="#ref-for-dfn-function-object-4">(2)</a> <a href="#ref-for-dfn-function-object-5">(3)</a>
-    <li><a href="#ref-for-dfn-function-object-6">3.6.2. Named constructors</a>
-    <li><a href="#ref-for-dfn-function-object-7">3.6.8.1. @@iterator</a>
-    <li><a href="#ref-for-dfn-function-object-8">3.6.8.2. forEach</a>
-    <li><a href="#ref-for-dfn-function-object-9">3.6.9.1. entries</a>
-    <li><a href="#ref-for-dfn-function-object-10">3.6.9.2. keys</a>
-    <li><a href="#ref-for-dfn-function-object-11">3.6.9.3. values</a>
-    <li><a href="#ref-for-dfn-function-object-12">3.6.9.5. Iterator prototype object</a>
-    <li><a href="#ref-for-dfn-function-object-13">3.6.10. Maplike declarations</a>
-    <li><a href="#ref-for-dfn-function-object-14">3.6.10.2. entries</a>
-    <li><a href="#ref-for-dfn-function-object-15">3.6.11. Setlike declarations</a>
-    <li><a href="#ref-for-dfn-function-object-16">3.6.11.2. values</a>
-    <li><a href="#ref-for-dfn-function-object-17">3.12.1. DOMException constructor object</a>
+    <li><a href="#ref-for-dfn-function-object-6">3.6.1.1. Constructible Interfaces</a>
+    <li><a href="#ref-for-dfn-function-object-7">3.6.2. Named constructors</a>
+    <li><a href="#ref-for-dfn-function-object-8">3.6.8.1. @@iterator</a>
+    <li><a href="#ref-for-dfn-function-object-9">3.6.8.2. forEach</a>
+    <li><a href="#ref-for-dfn-function-object-10">3.6.9.1. entries</a>
+    <li><a href="#ref-for-dfn-function-object-11">3.6.9.2. keys</a>
+    <li><a href="#ref-for-dfn-function-object-12">3.6.9.3. values</a>
+    <li><a href="#ref-for-dfn-function-object-13">3.6.9.5. Iterator prototype object</a>
+    <li><a href="#ref-for-dfn-function-object-14">3.6.10. Maplike declarations</a>
+    <li><a href="#ref-for-dfn-function-object-15">3.6.10.2. entries</a>
+    <li><a href="#ref-for-dfn-function-object-16">3.6.11. Setlike declarations</a>
+    <li><a href="#ref-for-dfn-function-object-17">3.6.11.2. values</a>
+    <li><a href="#ref-for-dfn-function-object-18">3.12.1. DOMException constructor object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="ecmascript-throw">
@@ -15582,26 +15588,26 @@ language binding.</p>
     <li><a href="#ref-for-ecmascript-throw-35">3.2.31. DOMException</a>
     <li><a href="#ref-for-ecmascript-throw-36">3.2.32. Buffer source types</a> <a href="#ref-for-ecmascript-throw-37">(2)</a> <a href="#ref-for-ecmascript-throw-38">(3)</a> <a href="#ref-for-ecmascript-throw-39">(4)</a> <a href="#ref-for-ecmascript-throw-40">(5)</a>
     <li><a href="#ref-for-ecmascript-throw-41">3.5. Overload resolution algorithm</a> <a href="#ref-for-ecmascript-throw-42">(2)</a>
-    <li><a href="#ref-for-ecmascript-throw-43">3.6.1.1. Interface object [[Call]] method</a>
-    <li><a href="#ref-for-ecmascript-throw-44">3.6.1.2. Interface object [[HasInstance]] method</a>
-    <li><a href="#ref-for-ecmascript-throw-45">3.6.6. Attributes</a> <a href="#ref-for-ecmascript-throw-46">(2)</a> <a href="#ref-for-ecmascript-throw-47">(3)</a> <a href="#ref-for-ecmascript-throw-48">(4)</a>
-    <li><a href="#ref-for-ecmascript-throw-49">3.6.7. Operations</a>
-    <li><a href="#ref-for-ecmascript-throw-50">3.6.7.1. Stringifiers</a>
-    <li><a href="#ref-for-ecmascript-throw-51">3.6.7.2. Serializers</a>
-    <li><a href="#ref-for-ecmascript-throw-52">3.6.8.1. @@iterator</a> <a href="#ref-for-ecmascript-throw-53">(2)</a>
-    <li><a href="#ref-for-ecmascript-throw-54">3.6.8.2. forEach</a> <a href="#ref-for-ecmascript-throw-55">(2)</a> <a href="#ref-for-ecmascript-throw-56">(3)</a>
-    <li><a href="#ref-for-ecmascript-throw-57">3.6.9.2. keys</a>
-    <li><a href="#ref-for-ecmascript-throw-58">3.6.9.3. values</a>
-    <li><a href="#ref-for-ecmascript-throw-59">3.6.9.5. Iterator prototype object</a>
-    <li><a href="#ref-for-ecmascript-throw-60">3.6.10. Maplike declarations</a> <a href="#ref-for-ecmascript-throw-61">(2)</a>
-    <li><a href="#ref-for-ecmascript-throw-62">3.6.10.1. size</a>
-    <li><a href="#ref-for-ecmascript-throw-63">3.6.10.4. get and has</a>
-    <li><a href="#ref-for-ecmascript-throw-64">3.6.10.6. delete</a>
-    <li><a href="#ref-for-ecmascript-throw-65">3.6.10.7. set</a>
-    <li><a href="#ref-for-ecmascript-throw-66">3.6.11. Setlike declarations</a> <a href="#ref-for-ecmascript-throw-67">(2)</a>
-    <li><a href="#ref-for-ecmascript-throw-68">3.6.11.1. size</a>
-    <li><a href="#ref-for-ecmascript-throw-69">3.6.11.4. has</a>
-    <li><a href="#ref-for-ecmascript-throw-70">3.6.11.5. add and delete</a>
+    <li><a href="#ref-for-ecmascript-throw-43">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-ecmascript-throw-44">(2)</a>
+    <li><a href="#ref-for-ecmascript-throw-45">3.6.1.2. Interface object [[HasInstance]] method</a>
+    <li><a href="#ref-for-ecmascript-throw-46">3.6.6. Attributes</a> <a href="#ref-for-ecmascript-throw-47">(2)</a> <a href="#ref-for-ecmascript-throw-48">(3)</a> <a href="#ref-for-ecmascript-throw-49">(4)</a>
+    <li><a href="#ref-for-ecmascript-throw-50">3.6.7. Operations</a>
+    <li><a href="#ref-for-ecmascript-throw-51">3.6.7.1. Stringifiers</a>
+    <li><a href="#ref-for-ecmascript-throw-52">3.6.7.2. Serializers</a>
+    <li><a href="#ref-for-ecmascript-throw-53">3.6.8.1. @@iterator</a> <a href="#ref-for-ecmascript-throw-54">(2)</a>
+    <li><a href="#ref-for-ecmascript-throw-55">3.6.8.2. forEach</a> <a href="#ref-for-ecmascript-throw-56">(2)</a> <a href="#ref-for-ecmascript-throw-57">(3)</a>
+    <li><a href="#ref-for-ecmascript-throw-58">3.6.9.2. keys</a>
+    <li><a href="#ref-for-ecmascript-throw-59">3.6.9.3. values</a>
+    <li><a href="#ref-for-ecmascript-throw-60">3.6.9.5. Iterator prototype object</a>
+    <li><a href="#ref-for-ecmascript-throw-61">3.6.10. Maplike declarations</a> <a href="#ref-for-ecmascript-throw-62">(2)</a>
+    <li><a href="#ref-for-ecmascript-throw-63">3.6.10.1. size</a>
+    <li><a href="#ref-for-ecmascript-throw-64">3.6.10.4. get and has</a>
+    <li><a href="#ref-for-ecmascript-throw-65">3.6.10.6. delete</a>
+    <li><a href="#ref-for-ecmascript-throw-66">3.6.10.7. set</a>
+    <li><a href="#ref-for-ecmascript-throw-67">3.6.11. Setlike declarations</a> <a href="#ref-for-ecmascript-throw-68">(2)</a>
+    <li><a href="#ref-for-ecmascript-throw-69">3.6.11.1. size</a>
+    <li><a href="#ref-for-ecmascript-throw-70">3.6.11.4. has</a>
+    <li><a href="#ref-for-ecmascript-throw-71">3.6.11.5. add and delete</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-initial-object">
@@ -15710,7 +15716,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-35">3.2.31. DOMException</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-36">3.2.32. Buffer source types</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-37">3.2.33. Frozen arrays — FrozenArray&lt;T></a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-38">(2)</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-39">3.6.1.1. Interface object [[Call]] method</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-39">3.6.1.1. Constructible Interfaces</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-40">3.6.2. Named constructors</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-41">3.6.4.1. Named properties object [[GetOwnProperty]] method</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-42">3.6.5. Constants</a>
@@ -15788,9 +15794,9 @@ language binding.</p>
     <li><a href="#ref-for-Constructor-10">2.4. Dictionaries</a>
     <li><a href="#ref-for-Constructor-11">3.3.2. [Constructor]</a> <a href="#ref-for-Constructor-12">(2)</a> <a href="#ref-for-Constructor-13">(3)</a> <a href="#ref-for-Constructor-14">(4)</a> <a href="#ref-for-Constructor-15">(5)</a> <a href="#ref-for-Constructor-16">(6)</a> <a href="#ref-for-Constructor-17">(7)</a> <a href="#ref-for-Constructor-18">(8)</a>
     <li><a href="#ref-for-Constructor-19">3.3.12. [NoInterfaceObject]</a>
-    <li><a href="#ref-for-Constructor-20">3.6.1.1. Interface object [[Call]] method</a> <a href="#ref-for-Constructor-21">(2)</a> <a href="#ref-for-Constructor-22">(3)</a>
-    <li><a href="#ref-for-Constructor-23">3.14. Creating and throwing exceptions</a>
-    <li><a href="#ref-for-Constructor-24">IDL grammar</a>
+    <li><a href="#ref-for-Constructor-20">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-Constructor-21">(2)</a> <a href="#ref-for-Constructor-22">(3)</a> <a href="#ref-for-Constructor-23">(4)</a>
+    <li><a href="#ref-for-Constructor-24">3.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-Constructor-25">IDL grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="EnforceRange">
@@ -16076,7 +16082,7 @@ language binding.</p>
   <aside class="dfn-panel" data-for="dfn-overload-resolution-algorithm">
    <b><a href="#dfn-overload-resolution-algorithm">#dfn-overload-resolution-algorithm</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-overload-resolution-algorithm-1">3.6.1.1. Interface object [[Call]] method</a>
+    <li><a href="#ref-for-dfn-overload-resolution-algorithm-1">3.6.1.1. Constructible Interfaces</a>
     <li><a href="#ref-for-dfn-overload-resolution-algorithm-2">3.6.2. Named constructors</a>
     <li><a href="#ref-for-dfn-overload-resolution-algorithm-3">3.6.7. Operations</a>
     <li><a href="#ref-for-dfn-overload-resolution-algorithm-4">3.8.10. Platform object [[Call]] method</a>
@@ -16090,13 +16096,13 @@ language binding.</p>
     <li><a href="#ref-for-dfn-interface-object-3">3.3.2. [Constructor]</a>
     <li><a href="#ref-for-dfn-interface-object-4">3.3.10. [NamedConstructor]</a>
     <li><a href="#ref-for-dfn-interface-object-5">3.3.12. [NoInterfaceObject]</a> <a href="#ref-for-dfn-interface-object-6">(2)</a>
-    <li><a href="#ref-for-dfn-interface-object-7">3.6.1.1. Interface object [[Call]] method</a> <a href="#ref-for-dfn-interface-object-8">(2)</a>
-    <li><a href="#ref-for-dfn-interface-object-9">3.6.1.2. Interface object [[HasInstance]] method</a>
-    <li><a href="#ref-for-dfn-interface-object-10">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-interface-object-11">(2)</a>
-    <li><a href="#ref-for-dfn-interface-object-12">3.6.5. Constants</a>
-    <li><a href="#ref-for-dfn-interface-object-13">3.6.6. Attributes</a>
-    <li><a href="#ref-for-dfn-interface-object-14">3.6.7. Operations</a>
-    <li><a href="#ref-for-dfn-interface-object-15">3.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-interface-object-7">3.6.1.1. Constructible Interfaces</a>
+    <li><a href="#ref-for-dfn-interface-object-8">3.6.1.2. Interface object [[HasInstance]] method</a>
+    <li><a href="#ref-for-dfn-interface-object-9">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-interface-object-10">(2)</a>
+    <li><a href="#ref-for-dfn-interface-object-11">3.6.5. Constants</a>
+    <li><a href="#ref-for-dfn-interface-object-12">3.6.6. Attributes</a>
+    <li><a href="#ref-for-dfn-interface-object-13">3.6.7. Operations</a>
+    <li><a href="#ref-for-dfn-interface-object-14">3.14. Creating and throwing exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-named-constructor">


### PR DESCRIPTION
Fixes #62.
Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=22808.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
    #es-constructible-interfaces
    Don't remove this comment or modify anything below this line.
-->
***
[Preview](https://cdn.rawgit.com/tobie/webidl/208dbe3/index.html#es-constructible-interfaces) | [Diff w/ current ED](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fheycam.github.io%2Fwebidl%2F&doc2=https%3A%2F%2Fcdn.rawgit.com%2Ftobie%2Fwebidl%2F208dbe3%2Findex.html#es-constructible-interfaces) | [Diff w/ base](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2Fd8901f6%2Findex.html&doc2=https%3A%2F%2Fcdn.rawgit.com%2Ftobie%2Fwebidl%2F208dbe3%2Findex.html#es-constructible-interfaces)