### PR TITLE
Remove support for [Unforgeable]-annotated interfaces

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -934,9 +934,8 @@ is all of those defined in this document that are applicable to
 [{{Exposed}}],
 [{{Global}}],
 [{{OverrideBuiltins}}],
-[{{PrimaryGlobal}}],
-[{{SecureContext}}] and
-[{{Unforgeable}}].
+[{{PrimaryGlobal}}], and
+[{{SecureContext}}].
 
 Any [=extended attribute=] specified
 on a [=partial interface=] definition
@@ -954,9 +953,8 @@ The following extended attributes are applicable to interfaces:
 [{{NamedConstructor}}],
 [{{NoInterfaceObject}}],
 [{{OverrideBuiltins}}],
-[{{PrimaryGlobal}}],
-[{{SecureContext}}],
-[{{Unforgeable}}].
+[{{PrimaryGlobal}}], and
+[{{SecureContext}}].
 
 <div data-fill-with="grammar-CallbackOrInterface"></div>
 
@@ -6496,7 +6494,6 @@ and comprise the following:
 *   <a href="#es-stringifier">the <emu-val>Function</emu-val> objects that correspond to stringifiers</a>
 *   <a href="#es-serializer">the <emu-val>Function</emu-val> objects that correspond to serializers</a>
 *   <a href="#es-iterators">the <emu-val>Function</emu-val> objects that correspond to iterators</a>
-*   [=default unforgeable valueOf functions=]
 *   [=map size getters=]
 *   [=DOMException constructor objects=]
 *   [=DOMException prototype objects=]
@@ -9739,33 +9736,10 @@ property value being returned.  In particular, the property will be
 non-configurable and will exist as an own property on the object
 itself rather than on its prototype.
 
-If the [{{Unforgeable}}]
-[=extended attribute=]
-appears on an [=interface=],
-it indicates that all of the non-[=Static attributes|static=]
-[=attributes=]
-and non-[=static operations|static=]
-[=operations=] declared on
-that interface and its [=consequential interfaces=]
-will be similarly reflected as own ECMAScript properties on objects
-that implement the interface, rather than on the prototype.
-
-An attribute or operation is said to be <dfn id="dfn-unforgeable-on-an-interface" export>unforgeable</dfn>
-on a given interface |A| if any of the following are true:
-
-*   The attribute or operation is declared on |A| or one
-    of |A|’s [=consequential interfaces=],
-    and is annotated with the [{{Unforgeable}}]
-    [=extended attribute=].
-*   The attribute or operation is declared on |A| or one
-    of |A|’s [=consequential interfaces=],
-    and that interface is annotated with the [{{Unforgeable}}]
-    [=extended attribute=].
-*   There exists an interface |B|, which is either |A| or one of
-    |A|’s [=consequential interfaces=],
-    |B| is annotated with the [{{Unforgeable}}]
-    [=extended attribute=],
-    and the attribute or operation is declared on one of |B|’s consequential interfaces.
+An attribute or operation is said to be
+<dfn id="dfn-unforgeable-on-an-interface" export>unforgeable</dfn> on a given interface |A| if the
+attribute or operation is declared on |A| or one of |A|’s [=consequential interfaces=], and is
+annotated with the [{{Unforgeable}}] [=extended attribute=].
 
 The [{{Unforgeable}}]
 extended attribute must
@@ -9773,9 +9747,8 @@ extended attribute must
 
 The [{{Unforgeable}}]
 extended attribute must not appear on
-anything other than an [=attribute=],
-non-[=static operations|static=] [=operation=]
-or an [=interface=].  If it does
+anything other than an [=attribute=] or a
+non-[=static operations|static=] [=operation=]. If it does
 appear on an [=operation=], then
 it must appear on all operations with
 the same [=identifier=] on that interface.
@@ -9805,26 +9778,6 @@ must not have a non-static attribute or
         B2 implements Mixin;
         interface Mixin {
           void x();  // Invalid; B2's copy of x would be shadowed by A1's x.
-        };
-
-        [Unforgeable]
-        interface A2 {
-          readonly attribute DOMString x;
-        };
-        interface B3 : A2 {
-          void x();  // Invalid; would be shadowed by A2's x.
-        };
-
-        interface B4 : A2 { };
-        B4 implements Mixin;
-        interface Mixin {
-          void x();  // Invalid; B4's copy of x would be shadowed by A2's x.
-        };
-
-        interface A3 { };
-        A3 implements A2;
-        interface B5 : A3 {
-          void x();  // Invalid; would be shadowed by A3's mixed-in copy of A2's x.
         };
     </pre>
 </div>
@@ -12056,44 +12009,6 @@ updated to be the [=interface prototype object=]
 of the [=primary interface=]
 from the [=platform object=]’s newly associated global environment.
 
-Every platform object that implements an [{{Unforgeable}}]-annotated
-interface and which does not have a [=stringifier=]
-that is [=unforgeable=] on any of the
-interfaces it implements must have a property with the
-following characteristics:
-
-*   The name of the property is “toString”.
-*   The property has attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>false</emu-val> }</span>.
-*   The value of the property is [=%ObjProto_toString%=], the initial value of Object.prototype.toString.
-
-Every platform object that implements an [{{Unforgeable}}]-annotated
-interface and which does not have a [=serializer=]
-that is [=unforgeable=] on any of the
-interfaces it implements must have a property with the
-following characteristics:
-
-*   The name of the property is “toJSON”.
-*   The property has attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>false</emu-val> }</span>.
-*   The value of the property is <emu-val>undefined</emu-val>.
-
-Every platform object that implements an [{{Unforgeable}}]-annotated
-interface must have a property with the
-following characteristics:
-
-*   The name of the property is “valueOf”.
-*   The property has attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>false</emu-val> }</span>.
-*   <div algorithm="to invoke the valueOf method of platform objects">
-        The value of the property is a <emu-val>Function</emu-val> object whose behavior is as follows:
-
-        1. Return the <emu-val>this</emu-val> value.
-    </div>
-    This <emu-val>Function</emu-val> object is the
-    <dfn id="dfn-default-unforgeable-valueOf-function" export>default unforgeable valueOf function</dfn>.
-*   The value of the <emu-val>Function</emu-val> object’s “length”
-    property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.
-*   The value of the <emu-val>Function</emu-val> object’s “name” property is the
-    <emu-val>String</emu-val> value “valueOf”.
-
 The [=class string=] of
 a platform object that implements one or more interfaces
 must be the [=identifier=] of
@@ -12150,11 +12065,7 @@ A property name is an <dfn id="dfn-unforgeable-property-name" export>unforgeable
 given platform object if the object implements an [=interface=] that
 has an [=interface member=] with that identifier
 and that interface member is [=unforgeable=] on any of
-the interfaces that |O| implements.  If the object implements an
-[{{Unforgeable}}]-annotated
-[=interface=], then “toString” and “valueOf” are
-also [=unforgeable property names=]
-on that object.
+the interfaces that |O| implements.
 
 <div algorithm>
 

