### PR TITLE
Extend the dfn of object types.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5121,7 +5121,7 @@ all [=interface types=],
 the [=promise type=],
 the [=exception types=],
 the [=buffer source types=], and
-[=union types=] whose [=member types|members=] are [=object types=]
+[=union types=] whose [=member types|members=] contain at least one [=object type=]
 are known as <dfn id="dfn-object-type" export>object types</dfn>.
 
 Every type has a <dfn id="dfn-type-name" export>type name</dfn>, which

--- a/index.bs
+++ b/index.bs
@@ -5117,8 +5117,11 @@ are {{ArrayBuffer}},
 and the [=typed array types=].
 
 The {{object}} type,
-all [=interface types=]
-and the [=exception types=]
+all [=interface types=],
+the [=promise type=],
+the [=exception types=],
+the [=buffer source types=], and
+[=union types=] whose [=member types|members=] are [=object types=]
 are known as <dfn id="dfn-object-type" export>object types</dfn>.
 
 Every type has a <dfn id="dfn-type-name" export>type name</dfn>, which
@@ -8970,14 +8973,9 @@ The [{{NewObject}}]
 extended attribute must
 [=takes no arguments|take no arguments=].
 
-The [{{NewObject}}]
-extended attribute must not
-be used on anything other than a [=regular operation|regular=]
-or [=static operations|static=]
-[=operation=]
-whose [=return type=]
-is an [=interface type=] or
-a [=promise type=].
+The [{{NewObject}}] extended attribute must not be used on anything other than
+a [=regular operation|regular=] or [=static operations|static=] [=operation=]
+whose [=return type=] is an [=object type=].
 
 <div class="example">
 
@@ -9371,12 +9369,9 @@ The [{{SameObject}}]
 extended attribute must
 [=takes no arguments|take no arguments=].
 
-The [{{SameObject}}]
-extended attribute must not
-be used on anything other than a [=read only=]
-[=attribute=]
-whose type is an [=interface type=]
-or {{object}}.
+The [{{SameObject}}] extended attribute must not be used
+on anything other than a [=read only=] [=attribute=]
+whose type is an [=object type=].
 
 <div class="example">
 

--- a/index.html
+++ b/index.html
@@ -5460,7 +5460,7 @@ and the <a data-link-type="dfn" href="#dfn-typed-array-type" id="ref-for-dfn-typ
 all <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-2">interface types</a>,
 the <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-3">promise type</a>,
 the <a data-link-type="dfn" href="#dfn-exception-type" id="ref-for-dfn-exception-type-1">exception types</a>,
-the <a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-1">buffer source types</a>, and <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-7">union types</a> whose <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-dfn-union-member-type-4">members</a> are <a data-link-type="dfn" href="#dfn-object-type" id="ref-for-dfn-object-type-1">object types</a> are known as <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-object-type">object types</dfn>.</p>
+the <a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-1">buffer source types</a>, and <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-7">union types</a> whose <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-dfn-union-member-type-4">members</a> contain at least one <a data-link-type="dfn" href="#dfn-object-type" id="ref-for-dfn-object-type-1">object type</a> are known as <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-object-type">object types</dfn>.</p>
    <p>Every type has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-type-name">type name</dfn>, which
 is a string, not necessarily unique, that identifies the type.
 Each sub-section below defines what the type name is for each

--- a/index.html
+++ b/index.html
@@ -5457,7 +5457,10 @@ the <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-typ
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-buffer-source-type">buffer source types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-ArrayBuffer" id="ref-for-idl-ArrayBuffer-1">ArrayBuffer</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-DataView" id="ref-for-idl-DataView-1">DataView</a></code>,
 and the <a data-link-type="dfn" href="#dfn-typed-array-type" id="ref-for-dfn-typed-array-type-1">typed array types</a>.</p>
    <p>The <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-1">object</a></code> type,
-all <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-2">interface types</a> and the <a data-link-type="dfn" href="#dfn-exception-type" id="ref-for-dfn-exception-type-1">exception types</a> are known as <dfn data-dfn-type="dfn" data-export="" id="dfn-object-type">object types<a class="self-link" href="#dfn-object-type"></a></dfn>.</p>
+all <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-2">interface types</a>,
+the <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-3">promise type</a>,
+the <a data-link-type="dfn" href="#dfn-exception-type" id="ref-for-dfn-exception-type-1">exception types</a>,
+the <a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-1">buffer source types</a>, and <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-7">union types</a> whose <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-dfn-union-member-type-4">members</a> are <a data-link-type="dfn" href="#dfn-object-type" id="ref-for-dfn-object-type-1">object types</a> are known as <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-object-type">object types</dfn>.</p>
    <p>Every type has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-type-name">type name</dfn>, which
 is a string, not necessarily unique, that identifies the type.
 Each sub-section below defines what the type name is for each
@@ -5551,7 +5554,7 @@ type.</p>
 </pre>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-level="2.11.1" data-lt="any" id="idl-any"><span class="secno">2.11.1. </span><span class="content">any</span><span id="dom-any"></span></h4>
    <p>The <code class="idl"><a data-link-type="idl" href="#idl-any" id="ref-for-idl-any-1">any</a></code> type is the union of all other possible
-non-<a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-7">union</a> types.
+non-<a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-8">union</a> types.
 Its <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-1">type name</a> is “Any”.</p>
    <p>The <code class="idl"><a data-link-type="idl" href="#idl-any" id="ref-for-idl-any-2">any</a></code> type is like
 a discriminated union type, in that each of its values has a
@@ -5559,7 +5562,7 @@ specific non-<code class="idl"><a data-link-type="idl" href="#idl-any" id="ref-f
 associated with it.  For example, one value of the <code class="idl"><a data-link-type="idl" href="#idl-any" id="ref-for-idl-any-4">any</a></code> type is the <code class="idl"><a data-link-type="idl" href="#idl-unsigned-long" id="ref-for-idl-unsigned-long-6">unsigned long</a></code> 150, while another is the <code class="idl"><a data-link-type="idl" href="#idl-long" id="ref-for-idl-long-2">long</a></code> 150.
 These are distinct values.</p>
    <p>The particular type of an <code class="idl"><a data-link-type="idl" href="#idl-any" id="ref-for-idl-any-5">any</a></code> value is known as its <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-specific-type">specific type</dfn>.
-(Values of <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-8">union types</a> also have <a data-link-type="dfn" href="#dfn-specific-type" id="ref-for-dfn-specific-type-2">specific types</a>.)</p>
+(Values of <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-9">union types</a> also have <a data-link-type="dfn" href="#dfn-specific-type" id="ref-for-dfn-specific-type-2">specific types</a>.)</p>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-level="2.11.2" data-lt="boolean" id="idl-boolean"><span class="secno">2.11.2. </span><span class="content">boolean</span><span id="dom-boolean"></span></h4>
    <p>The <code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref-for-idl-boolean-7">boolean</a></code> type has two values: <code class="idl">true</code> and <code class="idl">false</code>.</p>
    <p><code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref-for-idl-boolean-8">boolean</a></code> constant values in IDL are
@@ -5812,7 +5815,7 @@ is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier
 from an existing type (called the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-inner-type">inner type</dfn>),
 which just allows the additional value <emu-val>null</emu-val> to be a member of its set of values. <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-12">Nullable types</a> are represented in IDL by placing a <span class="char">U+003F QUESTION MARK ("?")</span> character after an existing type.  The inner type must not
 be <code class="idl"><a data-link-type="idl" href="#idl-any" id="ref-for-idl-any-6">any</a></code>,
-another nullable type, or a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-9">union type</a> that itself has <a data-link-type="dfn" href="#dfn-includes-a-nullable-type" id="ref-for-dfn-includes-a-nullable-type-2">includes a nullable type</a> or has a dictionary or record type as one of its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-4">flattened member types</a>.</p>
+another nullable type, or a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-10">union type</a> that itself has <a data-link-type="dfn" href="#dfn-includes-a-nullable-type" id="ref-for-dfn-includes-a-nullable-type-2">includes a nullable type</a> or has a dictionary or record type as one of its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-4">flattened member types</a>.</p>
    <p class="note" role="note">Note: Although dictionary and record types can in general be nullable,
 they cannot when used
 as the type of an operation argument or a dictionary member.</p>
@@ -5892,49 +5895,49 @@ with a set of surrounding parentheses.
 The types which comprise the union type are known as the
 union’s <dfn class="dfn-paneled" data-dfn-for="union" data-dfn-type="dfn" data-export="" id="dfn-union-member-type">member types</dfn>.</p>
    <div class="note" role="note">
-    <p>For example, you might write <code>(Node or DOMString)</code> or <code>(double or sequence&lt;double>)</code>.  When applying a <emu-t>?</emu-t> suffix to a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-10">union type</a> as a whole, it is placed after the closing parenthesis,
+    <p>For example, you might write <code>(Node or DOMString)</code> or <code>(double or sequence&lt;double>)</code>.  When applying a <emu-t>?</emu-t> suffix to a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-11">union type</a> as a whole, it is placed after the closing parenthesis,
     as in <code>(Node or DOMString)?</code>.</p>
-    <p>Note that the <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-dfn-union-member-type-4">member types</a> of a union type do not descend into nested union types.  So for <code>(double or (sequence&lt;long> or Event) or (Node or DOMString)?)</code> the member types
+    <p>Note that the <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-dfn-union-member-type-5">member types</a> of a union type do not descend into nested union types.  So for <code>(double or (sequence&lt;long> or Event) or (Node or DOMString)?)</code> the member types
     are <code>double</code>, <code>(sequence&lt;long> or Event)</code> and <code>(Node or DOMString)?</code>.</p>
    </div>
    <p>Like the <code class="idl"><a data-link-type="idl" href="#idl-any" id="ref-for-idl-any-7">any</a></code> type, values of
 union types have a <a data-link-type="dfn" href="#dfn-specific-type" id="ref-for-dfn-specific-type-3">specific type</a>,
-which is the particular <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-dfn-union-member-type-5">member type</a> that matches the value.</p>
+which is the particular <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-dfn-union-member-type-6">member type</a> that matches the value.</p>
    <div class="algorithm" data-algorithm="flattened member types">
-    <p>The <dfn class="dfn-paneled" data-dfn-for="union" data-dfn-type="dfn" data-export="" id="dfn-flattened-union-member-types">flattened member types</dfn> of a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-11">union type</a> is a set of types determined as follows:</p>
+    <p>The <dfn class="dfn-paneled" data-dfn-for="union" data-dfn-type="dfn" data-export="" id="dfn-flattened-union-member-types">flattened member types</dfn> of a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-12">union type</a> is a set of types determined as follows:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>T</var> be the <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-12">union type</a>.</p>
+      <p>Let <var>T</var> be the <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-13">union type</a>.</p>
      <li data-md="">
       <p>Initialize <var>S</var> to ∅.</p>
      <li data-md="">
-      <p>For each <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-dfn-union-member-type-6">member type</a> <var>U</var> of <var>T</var>:</p>
+      <p>For each <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-dfn-union-member-type-7">member type</a> <var>U</var> of <var>T</var>:</p>
       <ol>
        <li data-md="">
         <p>If <var>U</var> is a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-13">nullable type</a>, then
 set <var>U</var> to be the <a data-link-type="dfn" href="#dfn-inner-type" id="ref-for-dfn-inner-type-6">inner type</a> of <var>U</var>.</p>
        <li data-md="">
-        <p>If <var>U</var> is a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-13">union type</a>, then
+        <p>If <var>U</var> is a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-14">union type</a>, then
 add to <var>S</var> the <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-5">flattened member types</a> of <var>U</var>.</p>
        <li data-md="">
-        <p>Otherwise, <var>U</var> is not a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-14">union type</a>.
+        <p>Otherwise, <var>U</var> is not a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-15">union type</a>.
 Add <var>U</var> to <var>S</var>.</p>
       </ol>
      <li data-md="">
       <p>Return <var>S</var>.</p>
     </ol>
    </div>
-   <p class="note" role="note">Note: For example, the <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-6">flattened member types</a> of the <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-15">union type</a> <code>(Node or (sequence&lt;long> or Event) or (XMLHttpRequest or DOMString)? or sequence&lt;(sequence&lt;double> or NodeList)>)</code> are the six types <code>Node</code>, <code>sequence&lt;long></code>, <code>Event</code>, <code>XMLHttpRequest</code>, <code>DOMString</code> and <code>sequence&lt;(sequence&lt;double> or NodeList)></code>.</p>
+   <p class="note" role="note">Note: For example, the <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-6">flattened member types</a> of the <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-16">union type</a> <code>(Node or (sequence&lt;long> or Event) or (XMLHttpRequest or DOMString)? or sequence&lt;(sequence&lt;double> or NodeList)>)</code> are the six types <code>Node</code>, <code>sequence&lt;long></code>, <code>Event</code>, <code>XMLHttpRequest</code>, <code>DOMString</code> and <code>sequence&lt;(sequence&lt;double> or NodeList)></code>.</p>
    <div class="algorithm" data-algorithm="number of nullable member types">
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-number-of-nullable-member-types">number of nullable member types</dfn> of a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-16">union type</a> is an integer
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-number-of-nullable-member-types">number of nullable member types</dfn> of a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-17">union type</a> is an integer
     determined as follows:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>T</var> be the <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-17">union type</a>.</p>
+      <p>Let <var>T</var> be the <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-18">union type</a>.</p>
      <li data-md="">
       <p>Initialize <var>n</var> to 0.</p>
      <li data-md="">
-      <p>For each <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-dfn-union-member-type-7">member type</a> <var>U</var> of <var>T</var>:</p>
+      <p>For each <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-dfn-union-member-type-8">member type</a> <var>U</var> of <var>T</var>:</p>
       <ol>
        <li data-md="">
         <p>If <var>U</var> is a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-14">nullable type</a>, then:</p>
@@ -5945,7 +5948,7 @@ Add <var>U</var> to <var>S</var>.</p>
           <p>Set <var>U</var> to be the <a data-link-type="dfn" href="#dfn-inner-type" id="ref-for-dfn-inner-type-7">inner type</a> of <var>U</var>.</p>
         </ol>
        <li data-md="">
-        <p>If <var>U</var> is a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-18">union type</a>, then:</p>
+        <p>If <var>U</var> is a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-19">union type</a>, then:</p>
         <ol>
          <li data-md="">
           <p>Let <var>m</var> be the <a data-link-type="dfn" href="#dfn-number-of-nullable-member-types" id="ref-for-dfn-number-of-nullable-member-types-1">number of nullable member types</a> of <var>U</var>.</p>
@@ -5958,8 +5961,8 @@ Add <var>U</var> to <var>S</var>.</p>
     </ol>
    </div>
    <p>The <code class="idl"><a data-link-type="idl" href="#idl-any" id="ref-for-idl-any-8">any</a></code> type must not
-be used as a <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-dfn-union-member-type-8">union member type</a>.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-number-of-nullable-member-types" id="ref-for-dfn-number-of-nullable-member-types-2">number of nullable member types</a> of a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-19">union type</a> must
+be used as a <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-dfn-union-member-type-9">union member type</a>.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-number-of-nullable-member-types" id="ref-for-dfn-number-of-nullable-member-types-2">number of nullable member types</a> of a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-20">union type</a> must
 be 0 or 1, and if it is 1 then the union type must also not have
 a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-4">dictionary type</a> or <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-4">record type</a> in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-7">flattened member types</a>.</p>
    <p>A type <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-includes-a-nullable-type">includes a nullable type</dfn> if:</p>
@@ -5967,12 +5970,12 @@ a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-4">d
     <li data-md="">
      <p>the type is a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-15">nullable type</a>, or</p>
     <li data-md="">
-     <p>the type is a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-20">union type</a> and its <a data-link-type="dfn" href="#dfn-number-of-nullable-member-types" id="ref-for-dfn-number-of-nullable-member-types-3">number of nullable member types</a> is 1.</p>
+     <p>the type is a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-21">union type</a> and its <a data-link-type="dfn" href="#dfn-number-of-nullable-member-types" id="ref-for-dfn-number-of-nullable-member-types-3">number of nullable member types</a> is 1.</p>
    </ul>
-   <p>Each pair of <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-8">flattened member types</a> in a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-21">union type</a>, <var>T</var> and <var>U</var>,
+   <p>Each pair of <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-8">flattened member types</a> in a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-22">union type</a>, <var>T</var> and <var>U</var>,
 must be <a data-link-type="dfn" href="#dfn-distinguishable" id="ref-for-dfn-distinguishable-4">distinguishable</a>.</p>
-   <p><a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-22">Union type</a> constant values
-in IDL are represented in the same way that constant values of their <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-dfn-union-member-type-9">member types</a> would be
+   <p><a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-23">Union type</a> constant values
+in IDL are represented in the same way that constant values of their <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-dfn-union-member-type-10">member types</a> would be
 represented.</p>
    <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-27">type name</a> of a union
 type is formed by taking the type names of each member type, in order,
@@ -6032,7 +6035,7 @@ data.  The table below lists these types and the kind of buffer or view they rep
    <p>There is no way to represent a constant value of any of these types in IDL.</p>
    <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-31">type name</a> of all
 of these types is the name of the type itself.</p>
-   <p>At the specification prose level, IDL <a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-1">buffer source types</a> are simply references to objects.  To inspect or manipulate the bytes inside the buffer,
+   <p>At the specification prose level, IDL <a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-2">buffer source types</a> are simply references to objects.  To inspect or manipulate the bytes inside the buffer,
 specification prose must first either <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="get a reference to the buffer source" id="dfn-get-buffer-source-reference">get a reference to the bytes held by the buffer source</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="get a copy of the buffer source" id="dfn-get-buffer-source-copy">get a copy of the bytes held by the buffer source</dfn>.
 With a reference to the buffer source’s bytes, specification prose can get or set individual
 byte values using that reference.</p>
@@ -7536,7 +7539,7 @@ console<span class="p">.</span>assert<span class="p">(</span>entries<span class=
     </table>
    </div>
    <h4 class="heading settled" data-level="3.2.27" id="es-promise"><span class="secno">3.2.27. </span><span class="content">Promise types — Promise&lt;<var>T</var>></span><a class="self-link" href="#es-promise"></a></h4>
-   <p>IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-3">promise type</a> values are
+   <p>IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-4">promise type</a> values are
 represented by ECMAScript <emu-val>Promise</emu-val> objects.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to promise" id="es-to-promise">
     <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-32">converted</a> to an IDL <a class="idl-code" data-link-type="interface" href="#idl-promise" id="ref-for-idl-promise-1">Promise&lt;<var>T</var>></a> value as follows:</p>
@@ -7547,13 +7550,13 @@ represented by ECMAScript <emu-val>Promise</emu-val> objects.</p>
      <li data-md="">
       <p>Let <var>promise</var> be the result of calling <var>resolve</var> with <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a> as the <emu-val>this</emu-val> value and <var>V</var> as the single argument value.</p>
      <li data-md="">
-      <p>Return the IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-4">promise type</a> value that is a reference to the
+      <p>Return the IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-5">promise type</a> value that is a reference to the
 same object as <var>promise</var>.</p>
     </ol>
    </div>
-   <p id="promise-to-es"> The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-31">converting</a> an IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-5">promise type</a> value to an ECMAScript
+   <p id="promise-to-es"> The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-31">converting</a> an IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-6">promise type</a> value to an ECMAScript
     value is the <emu-val>Promise</emu-val> value that represents a reference to the same object that the
-    IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-6">promise type</a> represents. </p>
+    IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-7">promise type</a> represents. </p>
    <div class="algorithm" data-algorithm="perform some steps once a promise is settled">
     <p>One can <dfn data-dfn-type="dfn" data-export="" data-lt="upon settling" id="dfn-perform-steps-once-promise-is-settled">perform some steps once a promise is settled<a class="self-link" href="#dfn-perform-steps-once-promise-is-settled"></a></dfn>.
     There can be one or two sets of steps to perform,
@@ -7613,16 +7616,16 @@ with <var>reason</var> as the rejection reason.</p>
    </div>
    <p class="issue" id="issue-efe8490d"><a class="self-link" href="#issue-efe8490d"></a> Include an example of how to write spec text using this term. </p>
    <h4 class="heading settled" data-level="3.2.28" id="es-union"><span class="secno">3.2.28. </span><span class="content">Union types</span><a class="self-link" href="#es-union"></a></h4>
-   <p>IDL <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-23">union type</a> values are represented by ECMAScript values
-that correspond to the union’s <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-dfn-union-member-type-10">member types</a>.</p>
+   <p>IDL <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-24">union type</a> values are represented by ECMAScript values
+that correspond to the union’s <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-dfn-union-member-type-11">member types</a>.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to union" id="es-to-union">
-    <p>To <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-35">convert an ECMAScript value</a> <var>V</var> to an IDL <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-24">union type</a> value is done as follows:</p>
+    <p>To <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-35">convert an ECMAScript value</a> <var>V</var> to an IDL <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-25">union type</a> value is done as follows:</p>
     <ol>
      <li data-md="">
-      <p>If the <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-25">union type</a> <a data-link-type="dfn" href="#dfn-includes-a-nullable-type" id="ref-for-dfn-includes-a-nullable-type-3">includes a nullable type</a> and <var>V</var> is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>,
+      <p>If the <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-26">union type</a> <a data-link-type="dfn" href="#dfn-includes-a-nullable-type" id="ref-for-dfn-includes-a-nullable-type-3">includes a nullable type</a> and <var>V</var> is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>,
 then return the IDL value <emu-val>null</emu-val>.</p>
      <li data-md="">
-      <p>Let <var>types</var> be the <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-9">flattened member types</a> of the <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-26">union type</a>.</p>
+      <p>Let <var>types</var> be the <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-9">flattened member types</a> of the <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-27">union type</a>.</p>
      <li data-md="">
       <p>If <var>V</var> is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, then:</p>
       <ol>
@@ -7837,7 +7840,7 @@ to the same object as <var>V</var>.</p>
     value is the <emu-val>Object</emu-val> value that represents a reference to the same object that the
     IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-25">DOMException</a></code> represents. </p>
    <h4 class="heading settled" data-level="3.2.32" id="es-buffer-source-types"><span class="secno">3.2.32. </span><span class="content">Buffer source types</span><a class="self-link" href="#es-buffer-source-types"></a></h4>
-   <p>Values of the IDL <a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-2">buffer source types</a> are represented by objects of the corresponding ECMAScript class.</p>
+   <p>Values of the IDL <a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-3">buffer source types</a> are represented by objects of the corresponding ECMAScript class.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to buffer source" id="es-to-buffer-source">
     <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-56">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#idl-ArrayBuffer" id="ref-for-idl-ArrayBuffer-13">ArrayBuffer</a></code> value by running the following algorithm:</p>
     <ol>
@@ -7877,7 +7880,7 @@ then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-thr
       <p>Return the IDL value of type <var>T</var> that is a reference to the same object as <var>V</var>.</p>
     </ol>
    </div>
-   <p>The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-36">converting</a> an IDL value of any <a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-3">buffer source type</a> to an ECMAScript value is the <emu-val>Object</emu-val> value that represents
+   <p>The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-36">converting</a> an IDL value of any <a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-4">buffer source type</a> to an ECMAScript value is the <emu-val>Object</emu-val> value that represents
 a reference to the same object that the IDL value represents.</p>
    <div class="algorithm" data-algorithm="get a reference to a buffer source">
     <p>When <a data-link-type="dfn" href="#dfn-get-buffer-source-reference" id="ref-for-dfn-get-buffer-source-reference-2">getting a reference to</a> or <a data-link-type="dfn" href="#dfn-get-buffer-source-copy" id="ref-for-dfn-get-buffer-source-copy-2">getting a copy of the bytes held by a buffer source</a> that is an ECMAScript <emu-val>ArrayBuffer</emu-val>, <emu-val>DataView</emu-val> or typed array object, these steps must be followed:</p>
@@ -8596,10 +8599,8 @@ a reference to a newly created object
 must always be returned.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#NewObject" id="ref-for-NewObject-3">NewObject</a></code>]
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-9">take no arguments</a>.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#NewObject" id="ref-for-NewObject-4">NewObject</a></code>]
-extended attribute must not
-be used on anything other than a <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-10">regular</a> or <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-8">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-55">operation</a> whose <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-4">return type</a> is an <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-11">interface type</a> or
-a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-7">promise type</a>.</p>
+   <p>The [<code class="idl"><a data-link-type="idl" href="#NewObject" id="ref-for-NewObject-4">NewObject</a></code>] extended attribute must not be used on anything other than
+a <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-10">regular</a> or <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-8">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-55">operation</a> whose <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-4">return type</a> is an <a data-link-type="dfn" href="#dfn-object-type" id="ref-for-dfn-object-type-2">object type</a>.</p>
    <div class="example" id="example-245e5507">
     <a class="self-link" href="#example-245e5507"></a> 
     <p>As an example, this extended attribute is suitable for use on
@@ -8738,7 +8739,7 @@ the <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-na
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.14" data-lt="PutForwards" id="PutForwards"><span class="secno">3.3.14. </span><span class="content">[PutForwards]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-3">PutForwards</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-65">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-8">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-8">regular attribute</a> declaration whose type is
-an <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-12">interface type</a>,
+an <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-11">interface type</a>,
 it indicates that assigning to the attribute will have specific behavior.
 Namely, the assignment is “forwarded” to the attribute (specified by
 the extended attribute argument) on the object that is currently
@@ -8753,7 +8754,7 @@ extended attribute appears,</p>
     <li data-md="">
      <p><var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-72">interface</a> on which <var>A</var> is declared,</p>
     <li data-md="">
-     <p><var>J</var> is the <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-13">interface type</a> that <var>A</var> is declared to be of, and</p>
+     <p><var>J</var> is the <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-12">interface type</a> that <var>A</var> is declared to be of, and</p>
     <li data-md="">
      <p><var>N</var> is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-52">identifier</a> argument of the extended attribute,</p>
    </ul>
@@ -8871,9 +8872,8 @@ object, the same value must always
 be returned.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-3">SameObject</a></code>]
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-13">take no arguments</a>.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-4">SameObject</a></code>]
-extended attribute must not
-be used on anything other than a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-13">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-56">attribute</a> whose type is an <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-14">interface type</a> or <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-25">object</a></code>.</p>
+   <p>The [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-4">SameObject</a></code>] extended attribute must not be used
+on anything other than a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-13">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-56">attribute</a> whose type is an <a data-link-type="dfn" href="#dfn-object-type" id="ref-for-dfn-object-type-3">object type</a>.</p>
    <div class="example" id="example-87c35b5d">
     <a class="self-link" href="#example-87c35b5d"></a> 
     <p>As an example, this extended attribute is suitable for use on
@@ -9284,7 +9284,7 @@ and there is an entry in <var>S</var> that has one of the following types at pos
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-7">record type</a></p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-27">union type</a> that <a data-link-type="dfn" href="#dfn-includes-a-nullable-type" id="ref-for-dfn-includes-a-nullable-type-4">includes a nullable type</a> or that
+          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-28">union type</a> that <a data-link-type="dfn" href="#dfn-includes-a-nullable-type" id="ref-for-dfn-includes-a-nullable-type-4">includes a nullable type</a> or that
 has a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-10">dictionary type</a> or a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-8">record type</a> in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-10">flattened members</a></p>
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
@@ -9293,13 +9293,13 @@ has a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-
 there is an entry in <var>S</var> that has one of the following types at position <var>i</var> of its type list,</p>
         <ul>
          <li data-md="">
-          <p>an <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-15">interface type</a> that <var>V</var> implements</p>
+          <p>an <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-13">interface type</a> that <var>V</var> implements</p>
          <li data-md="">
-          <p><code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-26">object</a></code></p>
+          <p><code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-25">object</a></code></p>
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-27">nullable</a> version of any of the above types</p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-28">union type</a> or a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-28">nullable</a> union type
+          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-29">union type</a> or a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-28">nullable</a> union type
 that has one of the above types in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-11">flattened member types</a></p>
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
@@ -9310,11 +9310,11 @@ there is an entry in <var>S</var> that has one of the following types at positio
          <li data-md="">
           <p><code class="idl"><a data-link-type="idl" href="#idl-RegExp" id="ref-for-idl-RegExp-11">RegExp</a></code></p>
          <li data-md="">
-          <p><code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-27">object</a></code></p>
+          <p><code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-26">object</a></code></p>
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-29">nullable</a> version of either of the above types</p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-29">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-30">nullable</a> union type
+          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-30">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-30">nullable</a> union type
 that has one of the above types in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-12">flattened member types</a></p>
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
@@ -9327,11 +9327,11 @@ there is an entry in <var>S</var> that has one of the following types at positio
          <li data-md="">
           <p><code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-15">Error</a></code></p>
          <li data-md="">
-          <p><code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-28">object</a></code></p>
+          <p><code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-27">object</a></code></p>
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-31">nullable</a> version of either of the above types</p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-30">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-32">nullable</a> union type
+          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-31">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-32">nullable</a> union type
 that has one of the above types in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-13">flattened member types</a></p>
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
@@ -9342,11 +9342,11 @@ there is an entry in <var>S</var> that has one of the following types at positio
          <li data-md="">
           <p><code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-16">Error</a></code></p>
          <li data-md="">
-          <p><code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-29">object</a></code></p>
+          <p><code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-28">object</a></code></p>
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-33">nullable</a> version of either of the above types</p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-31">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-34">nullable</a> union type
+          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-32">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-34">nullable</a> union type
 that has one of the above types in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-14">flattened member types</a></p>
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
@@ -9357,11 +9357,11 @@ there is an entry in <var>S</var> that has one of the following types at positio
          <li data-md="">
           <p><code class="idl"><a data-link-type="idl" href="#idl-ArrayBuffer" id="ref-for-idl-ArrayBuffer-17">ArrayBuffer</a></code></p>
          <li data-md="">
-          <p><code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-30">object</a></code></p>
+          <p><code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-29">object</a></code></p>
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-35">nullable</a> version of either of the above types</p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-32">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-36">nullable</a> union type
+          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-33">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-36">nullable</a> union type
 that has one of the above types in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-15">flattened member types</a></p>
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
@@ -9372,11 +9372,11 @@ there is an entry in <var>S</var> that has one of the following types at positio
          <li data-md="">
           <p><code class="idl"><a data-link-type="idl" href="#idl-DataView" id="ref-for-idl-DataView-6">DataView</a></code></p>
          <li data-md="">
-          <p><code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-31">object</a></code></p>
+          <p><code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-30">object</a></code></p>
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-37">nullable</a> version of either of the above types</p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-33">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-38">nullable</a> union type
+          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-34">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-38">nullable</a> union type
 that has one of the above types in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-16">flattened member types</a></p>
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
@@ -9388,11 +9388,11 @@ there is an entry in <var>S</var> that has one of the following types at positio
           <p>a <a data-link-type="dfn" href="#dfn-typed-array-type" id="ref-for-dfn-typed-array-type-3">typed array type</a> whose name
 is equal to the value of <var>V</var>’s [[TypedArrayName]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a></p>
          <li data-md="">
-          <p><code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-32">object</a></code></p>
+          <p><code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-31">object</a></code></p>
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-39">nullable</a> version of either of the above types</p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-34">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-40">nullable</a> union type
+          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-35">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-40">nullable</a> union type
 that has one of the above types in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-17">flattened member types</a></p>
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
@@ -9403,11 +9403,11 @@ and there is an entry in <var>S</var> that has one of the following types at pos
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-27">callback function</a> type</p>
          <li data-md="">
-          <p><code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-33">object</a></code></p>
+          <p><code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-32">object</a></code></p>
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-41">nullable</a> version of any of the above types</p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-35">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-42">nullable</a> union type
+          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-36">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-42">nullable</a> union type
 that has one of the above types in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-18">flattened member types</a></p>
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
@@ -9424,7 +9424,7 @@ following types at position <var>i</var> of its type list,</p>
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-43">nullable</a> version of any of the above types</p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-36">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-44">nullable</a> union type
+          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-37">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-44">nullable</a> union type
 that has one of the above types in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-19">flattened member types</a></p>
         </ul>
         <p>and after performing the following steps,</p>
@@ -9448,11 +9448,11 @@ there is an entry in <var>S</var> that has one of the following types at positio
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-9">record type</a></p>
          <li data-md="">
-          <p><code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-34">object</a></code></p>
+          <p><code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-33">object</a></code></p>
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-45">nullable</a> version of any of the above types</p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-37">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-46">nullable</a> union type
+          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-38">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-46">nullable</a> union type
 that has one of the above types in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-20">flattened member types</a></p>
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
@@ -9465,7 +9465,7 @@ and there is an entry in <var>S</var> that has one of the following types at pos
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-47">nullable</a> <code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref-for-idl-boolean-20">boolean</a></code></p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-38">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-48">nullable</a> union type
+          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-39">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-48">nullable</a> union type
 that has one of the above types in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-21">flattened member types</a></p>
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
@@ -9478,7 +9478,7 @@ and there is an entry in <var>S</var> that has one of the following types at pos
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-49">nullable</a> <a data-link-type="dfn" href="#dfn-numeric-type" id="ref-for-dfn-numeric-type-7">numeric type</a></p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-39">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-50">nullable</a> union type
+          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-40">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-50">nullable</a> union type
 that has one of the above types in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-22">flattened member types</a></p>
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
@@ -9490,7 +9490,7 @@ that has one of the above types in its <a data-link-type="dfn" href="#dfn-flatte
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-51">nullable</a> version of any of the above types</p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-40">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-52">nullable</a> union type
+          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-41">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-52">nullable</a> union type
 that has one of the above types in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-23">flattened member types</a></p>
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
@@ -9502,7 +9502,7 @@ that has one of the above types in its <a data-link-type="dfn" href="#dfn-flatte
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-53">nullable</a> <a data-link-type="dfn" href="#dfn-numeric-type" id="ref-for-dfn-numeric-type-9">numeric type</a></p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-41">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-54">nullable</a> union type
+          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-42">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-54">nullable</a> union type
 that has one of the above types in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-24">flattened member types</a></p>
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
@@ -9514,7 +9514,7 @@ that has one of the above types in its <a data-link-type="dfn" href="#dfn-flatte
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-55">nullable</a> <code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref-for-idl-boolean-22">boolean</a></code></p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-42">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-56">nullable</a> union type
+          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-43">union type</a> or <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-56">nullable</a> union type
 that has one of the above types in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-25">flattened member types</a></p>
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
@@ -9701,7 +9701,7 @@ an exception when called as a function.</p>
      <li data-md="">
       <p>Let <var>R</var> be the result of performing the actions listed in the description of <var>constructor</var> with <var>values</var> as the argument values.</p>
      <li data-md="">
-      <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-39">converting</a> <var>R</var> to an ECMAScript <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-16">interface type</a> value <var>I</var>.</p>
+      <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-39">converting</a> <var>R</var> to an ECMAScript <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-14">interface type</a> value <var>I</var>.</p>
     </ol>
    </div>
    <p>If the internal [[Call]] method
@@ -9775,7 +9775,7 @@ implement the interface on which the
      <li data-md="">
       <p>Let <var>R</var> be the result of performing the actions listed in the description of <var>constructor</var> with <var>values</var> as the argument values.</p>
      <li data-md="">
-      <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-40">converting</a> <var>R</var> to an ECMAScript <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-17">interface type</a> value <var>I</var>.</p>
+      <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-40">converting</a> <var>R</var> to an ECMAScript <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-15">interface type</a> value <var>I</var>.</p>
     </ol>
    </div>
    <p>If the internal [[Call]] method
@@ -12010,7 +12010,7 @@ and no others.</p>
    </ul>
    <div class="algorithm" data-algorithm="to call a user object’s operation">
     <p>To <dfn data-dfn-type="dfn" data-export="" id="call-a-user-objects-operation">call a user object’s operation<a class="self-link" href="#call-a-user-objects-operation"></a></dfn>,
-    given a <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-18">callback interface type</a> value <var>value</var>,
+    given a <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-16">callback interface type</a> value <var>value</var>,
     sometimes-optional operation name <var>opName</var>,
     list of argument values <var>arg</var><sub>0..<var>n</var>−1</sub> each of which is either
     an IDL value or the special value “missing” (representing a missing optional argument),
@@ -12119,7 +12119,7 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
    </div>
    <div class="algorithm" data-algorithm="get a user object’s attribute value">
     <p>To <dfn data-dfn-type="dfn" data-export="" id="get-a-user-objects-attribute-value">get a user object’s attribute value<a class="self-link" href="#get-a-user-objects-attribute-value"></a></dfn>,
-    given a <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-19">callback interface type</a> value <var>object</var> and
+    given a <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-17">callback interface type</a> value <var>object</var> and
     attribute name <var>attributeName</var>, perform the following steps.
     These steps will either return an IDL value or throw an exception.</p>
     <ol>
@@ -12167,7 +12167,7 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
    </div>
    <div class="algorithm" data-algorithm="set a user object’s attribute value">
     <p>To <dfn data-dfn-type="dfn" data-export="" id="set-a-user-objects-attribute-value">set a user object’s attribute value<a class="self-link" href="#set-a-user-objects-attribute-value"></a></dfn>,
-    given a <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-20">callback interface type</a> value <var>object</var>,
+    given a <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-18">callback interface type</a> value <var>object</var>,
     attribute name <var>attributeName</var>, and IDL value <var>value</var>,
     perform the following steps.
     These steps will not return anything, but could throw an exception.</p>
@@ -14899,8 +14899,17 @@ language binding.</p>
   <aside class="dfn-panel" data-for="dfn-buffer-source-type">
    <b><a href="#dfn-buffer-source-type">#dfn-buffer-source-type</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-buffer-source-type-1">2.11.31. Buffer source types</a>
-    <li><a href="#ref-for-dfn-buffer-source-type-2">3.2.32. Buffer source types</a> <a href="#ref-for-dfn-buffer-source-type-3">(2)</a>
+    <li><a href="#ref-for-dfn-buffer-source-type-1">2.11. Types</a>
+    <li><a href="#ref-for-dfn-buffer-source-type-2">2.11.31. Buffer source types</a>
+    <li><a href="#ref-for-dfn-buffer-source-type-3">3.2.32. Buffer source types</a> <a href="#ref-for-dfn-buffer-source-type-4">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-object-type">
+   <b><a href="#dfn-object-type">#dfn-object-type</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-object-type-1">2.11. Types</a>
+    <li><a href="#ref-for-dfn-object-type-2">3.3.11. [NewObject]</a>
+    <li><a href="#ref-for-dfn-object-type-3">3.3.16. [SameObject]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-type-name">
@@ -15157,8 +15166,7 @@ language binding.</p>
     <li><a href="#ref-for-idl-object-5">3.2.1. any</a> <a href="#ref-for-idl-object-6">(2)</a> <a href="#ref-for-idl-object-7">(3)</a> <a href="#ref-for-idl-object-8">(4)</a> <a href="#ref-for-idl-object-9">(5)</a>
     <li><a href="#ref-for-idl-object-10">3.2.19. object</a> <a href="#ref-for-idl-object-11">(2)</a> <a href="#ref-for-idl-object-12">(3)</a> <a href="#ref-for-idl-object-13">(4)</a> <a href="#ref-for-idl-object-14">(5)</a>
     <li><a href="#ref-for-idl-object-15">3.2.28. Union types</a> <a href="#ref-for-idl-object-16">(2)</a> <a href="#ref-for-idl-object-17">(3)</a> <a href="#ref-for-idl-object-18">(4)</a> <a href="#ref-for-idl-object-19">(5)</a> <a href="#ref-for-idl-object-20">(6)</a> <a href="#ref-for-idl-object-21">(7)</a> <a href="#ref-for-idl-object-22">(8)</a> <a href="#ref-for-idl-object-23">(9)</a> <a href="#ref-for-idl-object-24">(10)</a>
-    <li><a href="#ref-for-idl-object-25">3.3.16. [SameObject]</a>
-    <li><a href="#ref-for-idl-object-26">3.5. Overload resolution algorithm</a> <a href="#ref-for-idl-object-27">(2)</a> <a href="#ref-for-idl-object-28">(3)</a> <a href="#ref-for-idl-object-29">(4)</a> <a href="#ref-for-idl-object-30">(5)</a> <a href="#ref-for-idl-object-31">(6)</a> <a href="#ref-for-idl-object-32">(7)</a> <a href="#ref-for-idl-object-33">(8)</a> <a href="#ref-for-idl-object-34">(9)</a>
+    <li><a href="#ref-for-idl-object-25">3.5. Overload resolution algorithm</a> <a href="#ref-for-idl-object-26">(2)</a> <a href="#ref-for-idl-object-27">(3)</a> <a href="#ref-for-idl-object-28">(4)</a> <a href="#ref-for-idl-object-29">(5)</a> <a href="#ref-for-idl-object-30">(6)</a> <a href="#ref-for-idl-object-31">(7)</a> <a href="#ref-for-idl-object-32">(8)</a> <a href="#ref-for-idl-object-33">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="idl-interface">
@@ -15169,13 +15177,11 @@ language binding.</p>
     <li><a href="#ref-for-idl-interface-3">2.11.22. Callback function types</a>
     <li><a href="#ref-for-idl-interface-4">3.2.20. Interface types</a> <a href="#ref-for-idl-interface-5">(2)</a> <a href="#ref-for-idl-interface-6">(3)</a> <a href="#ref-for-idl-interface-7">(4)</a> <a href="#ref-for-idl-interface-8">(5)</a> <a href="#ref-for-idl-interface-9">(6)</a>
     <li><a href="#ref-for-idl-interface-10">3.2.28. Union types</a>
-    <li><a href="#ref-for-idl-interface-11">3.3.11. [NewObject]</a>
-    <li><a href="#ref-for-idl-interface-12">3.3.14. [PutForwards]</a> <a href="#ref-for-idl-interface-13">(2)</a>
-    <li><a href="#ref-for-idl-interface-14">3.3.16. [SameObject]</a>
-    <li><a href="#ref-for-idl-interface-15">3.5. Overload resolution algorithm</a>
-    <li><a href="#ref-for-idl-interface-16">3.6.1.1. Interface object [[Call]] method</a>
-    <li><a href="#ref-for-idl-interface-17">3.6.2. Named constructors</a>
-    <li><a href="#ref-for-idl-interface-18">3.9. User objects implementing callback interfaces</a> <a href="#ref-for-idl-interface-19">(2)</a> <a href="#ref-for-idl-interface-20">(3)</a>
+    <li><a href="#ref-for-idl-interface-11">3.3.14. [PutForwards]</a> <a href="#ref-for-idl-interface-12">(2)</a>
+    <li><a href="#ref-for-idl-interface-13">3.5. Overload resolution algorithm</a>
+    <li><a href="#ref-for-idl-interface-14">3.6.1.1. Interface object [[Call]] method</a>
+    <li><a href="#ref-for-idl-interface-15">3.6.2. Named constructors</a>
+    <li><a href="#ref-for-idl-interface-16">3.9. User objects implementing callback interfaces</a> <a href="#ref-for-idl-interface-17">(2)</a> <a href="#ref-for-idl-interface-18">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-callback-context">
@@ -15301,8 +15307,8 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-dfn-promise-type-1">2.2.4.1. Legacy callers</a>
     <li><a href="#ref-for-dfn-promise-type-2">2.2.6. Overloading</a>
-    <li><a href="#ref-for-dfn-promise-type-3">3.2.27. Promise types — Promise&lt;T></a> <a href="#ref-for-dfn-promise-type-4">(2)</a> <a href="#ref-for-dfn-promise-type-5">(3)</a> <a href="#ref-for-dfn-promise-type-6">(4)</a>
-    <li><a href="#ref-for-dfn-promise-type-7">3.3.11. [NewObject]</a>
+    <li><a href="#ref-for-dfn-promise-type-3">2.11. Types</a>
+    <li><a href="#ref-for-dfn-promise-type-4">3.2.27. Promise types — Promise&lt;T></a> <a href="#ref-for-dfn-promise-type-5">(2)</a> <a href="#ref-for-dfn-promise-type-6">(3)</a> <a href="#ref-for-dfn-promise-type-7">(4)</a>
     <li><a href="#ref-for-dfn-promise-type-8">3.6.7. Operations</a>
     <li><a href="#ref-for-dfn-promise-type-9">3.9. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-promise-type-10">(2)</a>
     <li><a href="#ref-for-dfn-promise-type-11">3.10. Invoking callback functions</a>
@@ -15316,11 +15322,12 @@ language binding.</p>
     <li><a href="#ref-for-dfn-union-type-4">2.2.4.3. Serializers</a>
     <li><a href="#ref-for-dfn-union-type-5">2.2.6. Overloading</a>
     <li><a href="#ref-for-dfn-union-type-6">2.4. Dictionaries</a>
-    <li><a href="#ref-for-dfn-union-type-7">2.11.1. any</a> <a href="#ref-for-dfn-union-type-8">(2)</a>
-    <li><a href="#ref-for-dfn-union-type-9">2.11.23. Nullable types — T?</a>
-    <li><a href="#ref-for-dfn-union-type-10">2.11.27. Union types</a> <a href="#ref-for-dfn-union-type-11">(2)</a> <a href="#ref-for-dfn-union-type-12">(3)</a> <a href="#ref-for-dfn-union-type-13">(4)</a> <a href="#ref-for-dfn-union-type-14">(5)</a> <a href="#ref-for-dfn-union-type-15">(6)</a> <a href="#ref-for-dfn-union-type-16">(7)</a> <a href="#ref-for-dfn-union-type-17">(8)</a> <a href="#ref-for-dfn-union-type-18">(9)</a> <a href="#ref-for-dfn-union-type-19">(10)</a> <a href="#ref-for-dfn-union-type-20">(11)</a> <a href="#ref-for-dfn-union-type-21">(12)</a> <a href="#ref-for-dfn-union-type-22">(13)</a>
-    <li><a href="#ref-for-dfn-union-type-23">3.2.28. Union types</a> <a href="#ref-for-dfn-union-type-24">(2)</a> <a href="#ref-for-dfn-union-type-25">(3)</a> <a href="#ref-for-dfn-union-type-26">(4)</a>
-    <li><a href="#ref-for-dfn-union-type-27">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-union-type-28">(2)</a> <a href="#ref-for-dfn-union-type-29">(3)</a> <a href="#ref-for-dfn-union-type-30">(4)</a> <a href="#ref-for-dfn-union-type-31">(5)</a> <a href="#ref-for-dfn-union-type-32">(6)</a> <a href="#ref-for-dfn-union-type-33">(7)</a> <a href="#ref-for-dfn-union-type-34">(8)</a> <a href="#ref-for-dfn-union-type-35">(9)</a> <a href="#ref-for-dfn-union-type-36">(10)</a> <a href="#ref-for-dfn-union-type-37">(11)</a> <a href="#ref-for-dfn-union-type-38">(12)</a> <a href="#ref-for-dfn-union-type-39">(13)</a> <a href="#ref-for-dfn-union-type-40">(14)</a> <a href="#ref-for-dfn-union-type-41">(15)</a> <a href="#ref-for-dfn-union-type-42">(16)</a>
+    <li><a href="#ref-for-dfn-union-type-7">2.11. Types</a>
+    <li><a href="#ref-for-dfn-union-type-8">2.11.1. any</a> <a href="#ref-for-dfn-union-type-9">(2)</a>
+    <li><a href="#ref-for-dfn-union-type-10">2.11.23. Nullable types — T?</a>
+    <li><a href="#ref-for-dfn-union-type-11">2.11.27. Union types</a> <a href="#ref-for-dfn-union-type-12">(2)</a> <a href="#ref-for-dfn-union-type-13">(3)</a> <a href="#ref-for-dfn-union-type-14">(4)</a> <a href="#ref-for-dfn-union-type-15">(5)</a> <a href="#ref-for-dfn-union-type-16">(6)</a> <a href="#ref-for-dfn-union-type-17">(7)</a> <a href="#ref-for-dfn-union-type-18">(8)</a> <a href="#ref-for-dfn-union-type-19">(9)</a> <a href="#ref-for-dfn-union-type-20">(10)</a> <a href="#ref-for-dfn-union-type-21">(11)</a> <a href="#ref-for-dfn-union-type-22">(12)</a> <a href="#ref-for-dfn-union-type-23">(13)</a>
+    <li><a href="#ref-for-dfn-union-type-24">3.2.28. Union types</a> <a href="#ref-for-dfn-union-type-25">(2)</a> <a href="#ref-for-dfn-union-type-26">(3)</a> <a href="#ref-for-dfn-union-type-27">(4)</a>
+    <li><a href="#ref-for-dfn-union-type-28">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-union-type-29">(2)</a> <a href="#ref-for-dfn-union-type-30">(3)</a> <a href="#ref-for-dfn-union-type-31">(4)</a> <a href="#ref-for-dfn-union-type-32">(5)</a> <a href="#ref-for-dfn-union-type-33">(6)</a> <a href="#ref-for-dfn-union-type-34">(7)</a> <a href="#ref-for-dfn-union-type-35">(8)</a> <a href="#ref-for-dfn-union-type-36">(9)</a> <a href="#ref-for-dfn-union-type-37">(10)</a> <a href="#ref-for-dfn-union-type-38">(11)</a> <a href="#ref-for-dfn-union-type-39">(12)</a> <a href="#ref-for-dfn-union-type-40">(13)</a> <a href="#ref-for-dfn-union-type-41">(14)</a> <a href="#ref-for-dfn-union-type-42">(15)</a> <a href="#ref-for-dfn-union-type-43">(16)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-union-member-type">
@@ -15329,8 +15336,9 @@ language binding.</p>
     <li><a href="#ref-for-dfn-union-member-type-1">2.2.4.3. Serializers</a>
     <li><a href="#ref-for-dfn-union-member-type-2">2.2.6. Overloading</a>
     <li><a href="#ref-for-dfn-union-member-type-3">2.4. Dictionaries</a>
-    <li><a href="#ref-for-dfn-union-member-type-4">2.11.27. Union types</a> <a href="#ref-for-dfn-union-member-type-5">(2)</a> <a href="#ref-for-dfn-union-member-type-6">(3)</a> <a href="#ref-for-dfn-union-member-type-7">(4)</a> <a href="#ref-for-dfn-union-member-type-8">(5)</a> <a href="#ref-for-dfn-union-member-type-9">(6)</a>
-    <li><a href="#ref-for-dfn-union-member-type-10">3.2.28. Union types</a>
+    <li><a href="#ref-for-dfn-union-member-type-4">2.11. Types</a>
+    <li><a href="#ref-for-dfn-union-member-type-5">2.11.27. Union types</a> <a href="#ref-for-dfn-union-member-type-6">(2)</a> <a href="#ref-for-dfn-union-member-type-7">(3)</a> <a href="#ref-for-dfn-union-member-type-8">(4)</a> <a href="#ref-for-dfn-union-member-type-9">(5)</a> <a href="#ref-for-dfn-union-member-type-10">(6)</a>
+    <li><a href="#ref-for-dfn-union-member-type-11">3.2.28. Union types</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-flattened-union-member-types">


### PR DESCRIPTION
Update [SameObject] and [NewObject] to rely on it.

Fixes #71
Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=27605


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
    #dfn-object-type, #NewObject, #SameObject
    Don't remove this comment or modify anything below this line.
-->
***
[Preview](https://cdn.rawgit.com/tobie/webidl/e3b6245/index.html) (<a href="https://cdn.rawgit.com/tobie/webidl/e3b6245/index.html#dfn-object-type" title="#dfn-object-type">#dfn-object-t…</a>) (<a href="https://cdn.rawgit.com/tobie/webidl/e3b6245/index.html#NewObject" title="#NewObject">#NewObject</a>) (<a href="https://cdn.rawgit.com/tobie/webidl/e3b6245/index.html#SameObject" title="#SameObject">#SameObject</a>) | [Diff w/ current ED](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fheycam.github.io%2Fwebidl%2F&doc2=https%3A%2F%2Fcdn.rawgit.com%2Ftobie%2Fwebidl%2Fe3b6245%2Findex.html) | [Diff w/ base](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2F1c30812%2Findex.html&doc2=https%3A%2F%2Fcdn.rawgit.com%2Ftobie%2Fwebidl%2Fe3b6245%2Findex.html)