--- a/index.html
+++ b/index.html
@@ -2344,9 +2344,8 @@ be specified on partial interface definitions:
 [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-1">Exposed</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-1">Global</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-1">OverrideBuiltins</a></code>],
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-2">PrimaryGlobal</a></code>],
-[<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-1">SecureContext</a></code>] and
-[<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-1">Unforgeable</a></code>].</p>
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-2">PrimaryGlobal</a></code>], and
+[<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-1">SecureContext</a></code>].</p>
    <p>Any <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-6">extended attribute</a> specified
 on a <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-5">partial interface</a> definition
 is considered to appear on the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-11">interface</a> itself.</p>
@@ -2360,9 +2359,8 @@ in the language.</p>
 [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-2">NamedConstructor</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-2">NoInterfaceObject</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-2">OverrideBuiltins</a></code>],
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-4">PrimaryGlobal</a></code>],
-[<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-2">SecureContext</a></code>],
-[<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-2">Unforgeable</a></code>].</p>
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-4">PrimaryGlobal</a></code>], and
+[<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-2">SecureContext</a></code>].</p>
    <div data-fill-with="grammar-CallbackOrInterface"></div>
 <pre class="grammar" id="prod-CallbackRestOrInterface">CallbackRestOrInterface :
     CallbackRest
@@ -2742,7 +2740,7 @@ interface will be stringified to the value of the attribute.  See <a href="#idl-
 [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-1">LenientThis</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-1">PutForwards</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-1">Replaceable</a></code>],
-[<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-3">Unforgeable</a></code>].</p>
+[<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-1">Unforgeable</a></code>].</p>
 <pre class="grammar" id="prod-ReadOnlyMember">ReadOnlyMember :
     "readonly" ReadOnlyMemberRest
 </pre>
@@ -3043,7 +3041,7 @@ must be a <a data-link-type="dfn" href="#sequence-type" id="ref-for-sequence-typ
 [<code class="idl"><a data-link-type="idl" href="#NewObject" id="ref-for-NewObject-1">NewObject</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-5">SecureContext</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#TreatNullAs" id="ref-for-TreatNullAs-2">TreatNullAs</a></code>],
-[<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-4">Unforgeable</a></code>].</p>
+[<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-2">Unforgeable</a></code>].</p>
    <p>The following extended attributes are applicable to operation arguments:
 [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-2">Clamp</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-2">EnforceRange</a></code>],
@@ -6354,8 +6352,6 @@ and comprise the following:</p>
     <li data-md="">
      <p><a href="#es-iterators">the <emu-val>Function</emu-val> objects that correspond to iterators</a></p>
     <li data-md="">
-     <p><a data-link-type="dfn" href="#dfn-default-unforgeable-valueOf-function" id="ref-for-dfn-default-unforgeable-valueOf-function-1">default unforgeable valueOf functions</a></p>
-    <li data-md="">
      <p><a data-link-type="dfn" href="#dfn-map-size-getter" id="ref-for-dfn-map-size-getter-1">map size getters</a></p>
     <li data-md="">
      <p><a data-link-type="dfn" href="#dfn-DOMException-constructor-object" id="ref-for-dfn-DOMException-constructor-object-1">DOMException constructor objects</a></p>
@@ -9097,41 +9093,26 @@ d<span class="p">.</span>isMemberOfBreed<span class="p">(</span><span class="kc"
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.20" data-lt="Unforgeable" id="Unforgeable"><span class="secno">3.3.20. </span><span class="content">[Unforgeable]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-5">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-76">extended attribute</a> appears on a non-<a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-10">static</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-59">attribute</a> or non-<a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-10">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-60">operations</a>, it indicates
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-3">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-76">extended attribute</a> appears on a non-<a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-10">static</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-59">attribute</a> or non-<a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-10">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-60">operations</a>, it indicates
 that the attribute or operation will be reflected as an ECMAScript property in
 a way that means its behavior cannot be modified and that performing
 a property lookup on the object will always result in the attribute’s
 property value being returned.  In particular, the property will be
 non-configurable and will exist as an own property on the object
 itself rather than on its prototype.</p>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-6">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-77">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-77">interface</a>,
-it indicates that all of the non-<a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-11">static</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-60">attributes</a> and non-<a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-11">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-61">operations</a> declared on
-that interface and its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-16">consequential interfaces</a> will be similarly reflected as own ECMAScript properties on objects
-that implement the interface, rather than on the prototype.</p>
-   <p>An attribute or operation is said to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-unforgeable-on-an-interface">unforgeable</dfn> on a given interface <var>A</var> if any of the following are true:</p>
-   <ul>
-    <li data-md="">
-     <p>The attribute or operation is declared on <var>A</var> or one
-of <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-17">consequential interfaces</a>,
-and is annotated with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-7">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-78">extended attribute</a>.</p>
-    <li data-md="">
-     <p>The attribute or operation is declared on <var>A</var> or one
-of <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-18">consequential interfaces</a>,
-and that interface is annotated with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-8">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-79">extended attribute</a>.</p>
-    <li data-md="">
-     <p>There exists an interface <var>B</var>, which is either <var>A</var> or one of <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-19">consequential interfaces</a>, <var>B</var> is annotated with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-9">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-80">extended attribute</a>,
-and the attribute or operation is declared on one of <var>B</var>’s consequential interfaces.</p>
-   </ul>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-10">Unforgeable</a></code>]
+   <p>An attribute or operation is said to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-unforgeable-on-an-interface">unforgeable</dfn> on a given interface <var>A</var> if the
+attribute or operation is declared on <var>A</var> or one of <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-16">consequential interfaces</a>, and is
+annotated with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-4">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-77">extended attribute</a>.</p>
+   <p>The [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-5">Unforgeable</a></code>]
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-15">take no arguments</a>.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-11">Unforgeable</a></code>]
+   <p>The [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-6">Unforgeable</a></code>]
 extended attribute must not appear on
-anything other than an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-61">attribute</a>,
-non-<a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-12">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-62">operation</a> or an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-78">interface</a>.  If it does
-appear on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-63">operation</a>, then
+anything other than an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-60">attribute</a> or a
+non-<a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-11">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-61">operation</a>. If it does
+appear on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-62">operation</a>, then
 it must appear on all operations with
 the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-54">identifier</a> on that interface.</p>
-   <p>If an attribute or operation <var>X</var> is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-1">unforgeable</a> on an interface <var>A</var>, and <var>A</var> is one of the <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces-15">inherited interfaces</a> of another interface <var>B</var>, then <var>B</var> and all of its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-20">consequential interfaces</a> must not have a non-static attribute or <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-11">regular operation</a> with the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-55">identifier</a> as <var>X</var>.</p>
+   <p>If an attribute or operation <var>X</var> is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-1">unforgeable</a> on an interface <var>A</var>, and <var>A</var> is one of the <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces-15">inherited interfaces</a> of another interface <var>B</var>, then <var>B</var> and all of its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-17">consequential interfaces</a> must not have a non-static attribute or <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-11">regular operation</a> with the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-55">identifier</a> as <var>X</var>.</p>
    <div class="note" role="note">
     <p>For example, the following is disallowed:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">A1</span> {
@@ -9146,35 +9127,15 @@ the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifi
 <span class="kt">interface</span> <span class="nv">Mixin</span> {
   <span class="kt">void</span> <span class="nv">x</span>();  // Invalid; B2’s copy of x would be shadowed by A1’s x.
 };
-
-[<span class="nv">Unforgeable</span>]
-<span class="kt">interface</span> <span class="nv">A2</span> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <span class="nv">x</span>;
-};
-<span class="kt">interface</span> <span class="nv">B3</span> : <span class="n">A2</span> {
-  <span class="kt">void</span> <span class="nv">x</span>();  // Invalid; would be shadowed by A2’s x.
-};
-
-<span class="kt">interface</span> <span class="nv">B4</span> : <span class="n">A2</span> { };
-<span class="n">B4</span> <span class="kt">implements</span> <span class="n">Mixin</span>;
-<span class="kt">interface</span> <span class="nv">Mixin</span> {
-  <span class="kt">void</span> <span class="nv">x</span>();  // Invalid; B4’s copy of x would be shadowed by A2’s x.
-};
-
-<span class="kt">interface</span> <span class="nv">A3</span> { };
-<span class="n">A3</span> <span class="kt">implements</span> <span class="n">A2</span>;
-<span class="kt">interface</span> <span class="nv">B5</span> : <span class="n">A3</span> {
-  <span class="kt">void</span> <span class="nv">x</span>();  // Invalid; would be shadowed by A3’s mixed-in copy of A2’s x.
-};
 </pre>
    </div>
    <p>See <a href="#es-attributes">§3.6.6 Attributes</a>, <a href="#es-operations">§3.6.7 Operations</a>, <a href="#es-platform-objects">§3.8 Platform objects implementing interfaces</a>, <a href="#indexed-and-named-properties">§3.8.1 Indexed and named properties</a> and <a href="#defineownproperty">§3.8.7 Platform object [[DefineOwnProperty]] method</a> for the specific requirements that the use of
-[<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-12">Unforgeable</a></code>] entails.</p>
+[<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-7">Unforgeable</a></code>] entails.</p>
    <div class="example" id="example-8fe6c799">
     <a class="self-link" href="#example-8fe6c799"></a> 
     <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-44">IDL fragment</a> defines
-    an interface that has two <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-62">attributes</a>,
-    one of which is designated as [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-13">Unforgeable</a></code>]:</p>
+    an interface that has two <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-61">attributes</a>,
+    one of which is designated as [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-8">Unforgeable</a></code>]:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">System</span> {
   [<span class="nv">Unforgeable</span>] <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <span class="nv">username</span>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <span class="kt">long</span> <span class="nv">loginTime</span>;
@@ -9203,7 +9164,7 @@ system<span class="p">.</span>loginTime<span class="p">;</span>  <span class="c1
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.21" data-lt="Unscopable" id="Unscopable"><span class="secno">3.3.21. </span><span class="content">[Unscopable]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-1">Unscopable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-81">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-10">regular attribute</a> or <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-12">regular operation</a>, it
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-1">Unscopable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-78">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-10">regular attribute</a> or <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-12">regular operation</a>, it
 indicates that an object that implements an interface with the given
 interface member will not include its property name in any object
 environment record with it as its base object.  The result of this is
@@ -9235,7 +9196,7 @@ anything other than a <a data-link-type="dfn" href="#dfn-regular-attribute" id="
    </div>
    <h3 class="heading settled" data-level="3.4" id="es-security"><span class="secno">3.4. </span><span class="content">Security</span><a class="self-link" href="#es-security"></a></h3>
    <p>Certain algorithms in the sections below are defined to <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-perform-a-security-check">perform a security check</dfn> on a given
-object.  This check is used to determine whether a given <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-64">operation</a> invocation or <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-63">attribute</a> access should be
+object.  This check is used to determine whether a given <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-63">operation</a> invocation or <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-62">attribute</a> access should be
 allowed.  The security check takes the following four inputs:</p>
    <ol>
     <li data-md="">
@@ -9258,7 +9219,7 @@ appropriate exception or return normally. <a data-link-type="biblio" href="#bibl
    <h3 class="heading settled" data-level="3.5" id="es-overloads"><span class="secno">3.5. </span><span class="content">Overload resolution algorithm</span><a class="self-link" href="#es-overloads"></a></h3>
    <div class="algorithm" data-algorithm="overload resolution algorithm">
     <p>In order to define how overloaded function invocations are resolved, the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-overload-resolution-algorithm">overload resolution algorithm</dfn> is defined.  Its input is an <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-4">effective overload set</a>, <var>S</var>, and a list of ECMAScript values, <var>arg</var><sub>0..<var>n</var>−1</sub>.
-    Its output is a pair consisting of the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-65">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-82">extended attribute</a> of one of <var>S</var>’s entries
+    Its output is a pair consisting of the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-64">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-79">extended attribute</a> of one of <var>S</var>’s entries
     and a list of IDL values or the special value “missing”.  The algorithm behaves as follows:</p>
     <ol>
      <li data-md="">
@@ -9563,7 +9524,7 @@ that has one of the above types in its <a data-link-type="dfn" href="#dfn-flatte
         <p>Otherwise: <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-42">throw a <emu-val>TypeError</emu-val></a>.</p>
       </ol>
      <li data-md="">
-      <p>Let <var>callable</var> be the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-66">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-83">extended attribute</a> of the single entry in <var>S</var>.</p>
+      <p>Let <var>callable</var> be the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-65">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-80">extended attribute</a> of the single entry in <var>S</var>.</p>
      <li data-md="">
       <p>If <var>i</var> = <var>d</var> and <var>method</var> is not <emu-val>undefined</emu-val>, then</p>
       <ol>
@@ -9668,14 +9629,14 @@ If there are none, then a <emu-val>TypeError</emu-val> is thrown.</p>
     of variadic argument as would be done for a non-optional argument.</p>
    </div>
    <h3 class="heading settled" data-level="3.6" id="es-interfaces"><span class="secno">3.6. </span><span class="content">Interfaces</span><a class="self-link" href="#es-interfaces"></a></h3>
-   <p>For every <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-79">interface</a> that
+   <p>For every <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-77">interface</a> that
 is <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-2">exposed</a> in a given
 ECMAScript global environment and:</p>
    <ul>
     <li data-md="">
      <p>is a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-25">callback interface</a> that has <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-21">constants</a> declared on it, or</p>
     <li data-md="">
-     <p>is a non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-80">interface</a> that is not declared with the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-13">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-84">extended attribute</a>,</p>
+     <p>is a non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-78">interface</a> that is not declared with the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-13">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-81">extended attribute</a>,</p>
    </ul>
    <p>a corresponding property must exist on the
 ECMAScript environment’s global object.
@@ -9691,9 +9652,9 @@ construction of objects that implement the interface.  The property has the
 attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.
 The characteristics of a named constructor are described in <a href="#named-constructors">§3.6.2 Named constructors</a>.</p>
    <h4 class="heading settled" data-level="3.6.1" id="interface-object"><span class="secno">3.6.1. </span><span class="content">Interface object</span><a class="self-link" href="#interface-object"></a></h4>
-   <p>The interface object for a given non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-81">interface</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-3">function object</a>.
+   <p>The interface object for a given non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-79">interface</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-3">function object</a>.
 It has properties that correspond to
-the <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-22">constants</a> and <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-13">static operations</a> defined on that interface, as described in sections <a href="#es-constants">§3.6.5 Constants</a> and <a href="#es-operations">§3.6.7 Operations</a>.</p>
+the <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-22">constants</a> and <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-12">static operations</a> defined on that interface, as described in sections <a href="#es-constants">§3.6.5 Constants</a> and <a href="#es-operations">§3.6.7 Operations</a>.</p>
    <p>The [[Prototype]] internal property of
 an interface object for a non-callback interface is determined as
 follows:</p>
@@ -9719,22 +9680,22 @@ the Function.prototype object.</p>
    <p class="note" role="note">Note: Remember that interface objects for callback interfaces only exist if they have <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-23">constants</a> declared on them;
 when they do exist, they are not <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-5">function objects</a>.</p>
    <h5 class="heading settled" data-level="3.6.1.1" id="es-interface-call"><span class="secno">3.6.1.1. </span><span class="content">Interface object [[Call]] method</span><a class="self-link" href="#es-interface-call"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-82">interface</a> is declared with a
-[<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-20">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-85">extended attribute</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-80">interface</a> is declared with a
+[<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-20">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-82">extended attribute</a>,
 then the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-7">interface object</a> can be called as a function to create an object that implements that
 interface.  Interfaces that do not have a constructor will throw
 an exception when called as a function.</p>
    <div class="algorithm" data-algorithm="to invoke the internal [[Call]] method of interface objects">
     <p>The internal [[Call]] method
     of the interface object behaves as follows, assuming <var>arg</var><sub>0..<var>n</var>−1</sub> is the list
-    of argument values passed to the constructor, and <var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-83">interface</a>:</p>
+    of argument values passed to the constructor, and <var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-81">interface</a>:</p>
     <ol>
      <li data-md="">
-      <p>If <var>I</var> was not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-21">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-86">extended attribute</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-43">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <var>I</var> was not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-21">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-83">extended attribute</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-43">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>Let <var>id</var> be the identifier of interface <var>I</var>.</p>
      <li data-md="">
-      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-5">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-58">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-84">interface</a> <var>I</var> and with argument count <var>n</var>.</p>
+      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-5">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-58">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-82">interface</a> <var>I</var> and with argument count <var>n</var>.</p>
      <li data-md="">
       <p>Let &lt;<var>constructor</var>, <var>values</var>> be the result of passing <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to the <a data-link-type="dfn" href="#dfn-overload-resolution-algorithm" id="ref-for-dfn-overload-resolution-algorithm-1">overload resolution algorithm</a>.</p>
      <li data-md="">
@@ -9751,13 +9712,13 @@ associated with the ECMAScript global environment associated
 with the interface object.</p>
    <div class="algorithm" data-algorithm="determine value of length property of non-callback interfaces">
     <p>Interface objects for non-callback interfaces must have a property named “length” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> whose value is a <emu-val>Number</emu-val>.
-    If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-22">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-87">extended attribute</a> does not appear on the interface definition, then the value is 0.
+    If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-22">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-84">extended attribute</a> does not appear on the interface definition, then the value is 0.
     Otherwise, the value is determined as follows:</p>
     <ol>
      <li data-md="">
       <p>Let <var>id</var> be the identifier of interface <var>I</var>.</p>
      <li data-md="">
-      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-6">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-59">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-85">interface</a> <var>I</var> and with argument count 0.</p>
+      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-6">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-59">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-83">interface</a> <var>I</var> and with argument count 0.</p>
      <li data-md="">
       <p>Return the length of the shortest argument list of the entries in <var>S</var>.</p>
     </ol>
@@ -9795,7 +9756,7 @@ return <emu-val>true</emu-val>.</p>
    </div>
    <h4 class="heading settled" data-level="3.6.2" id="named-constructors"><span class="secno">3.6.2. </span><span class="content">Named constructors</span><a class="self-link" href="#named-constructors"></a></h4>
    <p>A <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-2">named constructor</a> that exists due to one or more
-[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-17">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-88">extended attributes</a> with a given <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-60">identifier</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-6">function object</a>.
+[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-17">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-85">extended attributes</a> with a given <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-60">identifier</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-6">function object</a>.
 It must have a [[Call]] internal property,
 which allows construction of objects that
 implement the interface on which the
@@ -9804,11 +9765,11 @@ implement the interface on which the
     <p>It behaves as follows, assuming <var>arg</var><sub>0..<var>n</var>−1</sub> is the list
     of argument values passed to the constructor, <var>id</var> is the identifier of the constructor specified in the
     extended attribute <a data-link-type="dfn" href="#dfn-xattr-named-argument-list" id="ref-for-dfn-xattr-named-argument-list-4">named argument list</a>,
-    and <var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-86">interface</a> on which the
+    and <var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-84">interface</a> on which the
     [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-19">NamedConstructor</a></code>] extended attribute appears:</p>
     <ol>
      <li data-md="">
-      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-7">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-61">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-87">interface</a> <var>I</var> and with argument count <var>n</var>.</p>
+      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-7">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-61">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-85">interface</a> <var>I</var> and with argument count <var>n</var>.</p>
      <li data-md="">
       <p>Let &lt;<var>constructor</var>, <var>values</var>> be the result of passing <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to the <a data-link-type="dfn" href="#dfn-overload-resolution-algorithm" id="ref-for-dfn-overload-resolution-algorithm-2">overload resolution algorithm</a>.</p>
      <li data-md="">
@@ -9827,7 +9788,7 @@ with the <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-n
     <p>A named constructor must have a property named “length” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> whose value is a <emu-val>Number</emu-val> determined as follows:</p>
     <ol>
      <li data-md="">
-      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-8">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-62">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-88">interface</a> <var>I</var> and with argument count 0.</p>
+      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-8">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-62">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-86">interface</a> <var>I</var> and with argument count 0.</p>
      <li data-md="">
       <p>Return the length of the shortest argument list of the entries in <var>S</var>.</p>
     </ol>
@@ -9835,11 +9796,11 @@ with the <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-n
    <p>A named constructor must have a property named “name”
 with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> whose value is the identifier used for the named constructor.</p>
    <p>A named constructor must also have a property named
-“prototype” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span> whose value is the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-9">interface prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-89">interface</a> on which the
-[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-20">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-89">extended attribute</a> appears.</p>
+“prototype” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span> whose value is the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-9">interface prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-87">interface</a> on which the
+[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-20">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-86">extended attribute</a> appears.</p>
    <h4 class="heading settled" data-level="3.6.3" id="interface-prototype-object"><span class="secno">3.6.3. </span><span class="content">Interface prototype object</span><a class="self-link" href="#interface-prototype-object"></a></h4>
-   <p>There must exist an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-10">interface prototype object</a> for every non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-90">interface</a> defined, regardless of whether the interface was declared with the
-[<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-14">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-90">extended attribute</a>.
+   <p>There must exist an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-10">interface prototype object</a> for every non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-88">interface</a> defined, regardless of whether the interface was declared with the
+[<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-14">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-87">extended attribute</a>.
 The interface prototype object for a particular interface has
 properties that correspond to the <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-13">regular attributes</a> and <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-15">regular operations</a> defined on that interface.  These properties are described in more detail in
 sections <a href="#es-attributes">§3.6.6 Attributes</a> and <a href="#es-operations">§3.6.7 Operations</a>.</p>
@@ -9858,7 +9819,7 @@ is a reference to the interface object for the interface.</p>
     <ol>
      <li data-md="">
       <p>If <var>A</var> is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-31">Global</a></code>]
-or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-32">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-91">extended attribute</a>, and <var>A</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-3">supports named properties</a>, then
+or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-32">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-88">extended attribute</a>, and <var>A</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-3">supports named properties</a>, then
 return the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-4">named properties object</a> for <var>A</var>, as defined in <a href="#named-properties-object">§3.6.4 Named properties object</a>.</p>
      <li data-md="">
       <p>Otherwise, if <var>A</var> is declared to inherit from another
@@ -9871,8 +9832,8 @@ extended attribute, then return <a data-link-type="dfn" href="https://tc39.githu
     </ol>
    </div>
    <div class="note" role="note">
-    <p>The <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-13">interface prototype object</a> of an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-91">interface</a> that is defined with
-    the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-16">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-92">extended attribute</a> will be accessible if the interface is used as a <a data-link-type="dfn" href="#dfn-supplemental-interface" id="ref-for-dfn-supplemental-interface-5">non-supplemental interface</a>.
+    <p>The <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-13">interface prototype object</a> of an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-89">interface</a> that is defined with
+    the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-16">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-89">extended attribute</a> will be accessible if the interface is used as a <a data-link-type="dfn" href="#dfn-supplemental-interface" id="ref-for-dfn-supplemental-interface-5">non-supplemental interface</a>.
     For example, with the following IDL:</p>
 <pre class="highlight">[<span class="nv">NoInterfaceObject</span>]
 <span class="kt">interface</span> <span class="nv">Foo</span> {
@@ -9895,7 +9856,7 @@ extended attribute, then return <a data-link-type="dfn" href="https://tc39.githu
     it is an acceptable optimization for this object not to exist.</p>
    </div>
    <div class="algorithm" data-algorithm="value of @@unscopables symbol property of interface objects">
-    <p>If the interface or any of its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-21">consequential interfaces</a> has any <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-19">interface member</a> declared with
+    <p>If the interface or any of its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-18">consequential interfaces</a> has any <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-19">interface member</a> declared with
     the [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-5">Unscopable</a></code>] extended attribute,
     then there must be a property on the
     interface prototype object whose name is the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@unscopables</a> symbol
@@ -9913,14 +9874,14 @@ interface member, <emu-val>true</emu-val>).</p>
     </ol>
    </div>
    <p>If the interface is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-33">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-34">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-93">extended attribute</a>, or the interface is in the set
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-34">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-90">extended attribute</a>, or the interface is in the set
 of <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces-16">inherited interfaces</a> for any
 other interface that is declared with one of these attributes, then the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-14">interface prototype object</a> must be an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">immutable prototype exotic object</a>.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-1">class string</a> of an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-15">interface prototype object</a> is the concatenation of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-92">interface</a>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-64">identifier</a> and the string
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-1">class string</a> of an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-15">interface prototype object</a> is the concatenation of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-90">interface</a>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-64">identifier</a> and the string
 “Prototype”.</p>
    <h4 class="heading settled" data-level="3.6.4" id="named-properties-object"><span class="secno">3.6.4. </span><span class="content">Named properties object</span><a class="self-link" href="#named-properties-object"></a></h4>
-   <p>For every <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-93">interface</a> declared with the
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-35">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-36">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-94">extended attribute</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-4">supports named properties</a>,
+   <p>For every <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-91">interface</a> declared with the
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-35">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-36">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-91">extended attribute</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-4">supports named properties</a>,
 there must exist an object known as the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-named-properties-object">named properties object</dfn> for that interface.</p>
    <div class="algorithm" data-algorithm="value of [[Prototype]] property of named properties objects">
     <p>The <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-5">named properties object</a> for a given interface <var>A</var> must have an internal
@@ -9936,16 +9897,16 @@ extended attribute, then return <a data-link-type="dfn" href="https://tc39.githu
       <p>Otherwise, return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a>.</p>
     </ol>
    </div>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-2">class string</a> of a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-6">named properties object</a> is the concatenation of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-94">interface</a>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-65">identifier</a> and the string “Properties”.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-2">class string</a> of a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-6">named properties object</a> is the concatenation of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-92">interface</a>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-65">identifier</a> and the string “Properties”.</p>
    <h5 class="heading settled" data-level="3.6.4.1" id="named-properties-object-getownproperty"><span class="secno">3.6.4.1. </span><span class="content">Named properties object [[GetOwnProperty]] method</span><a class="self-link" href="#named-properties-object-getownproperty"></a></h5>
    <div class="algorithm" data-algorithm="to invoke the internal [[GetOwnProperty]] method of named properties object">
     <p>When the [[GetOwnProperty]] internal method of a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-7">named properties object</a> <var>O</var> is called with property key <var>P</var>, the following steps are taken:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>A</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-95">interface</a> for the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-8">named properties object</a> <var>O</var>.</p>
+      <p>Let <var>A</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-93">interface</a> for the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-8">named properties object</a> <var>O</var>.</p>
      <li data-md="">
       <p>Let <var>object</var> be the sole object from <var>O</var>’s ECMAScript global environment that implements <var>A</var>.</p>
-      <p class="note" role="note">Note: For example, if the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-96">interface</a> is the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> interface,
+      <p class="note" role="note">Note: For example, if the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-94">interface</a> is the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> interface,
 then the sole object will be this global environment’s window object.</p>
      <li data-md="">
       <p>If the result of running the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-1">named property visibility algorithm</a> with
@@ -9967,7 +9928,7 @@ of performing the steps listed in the description of <var>operation</var> with <
         <p>Set <var>desc</var>.[[Value]] to the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-41">converting</a> <var>value</var> to an ECMAScript value.</p>
        <li data-md="">
         <p>If <var>A</var> implements an interface with the
-[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-5">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-95">extended attribute</a>,
+[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-5">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-92">extended attribute</a>,
 then set <var>desc</var>.[[Enumerable]] to <emu-val>false</emu-val>,
 otherwise set it to <emu-val>true</emu-val>.</p>
        <li data-md="">
@@ -10012,7 +9973,7 @@ called, the same algorithm must be executed as is defined for the [[SetPrototype
     making [[PreventExtensions]] fail.</p>
    </div>
    <h4 class="heading settled" data-level="3.6.5" id="es-constants"><span class="secno">3.6.5. </span><span class="content">Constants</span><a class="self-link" href="#es-constants"></a></h4>
-   <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-4">exposed</a> <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-25">constant</a> defined on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-97">interface</a> <var>A</var>,
+   <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-4">exposed</a> <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-25">constant</a> defined on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-95">interface</a> <var>A</var>,
 there must be a corresponding property.
 The property has the following characteristics:</p>
    <ul>
@@ -10025,7 +9986,7 @@ The property has the following characteristics:</p>
        <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-37">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-38">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on the single object that implements the interface.</p>
       <li data-md="">
-       <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-22">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-39">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-40">PrimaryGlobal</a></code>] annotated interface, then
+       <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-19">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-39">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-40">PrimaryGlobal</a></code>] annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-41">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-42">PrimaryGlobal</a></code>]-annotated interface as well as on
 the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-17">interface prototype object</a>.</p>
@@ -10040,25 +10001,25 @@ the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-pro
    <p>In addition, a property with the same characteristics must
 exist on the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-12">interface object</a>, if that object exists.</p>
    <h4 class="heading settled" data-level="3.6.6" id="es-attributes"><span class="secno">3.6.6. </span><span class="content">Attributes</span><a class="self-link" href="#es-attributes"></a></h4>
-   <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-5">exposed</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-64">attribute</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-98">interface</a>, whether it
-was declared on the interface itself or one of its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-23">consequential interfaces</a>,
+   <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-5">exposed</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-63">attribute</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-96">interface</a>, whether it
+was declared on the interface itself or one of its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-20">consequential interfaces</a>,
 there must exist a corresponding property.
 The characteristics of this property are as follows:</p>
    <ul>
     <li data-md="">
-     <p>The name of the property is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-68">identifier</a> of the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-65">attribute</a>.</p>
+     <p>The name of the property is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-68">identifier</a> of the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-64">attribute</a>.</p>
     <li data-md="">
      <p>The location of the property is determined as follows:</p>
      <ul>
       <li data-md="">
-       <p>If the attribute is a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-12">static attribute</a>,
+       <p>If the attribute is a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-11">static attribute</a>,
 then there is a single corresponding property and it exists on the interface’s <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-13">interface object</a>.</p>
       <li data-md="">
        <p>Otherwise, if the attribute is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-2">unforgeable</a> on
 the interface or if the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-43">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-44">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on every object that implements the interface.</p>
       <li data-md="">
-       <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-24">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-45">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-46">PrimaryGlobal</a></code>]-annotated interface, then
+       <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-21">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-45">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-46">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-47">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-48">PrimaryGlobal</a></code>]-annotated interface as well as on
 the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-19">interface prototype object</a>.</p>
@@ -10071,7 +10032,7 @@ where:</p>
      <ul>
       <li data-md="">
        <p><var>configurable</var> is <emu-val>false</emu-val> if the attribute was
-declared with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-14">Unforgeable</a></code>] extended attribute and <emu-val>true</emu-val> otherwise;</p>
+declared with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-9">Unforgeable</a></code>] extended attribute and <emu-val>true</emu-val> otherwise;</p>
       <li data-md="">
        <p><var>G</var> is the <a data-link-type="dfn" href="#dfn-attribute-getter" id="ref-for-dfn-attribute-getter-2">attribute getter</a>, defined below; and</p>
       <li data-md="">
@@ -10084,10 +10045,10 @@ declared with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable"
        <li data-md="">
         <p>Let <var>idlValue</var> be an IDL value determined as follows.</p>
        <li data-md="">
-        <p>If the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-66">attribute</a> is a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-14">regular attribute</a>, then:</p>
+        <p>If the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-65">attribute</a> is a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-14">regular attribute</a>, then:</p>
         <ol>
          <li data-md="">
-          <p>Let <var>I</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-99">interface</a> whose <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-21">interface prototype object</a> this property corresponding to the attribute appears on.</p>
+          <p>Let <var>I</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-97">interface</a> whose <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-21">interface prototype object</a> this property corresponding to the attribute appears on.</p>
           <p class="note" role="note">Note: This means that even if an implements statement was used to make
 an attribute available on the interface, <var>I</var> is the interface
 on the left hand side of the implements statement, and not the one
@@ -10104,7 +10065,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
             <p>the ECMAScript global environment associated with this <emu-val>Function</emu-val> that
 implements the <a data-link-type="dfn" href="#dfn-attribute-getter" id="ref-for-dfn-attribute-getter-3">attribute getter</a>,</p>
            <li data-md="">
-            <p>the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-69">identifier</a> of the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-67">attribute</a>, and</p>
+            <p>the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-69">identifier</a> of the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-66">attribute</a>, and</p>
            <li data-md="">
             <p>the type “getter”.</p>
           </ul>
@@ -10112,8 +10073,8 @@ implements the <a data-link-type="dfn" href="#dfn-attribute-getter" id="ref-for-
           <p>If <var>O</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-21">platform object</a> that implements <var>I</var>, then:</p>
           <ol>
            <li data-md="">
-            <p>If the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-68">attribute</a> was specified with the
-[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-8">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-96">extended attribute</a>,
+            <p>If the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-67">attribute</a> was specified with the
+[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-8">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-93">extended attribute</a>,
 then return <emu-val>undefined</emu-val>.</p>
            <li data-md="">
             <p>Otherwise, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-45">throw a <emu-val>TypeError</emu-val></a>.</p>
@@ -10124,7 +10085,7 @@ then return <emu-val>undefined</emu-val>.</p>
 with <var>O</var> as the object.</p>
         </ol>
        <li data-md="">
-        <p>Otherwise, the attribute is a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-13">static attribute</a>.
+        <p>Otherwise, the attribute is a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-12">static attribute</a>.
 Set <var>idlValue</var> to be the result of performing the actions listed in the description of the attribute that occur when getting.</p>
        <li data-md="">
         <p>Let <var>V</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-43">converting</a> <var>idlValue</var> to an ECMAScript value.</p>
@@ -10140,7 +10101,7 @@ concatenation of “get ” and the identifier of the attribute.</p>
     <li data-md="">
      <div class="algorithm" data-algorithm="attribute setter">
       <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-attribute-setter">attribute setter</dfn> is <emu-val>undefined</emu-val> if the attribute is declared <code>readonly</code> and does not have a
-    [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-9">LenientThis</a></code>], [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-15">PutForwards</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-11">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-97">extended attribute</a> declared on it.
+    [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-9">LenientThis</a></code>], [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-15">PutForwards</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-11">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-94">extended attribute</a> declared on it.
     Otherwise, it is a <emu-val>Function</emu-val> object whose behavior when invoked is as follows:</p>
       <ol>
        <li data-md="">
@@ -10148,10 +10109,10 @@ concatenation of “get ” and the identifier of the attribute.</p>
        <li data-md="">
         <p>Let <var>V</var> be the value of the first argument passed to the <emu-val>Function</emu-val>.</p>
        <li data-md="">
-        <p>If the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-69">attribute</a> is a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-15">regular attribute</a>, then:</p>
+        <p>If the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-68">attribute</a> is a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-15">regular attribute</a>, then:</p>
         <ol>
          <li data-md="">
-          <p>Let <var>I</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-100">interface</a> whose <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-22">interface prototype object</a> this property corresponding to the attribute appears on.</p>
+          <p>Let <var>I</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-98">interface</a> whose <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-22">interface prototype object</a> this property corresponding to the attribute appears on.</p>
          <li data-md="">
           <p>Let <var>O</var> be the <emu-val>this</emu-val> value.</p>
          <li data-md="">
@@ -10164,15 +10125,15 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
             <p>the ECMAScript global environment associated with this <emu-val>Function</emu-val> that
 implements the <a data-link-type="dfn" href="#dfn-attribute-setter" id="ref-for-dfn-attribute-setter-3">attribute setter</a>,</p>
            <li data-md="">
-            <p>the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-70">identifier</a> of the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-70">attribute</a>, and</p>
+            <p>the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-70">identifier</a> of the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-69">attribute</a>, and</p>
            <li data-md="">
             <p>the type “setter”.</p>
           </ul>
          <li data-md="">
           <p>Let <var>validThis</var> be <emu-val>true</emu-val> if <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-23">platform object</a> that implements <var>I</var>, or <emu-val>false</emu-val> otherwise.</p>
          <li data-md="">
-          <p>If <var>validThis</var> is <emu-val>false</emu-val> and the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-71">attribute</a> was not specified with the
-[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-10">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-98">extended attribute</a>,
+          <p>If <var>validThis</var> is <emu-val>false</emu-val> and the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-70">attribute</a> was not specified with the
+[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-10">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-95">extended attribute</a>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-47">throw a <emu-val>TypeError</emu-val></a>.</p>
          <li data-md="">
           <p>If the attribute is declared with a [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-12">Replaceable</a></code>]
@@ -10228,7 +10189,7 @@ The value of <var>idlValue</var> is the result of <a data-link-type="dfn" href="
         <p>If the attribute is a regular attribute, then perform the actions listed in the description of the attribute that occur when setting,
 with <var>O</var> as the object and <var>idlValue</var> as the value.</p>
        <li data-md="">
-        <p>Otherwise, the attribute is a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-14">static attribute</a>.
+        <p>Otherwise, the attribute is a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-13">static attribute</a>.
 Perform the actions listed in the description of the attribute that occur when setting with <var>idlValue</var> as the value.</p>
        <li data-md="">
         <p>Return <emu-val>undefined</emu-val>.</p>
@@ -10243,12 +10204,12 @@ concatenation of “set ” and the identifier of the attribute.</p>
    <p class="note" role="note">Note: Although there is only a single property for an IDL attribute, since
 accessor property getters and setters are passed a <emu-val>this</emu-val> value for the object on which property corresponding to the IDL attribute is
 accessed, they are able to expose instance-specific data.</p>
-   <p class="note" role="note">Note: Note that attempting to assign to a property corresponding to a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-14">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-72">attribute</a> results in different behavior depending on whether the script doing so is in strict mode.
+   <p class="note" role="note">Note: Note that attempting to assign to a property corresponding to a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-14">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-71">attribute</a> results in different behavior depending on whether the script doing so is in strict mode.
 When in strict mode, such an assignment will result in a <emu-val>TypeError</emu-val> being thrown.  When not in strict mode, the assignment attempt will be ignored.</p>
    <h4 class="heading settled" data-level="3.6.7" id="es-operations"><span class="secno">3.6.7. </span><span class="content">Operations</span><a class="self-link" href="#es-operations"></a></h4>
-   <p>For each unique <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-71">identifier</a> of an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-6">exposed</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-67">operation</a> defined on the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-101">interface</a>, there
+   <p>For each unique <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-71">identifier</a> of an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-6">exposed</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-66">operation</a> defined on the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-99">interface</a>, there
 must exist a corresponding property,
-unless the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-9">effective overload set</a> for that <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-72">identifier</a> and <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-68">operation</a> and with an argument count of 0 has no entries.</p>
+unless the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-9">effective overload set</a> for that <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-72">identifier</a> and <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-67">operation</a> and with an argument count of 0 has no entries.</p>
    <p>The characteristics of this property are as follows:</p>
    <ul>
     <li data-md="">
@@ -10257,14 +10218,14 @@ unless the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-fo
      <p>The location of the property is determined as follows:</p>
      <ul>
       <li data-md="">
-       <p>If the operation is <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-14">static</a>, then
+       <p>If the operation is <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-13">static</a>, then
 the property exists on the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-14">interface object</a>.</p>
       <li data-md="">
        <p>Otherwise, if the operation is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-3">unforgeable</a> on
 the interface or if the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-49">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-50">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on every object that implements the interface.</p>
       <li data-md="">
-       <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-25">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-51">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-52">PrimaryGlobal</a></code>]-annotated interface, then
+       <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-22">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-51">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-52">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-53">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-54">PrimaryGlobal</a></code>]-annotated interface as well as on
 the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-23">interface prototype object</a>.</p>
@@ -10287,7 +10248,7 @@ where the operation was originally declared.</p>
    <p>For <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-10">namespaces</a>, the properties corresponding to each declared operation are described in <a href="#namespace-object">§3.11.1 Namespace object</a>. (We hope to eventually move interfaces to the same explicit
 property-installation style as namespaces.)</p>
    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="creating an operation function" data-noexport="" id="dfn-create-operation-function">create an operation function</dfn>,
-given an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-69">operation</a> <var>op</var>, a <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-11">namespace</a> or <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-102">interface</a> <var>target</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>:</p>
+given an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-68">operation</a> <var>op</var>, a <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-11">namespace</a> or <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-100">interface</a> <var>target</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>:</p>
    <ol>
     <li data-md="">
      <p>Let <var>id</var> be <var>op</var>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-74">identifier</a>.</p>
@@ -10301,7 +10262,7 @@ values <var>arg</var><sub>0..<var>n</var>−1</sub>:</p>
         <li data-md="">
          <p>Let <var>O</var> be <emu-val>null</emu-val>.</p>
         <li data-md="">
-         <p>If <var>target</var> is an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-103">interface</a>, and <var>op</var> is not a <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-15">static operation</a>:</p>
+         <p>If <var>target</var> is an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-101">interface</a>, and <var>op</var> is not a <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-14">static operation</a>:</p>
          <ol>
           <li data-md="">
            <p>If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, set <var>O</var> to <var>realm</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global">global object</a>. (This
@@ -10316,7 +10277,7 @@ object does not implement <var>target</var>.)</p>
          </ol>
         <li data-md="">
          <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-10">effective overload set</a> for <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-16">regular operations</a> (if <var>op</var> is a
-regular operation) or for <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-16">static operations</a> (if <var>op</var> is a static operation) with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-75">identifier</a> <var>id</var> on <var>target</var> and with argument count <var>n</var>.</p>
+regular operation) or for <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-15">static operations</a> (if <var>op</var> is a static operation) with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-75">identifier</a> <var>id</var> on <var>target</var> and with argument count <var>n</var>.</p>
         <li data-md="">
          <p>Let &lt;<var>operation</var>, <var>values</var>> be the result of passing <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to the <a data-link-type="dfn" href="#dfn-overload-resolution-algorithm" id="ref-for-dfn-overload-resolution-algorithm-3">overload resolution algorithm</a>.</p>
         <li data-md="">
@@ -10347,7 +10308,7 @@ and the exception as the single argument value.</p>
      <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-setfunctionname">SetFunctionName</a>(<var>F</var>, <var>id</var>).</p>
     <li data-md="">
      <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-11">effective overload set</a> for <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-17">regular operations</a> (if <var>op</var> is a regular
-operation) or for <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-17">static operations</a> (if <var>op</var> is a static operation) with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-76">identifier</a> <var>id</var> on <var>target</var> and with argument count 0.</p>
+operation) or for <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-16">static operations</a> (if <var>op</var> is a static operation) with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-76">identifier</a> <var>id</var> on <var>target</var> and with argument count 0.</p>
     <li data-md="">
      <p>Let <var>length</var> be the length of the shortest argument list in the entries in <var>S</var>.</p>
     <li data-md="">
@@ -10355,7 +10316,7 @@ operation) or for <a data-link-type="dfn" href="#dfn-static-operation" id="ref-f
 PropertyDescriptor<span class="prop-desc">{[[Value]]: <var>length</var>, [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val>}</span>).</p>
    </ol>
    <h5 class="heading settled" data-level="3.6.7.1" id="es-stringifier"><span class="secno">3.6.7.1. </span><span class="content">Stringifiers</span><a class="self-link" href="#es-stringifier"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-104">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-7">exposed</a> <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-3">stringifier</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-102">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-7">exposed</a> <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-3">stringifier</a>,
 then there must exist a property with the following characteristics:</p>
    <ul>
     <li data-md="">
@@ -10390,26 +10351,26 @@ implements the <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-s
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-105">interface</a> on which the stringifier was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-50">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-103">interface</a> on which the stringifier was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-50">throw a <emu-val>TypeError</emu-val></a>.</p>
        <li data-md="">
         <p>Let <var>V</var> be an uninitialized variable.</p>
        <li data-md="">
         <p>Depending on where <code>stringifier</code> was specified:</p>
         <dl class="switch">
          <dt data-md="">
-          <p>on an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-73">attribute</a></p>
+          <p>on an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-72">attribute</a></p>
          <dd data-md="">
           <p>Set <var>V</var> to the result of performing the actions listed in the description of the attribute that occur when getting
 (or those listed in the description of the inherited attribute, if this attribute is declared to <a data-link-type="dfn" href="#dfn-inherit-getter" id="ref-for-dfn-inherit-getter-3">inherit its getter</a>),
 with <var>O</var> as the object.</p>
          <dt data-md="">
-          <p>on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-70">operation</a> with an identifier</p>
+          <p>on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-69">operation</a> with an identifier</p>
          <dd data-md="">
           <p>Set <var>V</var> to the result of performing the actions listed in the description
 of the operation, using <var>O</var> as the <emu-val>this</emu-val> value
 and passing no arguments.</p>
          <dt data-md="">
-          <p>on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-71">operation</a> with no identifier</p>
+          <p>on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-70">operation</a> with no identifier</p>
          <dd data-md="">
           <p>Set <var>V</var> to the result of performing the <a data-link-type="dfn" href="#dfn-stringification-behavior" id="ref-for-dfn-stringification-behavior-1">stringification behavior</a> of the interface.</p>
         </dl>
@@ -10425,7 +10386,7 @@ property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
 property is the <emu-val>String</emu-val> value “toString”.</p>
    </ul>
    <h5 class="heading settled" data-level="3.6.7.2" id="es-serializer"><span class="secno">3.6.7.2. </span><span class="content">Serializers</span><a class="self-link" href="#es-serializer"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-106">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-8">exposed</a> <a data-link-type="dfn" href="#dfn-serializer" id="ref-for-dfn-serializer-5">serializer</a>, then
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-104">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-8">exposed</a> <a data-link-type="dfn" href="#dfn-serializer" id="ref-for-dfn-serializer-5">serializer</a>, then
 a property must exist whose name is “toJSON”, with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <emu-val>Function</emu-val> object.</p>
    <p>The location of the property is determined as follows:</p>
    <ul>
@@ -10433,7 +10394,7 @@ a property must exist whose name is “toJSON”, with attributes <span class="p
      <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-57">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-58">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on the single object that implements the interface.</p>
     <li data-md="">
-     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-26">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-59">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-60">PrimaryGlobal</a></code>]-annotated interface, then
+     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-23">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-59">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-60">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-61">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-62">PrimaryGlobal</a></code>]-annotated interface as well as on
 the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-26">interface prototype object</a>.</p>
@@ -10461,12 +10422,12 @@ implements the <a data-link-type="dfn" href="#dfn-serializer" id="ref-for-dfn-se
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-107">interface</a> on which the serializer was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-51">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-105">interface</a> on which the serializer was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-51">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>Depending on how <code>serializer</code> was specified:</p>
       <dl class="switch">
        <dt data-md="">
-        <p>on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-72">operation</a> with an identifier</p>
+        <p>on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-71">operation</a> with an identifier</p>
        <dd data-md="">
         <ol>
          <li data-md="">
@@ -10478,7 +10439,7 @@ using <var>O</var> as the <emu-val>this</emu-val> value and passing no arguments
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-serialized-value" id="ref-for-dfn-serialized-value-8">serialized value</a> that is the result of invoking the <a data-link-type="dfn" href="#dfn-serialization-behavior" id="ref-for-dfn-serialization-behavior-15">serialization behavior</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-108">interface</a> for object <var>O</var>.</p>
+          <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-serialized-value" id="ref-for-dfn-serialized-value-8">serialized value</a> that is the result of invoking the <a data-link-type="dfn" href="#dfn-serialization-behavior" id="ref-for-dfn-serialization-behavior-15">serialization behavior</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-106">interface</a> for object <var>O</var>.</p>
          <li data-md="">
           <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-serialized-value-to-ecmascript-value" id="ref-for-dfn-convert-serialized-value-to-ecmascript-value-1">converting</a> <var>S</var> to an ECMAScript value.</p>
         </ol>
@@ -10551,13 +10512,13 @@ property is the <emu-val>String</emu-val> value “toJSON”.</p>
    </div>
    <h4 class="heading settled" data-level="3.6.8" id="es-iterators"><span class="secno">3.6.8. </span><span class="content">Common iterator behavior</span><a class="self-link" href="#es-iterators"></a></h4>
    <h5 class="heading settled" data-level="3.6.8.1" id="es-iterator"><span class="secno">3.6.8.1. </span><span class="content">@@iterator</span><a class="self-link" href="#es-iterator"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-109">interface</a> has any of the following:</p>
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-107">interface</a> has any of the following:</p>
    <ul>
     <li data-md="">
      <p>an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-9">iterable declaration</a></p>
     <li data-md="">
      <p>an <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-5">indexed property getter</a> and
-an <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-6">integer-typed</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-74">attribute</a> named “length”</p>
+an <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-6">integer-typed</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-73">attribute</a> named “length”</p>
     <li data-md="">
      <p>a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-7">maplike declaration</a></p>
     <li data-md="">
@@ -10571,7 +10532,7 @@ whose name is the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#
      <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-63">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-64">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on the single object that implements the interface.</p>
     <li data-md="">
-     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-27">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-65">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-66">PrimaryGlobal</a></code>]-annotated interface, then
+     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-24">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-65">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-66">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-67">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-68">PrimaryGlobal</a></code>]-annotated interface as well as on
 the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-28">interface prototype object</a>.</p>
@@ -10600,7 +10561,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-110">interface</a> the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-10">iterable declaration</a> is on.</p>
+      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-108">interface</a> the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-10">iterable declaration</a> is on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-29">platform object</a> that implements <var>interface</var>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-52">throw a <emu-val>TypeError</emu-val></a>.</p>
@@ -10631,7 +10592,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-31">platform object</a> that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-111">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-9">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-9">setlike declaration</a> is defined,
+      <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-31">platform object</a> that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-109">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-9">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-9">setlike declaration</a> is defined,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-53">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>If the interface has a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-10">maplike declaration</a>, then:</p>
@@ -10658,7 +10619,7 @@ is the <emu-val>String</emu-val> value “entries”
 if the interface has a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-5">pair iterator</a> or a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-11">maplike declaration</a> and the <emu-val>String</emu-val> “values”
 if the interface has a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-10">setlike declaration</a>.</p>
    <h5 class="heading settled" data-level="3.6.8.2" id="es-forEach"><span class="secno">3.6.8.2. </span><span class="content">forEach</span><a class="self-link" href="#es-forEach"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-112">interface</a> has any of the following:</p>
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-110">interface</a> has any of the following:</p>
    <ul>
     <li data-md="">
      <p>an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-11">iterable declaration</a></p>
@@ -10674,7 +10635,7 @@ if the interface has a <a data-link-type="dfn" href="#dfn-setlike-declaration" i
      <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-69">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-70">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on the single object that implements the interface.</p>
     <li data-md="">
-     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-28">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-71">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-72">PrimaryGlobal</a></code>]-annotated interface, then
+     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-25">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-71">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-72">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-73">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-74">PrimaryGlobal</a></code>]-annotated interface as well as on
 the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-30">interface prototype object</a>.</p>
@@ -10688,7 +10649,7 @@ the initial value of the “forEach” data property of <a data-link-type="dfn" 
     <p>If the interface has a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-6">pair iterator</a>,
     then the <emu-val>Function</emu-val> must have the same behavior,
     when invoked with argument <var>callback</var> and optional argument <var>thisArg</var>,
-    as one that would exist assuming the interface had this <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-73">operation</a> instead of the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-12">iterable declaration</a>:</p>
+    as one that would exist assuming the interface had this <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-72">operation</a> instead of the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-12">iterable declaration</a>:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Iterable</span> {
   <span class="kt">void</span> <span class="nv">forEach</span>(<span class="n">Function</span> <span class="nv">callback</span>, <span class="kt">optional</span> <span class="kt">any</span> <span class="nv">thisArg</span>);
 };
@@ -10740,7 +10701,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-113">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-14">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-13">setlike declaration</a> is declared.</p>
+      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-111">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-14">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-13">setlike declaration</a> is declared.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-33">platform object</a> that implements <var>interface</var>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-54">throw a <emu-val>TypeError</emu-val></a>.</p>
@@ -10784,7 +10745,7 @@ property is the <emu-val>Number</emu-val> value <emu-val>1</emu-val>.</p>
 property is the <emu-val>String</emu-val> value “forEach”.</p>
    <h4 class="heading settled" data-level="3.6.9" id="es-iterable"><span class="secno">3.6.9. </span><span class="content">Iterable declarations</span><a class="self-link" href="#es-iterable"></a></h4>
    <h5 class="heading settled" data-level="3.6.9.1" id="es-iterable-entries"><span class="secno">3.6.9.1. </span><span class="content">entries</span><a class="self-link" href="#es-iterable-entries"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-114">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-13">iterable declaration</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-112">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-13">iterable declaration</a>,
 then a property named “entries” must exist with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-9">function object</a>.</p>
    <p>The location of the property is determined as follows:</p>
    <ul>
@@ -10792,7 +10753,7 @@ then a property named “entries” must exist with attributes <span class="prop
      <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-75">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-76">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on the single object that implements the interface.</p>
     <li data-md="">
-     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-29">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-77">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-78">PrimaryGlobal</a></code>]-annotated interface, then
+     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-26">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-77">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-78">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-79">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-80">PrimaryGlobal</a></code>]-annotated interface as well as on
 the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-32">interface prototype object</a>.</p>
@@ -10806,7 +10767,7 @@ the initial value of the “entries” data property of <a data-link-type="dfn" 
 then the <emu-val>Function</emu-val> object is
 the value of the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> property.</p>
    <h5 class="heading settled" data-level="3.6.9.2" id="es-iterable-keys"><span class="secno">3.6.9.2. </span><span class="content">keys</span><a class="self-link" href="#es-iterable-keys"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-115">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-14">iterable declaration</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-113">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-14">iterable declaration</a>,
 then a property named “keys” must exist with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-10">function object</a>.</p>
    <p>The location of the property is determined as follows:</p>
    <ul>
@@ -10814,7 +10775,7 @@ then a property named “keys” must exist with attributes <span class="prop-de
      <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-81">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-82">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on the single object that implements the interface.</p>
     <li data-md="">
-     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-30">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-83">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-84">PrimaryGlobal</a></code>]-annotated interface, then
+     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-27">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-83">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-84">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-85">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-86">PrimaryGlobal</a></code>]-annotated interface as well as on
 the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-34">interface prototype object</a>.</p>
@@ -10844,7 +10805,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-116">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-15">iterable declaration</a> is declared on.</p>
+      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-114">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-15">iterable declaration</a> is declared on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-35">platform object</a> that implements <var>interface</var>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-57">throw a <emu-val>TypeError</emu-val></a>.</p>
@@ -10857,7 +10818,7 @@ then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-thr
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “keys”.</p>
    <h5 class="heading settled" data-level="3.6.9.3" id="es-iterable-values"><span class="secno">3.6.9.3. </span><span class="content">values</span><a class="self-link" href="#es-iterable-values"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-117">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-16">iterable declaration</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-115">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-16">iterable declaration</a>,
 then a property named “values” must exist
 with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-11">function object</a>.</p>
    <p>The location of the property is determined as follows:</p>
@@ -10866,7 +10827,7 @@ with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>,
      <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-87">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-88">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on the single object that implements the interface.</p>
     <li data-md="">
-     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-31">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-89">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-90">PrimaryGlobal</a></code>]-annotated interface, then
+     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-28">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-89">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-90">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-91">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-92">PrimaryGlobal</a></code>]-annotated interface as well as on
 the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-36">interface prototype object</a>.</p>
@@ -10896,7 +10857,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-118">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-17">iterable declaration</a> is declared on.</p>
+      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-116">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-17">iterable declaration</a> is declared on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-37">platform object</a> that implements <var>interface</var>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-58">throw a <emu-val>TypeError</emu-val></a>.</p>
@@ -10909,8 +10870,8 @@ then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-thr
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “values”.</p>
    <h5 class="heading settled" data-level="3.6.9.4" id="es-default-iterator-object"><span class="secno">3.6.9.4. </span><span class="content">Default iterator objects</span><a class="self-link" href="#es-default-iterator-object"></a></h5>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-default-iterator-object">default iterator object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-119">interface</a>, target and iteration kind
-is an object whose internal [[Prototype]] property is the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-2">iterator prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-120">interface</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-default-iterator-object">default iterator object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-117">interface</a>, target and iteration kind
+is an object whose internal [[Prototype]] property is the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-2">iterator prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-118">interface</a>.</p>
    <p>A <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-4">default iterator object</a> has three internal values:</p>
    <ol>
     <li data-md="">
@@ -10925,16 +10886,16 @@ restricted to iterating over an object’s <a data-link-type="dfn" href="#dfn-su
 use standard ECMAScript Array iterator objects.</p>
    <p>When a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-5">default iterator object</a> is first created,
 its index is set to 0.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-3">class string</a> of a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-6">default iterator object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-121">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-79">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-122">interface</a> and the string “Iterator”.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-3">class string</a> of a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-6">default iterator object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-119">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-79">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-120">interface</a> and the string “Iterator”.</p>
    <h5 class="heading settled" data-level="3.6.9.5" id="es-iterator-prototype-object"><span class="secno">3.6.9.5. </span><span class="content">Iterator prototype object</span><a class="self-link" href="#es-iterator-prototype-object"></a></h5>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-iterator-prototype-object">iterator prototype object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-123">interface</a> is an object that exists for every interface that has a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-11">pair iterator</a>.  It serves as the
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-iterator-prototype-object">iterator prototype object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-121">interface</a> is an object that exists for every interface that has a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-11">pair iterator</a>.  It serves as the
 prototype for <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-7">default iterator objects</a> for the interface.</p>
    <p>The internal [[Prototype]] property of an <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-3">iterator prototype object</a> must be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%IteratorPrototype%</a>.</p>
    <div class="algorithm" data-algorithm="to invoke the next property of iterators">
     <p>An <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-4">iterator prototype object</a> must have a property named “next” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-12">function object</a> that behaves as follows:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-124">interface</a> for which the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-5">iterator prototype object</a> exists.</p>
+      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-122">interface</a> for which the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-5">iterator prototype object</a> exists.</p>
      <li data-md="">
       <p>Let <var>object</var> be the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-toobject">ToObject</a> on the <emu-val>this</emu-val> value.</p>
      <li data-md="">
@@ -11019,13 +10980,13 @@ return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createi
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createiterresultobject">CreateIterResultObject</a>(<var>result</var>, <emu-val>false</emu-val>).</p>
     </ol>
    </div>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-4">class string</a> of an <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-6">iterator prototype object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-125">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-80">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-126">interface</a> and the string “Iterator”.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-4">class string</a> of an <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-6">iterator prototype object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-123">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-80">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-124">interface</a> and the string “Iterator”.</p>
    <h4 class="heading settled" data-level="3.6.10" id="es-maplike"><span class="secno">3.6.10. </span><span class="content">Maplike declarations</span><a class="self-link" href="#es-maplike"></a></h4>
-   <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-127">interface</a> that has a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-16">maplike declaration</a> must have a [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
+   <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-125">interface</a> that has a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-16">maplike declaration</a> must have a [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
 initially set to a newly created <emu-val>Map</emu-val> object.
 This <emu-val>Map</emu-val> object’s [[MapData]] internal slot is
 the object’s <a data-link-type="dfn" href="#dfn-map-entries" id="ref-for-dfn-map-entries-3">map entries</a>.</p>
-   <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-128">interface</a> <var>A</var> is declared with
+   <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-126">interface</a> <var>A</var> is declared with
 a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-17">maplike declaration</a>, then
 there exists a number of additional properties on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-38">interface prototype object</a>.
 These additional properties are described in the sub-sections below.</p>
@@ -11163,7 +11124,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
    <p>The value of the <emu-val>Function</emu-val> objects’ “length” properties is the <emu-val>Number</emu-val> value <emu-val>1</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “get” or “has”, correspondingly.</p>
    <h5 class="heading settled" data-level="3.6.10.5" id="es-map-clear"><span class="secno">3.6.10.5. </span><span class="content">clear</span><a class="self-link" href="#es-map-clear"></a></h5>
-   <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-32">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-21">interface member</a> with identifier “clear”, and <var>A</var> was declared with a read–write maplike declaration,
+   <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-29">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-21">interface member</a> with identifier “clear”, and <var>A</var> was declared with a read–write maplike declaration,
 then a property named “clear” and the following characteristics
 must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-43">interface prototype object</a>:</p>
    <ul>
@@ -11175,7 +11136,7 @@ must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prot
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “clear”.</p>
    <h5 class="heading settled" data-level="3.6.10.6" id="es-map-delete"><span class="secno">3.6.10.6. </span><span class="content">delete</span><a class="self-link" href="#es-map-delete"></a></h5>
-   <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-33">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-22">interface member</a> with identifier “delete”, and <var>A</var> was declared with a read–write maplike declaration,
+   <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-30">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-22">interface member</a> with identifier “delete”, and <var>A</var> was declared with a read–write maplike declaration,
 then a property named “delete” and the following characteristics
 must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-44">interface prototype object</a>:</p>
    <ul>
@@ -11222,7 +11183,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>1</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “delete”.</p>
    <h5 class="heading settled" data-level="3.6.10.7" id="es-map-set"><span class="secno">3.6.10.7. </span><span class="content">set</span><a class="self-link" href="#es-map-set"></a></h5>
-   <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-34">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-23">interface member</a> with identifier “set”,
+   <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-31">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-23">interface member</a> with identifier “set”,
 and <var>A</var> was declared with a read–write maplike declaration,
 then a property named “set” and the following characteristics
 must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-45">interface prototype object</a>:</p>
@@ -11278,11 +11239,11 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>2</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “set”.</p>
    <h4 class="heading settled" data-level="3.6.11" id="es-setlike"><span class="secno">3.6.11. </span><span class="content">Setlike declarations</span><a class="self-link" href="#es-setlike"></a></h4>
-   <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-129">interface</a> that has a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-14">setlike declaration</a> must have a [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
+   <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-127">interface</a> that has a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-14">setlike declaration</a> must have a [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
 initially set to a newly created <emu-val>Set</emu-val> object.
 This <emu-val>Set</emu-val> object’s [[SetData]] internal slot is
 the object’s <a data-link-type="dfn" href="#dfn-set-entries" id="ref-for-dfn-set-entries-3">set entries</a>.</p>
-   <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-130">interface</a> <var>A</var> is declared with a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-15">setlike declaration</a>, then
+   <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-128">interface</a> <var>A</var> is declared with a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-15">setlike declaration</a>, then
 there exists a number of additional properties
 on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-46">interface prototype object</a>.
 These additional properties are described in the sub-sections below.</p>
@@ -11426,7 +11387,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
    <p>For both of “add” and “delete”, if:</p>
    <ul>
     <li data-md="">
-     <p><var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-35">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-24">interface member</a> with a matching identifier, and</p>
+     <p><var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-32">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-24">interface member</a> with a matching identifier, and</p>
     <li data-md="">
      <p><var>A</var> was declared with a read–write setlike declaration,</p>
    </ul>
@@ -11482,7 +11443,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>1</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “add” or “delete”, correspondingly.</p>
    <h5 class="heading settled" data-level="3.6.11.6" id="es-set-clear"><span class="secno">3.6.11.6. </span><span class="content">clear</span><a class="self-link" href="#es-set-clear"></a></h5>
-   <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-36">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-25">interface member</a> with a matching identifier, and <var>A</var> was declared with a read–write setlike declaration,
+   <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-33">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-25">interface member</a> with a matching identifier, and <var>A</var> was declared with a read–write setlike declaration,
 then a property named “clear” and the following characteristics
 must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-52">interface prototype object</a>:</p>
    <ul>
@@ -11495,17 +11456,17 @@ must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prot
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “clear”.</p>
    <h3 class="heading settled" data-level="3.7" id="es-implements-statements"><span class="secno">3.7. </span><span class="content">Implements statements</span><a class="self-link" href="#es-implements-statements"></a></h3>
    <p>The <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-53">interface prototype object</a> of an interface <var>A</var> must have a copy of
-each property that corresponds to one of the <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-28">constants</a>, <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-75">attributes</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-74">operations</a>, <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-18">iterable declarations</a>, <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-21">maplike declarations</a> and <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-18">setlike declarations</a> that exist on all of the interface prototype objects of <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-37">consequential interfaces</a>.
+each property that corresponds to one of the <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-28">constants</a>, <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-74">attributes</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-73">operations</a>, <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-18">iterable declarations</a>, <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-21">maplike declarations</a> and <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-18">setlike declarations</a> that exist on all of the interface prototype objects of <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-34">consequential interfaces</a>.
 For operations, where the property is a data property with a <emu-val>Function</emu-val> object value, each copy of the property must have
 distinct <emu-val>Function</emu-val> objects.  For attributes, each
 copy of the accessor property must have
 distinct <emu-val>Function</emu-val> objects for their getters,
 and similarly with their setters.</p>
    <div class="note" role="note">
-    <p>When invoking an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-75">operation</a> by calling
+    <p>When invoking an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-74">operation</a> by calling
     a <emu-val>Function</emu-val> object that is the value of one of the copies that exists
     due to an implements statement, the <emu-val>this</emu-val> value is
-    checked to ensure that it is an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-131">interface</a> corresponding to the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-54">interface prototype object</a> that the property is on.</p>
+    checked to ensure that it is an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-129">interface</a> corresponding to the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-54">interface prototype object</a> that the property is on.</p>
     <p>For example, consider the following IDL:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">A</span> {
   <span class="kt">void</span> <span class="nv">f</span>();
@@ -11520,7 +11481,7 @@ and similarly with their setters.</p>
     <p>Attempting to call <code>B.prototype.f</code> on an object that implements <code class="idl">A</code> (but not <code class="idl">B</code>) or one
     that implements <code class="idl">C</code> will result in a <code class="idl"><a data-link-type="idl" href="#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror-2">TypeError</a></code> being thrown.  However,
     calling <code>A.prototype.f</code> on an object that implements <code class="idl">B</code> or one that implements <code class="idl">C</code> would succeed.  This is handled by the algorithm in <a href="#es-operations">§3.6.7 Operations</a> that defines how IDL operation invocation works in ECMAScript.</p>
-    <p>Similar behavior is required for the getter and setter <emu-val>Function</emu-val> objects that correspond to an IDL <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-76">attributes</a>,
+    <p>Similar behavior is required for the getter and setter <emu-val>Function</emu-val> objects that correspond to an IDL <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-75">attributes</a>,
     and this is handled in <a href="#es-attributes">§3.6.6 Attributes</a>.</p>
    </div>
    <h3 class="heading settled" data-level="3.8" id="es-platform-objects"><span class="secno">3.8. </span><span class="content">Platform objects implementing interfaces</span><a class="self-link" href="#es-platform-objects"></a></h3>
@@ -11536,65 +11497,18 @@ property of the platform object is the <a data-link-type="dfn" href="#dfn-interf
 the global environment associated with a platform object is changed, its internal
 [[Prototype]] property must be immediately
 updated to be the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-56">interface prototype object</a> of the <a data-link-type="dfn" href="#dfn-primary-interface" id="ref-for-dfn-primary-interface-2">primary interface</a> from the <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-51">platform object</a>’s newly associated global environment.</p>
-   <p>Every platform object that implements an [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-15">Unforgeable</a></code>]-annotated
-interface and which does not have a <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-7">stringifier</a> that is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-7">unforgeable</a> on any of the
-interfaces it implements must have a property with the
-following characteristics:</p>
-   <ul>
-    <li data-md="">
-     <p>The name of the property is “toString”.</p>
-    <li data-md="">
-     <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span>.</p>
-    <li data-md="">
-     <p>The value of the property is <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ObjProto_toString%</a>, the initial value of Object.prototype.toString.</p>
-   </ul>
-   <p>Every platform object that implements an [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-16">Unforgeable</a></code>]-annotated
-interface and which does not have a <a data-link-type="dfn" href="#dfn-serializer" id="ref-for-dfn-serializer-8">serializer</a> that is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-8">unforgeable</a> on any of the
-interfaces it implements must have a property with the
-following characteristics:</p>
-   <ul>
-    <li data-md="">
-     <p>The name of the property is “toJSON”.</p>
-    <li data-md="">
-     <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span>.</p>
-    <li data-md="">
-     <p>The value of the property is <emu-val>undefined</emu-val>.</p>
-   </ul>
-   <p>Every platform object that implements an [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-17">Unforgeable</a></code>]-annotated
-interface must have a property with the
-following characteristics:</p>
-   <ul>
-    <li data-md="">
-     <p>The name of the property is “valueOf”.</p>
-    <li data-md="">
-     <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span>.</p>
-    <li data-md="">
-     <div class="algorithm" data-algorithm="to invoke the valueOf method of platform objects">
-       The value of the property is a <emu-val>Function</emu-val> object whose behavior is as follows: 
-      <ol>
-       <li data-md="">
-        <p>Return the <emu-val>this</emu-val> value.</p>
-      </ol>
-     </div>
-      This <emu-val>Function</emu-val> object is the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-default-unforgeable-valueOf-function">default unforgeable valueOf function</dfn>. 
-    <li data-md="">
-     <p>The value of the <emu-val>Function</emu-val> object’s “length”
-property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
-    <li data-md="">
-     <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “valueOf”.</p>
-   </ul>
    <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-5">class string</a> of
 a platform object that implements one or more interfaces
 must be the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-81">identifier</a> of
 the <a data-link-type="dfn" href="#dfn-primary-interface" id="ref-for-dfn-primary-interface-3">primary interface</a> of the platform object.</p>
    <h4 class="heading settled" data-level="3.8.1" id="indexed-and-named-properties"><span class="secno">3.8.1. </span><span class="content">Indexed and named properties</span><a class="self-link" href="#indexed-and-named-properties"></a></h4>
-   <p>If a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-52">platform object</a> implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-132">interface</a> that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-9">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-5">named properties</a>,
+   <p>If a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-52">platform object</a> implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-130">interface</a> that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-9">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-5">named properties</a>,
 the object will appear to have additional properties that correspond to the
 object’s indexed and named properties.  These properties are not “real” own
 properties on the object, but are made to look like they are by being exposed
 by the [[GetOwnProperty]] internal method.</p>
    <p>However, when the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-93">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-94">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-99">extended attribute</a> has been used,
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-94">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-96">extended attribute</a> has been used,
 named properties are not exposed on the object but on another object
 in the prototype chain, the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-14">named properties object</a>.</p>
    <p>It is permissible for an object to implement multiple interfaces that support indexed properties.
@@ -11625,16 +11539,14 @@ ancestor interfaces can be overridden.</p>
     </ol>
    </div>
    <p>A property name is an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-unforgeable-property-name">unforgeable property name</dfn> on a
-given platform object if the object implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-133">interface</a> that
+given platform object if the object implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-131">interface</a> that
 has an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-26">interface member</a> with that identifier
-and that interface member is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-9">unforgeable</a> on any of
-the interfaces that <var>O</var> implements.  If the object implements an
-[<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-18">Unforgeable</a></code>]-annotated <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-134">interface</a>, then “toString” and “valueOf” are
-also <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-dfn-unforgeable-property-name-1">unforgeable property names</a> on that object.</p>
+and that interface member is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-7">unforgeable</a> on any of
+the interfaces that <var>O</var> implements.</p>
    <div class="algorithm" data-algorithm="named property visibility algorithm">
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-named-property-visibility">named property visibility algorithm</dfn> is used to determine if a given named property is exposed on an object.
     Some named properties are not exposed on an object depending on whether
-    the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-8">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-100">extended attribute</a> was used.
+    the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-8">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-97">extended attribute</a> was used.
     The algorithm operates as follows, with property name <var>P</var> and object <var>O</var>:</p>
     <ol>
      <li data-md="">
@@ -11643,7 +11555,7 @@ also <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-d
       <p>If <var>O</var> has an own property named <var>P</var>, then return false.</p>
       <p class="note" role="note">Note: This will include cases in which <var>O</var> has unforgeable properties, because in practice those are always set up before objects have any supported property names, and once set up will make the corresponding named properties invisible.</p>
      <li data-md="">
-      <p>If <var>O</var> implements an interface that has the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-9">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-101">extended attribute</a>, then return true.</p>
+      <p>If <var>O</var> implements an interface that has the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-9">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-98">extended attribute</a>, then return true.</p>
      <li data-md="">
       <p>Initialize <var>prototype</var> to be the value of the internal [[Prototype]] property of <var>O</var>.</p>
      <li data-md="">
@@ -11726,7 +11638,7 @@ of performing the steps listed in the description of <var>operation</var> with <
       </ol>
      <li data-md="">
       <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-6">supports named properties</a>, <var>O</var> does not
-implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-135">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-95">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-96">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-102">extended attribute</a>, the result of running the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-2">named property visibility algorithm</a> with
+implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-132">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-95">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-96">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-99">extended attribute</a>, the result of running the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-2">named property visibility algorithm</a> with
 property name <var>P</var> and object <var>O</var> is true, and <var>ignoreNamedProps</var> is false, then:</p>
       <ol>
        <li data-md="">
@@ -11747,7 +11659,7 @@ of performing the steps listed in the description of <var>operation</var> with <
         <p>If <var>O</var> implements an interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="ref-for-dfn-named-property-setter-4">named property setter</a>, then set <var>desc</var>.[[Writable]] to <emu-val>true</emu-val>, otherwise set it to <emu-val>false</emu-val>.</p>
        <li data-md="">
         <p>If <var>O</var> implements an interface with the
-[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-6">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-103">extended attribute</a>,
+[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-6">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-100">extended attribute</a>,
 then set <var>desc</var>.[[Enumerable]] to <emu-val>false</emu-val>,
 otherwise set it to <emu-val>true</emu-val>.</p>
        <li data-md="">
@@ -11761,7 +11673,7 @@ otherwise set it to <emu-val>true</emu-val>.</p>
    </div>
    <h4 class="heading settled" data-level="3.8.3" id="getownproperty"><span class="secno">3.8.3. </span><span class="content">Platform object [[GetOwnProperty]] method</span><a class="self-link" href="#getownproperty"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[GetOwnProperty]] method of platform objects">
-    <p>The internal [[GetOwnProperty]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-53">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-136">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-11">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-7">named properties</a> must behave as follows when called with property name <var>P</var>:</p>
+    <p>The internal [[GetOwnProperty]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-53">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-133">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-11">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-7">named properties</a> must behave as follows when called with property name <var>P</var>:</p>
     <ol>
      <li data-md="">
       <p>Return the result of invoking the <a data-link-type="dfn" href="#getownproperty-guts" id="ref-for-getownproperty-guts-1">PlatformObjectGetOwnProperty</a> abstract operation with <var>O</var>, <var>P</var>, and <emu-val>false</emu-val> as arguments.</p>
@@ -11820,7 +11732,7 @@ and false otherwise.</p>
    </div>
    <h4 class="heading settled" data-level="3.8.6" id="platformobjectset"><span class="secno">3.8.6. </span><span class="content">Platform object [[Set]] method</span><a class="self-link" href="#platformobjectset"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[Set]] method of platform objects">
-    <p>The internal [[Set]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-54">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-137">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-12">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-8">named properties</a> must behave as follows when called with
+    <p>The internal [[Set]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-54">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-134">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-12">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-8">named properties</a> must behave as follows when called with
     property name <var>P</var>, value <var>V</var>, and ECMAScript language value <var>Receiver</var>:</p>
     <ol>
      <li data-md="">
@@ -11852,7 +11764,7 @@ and <var>O</var> implements an interface with a <a data-link-type="dfn" href="#d
    </div>
    <h4 class="heading settled" data-level="3.8.7" id="defineownproperty"><span class="secno">3.8.7. </span><span class="content">Platform object [[DefineOwnProperty]] method</span><a class="self-link" href="#defineownproperty"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[DefineOwnProperty]] method of platform objects">
-    <p>When the internal [[DefineOwnProperty]] method of a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-55">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-138">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-14">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-10">named properties</a> is called with
+    <p>When the internal [[DefineOwnProperty]] method of a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-55">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-135">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-14">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-10">named properties</a> is called with
     property key <var>P</var> and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">Property Descriptor</a> <var>Desc</var>,
     the following steps must be taken:</p>
     <ol>
@@ -11869,13 +11781,13 @@ and <var>O</var> implements an interface with a <a data-link-type="dfn" href="#d
         <p>Return <emu-val>true</emu-val>.</p>
       </ol>
      <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-11">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-139">interface</a> with the
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-97">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-98">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-104">extended attribute</a> and <var>P</var> is not an <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-dfn-unforgeable-property-name-2">unforgeable property name</a> of <var>O</var>, then:</p>
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-11">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-136">interface</a> with the
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-97">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-98">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-101">extended attribute</a> and <var>P</var> is not an <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-dfn-unforgeable-property-name-1">unforgeable property name</a> of <var>O</var>, then:</p>
       <ol>
        <li data-md="">
         <p>Let <var>creating</var> be true if <var>P</var> is not a <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-6">supported property name</a>, and false otherwise.</p>
        <li data-md="">
-        <p>If <var>O</var> implements an interface with the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-12">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-105">extended attribute</a> or <var>O</var> does not have an own property
+        <p>If <var>O</var> implements an interface with the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-12">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-102">extended attribute</a> or <var>O</var> does not have an own property
 named <var>P</var>, then:</p>
         <ol>
          <li data-md="">
@@ -11894,16 +11806,16 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
         </ol>
       </ol>
      <li data-md="">
-      <p>If <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-140">interface</a> with the
+      <p>If <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-137">interface</a> with the
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-99">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-100">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-106">extended attribute</a>, then set <var>Desc</var>.[[Configurable]] to <emu-val>true</emu-val>.</p>
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-100">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-103">extended attribute</a>, then set <var>Desc</var>.[[Configurable]] to <emu-val>true</emu-val>.</p>
      <li data-md="">
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinarydefineownproperty">OrdinaryDefineOwnProperty</a>(<var>O</var>, <var>P</var>, <var>Desc</var>).</p>
     </ol>
    </div>
    <h4 class="heading settled" data-level="3.8.8" id="delete"><span class="secno">3.8.8. </span><span class="content">Platform object [[Delete]] method</span><a class="self-link" href="#delete"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[Delete]] method of platform objects">
-    <p>The internal [[Delete]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-56">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-141">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-16">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-12">named properties</a> must behave as follows when called with property name <var>P</var>.</p>
+    <p>The internal [[Delete]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-56">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-138">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-16">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-12">named properties</a> must behave as follows when called with property name <var>P</var>.</p>
     <ol>
      <li data-md="">
       <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-17">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-5">array index property name</a>, then:</p>
@@ -11916,8 +11828,8 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
         <p>Return <emu-val>false</emu-val>.</p>
       </ol>
      <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-13">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-142">interface</a> with the
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-101">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-102">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-107">extended attribute</a> and the result of calling the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-3">named property visibility algorithm</a> with property name <var>P</var> and object <var>O</var> is true, then:</p>
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-13">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-139">interface</a> with the
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-101">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-102">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-104">extended attribute</a> and the result of calling the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-3">named property visibility algorithm</a> with property name <var>P</var> and object <var>O</var> is true, then:</p>
       <ol>
        <li data-md="">
         <p>If <var>O</var> does not implement an interface with a <a data-link-type="dfn" href="#dfn-named-property-deleter" id="ref-for-dfn-named-property-deleter-5">named property deleter</a>, then return <emu-val>false</emu-val>.</p>
@@ -11957,7 +11869,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
    <h4 class="heading settled" data-level="3.8.9" id="call"><span class="secno">3.8.9. </span><span class="content">Platform object [[Call]] method</span><a class="self-link" href="#call"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[Call]] method of platform objects">
     <p>The internal [[Call]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-57">platform object</a> that implements
-    an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-143">interface</a> <var>I</var> with at least one <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-8">legacy caller</a> must behave as follows,
+    an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-140">interface</a> <var>I</var> with at least one <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-8">legacy caller</a> must behave as follows,
     assuming <var>arg</var><sub>0..<var>n</var>−1</sub> is the list of argument values passed to [[Call]]:</p>
     <ol>
      <li data-md="">
@@ -11986,7 +11898,7 @@ return <emu-val>false</emu-val>.</p>
    </div>
    <h4 class="heading settled" data-level="3.8.11" id="property-enumeration"><span class="secno">3.8.11. </span><span class="content">Property enumeration</span><a class="self-link" href="#property-enumeration"></a></h4>
    <p>This document does not define a complete property enumeration order
-for all <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-60">platform objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-144">interfaces</a> (or for <a href="#es-exception-objects" id="ref-for-es-exception-objects-1">platform objects representing exceptions</a>).
+for all <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-60">platform objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-141">interfaces</a> (or for <a href="#es-exception-objects" id="ref-for-es-exception-objects-1">platform objects representing exceptions</a>).
 However, if a platform object implements an interface that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-20">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-16">named properties</a>, then
 properties on the object must be
 enumerated in the following order:</p>
@@ -11996,8 +11908,8 @@ enumerated in the following order:</p>
 the object’s <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-8">supported property indices</a> are
 enumerated first, in numerical order.</p>
     <li data-md="">
-     <p>If the object <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-17">supports named properties</a> and doesn’t implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-145">interface</a> with the
-[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-7">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-108">extended attribute</a>, then
+     <p>If the object <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-17">supports named properties</a> and doesn’t implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-142">interface</a> with the
+[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-7">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-105">extended attribute</a>, then
 the object’s <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-7">supported property names</a> that
 are visible according to the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-4">named property visibility algorithm</a> are enumerated next, in the order given in the definition of the set of supported property names.</p>
     <li data-md="">
@@ -12034,7 +11946,7 @@ is the result of invoking [[Get]] on the object with a
 property name that is that identifier.</p>
    </ul>
    <p>Note that ECMAScript objects need not have
-properties corresponding to <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-29">constants</a> on them to be considered as <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-9">user objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-146">interfaces</a> that happen
+properties corresponding to <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-29">constants</a> on them to be considered as <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-9">user objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-143">interfaces</a> that happen
 to have constants declared on them.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-single-operation-callback-interface">single operation callback interface</dfn> is
 a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-27">callback interface</a> that:</p>
@@ -12042,7 +11954,7 @@ a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callbac
     <li data-md="">
      <p>is not declared to <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-14">inherit</a> from another interface,</p>
     <li data-md="">
-     <p>has no <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-77">attributes</a>, and</p>
+     <p>has no <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-76">attributes</a>, and</p>
     <li data-md="">
      <p>has one or more <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-18">regular operations</a> that all have the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-89">identifier</a>,
 and no others.</p>
@@ -12250,7 +12162,7 @@ either an abrupt completion or a normal completion for the value <emu-val>true</
    <h3 class="heading settled" data-level="3.10" id="es-invoking-callback-functions"><span class="secno">3.10. </span><span class="content">Invoking callback functions</span><a class="self-link" href="#es-invoking-callback-functions"></a></h3>
    <p>An ECMAScript <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">callable</a> object that is being
 used as a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-28">callback function</a> value is
-called in a manner similar to how <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-76">operations</a> on <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-10">user objects</a> are called (as
+called in a manner similar to how <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-75">operations</a> on <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-10">user objects</a> are called (as
 described in the previous section).</p>
    <div class="algorithm" data-algorithm="invoke">
     <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="invoke-a-callback-function">invoke</dfn> a <a data-link-type="dfn" href="#idl-callback-function" id="ref-for-idl-callback-function-6">callback function type</a> value <var>callable</var> with
@@ -12457,10 +12369,10 @@ on exception objects too.</p>
      <li data-md="">
       <p>Let <var>F</var> be the <emu-val>Function</emu-val> object used
 as the <emu-val>this</emu-val> value in the top-most call
-on the ECMAScript call stack where <var>F</var> corresponds to an IDL <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-78">attribute</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-77">operation</a>, <a data-link-type="dfn" href="#idl-indexed-properties" id="ref-for-idl-indexed-properties-3">indexed property</a>, <a data-link-type="dfn" href="#idl-named-properties" id="ref-for-idl-named-properties-3">named property</a>, <a href="#Constructor" id="ref-for-Constructor-23">constructor</a>, <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-5">named constructor</a> or <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-8">stringifier</a>.</p>
+on the ECMAScript call stack where <var>F</var> corresponds to an IDL <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-77">attribute</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-76">operation</a>, <a data-link-type="dfn" href="#idl-indexed-properties" id="ref-for-idl-indexed-properties-3">indexed property</a>, <a data-link-type="dfn" href="#idl-named-properties" id="ref-for-idl-named-properties-3">named property</a>, <a href="#Constructor" id="ref-for-Constructor-23">constructor</a>, <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-5">named constructor</a> or <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-7">stringifier</a>.</p>
      <li data-md="">
       <p>If <var>F</var> corresponds to an attribute, operation or stringifier, then return
-the global environment associated with the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-147">interface</a> that definition appears on.</p>
+the global environment associated with the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-144">interface</a> that definition appears on.</p>
      <li data-md="">
       <p>Otherwise, if <var>F</var> corresponds to an indexed or named property, then return
 the global environment associated with the interface that
@@ -12581,7 +12493,7 @@ must propagate to the caller, and if
 not caught there, to its caller, and so on.</p>
    <div class="example" id="example-1432e05c">
     <a class="self-link" href="#example-1432e05c"></a> 
-    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-45">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-148">interfaces</a> and an <a data-link-type="dfn" href="#dfn-exception" id="ref-for-dfn-exception-1">exception</a>.
+    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-45">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-145">interfaces</a> and an <a data-link-type="dfn" href="#dfn-exception" id="ref-for-dfn-exception-1">exception</a>.
     The <code>valueOf</code> attribute on <code class="idl">ExceptionThrower</code> is defined to throw an exception whenever an attempt is made
     to get its value.</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Dahut</span> {
@@ -12653,7 +12565,7 @@ return any value.</p>
    <h2 class="heading settled" data-level="5" id="extensibility"><span class="secno">5. </span><span class="content">Extensibility</span><a class="self-link" href="#extensibility"></a></h2>
    <p><i>This section is informative.</i></p>
    <p>Extensions to language binding requirements can be specified
-using <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-109">extended attributes</a> that do not conflict with those defined in this document.  Extensions for
+using <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-106">extended attributes</a> that do not conflict with those defined in this document.  Extensions for
 private, project-specific use should not be included in <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-46">IDL fragments</a> appearing in other specifications.  It is recommended that extensions
 that are required for use in other specifications be coordinated
 with the group responsible for work on <cite>Web IDL</cite>, which
@@ -12812,7 +12724,7 @@ and “<span class="input">.</span>” is tokenized as the quoted terminal symbo
 used in the grammar and the values used for <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> terminals.  Thus, for
 example, the input text “<span class="input">Const</span>” is tokenized as
 an <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> rather than the
-terminal symbol <emu-t>const</emu-t>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-149">interface</a> with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-92">identifier</a> “A” is distinct from one named “a”, and an <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-110">extended attribute</a> [<code class="idl">constructor</code>] will not be recognized as
+terminal symbol <emu-t>const</emu-t>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-146">interface</a> with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-92">identifier</a> “A” is distinct from one named “a”, and an <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-107">extended attribute</a> [<code class="idl">constructor</code>] will not be recognized as
 the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-24">Constructor</a></code>]
 extended attribute.</p>
    <p>Implicitly, any number of <emu-t class="regex"><a href="#prod-whitespace">whitespace</a></emu-t> and <emu-t class="regex"><a href="#prod-comment">comment</a></emu-t> terminals are allowed between every other terminal
@@ -12824,7 +12736,7 @@ matches an <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-
    <p>While the <emu-nt><a href="#prod-ExtendedAttribute">ExtendedAttribute</a></emu-nt> non-terminal matches any non-empty sequence of terminal symbols (as long as any
 parentheses, square brackets or braces are balanced, and the <emu-t>,</emu-t> token appears only within those balanced brackets),
 only a subset of those
-possible sequences are used by the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-111">extended attributes</a> defined in this specification — see <a href="#idl-extended-attributes">§2.12 Extended attributes</a> for the syntaxes that are used by these extended attributes.</p>
+possible sequences are used by the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-108">extended attributes</a> defined in this specification — see <a href="#idl-extended-attributes">§2.12 Extended attributes</a> for the syntaxes that are used by these extended attributes.</p>
    <h2 class="no-num heading settled" id="conventions"><span class="content">Document conventions</span><a class="self-link" href="#conventions"></a></h2>
    <p>The following typographic conventions are used in this document:</p>
    <ul>
@@ -13147,7 +13059,6 @@ language binding.</p>
    <li><a href="#dataerror">DataError</a><span>, in §2.5.1</span>
    <li><a href="#idl-DataView">DataView</a><span>, in §2.11.31</span>
    <li><a href="#dfn-default-iterator-object">default iterator object</a><span>, in §3.6.9.4</span>
-   <li><a href="#dfn-default-unforgeable-valueOf-function">default unforgeable valueOf function</a><span>, in §3.8</span>
    <li>
     default value
     <ul>
@@ -13448,7 +13359,6 @@ language binding.</p>
      <li><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-function-prototype-object">%functionprototype%</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%iteratorprototype%</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%objectprototype%</a>
-     <li><a href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%objproto_tostring%</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-promise-constructor">%promise%</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-built-in-function-objects-call-thisargument-argumentslist">9.3.1</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a>
@@ -13739,41 +13649,40 @@ language binding.</p>
     <li><a href="#ref-for-dfn-interface-72">3.3.14. [PutForwards]</a> <a href="#ref-for-dfn-interface-73">(2)</a>
     <li><a href="#ref-for-dfn-interface-74">3.3.15. [Replaceable]</a>
     <li><a href="#ref-for-dfn-interface-75">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-interface-76">(2)</a>
-    <li><a href="#ref-for-dfn-interface-77">3.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-interface-78">(2)</a>
-    <li><a href="#ref-for-dfn-interface-79">3.6. Interfaces</a> <a href="#ref-for-dfn-interface-80">(2)</a>
-    <li><a href="#ref-for-dfn-interface-81">3.6.1. Interface object</a>
-    <li><a href="#ref-for-dfn-interface-82">3.6.1.1. Interface object [[Call]] method</a> <a href="#ref-for-dfn-interface-83">(2)</a> <a href="#ref-for-dfn-interface-84">(3)</a> <a href="#ref-for-dfn-interface-85">(4)</a>
-    <li><a href="#ref-for-dfn-interface-86">3.6.2. Named constructors</a> <a href="#ref-for-dfn-interface-87">(2)</a> <a href="#ref-for-dfn-interface-88">(3)</a> <a href="#ref-for-dfn-interface-89">(4)</a>
-    <li><a href="#ref-for-dfn-interface-90">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-interface-91">(2)</a> <a href="#ref-for-dfn-interface-92">(3)</a>
-    <li><a href="#ref-for-dfn-interface-93">3.6.4. Named properties object</a> <a href="#ref-for-dfn-interface-94">(2)</a>
-    <li><a href="#ref-for-dfn-interface-95">3.6.4.1. Named properties object [[GetOwnProperty]] method</a> <a href="#ref-for-dfn-interface-96">(2)</a>
-    <li><a href="#ref-for-dfn-interface-97">3.6.5. Constants</a>
-    <li><a href="#ref-for-dfn-interface-98">3.6.6. Attributes</a> <a href="#ref-for-dfn-interface-99">(2)</a> <a href="#ref-for-dfn-interface-100">(3)</a>
-    <li><a href="#ref-for-dfn-interface-101">3.6.7. Operations</a> <a href="#ref-for-dfn-interface-102">(2)</a> <a href="#ref-for-dfn-interface-103">(3)</a>
-    <li><a href="#ref-for-dfn-interface-104">3.6.7.1. Stringifiers</a> <a href="#ref-for-dfn-interface-105">(2)</a>
-    <li><a href="#ref-for-dfn-interface-106">3.6.7.2. Serializers</a> <a href="#ref-for-dfn-interface-107">(2)</a> <a href="#ref-for-dfn-interface-108">(3)</a>
-    <li><a href="#ref-for-dfn-interface-109">3.6.8.1. @@iterator</a> <a href="#ref-for-dfn-interface-110">(2)</a> <a href="#ref-for-dfn-interface-111">(3)</a>
-    <li><a href="#ref-for-dfn-interface-112">3.6.8.2. forEach</a> <a href="#ref-for-dfn-interface-113">(2)</a>
-    <li><a href="#ref-for-dfn-interface-114">3.6.9.1. entries</a>
-    <li><a href="#ref-for-dfn-interface-115">3.6.9.2. keys</a> <a href="#ref-for-dfn-interface-116">(2)</a>
-    <li><a href="#ref-for-dfn-interface-117">3.6.9.3. values</a> <a href="#ref-for-dfn-interface-118">(2)</a>
-    <li><a href="#ref-for-dfn-interface-119">3.6.9.4. Default iterator objects</a> <a href="#ref-for-dfn-interface-120">(2)</a> <a href="#ref-for-dfn-interface-121">(3)</a> <a href="#ref-for-dfn-interface-122">(4)</a>
-    <li><a href="#ref-for-dfn-interface-123">3.6.9.5. Iterator prototype object</a> <a href="#ref-for-dfn-interface-124">(2)</a> <a href="#ref-for-dfn-interface-125">(3)</a> <a href="#ref-for-dfn-interface-126">(4)</a>
-    <li><a href="#ref-for-dfn-interface-127">3.6.10. Maplike declarations</a> <a href="#ref-for-dfn-interface-128">(2)</a>
-    <li><a href="#ref-for-dfn-interface-129">3.6.11. Setlike declarations</a> <a href="#ref-for-dfn-interface-130">(2)</a>
-    <li><a href="#ref-for-dfn-interface-131">3.7. Implements statements</a>
-    <li><a href="#ref-for-dfn-interface-132">3.8.1. Indexed and named properties</a> <a href="#ref-for-dfn-interface-133">(2)</a> <a href="#ref-for-dfn-interface-134">(3)</a>
-    <li><a href="#ref-for-dfn-interface-135">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-dfn-interface-136">3.8.3. Platform object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-interface-137">3.8.6. Platform object [[Set]] method</a>
-    <li><a href="#ref-for-dfn-interface-138">3.8.7. Platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-interface-139">(2)</a> <a href="#ref-for-dfn-interface-140">(3)</a>
-    <li><a href="#ref-for-dfn-interface-141">3.8.8. Platform object [[Delete]] method</a> <a href="#ref-for-dfn-interface-142">(2)</a>
-    <li><a href="#ref-for-dfn-interface-143">3.8.9. Platform object [[Call]] method</a>
-    <li><a href="#ref-for-dfn-interface-144">3.8.11. Property enumeration</a> <a href="#ref-for-dfn-interface-145">(2)</a>
-    <li><a href="#ref-for-dfn-interface-146">3.9. User objects implementing callback interfaces</a>
-    <li><a href="#ref-for-dfn-interface-147">3.14. Creating and throwing exceptions</a>
-    <li><a href="#ref-for-dfn-interface-148">3.15. Handling exceptions</a>
-    <li><a href="#ref-for-dfn-interface-149">IDL grammar</a>
+    <li><a href="#ref-for-dfn-interface-77">3.6. Interfaces</a> <a href="#ref-for-dfn-interface-78">(2)</a>
+    <li><a href="#ref-for-dfn-interface-79">3.6.1. Interface object</a>
+    <li><a href="#ref-for-dfn-interface-80">3.6.1.1. Interface object [[Call]] method</a> <a href="#ref-for-dfn-interface-81">(2)</a> <a href="#ref-for-dfn-interface-82">(3)</a> <a href="#ref-for-dfn-interface-83">(4)</a>
+    <li><a href="#ref-for-dfn-interface-84">3.6.2. Named constructors</a> <a href="#ref-for-dfn-interface-85">(2)</a> <a href="#ref-for-dfn-interface-86">(3)</a> <a href="#ref-for-dfn-interface-87">(4)</a>
+    <li><a href="#ref-for-dfn-interface-88">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-interface-89">(2)</a> <a href="#ref-for-dfn-interface-90">(3)</a>
+    <li><a href="#ref-for-dfn-interface-91">3.6.4. Named properties object</a> <a href="#ref-for-dfn-interface-92">(2)</a>
+    <li><a href="#ref-for-dfn-interface-93">3.6.4.1. Named properties object [[GetOwnProperty]] method</a> <a href="#ref-for-dfn-interface-94">(2)</a>
+    <li><a href="#ref-for-dfn-interface-95">3.6.5. Constants</a>
+    <li><a href="#ref-for-dfn-interface-96">3.6.6. Attributes</a> <a href="#ref-for-dfn-interface-97">(2)</a> <a href="#ref-for-dfn-interface-98">(3)</a>
+    <li><a href="#ref-for-dfn-interface-99">3.6.7. Operations</a> <a href="#ref-for-dfn-interface-100">(2)</a> <a href="#ref-for-dfn-interface-101">(3)</a>
+    <li><a href="#ref-for-dfn-interface-102">3.6.7.1. Stringifiers</a> <a href="#ref-for-dfn-interface-103">(2)</a>
+    <li><a href="#ref-for-dfn-interface-104">3.6.7.2. Serializers</a> <a href="#ref-for-dfn-interface-105">(2)</a> <a href="#ref-for-dfn-interface-106">(3)</a>
+    <li><a href="#ref-for-dfn-interface-107">3.6.8.1. @@iterator</a> <a href="#ref-for-dfn-interface-108">(2)</a> <a href="#ref-for-dfn-interface-109">(3)</a>
+    <li><a href="#ref-for-dfn-interface-110">3.6.8.2. forEach</a> <a href="#ref-for-dfn-interface-111">(2)</a>
+    <li><a href="#ref-for-dfn-interface-112">3.6.9.1. entries</a>
+    <li><a href="#ref-for-dfn-interface-113">3.6.9.2. keys</a> <a href="#ref-for-dfn-interface-114">(2)</a>
+    <li><a href="#ref-for-dfn-interface-115">3.6.9.3. values</a> <a href="#ref-for-dfn-interface-116">(2)</a>
+    <li><a href="#ref-for-dfn-interface-117">3.6.9.4. Default iterator objects</a> <a href="#ref-for-dfn-interface-118">(2)</a> <a href="#ref-for-dfn-interface-119">(3)</a> <a href="#ref-for-dfn-interface-120">(4)</a>
+    <li><a href="#ref-for-dfn-interface-121">3.6.9.5. Iterator prototype object</a> <a href="#ref-for-dfn-interface-122">(2)</a> <a href="#ref-for-dfn-interface-123">(3)</a> <a href="#ref-for-dfn-interface-124">(4)</a>
+    <li><a href="#ref-for-dfn-interface-125">3.6.10. Maplike declarations</a> <a href="#ref-for-dfn-interface-126">(2)</a>
+    <li><a href="#ref-for-dfn-interface-127">3.6.11. Setlike declarations</a> <a href="#ref-for-dfn-interface-128">(2)</a>
+    <li><a href="#ref-for-dfn-interface-129">3.7. Implements statements</a>
+    <li><a href="#ref-for-dfn-interface-130">3.8.1. Indexed and named properties</a> <a href="#ref-for-dfn-interface-131">(2)</a>
+    <li><a href="#ref-for-dfn-interface-132">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
+    <li><a href="#ref-for-dfn-interface-133">3.8.3. Platform object [[GetOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-interface-134">3.8.6. Platform object [[Set]] method</a>
+    <li><a href="#ref-for-dfn-interface-135">3.8.7. Platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-interface-136">(2)</a> <a href="#ref-for-dfn-interface-137">(3)</a>
+    <li><a href="#ref-for-dfn-interface-138">3.8.8. Platform object [[Delete]] method</a> <a href="#ref-for-dfn-interface-139">(2)</a>
+    <li><a href="#ref-for-dfn-interface-140">3.8.9. Platform object [[Call]] method</a>
+    <li><a href="#ref-for-dfn-interface-141">3.8.11. Property enumeration</a> <a href="#ref-for-dfn-interface-142">(2)</a>
+    <li><a href="#ref-for-dfn-interface-143">3.9. User objects implementing callback interfaces</a>
+    <li><a href="#ref-for-dfn-interface-144">3.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-interface-145">3.15. Handling exceptions</a>
+    <li><a href="#ref-for-dfn-interface-146">IDL grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-interface-member">
@@ -13921,14 +13830,14 @@ language binding.</p>
     <li><a href="#ref-for-dfn-attribute-55">3.3.16. [SameObject]</a> <a href="#ref-for-dfn-attribute-56">(2)</a>
     <li><a href="#ref-for-dfn-attribute-57">3.3.18. [TreatNonObjectAsNull]</a>
     <li><a href="#ref-for-dfn-attribute-58">3.3.19. [TreatNullAs]</a>
-    <li><a href="#ref-for-dfn-attribute-59">3.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-attribute-60">(2)</a> <a href="#ref-for-dfn-attribute-61">(3)</a> <a href="#ref-for-dfn-attribute-62">(4)</a>
-    <li><a href="#ref-for-dfn-attribute-63">3.4. Security</a>
-    <li><a href="#ref-for-dfn-attribute-64">3.6.6. Attributes</a> <a href="#ref-for-dfn-attribute-65">(2)</a> <a href="#ref-for-dfn-attribute-66">(3)</a> <a href="#ref-for-dfn-attribute-67">(4)</a> <a href="#ref-for-dfn-attribute-68">(5)</a> <a href="#ref-for-dfn-attribute-69">(6)</a> <a href="#ref-for-dfn-attribute-70">(7)</a> <a href="#ref-for-dfn-attribute-71">(8)</a> <a href="#ref-for-dfn-attribute-72">(9)</a>
-    <li><a href="#ref-for-dfn-attribute-73">3.6.7.1. Stringifiers</a>
-    <li><a href="#ref-for-dfn-attribute-74">3.6.8.1. @@iterator</a>
-    <li><a href="#ref-for-dfn-attribute-75">3.7. Implements statements</a> <a href="#ref-for-dfn-attribute-76">(2)</a>
-    <li><a href="#ref-for-dfn-attribute-77">3.9. User objects implementing callback interfaces</a>
-    <li><a href="#ref-for-dfn-attribute-78">3.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-attribute-59">3.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-attribute-60">(2)</a> <a href="#ref-for-dfn-attribute-61">(3)</a>
+    <li><a href="#ref-for-dfn-attribute-62">3.4. Security</a>
+    <li><a href="#ref-for-dfn-attribute-63">3.6.6. Attributes</a> <a href="#ref-for-dfn-attribute-64">(2)</a> <a href="#ref-for-dfn-attribute-65">(3)</a> <a href="#ref-for-dfn-attribute-66">(4)</a> <a href="#ref-for-dfn-attribute-67">(5)</a> <a href="#ref-for-dfn-attribute-68">(6)</a> <a href="#ref-for-dfn-attribute-69">(7)</a> <a href="#ref-for-dfn-attribute-70">(8)</a> <a href="#ref-for-dfn-attribute-71">(9)</a>
+    <li><a href="#ref-for-dfn-attribute-72">3.6.7.1. Stringifiers</a>
+    <li><a href="#ref-for-dfn-attribute-73">3.6.8.1. @@iterator</a>
+    <li><a href="#ref-for-dfn-attribute-74">3.7. Implements statements</a> <a href="#ref-for-dfn-attribute-75">(2)</a>
+    <li><a href="#ref-for-dfn-attribute-76">3.9. User objects implementing callback interfaces</a>
+    <li><a href="#ref-for-dfn-attribute-77">3.14. Creating and throwing exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-regular-attribute">
@@ -14005,16 +13914,16 @@ language binding.</p>
     <li><a href="#ref-for-dfn-operation-56">3.3.15. [Replaceable]</a>
     <li><a href="#ref-for-dfn-operation-57">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-operation-58">(2)</a>
     <li><a href="#ref-for-dfn-operation-59">3.3.19. [TreatNullAs]</a>
-    <li><a href="#ref-for-dfn-operation-60">3.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-operation-61">(2)</a> <a href="#ref-for-dfn-operation-62">(3)</a> <a href="#ref-for-dfn-operation-63">(4)</a>
-    <li><a href="#ref-for-dfn-operation-64">3.4. Security</a>
-    <li><a href="#ref-for-dfn-operation-65">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-operation-66">(2)</a>
-    <li><a href="#ref-for-dfn-operation-67">3.6.7. Operations</a> <a href="#ref-for-dfn-operation-68">(2)</a> <a href="#ref-for-dfn-operation-69">(3)</a>
-    <li><a href="#ref-for-dfn-operation-70">3.6.7.1. Stringifiers</a> <a href="#ref-for-dfn-operation-71">(2)</a>
-    <li><a href="#ref-for-dfn-operation-72">3.6.7.2. Serializers</a>
-    <li><a href="#ref-for-dfn-operation-73">3.6.8.2. forEach</a>
-    <li><a href="#ref-for-dfn-operation-74">3.7. Implements statements</a> <a href="#ref-for-dfn-operation-75">(2)</a>
-    <li><a href="#ref-for-dfn-operation-76">3.10. Invoking callback functions</a>
-    <li><a href="#ref-for-dfn-operation-77">3.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-operation-60">3.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-operation-61">(2)</a> <a href="#ref-for-dfn-operation-62">(3)</a>
+    <li><a href="#ref-for-dfn-operation-63">3.4. Security</a>
+    <li><a href="#ref-for-dfn-operation-64">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-operation-65">(2)</a>
+    <li><a href="#ref-for-dfn-operation-66">3.6.7. Operations</a> <a href="#ref-for-dfn-operation-67">(2)</a> <a href="#ref-for-dfn-operation-68">(3)</a>
+    <li><a href="#ref-for-dfn-operation-69">3.6.7.1. Stringifiers</a> <a href="#ref-for-dfn-operation-70">(2)</a>
+    <li><a href="#ref-for-dfn-operation-71">3.6.7.2. Serializers</a>
+    <li><a href="#ref-for-dfn-operation-72">3.6.8.2. forEach</a>
+    <li><a href="#ref-for-dfn-operation-73">3.7. Implements statements</a> <a href="#ref-for-dfn-operation-74">(2)</a>
+    <li><a href="#ref-for-dfn-operation-75">3.10. Invoking callback functions</a>
+    <li><a href="#ref-for-dfn-operation-76">3.14. Creating and throwing exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-regular-operation">
@@ -14127,8 +14036,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-stringifier-1">2.2.4.2. Stringifiers</a>
     <li><a href="#ref-for-dfn-stringifier-2">3.3.5. [Global] and [PrimaryGlobal]</a>
     <li><a href="#ref-for-dfn-stringifier-3">3.6.7.1. Stringifiers</a> <a href="#ref-for-dfn-stringifier-4">(2)</a> <a href="#ref-for-dfn-stringifier-5">(3)</a> <a href="#ref-for-dfn-stringifier-6">(4)</a>
-    <li><a href="#ref-for-dfn-stringifier-7">3.8. Platform objects implementing interfaces</a>
-    <li><a href="#ref-for-dfn-stringifier-8">3.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-stringifier-7">3.14. Creating and throwing exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-serializer">
@@ -14137,7 +14045,6 @@ language binding.</p>
     <li><a href="#ref-for-dfn-serializer-1">2.2.4.3. Serializers</a> <a href="#ref-for-dfn-serializer-2">(2)</a> <a href="#ref-for-dfn-serializer-3">(3)</a>
     <li><a href="#ref-for-dfn-serializer-4">3.3.5. [Global] and [PrimaryGlobal]</a>
     <li><a href="#ref-for-dfn-serializer-5">3.6.7.2. Serializers</a> <a href="#ref-for-dfn-serializer-6">(2)</a> <a href="#ref-for-dfn-serializer-7">(3)</a>
-    <li><a href="#ref-for-dfn-serializer-8">3.8. Platform objects implementing interfaces</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-named-property-getter">
@@ -14361,8 +14268,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-static-attribute-7">3.3.9. [LenientThis]</a>
     <li><a href="#ref-for-dfn-static-attribute-8">3.3.14. [PutForwards]</a>
     <li><a href="#ref-for-dfn-static-attribute-9">3.3.15. [Replaceable]</a>
-    <li><a href="#ref-for-dfn-static-attribute-10">3.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-static-attribute-11">(2)</a>
-    <li><a href="#ref-for-dfn-static-attribute-12">3.6.6. Attributes</a> <a href="#ref-for-dfn-static-attribute-13">(2)</a> <a href="#ref-for-dfn-static-attribute-14">(3)</a>
+    <li><a href="#ref-for-dfn-static-attribute-10">3.3.20. [Unforgeable]</a>
+    <li><a href="#ref-for-dfn-static-attribute-11">3.6.6. Attributes</a> <a href="#ref-for-dfn-static-attribute-12">(2)</a> <a href="#ref-for-dfn-static-attribute-13">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-static-operation">
@@ -14373,9 +14280,9 @@ language binding.</p>
     <li><a href="#ref-for-dfn-static-operation-5">2.2.6. Overloading</a> <a href="#ref-for-dfn-static-operation-6">(2)</a>
     <li><a href="#ref-for-dfn-static-operation-7">3.3.11. [NewObject]</a> <a href="#ref-for-dfn-static-operation-8">(2)</a>
     <li><a href="#ref-for-dfn-static-operation-9">3.3.12. [NoInterfaceObject]</a>
-    <li><a href="#ref-for-dfn-static-operation-10">3.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-static-operation-11">(2)</a> <a href="#ref-for-dfn-static-operation-12">(3)</a>
-    <li><a href="#ref-for-dfn-static-operation-13">3.6.1. Interface object</a>
-    <li><a href="#ref-for-dfn-static-operation-14">3.6.7. Operations</a> <a href="#ref-for-dfn-static-operation-15">(2)</a> <a href="#ref-for-dfn-static-operation-16">(3)</a> <a href="#ref-for-dfn-static-operation-17">(4)</a>
+    <li><a href="#ref-for-dfn-static-operation-10">3.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-static-operation-11">(2)</a>
+    <li><a href="#ref-for-dfn-static-operation-12">3.6.1. Interface object</a>
+    <li><a href="#ref-for-dfn-static-operation-13">3.6.7. Operations</a> <a href="#ref-for-dfn-static-operation-14">(2)</a> <a href="#ref-for-dfn-static-operation-15">(3)</a> <a href="#ref-for-dfn-static-operation-16">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-overloaded">
@@ -14807,23 +14714,23 @@ language binding.</p>
     <li><a href="#ref-for-dfn-consequential-interfaces-9">2.2.9. Setlike declarations</a> <a href="#ref-for-dfn-consequential-interfaces-10">(2)</a> <a href="#ref-for-dfn-consequential-interfaces-11">(3)</a> <a href="#ref-for-dfn-consequential-interfaces-12">(4)</a>
     <li><a href="#ref-for-dfn-consequential-interfaces-13">3.3.4. [Exposed]</a>
     <li><a href="#ref-for-dfn-consequential-interfaces-14">3.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-consequential-interfaces-15">(2)</a>
-    <li><a href="#ref-for-dfn-consequential-interfaces-16">3.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-consequential-interfaces-17">(2)</a> <a href="#ref-for-dfn-consequential-interfaces-18">(3)</a> <a href="#ref-for-dfn-consequential-interfaces-19">(4)</a> <a href="#ref-for-dfn-consequential-interfaces-20">(5)</a>
-    <li><a href="#ref-for-dfn-consequential-interfaces-21">3.6.3. Interface prototype object</a>
-    <li><a href="#ref-for-dfn-consequential-interfaces-22">3.6.5. Constants</a>
-    <li><a href="#ref-for-dfn-consequential-interfaces-23">3.6.6. Attributes</a> <a href="#ref-for-dfn-consequential-interfaces-24">(2)</a>
-    <li><a href="#ref-for-dfn-consequential-interfaces-25">3.6.7. Operations</a>
-    <li><a href="#ref-for-dfn-consequential-interfaces-26">3.6.7.2. Serializers</a>
-    <li><a href="#ref-for-dfn-consequential-interfaces-27">3.6.8.1. @@iterator</a>
-    <li><a href="#ref-for-dfn-consequential-interfaces-28">3.6.8.2. forEach</a>
-    <li><a href="#ref-for-dfn-consequential-interfaces-29">3.6.9.1. entries</a>
-    <li><a href="#ref-for-dfn-consequential-interfaces-30">3.6.9.2. keys</a>
-    <li><a href="#ref-for-dfn-consequential-interfaces-31">3.6.9.3. values</a>
-    <li><a href="#ref-for-dfn-consequential-interfaces-32">3.6.10.5. clear</a>
-    <li><a href="#ref-for-dfn-consequential-interfaces-33">3.6.10.6. delete</a>
-    <li><a href="#ref-for-dfn-consequential-interfaces-34">3.6.10.7. set</a>
-    <li><a href="#ref-for-dfn-consequential-interfaces-35">3.6.11.5. add and delete</a>
-    <li><a href="#ref-for-dfn-consequential-interfaces-36">3.6.11.6. clear</a>
-    <li><a href="#ref-for-dfn-consequential-interfaces-37">3.7. Implements statements</a>
+    <li><a href="#ref-for-dfn-consequential-interfaces-16">3.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-consequential-interfaces-17">(2)</a>
+    <li><a href="#ref-for-dfn-consequential-interfaces-18">3.6.3. Interface prototype object</a>
+    <li><a href="#ref-for-dfn-consequential-interfaces-19">3.6.5. Constants</a>
+    <li><a href="#ref-for-dfn-consequential-interfaces-20">3.6.6. Attributes</a> <a href="#ref-for-dfn-consequential-interfaces-21">(2)</a>
+    <li><a href="#ref-for-dfn-consequential-interfaces-22">3.6.7. Operations</a>
+    <li><a href="#ref-for-dfn-consequential-interfaces-23">3.6.7.2. Serializers</a>
+    <li><a href="#ref-for-dfn-consequential-interfaces-24">3.6.8.1. @@iterator</a>
+    <li><a href="#ref-for-dfn-consequential-interfaces-25">3.6.8.2. forEach</a>
+    <li><a href="#ref-for-dfn-consequential-interfaces-26">3.6.9.1. entries</a>
+    <li><a href="#ref-for-dfn-consequential-interfaces-27">3.6.9.2. keys</a>
+    <li><a href="#ref-for-dfn-consequential-interfaces-28">3.6.9.3. values</a>
+    <li><a href="#ref-for-dfn-consequential-interfaces-29">3.6.10.5. clear</a>
+    <li><a href="#ref-for-dfn-consequential-interfaces-30">3.6.10.6. delete</a>
+    <li><a href="#ref-for-dfn-consequential-interfaces-31">3.6.10.7. set</a>
+    <li><a href="#ref-for-dfn-consequential-interfaces-32">3.6.11.5. add and delete</a>
+    <li><a href="#ref-for-dfn-consequential-interfaces-33">3.6.11.6. clear</a>
+    <li><a href="#ref-for-dfn-consequential-interfaces-34">3.7. Implements statements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-platform-object">
@@ -15581,23 +15488,23 @@ language binding.</p>
     <li><a href="#ref-for-dfn-extended-attribute-69">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-extended-attribute-70">(2)</a> <a href="#ref-for-dfn-extended-attribute-71">(3)</a> <a href="#ref-for-dfn-extended-attribute-72">(4)</a>
     <li><a href="#ref-for-dfn-extended-attribute-73">3.3.18. [TreatNonObjectAsNull]</a> <a href="#ref-for-dfn-extended-attribute-74">(2)</a>
     <li><a href="#ref-for-dfn-extended-attribute-75">3.3.19. [TreatNullAs]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-76">3.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-extended-attribute-77">(2)</a> <a href="#ref-for-dfn-extended-attribute-78">(3)</a> <a href="#ref-for-dfn-extended-attribute-79">(4)</a> <a href="#ref-for-dfn-extended-attribute-80">(5)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-81">3.3.21. [Unscopable]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-82">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-extended-attribute-83">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-84">3.6. Interfaces</a>
-    <li><a href="#ref-for-dfn-extended-attribute-85">3.6.1.1. Interface object [[Call]] method</a> <a href="#ref-for-dfn-extended-attribute-86">(2)</a> <a href="#ref-for-dfn-extended-attribute-87">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-88">3.6.2. Named constructors</a> <a href="#ref-for-dfn-extended-attribute-89">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-90">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-extended-attribute-91">(2)</a> <a href="#ref-for-dfn-extended-attribute-92">(3)</a> <a href="#ref-for-dfn-extended-attribute-93">(4)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-94">3.6.4. Named properties object</a>
-    <li><a href="#ref-for-dfn-extended-attribute-95">3.6.4.1. Named properties object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-extended-attribute-96">3.6.6. Attributes</a> <a href="#ref-for-dfn-extended-attribute-97">(2)</a> <a href="#ref-for-dfn-extended-attribute-98">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-99">3.8.1. Indexed and named properties</a> <a href="#ref-for-dfn-extended-attribute-100">(2)</a> <a href="#ref-for-dfn-extended-attribute-101">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-102">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a> <a href="#ref-for-dfn-extended-attribute-103">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-104">3.8.7. Platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-extended-attribute-105">(2)</a> <a href="#ref-for-dfn-extended-attribute-106">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-107">3.8.8. Platform object [[Delete]] method</a>
-    <li><a href="#ref-for-dfn-extended-attribute-108">3.8.11. Property enumeration</a>
-    <li><a href="#ref-for-dfn-extended-attribute-109">5. Extensibility</a>
-    <li><a href="#ref-for-dfn-extended-attribute-110">IDL grammar</a> <a href="#ref-for-dfn-extended-attribute-111">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-76">3.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-extended-attribute-77">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-78">3.3.21. [Unscopable]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-79">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-extended-attribute-80">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-81">3.6. Interfaces</a>
+    <li><a href="#ref-for-dfn-extended-attribute-82">3.6.1.1. Interface object [[Call]] method</a> <a href="#ref-for-dfn-extended-attribute-83">(2)</a> <a href="#ref-for-dfn-extended-attribute-84">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-85">3.6.2. Named constructors</a> <a href="#ref-for-dfn-extended-attribute-86">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-87">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-extended-attribute-88">(2)</a> <a href="#ref-for-dfn-extended-attribute-89">(3)</a> <a href="#ref-for-dfn-extended-attribute-90">(4)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-91">3.6.4. Named properties object</a>
+    <li><a href="#ref-for-dfn-extended-attribute-92">3.6.4.1. Named properties object [[GetOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-extended-attribute-93">3.6.6. Attributes</a> <a href="#ref-for-dfn-extended-attribute-94">(2)</a> <a href="#ref-for-dfn-extended-attribute-95">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-96">3.8.1. Indexed and named properties</a> <a href="#ref-for-dfn-extended-attribute-97">(2)</a> <a href="#ref-for-dfn-extended-attribute-98">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-99">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a> <a href="#ref-for-dfn-extended-attribute-100">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-101">3.8.7. Platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-extended-attribute-102">(2)</a> <a href="#ref-for-dfn-extended-attribute-103">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-104">3.8.8. Platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-extended-attribute-105">3.8.11. Property enumeration</a>
+    <li><a href="#ref-for-dfn-extended-attribute-106">5. Extensibility</a>
+    <li><a href="#ref-for-dfn-extended-attribute-107">IDL grammar</a> <a href="#ref-for-dfn-extended-attribute-108">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-xattr-no-arguments">
@@ -16154,13 +16061,10 @@ language binding.</p>
   <aside class="dfn-panel" data-for="Unforgeable">
    <b><a href="#Unforgeable">#Unforgeable</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-Unforgeable-1">2.2. Interfaces</a> <a href="#ref-for-Unforgeable-2">(2)</a>
-    <li><a href="#ref-for-Unforgeable-3">2.2.2. Attributes</a>
-    <li><a href="#ref-for-Unforgeable-4">2.2.3. Operations</a>
-    <li><a href="#ref-for-Unforgeable-5">3.3.20. [Unforgeable]</a> <a href="#ref-for-Unforgeable-6">(2)</a> <a href="#ref-for-Unforgeable-7">(3)</a> <a href="#ref-for-Unforgeable-8">(4)</a> <a href="#ref-for-Unforgeable-9">(5)</a> <a href="#ref-for-Unforgeable-10">(6)</a> <a href="#ref-for-Unforgeable-11">(7)</a> <a href="#ref-for-Unforgeable-12">(8)</a> <a href="#ref-for-Unforgeable-13">(9)</a>
-    <li><a href="#ref-for-Unforgeable-14">3.6.6. Attributes</a>
-    <li><a href="#ref-for-Unforgeable-15">3.8. Platform objects implementing interfaces</a> <a href="#ref-for-Unforgeable-16">(2)</a> <a href="#ref-for-Unforgeable-17">(3)</a>
-    <li><a href="#ref-for-Unforgeable-18">3.8.1. Indexed and named properties</a>
+    <li><a href="#ref-for-Unforgeable-1">2.2.2. Attributes</a>
+    <li><a href="#ref-for-Unforgeable-2">2.2.3. Operations</a>
+    <li><a href="#ref-for-Unforgeable-3">3.3.20. [Unforgeable]</a> <a href="#ref-for-Unforgeable-4">(2)</a> <a href="#ref-for-Unforgeable-5">(3)</a> <a href="#ref-for-Unforgeable-6">(4)</a> <a href="#ref-for-Unforgeable-7">(5)</a> <a href="#ref-for-Unforgeable-8">(6)</a>
+    <li><a href="#ref-for-Unforgeable-9">3.6.6. Attributes</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-unforgeable-on-an-interface">
@@ -16170,8 +16074,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-unforgeable-on-an-interface-2">3.6.6. Attributes</a>
     <li><a href="#ref-for-dfn-unforgeable-on-an-interface-3">3.6.7. Operations</a> <a href="#ref-for-dfn-unforgeable-on-an-interface-4">(2)</a>
     <li><a href="#ref-for-dfn-unforgeable-on-an-interface-5">3.6.7.1. Stringifiers</a> <a href="#ref-for-dfn-unforgeable-on-an-interface-6">(2)</a>
-    <li><a href="#ref-for-dfn-unforgeable-on-an-interface-7">3.8. Platform objects implementing interfaces</a> <a href="#ref-for-dfn-unforgeable-on-an-interface-8">(2)</a>
-    <li><a href="#ref-for-dfn-unforgeable-on-an-interface-9">3.8.1. Indexed and named properties</a>
+    <li><a href="#ref-for-dfn-unforgeable-on-an-interface-7">3.8.1. Indexed and named properties</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="Unscopable">
@@ -16373,12 +16276,6 @@ language binding.</p>
     <li><a href="#ref-for-dfn-primary-interface-1">3.8. Platform objects implementing interfaces</a> <a href="#ref-for-dfn-primary-interface-2">(2)</a> <a href="#ref-for-dfn-primary-interface-3">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-default-unforgeable-valueOf-function">
-   <b><a href="#dfn-default-unforgeable-valueOf-function">#dfn-default-unforgeable-valueOf-function</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dfn-default-unforgeable-valueOf-function-1">3.1. ECMAScript environment</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="dfn-array-index-property-name">
    <b><a href="#dfn-array-index-property-name">#dfn-array-index-property-name</a></b><b>Referenced in:</b>
    <ul>
@@ -16391,8 +16288,7 @@ language binding.</p>
   <aside class="dfn-panel" data-for="dfn-unforgeable-property-name">
    <b><a href="#dfn-unforgeable-property-name">#dfn-unforgeable-property-name</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-unforgeable-property-name-1">3.8.1. Indexed and named properties</a>
-    <li><a href="#ref-for-dfn-unforgeable-property-name-2">3.8.7. Platform object [[DefineOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-unforgeable-property-name-1">3.8.7. Platform object [[DefineOwnProperty]] method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-named-property-visibility">


### PR DESCRIPTION
Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=29384.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
    
    Don't remove this comment or modify anything below this line.
-->
***
[Preview](https://rawgit.com/heycam/webidl/annevk/remove-unforgeable-interfaces/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fheycam.github.io%2Fwebidl%2F&doc2=https%3A%2F%2Frawgit.com%2Fheycam%2Fwebidl%2Fannevk%2Fremove-unforgeable-interfaces%2Findex.html) 
