### PR TITLE
Update attribute setter/getters in various ways

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1377,9 +1377,9 @@ ignored or an exception is thrown.
     };
 </pre>
 
-The type of an attribute that is not [=read only=] must not be a [=promise type=]. Additionally,
-the type of an attribute with any of the [=extended attributes=] [{{LenientThis}}],
-[{{PutForwards}}], [{{Replaceable}}], or [{{SameObject}}] must not be a [=promise type=].
+Attributes whose type is a [=promise type=] must be [=read only=]. Additionally, they cannot have
+any of the [=extended attributes=] [{{LenientThis}}], [{{PutForwards}}], [{{Replaceable}}], or
+[{{SameObject}}].
 
 A [=regular attribute=]
 that is not [=read only=]
@@ -10537,7 +10537,7 @@ The characteristics of this property are as follows:
     1.  Let |steps| be the following series of steps:
         1.  Try running the following steps:
             1.  Let |O| be <emu-val>null</emu-val>.
-            1.  If |attribute| is not a [=static attribute=]:
+            1.  If |attribute| is a [=regular attribute=]:
                 1.  If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or
                     <emu-val>undefined</emu-val>, set |O| to |realm|'s [=Realm/global object=].
                     (This will subsequently cause a <emu-val>TypeError</emu-val> in a few steps, if
@@ -10586,11 +10586,11 @@ The characteristics of this property are as follows:
         <emu-val>undefined</emu-val>; there is no [=attribute setter=] function.
     1.  Assert: |attribute|'s type is not a [=promise type=].
     1.  Let |steps| be the following series of steps:
-        1.  If no arguments were passed, then
+        1.  If no arguments were passed, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
         1.  Let |V| be the value of the first argument passed.
         1.  Let |id| be |attribute|'s [=identifier=].
         1.  Let |O| be <emu-val>null</emu-val>.
-        1.  If |attribute| is not a [=static attribute=]:
+        1.  If |attribute| is a [=regular attribute=]:
             1.  If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or
                 <emu-val>undefined</emu-val>, set |O| to |realm|'s [=Realm/global object=].
                 (This will subsequently cause a <emu-val>TypeError</emu-val> in a few steps, if
@@ -10600,16 +10600,14 @@ The characteristics of this property are as follows:
             1.  Otherwise, set |O| to the <emu-val>this</emu-val> value.
             1.  If |O| is a [=platform object=], then [=perform a security check=], passing |O|,
                 |id|, and "setter".
-            1.  Let |validThis| be <emu-val>true</emu-val> if |O| is a [=platform object=] that
-                implements the interface |target|, or <emu-val>false</emu-val> otherwise.
-            1.  If |validThis| is <emu-val>false</emu-val> and |attribute| was not specified
-                with the [{{LenientThis}}] [=extended attribute=], then [=ECMAScript/throw=] a
-                <emu-val>TypeError</emu-val>.
+            1.  Let |validThis| be true if |O| is a [=platform object=] that implements the
+                interface |target|, or false otherwise.
+            1.  If |validThis| is false and |attribute| was not specified with the [{{LenientThis}}]
+                [=extended attribute=], then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
             1.  If |attribute| is declared with the [{{Replaceable}}] extended attribute, then:
                 1.  Perform [=?=] [=CreateDataProperty=](|O|, |id|, |V|).
                 1.  Return <emu-val>undefined</emu-val>.
-            1.  If |validThis| is <emu-val>false</emu-val>, then return
-                <emu-val>undefined</emu-val>.
+            1.  If |validThis| is false, then return <emu-val>undefined</emu-val>.
             1.  If |attribute| is declared with a [{{LenientSetter}}] extended attribute, then
                 return <emu-val>undefined</emu-val>.
             1.  If |attribute| is declared with a [{{PutForwards}}] extended attribute, then:

--- a/index.bs
+++ b/index.bs
@@ -1377,6 +1377,10 @@ ignored or an exception is thrown.
     };
 </pre>
 
+The type of an attribute that is not [=read only=] must not be a [=promise type=]. Additionally,
+the type of an attribute with any of the [=extended attributes=] [{{LenientThis}}],
+[{{PutForwards}}], [{{Replaceable}}], or [{{SameObject}}] must not be a [=promise type=].
+
 A [=regular attribute=]
 that is not [=read only=]
 can be declared to <dfn id="dfn-inherit-getter" export>inherit its getter</dfn>
@@ -10518,126 +10522,140 @@ The characteristics of this property are as follows:
     where:
     *   |configurable| is <emu-val>false</emu-val> if the attribute was
         declared with the [{{Unforgeable}}] extended attribute and <emu-val>true</emu-val> otherwise;
-    *   |G| is the [=attribute getter=], defined below; and
-    *   |S| is the [=attribute setter=], also defined below.
-*   <div algorithm>
+    *   |G| is the [=attribute getter=] created given the attribute, the interface (or the interface
+        it's being mixed in to, if the interface is actually a mixin), and the [=relevant Realm=] of
+        the object that is the location of the property; and
+    *   |S| is the [=attribute setter=] created given the attribute, the interface (or the interface
+        it's being mixed in to, if the interface is actually a mixin), and the [=relevant Realm=] of
+        the object that is the location of the property.
 
-        The <dfn id="dfn-attribute-getter" export>attribute getter</dfn> is a <emu-val>Function</emu-val>
-        object whose behavior when invoked is as follows:
+<div algorithm>
 
-        1.  Let |idlValue| be an IDL value determined as follows.
-        1.  If the [=attribute=] is a [=regular attribute=], then:
-            1.  Let |I| be the [=interface=]
-                whose [=interface prototype object=]
-                this property corresponding to the attribute appears on.
+    The <dfn id="dfn-attribute-getter" export>attribute getter</dfn> is created as follows, given an
+    [=attribute=] |attribute|, an [=interface=] |target|, and a [=Realm=] |realm|:
 
-                Note: This means that even if an implements statement was used to make
-                an attribute available on the interface, |I| is the interface
-                on the left hand side of the implements statement, and not the one
-                that the attribute was originally declared on.
+    1.  Let |steps| be the following series of steps:
+        1.  Try running the following steps:
+            1.  Let |O| be <emu-val>null</emu-val>.
+            1.  If |attribute| is not a [=static attribute=]:
+                1.  If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or
+                    <emu-val>undefined</emu-val>, set |O| to |realm|'s [=Realm/global object=].
+                    (This will subsequently cause a <emu-val>TypeError</emu-val> in a few steps, if
+                    the global object does not implement |target| and [{{LenientThis}}] is not
+                    specified.)
+                    <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
+                1.  Otherwise, set |O| to the <emu-val>this</emu-val> value.
+                1.  If |O| is a [=platform object=], then [=perform a security check=], passing |O|,
+                    |attribute|'s [=identifier=], and "getter".
+                1.  If |O| is not a [=platform object=] that implements the interface |target|,
+                    then:
+                    1.  If |attribute| was specified with the [{{LenientThis}}]
+                        [=extended attribute=], then return <emu-val>undefined</emu-val>.
+                    1. Otherwise, [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+            1.  Let |R| be the result of performing the actions listed in the
+                description of |attribute| that occur on getting (or those listed in the description
+                of the inherited attribute, if this attribute is declared to
+                [=inherit its getter=]), on |O| if |O| is not <emu-val>null</emu-val>.
+            1.  Return the result of [=converted to an ECMAScript value|converting=] |R| to an
+                ECMAScript value of the type |attribute| is declared as.
 
-            1.  Let |O| be the <emu-val>this</emu-val> value.
-            1.  If |O| is a [=platform object=],
-                then [=perform a security check=], passing:
-                *   the platform object |O|,
-                *   the [=identifier=] of the [=attribute=], and
-                *   the type “getter”.
-            1.  If |O| is not a [=platform object=] that implements |I|, then:
-                1.  If the [=attribute=] was specified with the
-                    [{{LenientThis}}] [=extended attribute=],
-                    then return <emu-val>undefined</emu-val>.
-                1.  Otherwise, [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
-            1.  Set |idlValue| to be the result of performing the actions listed in the description of the attribute that occur when getting
-                (or those listed in the description of the inherited attribute, if this attribute is declared to
-                [=inherit its getter=]),
-                with |O| as the object.
-        1.  Otherwise, the attribute is a [=static attribute=].
-            Set |idlValue| to be the result of performing the actions listed in the description of the attribute that occur when getting.
-        1.  Let |V| be the result of [=converted to an ECMAScript value|converting=]
-            |idlValue| to an ECMAScript value.
-        1.  Return |V|.
-    </div>
+        And then, if an exception was thrown:
 
-    The value of the <emu-val>Function</emu-val> object’s “length”
-    property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.
+        1.  If |attribute|'s type is a [=promise type=], then:
+            1.  Let |reject| be the initial value of [=%Promise%=].reject.
+            1.  Return the result of calling |reject| with [=%Promise%=] as the
+                <emu-val>this</emu-val> object and the exception as the single argument value.
+        1.  Otherwise, end these steps and allow the exception to propagate.
+    1.  Let |F| be [=!=] [=CreateBuiltinFunction=](|realm|,
+        |steps|, the [=%FunctionPrototype%=] of |realm|).
+    1.  Let |name| be the string "get " prepended to |attribute|'s [=identifier=].
+    1.  Perform [=!=] [=SetFunctionName=](|F|, |name|).
+    1.  Perform [=!=] [=DefinePropertyOrThrow=](|F|, "length",
+        PropertyDescriptor<span class="prop-desc">{\[[Value]]: 0, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}</span>).
+    1. Return |F|.
 
-    The value of the <emu-val>Function</emu-val> object’s “name”
-    property is a <emu-val>String</emu-val> whose value is the
-    concatenation of “get ” and the identifier of the attribute.
+</div>
 
-*   <div algorithm>
+<div algorithm>
 
-        The <dfn id="dfn-attribute-setter" export>attribute setter</dfn> is <emu-val>undefined</emu-val>
-        if the attribute is declared <code>readonly</code> and does not have a
-        [{{LenientThis}}], [{{PutForwards}}] or [{{Replaceable}}] [=extended attribute=]
-        declared on it.
-        Otherwise, it is a <emu-val>Function</emu-val> object whose behavior when invoked is as follows:
+    The <dfn id="dfn-attribute-setter" export>attribute setter</dfn> is created as follows, given an
+    [=attribute=] |attribute|, an [=interface=] |target|, and a [=Realm=] |realm|:
 
-        1.  If no arguments were passed to the <emu-val>Function</emu-val>, then
-            [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
-        1.  Let |V| be the value of the first argument passed to the <emu-val>Function</emu-val>.
-        1.  If the [=attribute=] is a [=regular attribute=], then:
-            1.  Let |I| be the [=interface=]
-                whose [=interface prototype object=]
-                this property corresponding to the attribute appears on.
-            1.  Let |O| be the <emu-val>this</emu-val> value.
-            1.  If |O| is a [=platform object=],
-                then [=perform a security check=], passing:
-                *   the platform object |O|,
-                *   the [=identifier=] of the [=attribute=], and
-                *   the type “setter”.
-            1.  Let |validThis| be <emu-val>true</emu-val> if |O| is a
-                [=platform object=] that implements |I|, or
-                <emu-val>false</emu-val> otherwise.
-            1.  If |validThis| is <emu-val>false</emu-val> and the
-                [=attribute=] was not specified with the
-                [{{LenientThis}}] [=extended attribute=],
-                then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
-            1.  If the attribute is declared with a [{{Replaceable}}]
-                extended attribute, then:
-                1.  Let |P| be the identifier of the attribute.
-                1.  Call [=CreateDataProperty=](|O|, |P|, |V|).
+    1.  If |attribute| is [=read only=] and does not have a
+        [{{LenientThis}}], [{{PutForwards}}] or [{{Replaceable}}] [=extended attribute=], return
+        <emu-val>undefined</emu-val>; there is no [=attribute setter=] function.
+    1.  Assert: |attribute|'s type is not a [=promise type=].
+    1.  Let |steps| be the following series of steps:
+        1.  If no arguments were passed, then
+        1.  Let |V| be the value of the first argument passed.
+        1.  Let |id| be |attribute|'s [=identifier=].
+        1.  Let |O| be <emu-val>null</emu-val>.
+        1.  If |attribute| is not a [=static attribute=]:
+            1.  If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or
+                <emu-val>undefined</emu-val>, set |O| to |realm|'s [=Realm/global object=].
+                (This will subsequently cause a <emu-val>TypeError</emu-val> in a few steps, if
+                the global object does not implement |target| and [{{LenientThis}}] is not
+                specified.)
+                <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
+            1.  Otherwise, set |O| to the <emu-val>this</emu-val> value.
+            1.  If |O| is a [=platform object=], then [=perform a security check=], passing |O|,
+                |id|, and "setter".
+            1.  Let |validThis| be <emu-val>true</emu-val> if |O| is a [=platform object=] that
+                implements the interface |target|, or <emu-val>false</emu-val> otherwise.
+            1.  If |validThis| is <emu-val>false</emu-val> and |attribute| was not specified
+                with the [{{LenientThis}}] [=extended attribute=], then [=ECMAScript/throw=] a
+                <emu-val>TypeError</emu-val>.
+            1.  If |attribute| is declared with the [{{Replaceable}}] extended attribute, then:
+                1.  Perform [=?=] [=CreateDataProperty=](|O|, |id|, |V|).
                 1.  Return <emu-val>undefined</emu-val>.
-            1.  If |validThis| is <emu-val>false</emu-val>, then return <emu-val>undefined</emu-val>.
-            1.  If the attribute is declared with a [{{LenientSetter}}]
-                extended attribute, then return <emu-val>undefined</emu-val>.
-            1.  If the attribute is declared with a [{{PutForwards}}]
-                extended attribute, then:
-                1.  Let |Q| be the result of calling the \[[Get]] method
-                    on |O| using the identifier of the attribute as the property name.
-                1.  If |Q| is not an object, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
-                1.  Let |A| be the attribute identified by the [{{PutForwards}}] extended attribute.
-                1.  Call the \[[Put]] method on |Q|
-                    using the identifier of |A| as the property name and |V| as the value.
+            1.  If |validThis| is <emu-val>false</emu-val>, then return
+                <emu-val>undefined</emu-val>.
+            1.  If |attribute| is declared with a [{{LenientSetter}}] extended attribute, then
+                return <emu-val>undefined</emu-val>.
+            1.  If |attribute| is declared with a [{{PutForwards}}] extended attribute, then:
+                1.  Let |Q| be [=?=] [=Get=](|O|, |id|).
+                1.  If [=Type=](|Q|) is not Object, then [=ECMAScript/throw=] a
+                    <emu-val>TypeError</emu-val>.
+                1.  Let |forwardId| be the identifier argument of the [{{PutForwards}}] extended
+                    attribute.
+                1.  Perform [=?=] [=Set=](|Q|, |forwardId|, |V|).
                 1.  Return <emu-val>undefined</emu-val>.
-        1.  Let |idlValue| be an IDL value determined as follows:
-            *   If the type of the attribute is an [=enumeration=], then:
-                1.  Let |S| be the result of calling [=ToString=](|V|).
-                1.  If |S| is not one of the [=enumeration values|enumeration’s values=], then return <emu-val>undefined</emu-val>.
-                1.  The value of |idlValue| is the enumeration value equal to |S|.
-            *   Otherwise, the type of the attribute is not an [=enumeration=].
-                The value of |idlValue| is the result of [=converted to an IDL value|converting=]
-                |V| to an IDL value.
-        1.  If the attribute is a regular attribute, then perform the actions listed in the description of the attribute that occur when setting,
-            with |O| as the object and |idlValue| as the value.
-        1.  Otherwise, the attribute is a [=static attribute=].
-            Perform the actions listed in the description of the attribute that occur when setting with |idlValue| as the value.
-        1.  Return <emu-val>undefined</emu-val>.
-    </div>
+        1.  Let |idlValue| be determined as follows:
 
-    The value of the <emu-val>Function</emu-val> object’s “length”
-    property is the <emu-val>Number</emu-val> value <emu-val>1</emu-val>.
+            <dl class="switch">
+                <dt>|attribute|'s type is an [=enumeration=]</dt>
+                <dd>
+                    1.  Let |S| be [=?=] [=ToString=](|V|).
+                    1.  If |S| is not one of the [=enumeration values|enumeration’s values=], then
+                        return <emu-val>undefined</emu-val>.
+                    1.  Otherwise, |idlValue| is the enumeration value equal to |S|.
+                </dd>
 
-    The value of the <emu-val>Function</emu-val> object’s “name”
-    property is a <emu-val>String</emu-val> whose value is the
-    concatenation of “set ” and the identifier of the attribute.
+                <dt>Otherwise</dt>
+                <dd>
+                    |idlValue| is the result of [=converted to an IDL value|converting=] |V| to an
+                    IDL value of |attribute|'s type.
+                </dd>
+            </dl>
+
+        1.  Perform the actions listed in the description of |attribute| that occur on setting, on
+            |O| if |O| is not <emu-val>null</emu-val>.
+        1.  Return <emu-val>undefined</emu-val>
+    1.  Let |F| be [=!=] [=CreateBuiltinFunction=](|realm|,
+        |steps|, the [=%FunctionPrototype%=] of |realm|).
+    1.  Let |name| be the string "set " prepended to |id|.
+    1.  Perform [=!=] [=SetFunctionName=](|F|, |name|).
+    1.  Perform [=!=] [=DefinePropertyOrThrow=](|F|, "length",
+        PropertyDescriptor<span class="prop-desc">{\[[Value]]: 1, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}</span>).
+    1. Return |F|.
+</div>
 
 Note: Although there is only a single property for an IDL attribute, since
 accessor property getters and setters are passed a <emu-val>this</emu-val>
 value for the object on which property corresponding to the IDL attribute is
 accessed, they are able to expose instance-specific data.
 
-Note: Note that attempting to assign to a property corresponding to a
+Note: Attempting to assign to a property corresponding to a
 [=read only=] [=attribute=]
 results in different behavior depending on whether the script doing so is in strict mode.
 When in strict mode, such an assignment will result in a <emu-val>TypeError</emu-val>

--- a/index.html
+++ b/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 0feafaae1a97b66d9da46b325858f9805ac01fb2" name="generator">
+  <meta content="Bikeshed version 176d39d5a285c04f57d2f0e078fa69273028eb45" name="generator">
 <style>
         pre.set {
           font-size: 80%;
@@ -1557,7 +1557,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web IDL</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-13">13 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-10">10 January 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1572,7 +1572,7 @@ pre.idl.highlight { color: #708090; }
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" rel="license">permissive document license</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" rel="license">permissive document license</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
@@ -2704,14 +2704,17 @@ ignored or an exception is thrown.</p>
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="n">type</span> <span class="nv">identifier</span>;
 };
 </pre>
-   <p>A <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-2">regular attribute</a> that is not <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-2">read only</a> can be declared to <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-inherit-getter">inherit its getter</dfn> from an ancestor interface.  This can be used to make a read only attribute
+   <p>The type of an attribute that is not <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-2">read only</a> must not be a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-1">promise type</a>. Additionally,
+the type of an attribute with any of the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-7">extended attributes</a> [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-1">LenientThis</a></code>],
+[<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-1">PutForwards</a></code>], [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-1">Replaceable</a></code>], or [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-1">SameObject</a></code>] must not be a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-2">promise type</a>.</p>
+   <p>A <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-2">regular attribute</a> that is not <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-3">read only</a> can be declared to <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-inherit-getter">inherit its getter</dfn> from an ancestor interface.  This can be used to make a read only attribute
 in an ancestor interface be writable on a derived interface.  An attribute <a data-link-type="dfn" href="#dfn-inherit-getter" id="ref-for-dfn-inherit-getter-1">inherits its getter</a> if
 its declaration includes <emu-t>inherit</emu-t> in the declaration.
 The read only attribute from which the attribute inherits its getter
 is the attribute with the same identifier on the closest ancestor interface
 of the one on which the inheriting attribute is defined.  The attribute
 whose getter is being inherited must be
-of the same type as the inheriting attribute, and <emu-t>inherit</emu-t> must not appear on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-3">read only</a> attribute or a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-4">static attribute</a>.</p>
+of the same type as the inheriting attribute, and <emu-t>inherit</emu-t> must not appear on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-4">read only</a> attribute or a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-4">static attribute</a>.</p>
 <pre class="syntax highlight"><span class="kt">interface</span> <span class="nv">Ancestor</span> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="n">TheType</span> <span class="nv">theIdentifier</span>;
 };
@@ -2735,18 +2738,18 @@ interface will be stringified to the value of the attribute.  See <a href="#idl-
     an IDL type, then any exception resulting from this will also
     be propagated to the user code that resulted in the implementation
     attempting to get the value of the attribute. </p>
-   <p>The following <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-7">extended attributes</a> are applicable to regular and static attributes:
+   <p>The following <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-8">extended attributes</a> are applicable to regular and static attributes:
 [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-1">Clamp</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-1">EnforceRange</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-4">Exposed</a></code>],
-[<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-1">SameObject</a></code>],
+[<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-2">SameObject</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-4">SecureContext</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#TreatNullAs" id="ref-for-TreatNullAs-1">TreatNullAs</a></code>].</p>
-   <p>The following <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-8">extended attributes</a> are applicable only to regular attributes:
+   <p>The following <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-9">extended attributes</a> are applicable only to regular attributes:
 [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-1">LenientSetter</a></code>],
-[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-1">LenientThis</a></code>],
-[<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-1">PutForwards</a></code>],
-[<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-1">Replaceable</a></code>],
+[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-2">LenientThis</a></code>],
+[<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-2">PutForwards</a></code>],
+[<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-2">Replaceable</a></code>],
 [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-1">Unforgeable</a></code>].</p>
 <pre class="grammar" id="prod-ReadOnlyMember">ReadOnlyMember :
     "readonly" ReadOnlyMemberRest
@@ -2871,7 +2874,7 @@ identify any one of those definitions or a <a data-link-type="dfn" href="#dfn-di
 </pre>
    <p>The identifier of each argument must not be the same
 as the identifier of another argument in the same operation declaration.</p>
-   <p>Each argument can be preceded by a list of <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-9">extended attributes</a> (matching <emu-nt><a href="#prod-ExtendedAttributeList">ExtendedAttributeList</a></emu-nt>),
+   <p>Each argument can be preceded by a list of <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-10">extended attributes</a> (matching <emu-nt><a href="#prod-ExtendedAttributeList">ExtendedAttributeList</a></emu-nt>),
 which can control how a value passed as the argument will be handled in
 language bindings.</p>
 <pre class="syntax highlight"><span class="kt">interface</span> <span class="nv">interface_identifier</span> {
@@ -2910,7 +2913,7 @@ is the final argument in the operation’s argument list.</p>
   <span class="n">return_type</span> <span class="nv">identifier</span>(<span class="n">type</span> <span class="nv">identifier</span>, <span class="n">type</span><mark>...</mark> <span class="nv">identifier</span>);
 };
 </pre>
-   <p><a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-10">Extended attributes</a> that <a data-link-type="dfn" href="#dfn-xattr-argument-list" id="ref-for-dfn-xattr-argument-list-1">take an argument list</a> ([<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-4">Constructor</a></code>] and
+   <p><a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-11">Extended attributes</a> that <a data-link-type="dfn" href="#dfn-xattr-argument-list" id="ref-for-dfn-xattr-argument-list-1">take an argument list</a> ([<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-4">Constructor</a></code>] and
 [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-3">NamedConstructor</a></code>], of those
 defined in this specification) and <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-10">callback functions</a> are also considered to be <a data-link-type="dfn" href="#dfn-variadic" id="ref-for-dfn-variadic-1">variadic</a> when the <emu-t>...</emu-t> token is used in their argument lists.</p>
    <div class="example" id="example-20770917">
@@ -3232,7 +3235,7 @@ as if it were a function.</p>
    <p class="note" role="note">Note: This artificial restriction allows bundling all interfaces with exotic object behavior
 into a single <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-2">platform object</a> category: <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-1">legacy platform objects</a>.
 This is possible because all existing interfaces which have a <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-3">legacy caller</a> also <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-2">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-2">named properties</a>.</p>
-   <p>Legacy callers must not be defined to return a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-1">promise type</a>.</p>
+   <p>Legacy callers must not be defined to return a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-3">promise type</a>.</p>
    <p class="advisement"> Legacy callers are universally recognised as an undesirable feature.  They exist
     only so that legacy Web platform features can be specified.  Legacy callers
     should not be used in specifications unless required to
@@ -4011,7 +4014,7 @@ the notion of an <em>effective overload set</em> is used.</p>
 };
 </pre>
     <p>Note that the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-6">Constructor</a></code>] and
-    [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-4">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-11">extended attributes</a> are disallowed from appearing
+    [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-4">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-12">extended attributes</a> are disallowed from appearing
     on <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-7">partial interface</a> definitions,
     so there is no need to also disallow overloading for constructors.</p>
    </div>
@@ -4048,7 +4051,7 @@ the inputs to the algorithm needed to compute the set.</p>
     <dd data-md="">
      <ul>
       <li data-md="">
-       <p>the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-39">interface</a> on which the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-8">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-12">extended attributes</a> are to be found</p>
+       <p>the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-39">interface</a> on which the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-8">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-13">extended attributes</a> are to be found</p>
       <li data-md="">
        <p>the number of arguments to be passed</p>
      </ul>
@@ -4057,7 +4060,7 @@ the inputs to the algorithm needed to compute the set.</p>
     <dd data-md="">
      <ul>
       <li data-md="">
-       <p>the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-40">interface</a> on which the [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-6">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-13">extended attributes</a> are to be found</p>
+       <p>the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-40">interface</a> on which the [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-6">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-14">extended attributes</a> are to be found</p>
       <li data-md="">
        <p>the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-31">identifier</a> of the named constructors</p>
       <li data-md="">
@@ -4124,12 +4127,12 @@ identifier <var>A</var> defined on interface <var>I</var>.</p>
         <p>For constructors</p>
        <dd data-md="">
         <p>The elements of <var>F</var> are the
-[<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-9">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-14">extended attributes</a> on interface <var>I</var>.</p>
+[<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-9">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-15">extended attributes</a> on interface <var>I</var>.</p>
        <dt data-md="">
         <p>For named constructors</p>
        <dd data-md="">
         <p>The elements of <var>F</var> are the
-[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-7">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-15">extended attributes</a> on interface <var>I</var> whose <a data-link-type="dfn" href="#dfn-xattr-named-argument-list" id="ref-for-dfn-xattr-named-argument-list-2">named argument lists’</a> identifiers are <var>A</var>.</p>
+[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-7">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-16">extended attributes</a> on interface <var>I</var> whose <a data-link-type="dfn" href="#dfn-xattr-named-argument-list" id="ref-for-dfn-xattr-named-argument-list-2">named argument lists’</a> identifiers are <var>A</var>.</p>
        <dt data-md="">
         <p>For legacy callers</p>
        <dd data-md="">
@@ -4451,7 +4454,7 @@ and it is not the case that both are <a data-link-type="dfn" href="#dfn-callback
       <p><code>CBIface</code> is distinguishable from <code>Iface</code> because the pair satisfies note (a),
     but it is not distinguishable from <code>Dict</code> because that pair does not satisfy note (b).</p>
      </div>
-     <div class="example" id="example-distinguishability-promises"><a class="self-link" href="#example-distinguishability-promises"></a> <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-2">Promise types</a> do not appear in the above table, and as a consequence are
+     <div class="example" id="example-distinguishability-promises"><a class="self-link" href="#example-distinguishability-promises"></a> <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-4">Promise types</a> do not appear in the above table, and as a consequence are
     not distinguishable with any other type. </div>
    </ol>
    <p>If there is more than one entry in an <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-3">effective overload set</a> that has a given type list length, then for those entries there
@@ -4645,7 +4648,7 @@ A maplike interface and its <a data-link-type="dfn" href="#dfn-inherited-interfa
 <pre class="grammar" id="prod-MaplikeRest">MaplikeRest :
     "maplike" "&lt;" Type "," Type ">" ";"
 </pre>
-   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-16">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-4">maplike declarations</a>.</p>
+   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-17">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-4">maplike declarations</a>.</p>
    <p class="issue" id="issue-dbe4d1af"><a class="self-link" href="#issue-dbe4d1af"></a> Add example. </p>
    <h4 class="heading settled" data-level="2.2.9" id="idl-setlike"><span class="secno">2.2.9. </span><span class="content">Setlike declarations</span><a class="self-link" href="#idl-setlike"></a></h4>
    <p>An <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-46">interface</a> can be declared to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-setlike">setlike</dfn> by using a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-setlike-declaration">setlike declaration</dfn> (matching <emu-nt><a href="#prod-ReadWriteSetlike">ReadWriteSetlike</a></emu-nt> or <emu-t>readonly</emu-t> <emu-nt><a href="#prod-SetlikeRest">SetlikeRest</a></emu-nt>) in the body of the interface.</p>
@@ -4691,7 +4694,7 @@ A setlike interface and its <a data-link-type="dfn" href="#dfn-inherited-interfa
 <pre class="grammar" id="prod-SetlikeRest">SetlikeRest :
     "setlike" "&lt;" Type ">" ";"
 </pre>
-   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-17">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-5">setlike declarations</a>.</p>
+   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-18">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-5">setlike declarations</a>.</p>
    <p class="issue" id="issue-dbe4d1af0"><a class="self-link" href="#issue-dbe4d1af0"></a> Add example. </p>
    <h3 class="heading settled" data-level="2.3" id="idl-namespaces"><span class="secno">2.3. </span><span class="content">Namespaces</span><a class="self-link" href="#idl-namespaces"></a></h3>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-namespace">namespace</dfn> is a definition (matching <emu-nt><a href="#prod-Namespace">Namespace</a></emu-nt>) that declares a global singleton with
@@ -5224,7 +5227,7 @@ whose type is the enumeration, is language binding specific.</p>
    <p class="note" role="note">Note: In the ECMAScript binding, assignment of an invalid string value to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-18">attribute</a> is ignored, while
 passing such a value as an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-25">operation</a> argument
 results in an exception being thrown.</p>
-   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-18">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-enumeration" id="ref-for-dfn-enumeration-12">enumerations</a>.</p>
+   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-19">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-enumeration" id="ref-for-dfn-enumeration-12">enumerations</a>.</p>
 <pre class="grammar" id="prod-Enum">Enum :
     "enum" identifier "{" EnumValueList "}" ";"
 </pre>
@@ -5317,7 +5320,7 @@ the type in the IDL.</p>
 type gives the name.</p>
    <p>The <emu-nt><a href="#prod-Type">Type</a></emu-nt> must not
 be the identifier of the same or another <a data-link-type="dfn" href="#dfn-typedef" id="ref-for-dfn-typedef-11">typedef</a>.</p>
-   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-19">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-typedef" id="ref-for-dfn-typedef-12">typedefs</a>.</p>
+   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-20">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-typedef" id="ref-for-dfn-typedef-12">typedefs</a>.</p>
 <pre class="grammar" id="prod-Typedef">Typedef :
     "typedef" Type identifier ";"
 </pre>
@@ -5417,7 +5420,7 @@ of those consequential interfaces or on the original interface itself.</p>
 <span class="n">F</span> <span class="kt">implements</span> <span class="n">I</span>;  // H::z and I::z would clash when mixed in to F
 </pre>
    </div>
-   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-20">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-implements-statement" id="ref-for-dfn-implements-statement-6">implements statements</a>.</p>
+   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-21">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-implements-statement" id="ref-for-dfn-implements-statement-6">implements statements</a>.</p>
 <pre class="grammar" id="prod-ImplementsStatement">ImplementsStatement :
     identifier "implements" identifier ";"
 </pre>
@@ -5457,7 +5460,7 @@ object that are considered to be platform objects:</p>
      <p>objects representing IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-16">DOMExceptions</a></code>.</p>
    </ul>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-legacy-platform-object">Legacy platform objects</dfn> are <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-7">platform objects</a> that implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-50">interface</a> which
-does not have a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-5">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-6">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-21">extended attribute</a>, <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-9">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-4">named properties</a>,
+does not have a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-5">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-6">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-22">extended attribute</a>, <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-9">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-4">named properties</a>,
 and may have one or multiple <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-10">legacy callers</a>.</p>
    <p>In a browser, for example,
 the browser-implemented DOM objects (implementing interfaces such as <code class="idl">Node</code> and <code class="idl">Document</code>) that provide access to a web page’s contents
@@ -5851,7 +5854,7 @@ The inner type must not be:</p>
     <li data-md="">
      <p><code class="idl"><a data-link-type="idl" href="#idl-any" id="ref-for-idl-any-6">any</a></code>,</p>
     <li data-md="">
-     <p>a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-3">Promise type</a>,</p>
+     <p>a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-5">Promise type</a>,</p>
     <li data-md="">
      <p>another nullable type, or</p>
     <li data-md="">
@@ -6123,7 +6126,7 @@ and <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-29">
 is used to control how language bindings will handle those constructs.
 Extended attributes are specified with an <emu-nt><a href="#prod-ExtendedAttributeList">ExtendedAttributeList</a></emu-nt>,
 which is a square bracket enclosed, comma separated list of <emu-nt><a href="#prod-ExtendedAttribute">ExtendedAttribute</a></emu-nt>s.</p>
-   <p>The <emu-nt><a href="#prod-ExtendedAttribute">ExtendedAttribute</a></emu-nt> grammar symbol matches nearly any sequence of tokens, however the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-22">extended attributes</a> defined in this document only accept a more restricted syntax.
+   <p>The <emu-nt><a href="#prod-ExtendedAttribute">ExtendedAttribute</a></emu-nt> grammar symbol matches nearly any sequence of tokens, however the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-23">extended attributes</a> defined in this document only accept a more restricted syntax.
 Any extended attribute encountered in an <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-31">IDL fragment</a> is
 matched against the following six grammar symbols to determine
 which form (or forms) it is in:</p>
@@ -6608,7 +6611,7 @@ ECMAScript <emu-val>Boolean</emu-val> value <var>x</var>.</p>
        <li data-md="">
         <p>Otherwise let <var>lowerBound</var> be −2<sup>53</sup> + 1.</p>
         <p class="note" role="note">Note: this ensures <code class="idl"><a data-link-type="idl" href="#idl-long-long" id="ref-for-idl-long-long-11">long long</a></code> types annotated with
-[<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-4">EnforceRange</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-4">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-23">extended attributes</a> are representable in ECMAScript’s <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">Number type</a> as unambiguous integers.</p>
+[<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-4">EnforceRange</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-4">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-24">extended attributes</a> are representable in ECMAScript’s <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">Number type</a> as unambiguous integers.</p>
       </ol>
      <li data-md="">
       <p>Otherwise, if <var>signedness</var> is "unsigned", then:</p>
@@ -6632,7 +6635,7 @@ ECMAScript <emu-val>Boolean</emu-val> value <var>x</var>.</p>
       <p>If the conversion to an IDL value is being performed due to any of the following:</p>
       <ul>
        <li data-md="">
-        <p><var>V</var> is being assigned to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-25">attribute</a> annotated with the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-5">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-24">extended attribute</a>,</p>
+        <p><var>V</var> is being assigned to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-25">attribute</a> annotated with the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-5">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-25">extended attribute</a>,</p>
        <li data-md="">
         <p><var>V</var> is being passed as an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-31">operation</a> argument annotated with the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-6">EnforceRange</a></code>] extended attribute, or</p>
        <li data-md="">
@@ -6655,7 +6658,7 @@ then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-thr
       <p>If <var>x</var> is not <emu-val>NaN</emu-val> and the conversion to an IDL value is being performed due to any of the following:</p>
       <ul>
        <li data-md="">
-        <p><var>V</var> is being assigned to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-26">attribute</a> annotated with the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-5">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-25">extended attribute</a>,</p>
+        <p><var>V</var> is being assigned to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-26">attribute</a> annotated with the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-5">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-26">extended attribute</a>,</p>
        <li data-md="">
         <p><var>V</var> is being passed as an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-32">operation</a> argument annotated with the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-6">Clamp</a></code>] extended attribute, or</p>
        <li data-md="">
@@ -7310,7 +7313,7 @@ console<span class="p">.</span>assert<span class="p">(</span>entries<span class=
     </table>
    </div>
    <h4 class="heading settled" data-level="3.2.20" id="es-promise"><span class="secno">3.2.20. </span><span class="content">Promise types — Promise&lt;<var>T</var>></span><a class="self-link" href="#es-promise"></a></h4>
-   <p>IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-4">promise type</a> values are
+   <p>IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-6">promise type</a> values are
 represented by ECMAScript <emu-val>Promise</emu-val> objects.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to promise" id="es-to-promise">
     <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-32">converted</a> to an IDL <a class="idl-code" data-link-type="interface" href="#idl-promise" id="ref-for-idl-promise-1">Promise<var>T</var></a> value as follows:</p>
@@ -7321,13 +7324,13 @@ represented by ECMAScript <emu-val>Promise</emu-val> objects.</p>
      <li data-md="">
       <p>Let <var>promise</var> be the result of calling <var>resolve</var> with <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a> as the <emu-val>this</emu-val> value and <var>V</var> as the single argument value.</p>
      <li data-md="">
-      <p>Return the IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-5">promise type</a> value that is a reference to the
+      <p>Return the IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-7">promise type</a> value that is a reference to the
 same object as <var>promise</var>.</p>
     </ol>
    </div>
-   <p id="promise-to-es"> The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-31">converting</a> an IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-6">promise type</a> value to an ECMAScript
+   <p id="promise-to-es"> The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-31">converting</a> an IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-8">promise type</a> value to an ECMAScript
     value is the <emu-val>Promise</emu-val> value that represents a reference to the same object that the
-    IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-7">promise type</a> represents. </p>
+    IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-9">promise type</a> represents. </p>
    <div class="algorithm" data-algorithm="perform some steps once a promise is settled">
     <p>One can <dfn data-dfn-type="dfn" data-export="" data-lt="upon settling" id="dfn-perform-steps-once-promise-is-settled">perform some steps once a promise is settled<a class="self-link" href="#dfn-perform-steps-once-promise-is-settled"></a></dfn>.
     There can be one or two sets of steps to perform,
@@ -7701,9 +7704,9 @@ to the same object that the IDL <a class="idl-code" data-link-type="interface" h
     </ol>
    </div>
    <h3 class="heading settled" data-level="3.3" id="es-extended-attributes"><span class="secno">3.3. </span><span class="content">ECMAScript-specific extended attributes</span><a class="self-link" href="#es-extended-attributes"></a></h3>
-   <p>This section defines a number of <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-26">extended attributes</a> whose presence affects only the ECMAScript binding.</p>
+   <p>This section defines a number of <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-27">extended attributes</a> whose presence affects only the ECMAScript binding.</p>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.1" data-lt="Clamp" id="Clamp"><span class="secno">3.3.1. </span><span class="content">[Clamp]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-8">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-27">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-35">operation</a> argument,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-8">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-28">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-35">operation</a> argument,
 writable <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-31">attribute</a> or <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-19">dictionary member</a> whose type is one of the <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-4">integer types</a>,
 it indicates that when an ECMAScript <emu-val>Number</emu-val> is
 converted to the IDL type, out of range values will be clamped to the range
@@ -7712,7 +7715,7 @@ of valid values, rather than using the operators that use a modulo operation
    <p>The [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-9">Clamp</a></code>]
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-1">take no arguments</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-10">Clamp</a></code>] extended attribute
-must not appear on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-4">read only</a> attribute, or an attribute, operation argument or dictionary member
+must not appear on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-5">read only</a> attribute, or an attribute, operation argument or dictionary member
 that is not of an integer type.  It also must not
 be used in conjunction with the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-8">EnforceRange</a></code>]
 extended attribute.</p>
@@ -7724,7 +7727,7 @@ types in <a href="#es-type-mapping">§3.2 ECMAScript type mapping</a> for the sp
     <p>In the following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-34">IDL fragment</a>,
     two <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-36">operations</a> are declared that
     take three <code class="idl"><a data-link-type="idl" href="#idl-octet" id="ref-for-idl-octet-10">octet</a></code> arguments; one uses
-    the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-12">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-28">extended attribute</a> on all three arguments, while the other does not:</p>
+    the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-12">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-29">extended attribute</a> on all three arguments, while the other does not:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">GraphicsContext</span> {
   <span class="kt">void</span> <span class="nv">setColor</span>(<span class="kt">octet</span> <span class="nv">red</span>, <span class="kt">octet</span> <span class="nv">green</span>, <span class="kt">octet</span> <span class="nv">blue</span>);
   <span class="kt">void</span> <span class="nv">setColorClamped</span>([<span class="nv">Clamp</span>] <span class="kt">octet</span> <span class="nv">red</span>, [<span class="nv">Clamp</span>] <span class="kt">octet</span> <span class="nv">green</span>, [<span class="nv">Clamp</span>] <span class="kt">octet</span> <span class="nv">blue</span>);
@@ -7744,7 +7747,7 @@ types in <a href="#es-type-mapping">§3.2 ECMAScript type mapping</a> for the sp
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.2" data-lt="Constructor" id="Constructor"><span class="secno">3.3.2. </span><span class="content">[Constructor]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-11">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-29">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-57">interface</a>, it indicates that
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-11">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-30">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-57">interface</a>, it indicates that
 the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-3">interface object</a> for this interface
 will have an [[Construct]] internal method,
 allowing objects implementing the interface to be constructed.</p>
@@ -7804,7 +7807,7 @@ for an interface is to be implemented.</p>
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.3" data-lt="EnforceRange" id="EnforceRange"><span class="secno">3.3.3. </span><span class="content">[EnforceRange]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-9">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-30">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-37">operation</a> argument,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-9">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-31">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-37">operation</a> argument,
 writable <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-4">regular attribute</a> or <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-20">dictionary member</a> whose type is one of the <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-5">integer types</a>,
 it indicates that when an ECMAScript <emu-val>Number</emu-val> is
 converted to the IDL type, out of range values will cause an exception to
@@ -7813,7 +7816,7 @@ be thrown, rather than converted to being a valid value using the operators that
    <p>The [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-10">EnforceRange</a></code>]
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-3">take no arguments</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-11">EnforceRange</a></code>] extended attribute
-must not appear on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-5">read only</a> attribute, a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-6">static attribute</a>,
+must not appear on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-6">read only</a> attribute, a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-6">static attribute</a>,
 or an attribute, operation argument or dictionary member
 that is not of an integer type.  It also must not
 be used in conjunction with the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-13">Clamp</a></code>]
@@ -7826,7 +7829,7 @@ types in <a href="#es-type-mapping">§3.2 ECMAScript type mapping</a> for the sp
     <p>In the following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-35">IDL fragment</a>,
     two <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-38">operations</a> are declared that
     take three <code class="idl"><a data-link-type="idl" href="#idl-octet" id="ref-for-idl-octet-12">octet</a></code> arguments; one uses
-    the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-13">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-31">extended attribute</a> on all three arguments, while the other does not:</p>
+    the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-13">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-32">extended attribute</a> on all three arguments, while the other does not:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">GraphicsContext</span> {
   <span class="kt">void</span> <span class="nv">setColor</span>(<span class="kt">octet</span> <span class="nv">red</span>, <span class="kt">octet</span> <span class="nv">green</span>, <span class="kt">octet</span> <span class="nv">blue</span>);
   <span class="kt">void</span> <span class="nv">setColorEnforcedRange</span>([<span class="nv">EnforceRange</span>] <span class="kt">octet</span> <span class="nv">red</span>, [<span class="nv">EnforceRange</span>] <span class="kt">octet</span> <span class="nv">green</span>, [<span class="nv">EnforceRange</span>] <span class="kt">octet</span> <span class="nv">blue</span>);
@@ -7851,22 +7854,22 @@ types in <a href="#es-type-mapping">§3.2 ECMAScript type mapping</a> for the sp
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.4" data-lt="Exposed" id="Exposed"><span class="secno">3.3.4. </span><span class="content">[Exposed]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-9">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-32">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-58">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-8">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-6">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-3">partial namespace</a>, or
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-9">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-33">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-58">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-8">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-6">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-3">partial namespace</a>, or
 an individual <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-11">interface member</a> or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-3">namespace member</a>,
 it indicates that the construct is exposed
 on a particular set of global interfaces, rather than the default of
 being exposed only on the <a data-link-type="dfn" href="#dfn-primary-global-interface" id="ref-for-dfn-primary-global-interface-1">primary global interface</a>.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-10">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-33">extended attribute</a> must either <a data-link-type="dfn" href="#dfn-xattr-identifier" id="ref-for-dfn-xattr-identifier-1">take an identifier</a> or <a data-link-type="dfn" href="#dfn-xattr-identifier-list" id="ref-for-dfn-xattr-identifier-list-1">take an identifier list</a>.
+   <p>The [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-10">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-34">extended attribute</a> must either <a data-link-type="dfn" href="#dfn-xattr-identifier" id="ref-for-dfn-xattr-identifier-1">take an identifier</a> or <a data-link-type="dfn" href="#dfn-xattr-identifier-list" id="ref-for-dfn-xattr-identifier-list-1">take an identifier list</a>.
 Each of the identifiers mentioned must be
 a <a data-link-type="dfn" href="#dfn-global-name" id="ref-for-dfn-global-name-1">global name</a>.</p>
-   <p>Every construct that the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-11">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-34">extended attribute</a> can be specified on has an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exposure-set">exposure set</dfn>,
+   <p>Every construct that the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-11">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-35">extended attribute</a> can be specified on has an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exposure-set">exposure set</dfn>,
 which is a set of <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-59">interfaces</a> defining which global environments the construct can be used in.
 The <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-1">exposure set</a> for a given construct is defined as follows:</p>
    <ul>
     <li data-md="">
-     <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-12">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-35">extended attribute</a> is specified on the construct, then the <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-2">exposure set</a> is the set of all interfaces that have a <a data-link-type="dfn" href="#dfn-global-name" id="ref-for-dfn-global-name-2">global name</a> that is listed in the extended attribute’s argument.</p>
+     <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-12">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-36">extended attribute</a> is specified on the construct, then the <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-2">exposure set</a> is the set of all interfaces that have a <a data-link-type="dfn" href="#dfn-global-name" id="ref-for-dfn-global-name-2">global name</a> that is listed in the extended attribute’s argument.</p>
     <li data-md="">
-     <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-13">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-36">extended attribute</a> does not appear on a construct, then its <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-3">exposure set</a> is defined
+     <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-13">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-37">extended attribute</a> does not appear on a construct, then its <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-3">exposure set</a> is defined
 implicitly, depending on the type of construct:</p>
      <dl class="switch">
       <dt data-md="">
@@ -7994,7 +7997,7 @@ can be made once, at the time the <a data-link-type="dfn" href="#dfn-initial-obj
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.5" data-lt="Global|PrimaryGlobal" dfn="" id="Global"><span class="secno">3.3.5. </span><span class="content">[Global] and [PrimaryGlobal]</span><span id="PrimaryGlobal"></span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-7">Global</a></code>]
-or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-8">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-37">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-61">interface</a>,
+or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-8">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-38">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-61">interface</a>,
 it indicates that objects implementing this interface can
 be used as the global object in an ECMAScript environment,
 and that the structure of the prototype chain and how
@@ -8028,7 +8031,7 @@ will correspond to properties on the object itself rather than on <a data-link-t
     property would already have been created before the
     assignment is evaluated.</p>
    </div>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-9">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-10">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-38">extended attributes</a> is
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-9">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-10">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-39">extended attributes</a> is
 used on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-63">interface</a>, then:</p>
    <ul>
     <li data-md="">
@@ -8048,7 +8051,7 @@ extended attribute.</p>
 a <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-9">partial interface</a> definition, then that partial interface definition must
 be the part of the interface definition that defines
 the <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-named-property-getter-5">named property getter</a>.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-13">Global</a></code>] and [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-14">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-39">extended attribute</a> must not
+   <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-13">Global</a></code>] and [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-14">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-40">extended attribute</a> must not
 be used on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-64">interface</a> that can have more
 than one object implementing it in the same ECMAScript global environment.</p>
    <p class="note" role="note">Note: This is because the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-3">named properties object</a>,
@@ -8056,7 +8059,7 @@ which exposes the named properties, is in the prototype chain, and it would not 
 sense for more than one object’s named properties to be exposed on an object that
 all of those objects inherit from.</p>
    <p>If an interface is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-15">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-16">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-40">extended attribute</a>, then
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-16">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-41">extended attribute</a>, then
 there must not be more than one <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-15">interface member</a> across
 the interface and its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-15">consequential interfaces</a> with the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-51">identifier</a>.
 There also must not be more than
@@ -8074,12 +8077,12 @@ extended attribute.</p>
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-20">PrimaryGlobal</a></code>]
 extended attributes must either <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-4">take no arguments</a> or <a data-link-type="dfn" href="#dfn-xattr-identifier-list" id="ref-for-dfn-xattr-identifier-list-2">take an identifier list</a>.</p>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-21">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-22">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-41">extended attribute</a> is declared with an identifier list argument, then those identifiers are the interface’s <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-global-name">global names</dfn>; otherwise, the interface has
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-22">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-42">extended attribute</a> is declared with an identifier list argument, then those identifiers are the interface’s <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-global-name">global names</dfn>; otherwise, the interface has
 a single global name, which is the interface’s identifier.</p>
    <p class="note" role="note">Note: The identifier argument list exists so that more than one global interface can
-be addressed with a single name in an [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-22">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-42">extended attribute</a>.</p>
+be addressed with a single name in an [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-22">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-43">extended attribute</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-23">Global</a></code>] and
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-24">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-43">extended attributes</a> must not be declared on the same
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-24">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-44">extended attributes</a> must not be declared on the same
 interface.  The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-25">PrimaryGlobal</a></code>]
 extended attribute must be declared on
 at most one interface.  The interface [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-26">PrimaryGlobal</a></code>]
@@ -8091,7 +8094,7 @@ and <a href="#es-constants">§3.6.5 Constants</a>, <a href="#es-attributes">§3.
 corresponding to <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-16">interface members</a>.</p>
    <div class="example" id="example-2b45d97a">
     <a class="self-link" href="#example-2b45d97a"></a> 
-    <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-29">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-44">extended attribute</a> is intended
+    <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-29">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-45">extended attribute</a> is intended
     to be used by the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> interface.
     ([<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-30">Global</a></code>] is intended to be used by worker global interfaces.)
     The <code class="idl">Window</code> interface exposes frames as properties on the <code class="idl">Window</code> object.  Since the <code class="idl">Window</code> object also serves as the
@@ -8134,7 +8137,7 @@ corresponding to <a data-link-type="dfn" href="#dfn-interface-member" id="ref-fo
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.6" data-lt="LegacyArrayClass" id="LegacyArrayClass"><span class="secno">3.3.6. </span><span class="content">[LegacyArrayClass]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-3">LegacyArrayClass</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-45">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-65">interface</a> that is not defined to <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-12">inherit</a> from another, it indicates that the internal [[Prototype]]
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-3">LegacyArrayClass</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-46">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-65">interface</a> that is not defined to <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-12">inherit</a> from another, it indicates that the internal [[Prototype]]
 property of its <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-5">interface prototype object</a> will be the <emu-val>Array</emu-val> prototype object rather than
 the <emu-val>Object</emu-val> prototype object.  This allows <emu-val>Array</emu-val> methods to be used more easily
 with objects implementing the interface.</p>
@@ -8181,7 +8184,7 @@ list<span class="p">.</span>concat<span class="p">(</span><span class="p">)</spa
     The exact behavior depends on the definition of the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-array-prototype-object">Array methods</a> themselves.</p>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.7" data-lt="LegacyUnenumerableNamedProperties" id="LegacyUnenumerableNamedProperties"><span class="secno">3.3.7. </span><span class="content">[LegacyUnenumerableNamedProperties]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-1">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-46">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-67">interface</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-5">supports named properties</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-1">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-47">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-67">interface</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-5">supports named properties</a>,
 it indicates that all the interface’s named properties are unenumerable.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-2">LegacyUnenumerableNamedProperties</a></code>]
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-6">take no arguments</a> and must not appear on an interface
@@ -8193,7 +8196,7 @@ must not be specified on any of them.</p>
 [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-4">LegacyUnenumerableNamedProperties</a></code>]
 entails.</p>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.8" data-lt="LenientSetter" id="LenientSetter"><span class="secno">3.3.8. </span><span class="content">[LenientSetter]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-2">LenientSetter</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-47">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-6">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-5">regular attribute</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-2">LenientSetter</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-48">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-7">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-5">regular attribute</a>,
 it indicates that a no-op setter will be generated for the attribute’s
 accessor property.  This results in erroneous assignments to the property
 in strict mode to be ignored rather than causing an exception to be thrown.</p>
@@ -8208,14 +8211,14 @@ in strict mode to be ignored rather than causing an exception to be thrown.</p>
     <p>Specification authors who
     wish to use this feature are strongly advised to discuss this on the <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a> mailing list before proceeding.</p>
    </div>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-2">LenientThis</a></code>] extended attribute
+   <p>The [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-3">LenientThis</a></code>] extended attribute
 must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-7">take no arguments</a>.
 It must not be used on anything other than
-a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-7">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-6">regular attribute</a>.</p>
+a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-8">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-6">regular attribute</a>.</p>
    <p>An attribute with the [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-5">LenientSetter</a></code>]
 extended attribute must not also be declared
-with the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-2">PutForwards</a></code>]
-or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-2">Replaceable</a></code>] extended attributes.</p>
+with the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-3">PutForwards</a></code>]
+or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-3">Replaceable</a></code>] extended attributes.</p>
    <p>See the <a href="#es-attributes">Attributes</a> section for how
 [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-6">LenientSetter</a></code>] is to be implemented.</p>
    <div class="example" id="example-c0b45430">
@@ -8243,23 +8246,23 @@ or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Re
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.9" data-lt="LenientThis" id="LenientThis"><span class="secno">3.3.9. </span><span class="content">[LenientThis]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-3">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-48">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-7">regular attribute</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-4">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-49">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-7">regular attribute</a>,
 it indicates that invocations of the attribute’s getter or setter
 with a <emu-val>this</emu-val> value that is not an
 object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-68">interface</a> on which the attribute appears will be ignored.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-4">LenientThis</a></code>] extended attribute
+   <p>The [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-5">LenientThis</a></code>] extended attribute
 must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-8">take no arguments</a>.
 It must not be used on a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-7">static attribute</a>.</p>
-   <p class="advisement"> Specifications should not use [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-5">LenientThis</a></code>]
+   <p class="advisement"> Specifications should not use [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-6">LenientThis</a></code>]
     unless required for compatibility reasons.  Specification authors who
     wish to use this feature are strongly advised to discuss this on the <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a> mailing list before proceeding. </p>
    <p>See the <a href="#es-attributes">Attributes</a> section for how
-[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-6">LenientThis</a></code>]
+[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-7">LenientThis</a></code>]
 is to be implemented.</p>
    <div class="example" id="example-9e113db6">
     <a class="self-link" href="#example-9e113db6"></a> 
     <p>The following IDL fragment defines an interface that uses the
-    [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-7">LenientThis</a></code>] extended
+    [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-8">LenientThis</a></code>] extended
     attribute.</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Example</span> {
   [<span class="nv">LenientThis</span>] <span class="kt">attribute</span> <span class="kt">DOMString</span> <span class="nv">x</span>;
@@ -8286,7 +8289,7 @@ is to be implemented.</p>
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.10" data-lt="NamedConstructor" id="NamedConstructor"><span class="secno">3.3.10. </span><span class="content">[NamedConstructor]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-8">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-49">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-69">interface</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-8">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-50">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-69">interface</a>,
 it indicates that the ECMAScript global object will have a property with the
 specified name whose value is a constructor function that can
 create objects that implement the interface.
@@ -8334,7 +8337,7 @@ are to be implemented.</p>
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.11" data-lt="NewObject" id="NewObject"><span class="secno">3.3.11. </span><span class="content">[NewObject]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#NewObject" id="ref-for-NewObject-2">NewObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-50">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-9">regular</a> or <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-7">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-40">operation</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#NewObject" id="ref-for-NewObject-2">NewObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-51">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-9">regular</a> or <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-7">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-40">operation</a>,
 then it indicates that when calling the operation,
 a reference to a newly created object
 must always be returned.</p>
@@ -8343,7 +8346,7 @@ extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" i
    <p>The [<code class="idl"><a data-link-type="idl" href="#NewObject" id="ref-for-NewObject-4">NewObject</a></code>]
 extended attribute must not
 be used on anything other than a <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-10">regular</a> or <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-8">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-41">operation</a> whose <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-4">return type</a> is an <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-11">interface type</a> or
-a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-8">promise type</a>.</p>
+a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-10">promise type</a>.</p>
    <div class="example" id="example-245e5507">
     <a class="self-link" href="#example-245e5507"></a> 
     <p>As an example, this extended attribute is suitable for use on
@@ -8357,7 +8360,7 @@ a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.12" data-lt="NoInterfaceObject" id="NoInterfaceObject"><span class="secno">3.3.12. </span><span class="content">[NoInterfaceObject]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-4">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-51">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-70">interface</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-4">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-52">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-70">interface</a>,
 it indicates that an <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-5">interface object</a> will not exist for the interface in the ECMAScript binding.</p>
    <p class="advisement"> The [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-5">NoInterfaceObject</a></code>] extended attribute
     should not be used on interfaces that are not
@@ -8412,7 +8415,7 @@ Storage<span class="p">.</span>prototype<span class="p">.</span>addEntry <span c
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.13" data-lt="OverrideBuiltins" id="OverrideBuiltins"><span class="secno">3.3.13. </span><span class="content">[OverrideBuiltins]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-5">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-52">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-71">interface</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-5">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-53">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-71">interface</a>,
 it indicates that for a <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-3">legacy platform object</a> implementing the interface,
 properties corresponding to all of
 the object’s <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-3">supported property names</a> will appear to be on the object,
@@ -8481,18 +8484,18 @@ the <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-na
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.14" data-lt="PutForwards" id="PutForwards"><span class="secno">3.3.14. </span><span class="content">[PutForwards]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-3">PutForwards</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-53">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-8">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-8">regular attribute</a> declaration whose type is
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-4">PutForwards</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-54">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-9">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-8">regular attribute</a> declaration whose type is
 an <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-12">interface type</a>,
 it indicates that assigning to the attribute will have specific behavior.
 Namely, the assignment is “forwarded” to the attribute (specified by
 the extended attribute argument) on the object that is currently
 referenced by the attribute being assigned to.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-4">PutForwards</a></code>] extended
+   <p>The [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-5">PutForwards</a></code>] extended
 attribute must <a data-link-type="dfn" href="#dfn-xattr-identifier" id="ref-for-dfn-xattr-identifier-3">take an identifier</a>.
 Assuming that:</p>
    <ul>
     <li data-md="">
-     <p><var>A</var> is the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-34">attribute</a> on which the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-5">PutForwards</a></code>]
+     <p><var>A</var> is the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-34">attribute</a> on which the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-6">PutForwards</a></code>]
 extended attribute appears,</p>
     <li data-md="">
      <p><var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-73">interface</a> on which <var>A</var> is declared,</p>
@@ -8503,33 +8506,33 @@ extended attribute appears,</p>
    </ul>
    <p>then there must be another <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-35">attribute</a> <var>B</var> declared on <var>J</var> whose <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-53">identifier</a> is <var>N</var>.  Assignment of a value to the attribute <var>A</var> on an object implementing <var>I</var> will result in that value
 being assigned to attribute <var>B</var> of the object that <var>A</var> references, instead.</p>
-   <p>Note that [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-6">PutForwards</a></code>]-annotated <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-36">attributes</a> can be
-chained.  That is, an attribute with the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-7">PutForwards</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-54">extended attribute</a> can refer to an attribute that itself has that extended attribute.
+   <p>Note that [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-7">PutForwards</a></code>]-annotated <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-36">attributes</a> can be
+chained.  That is, an attribute with the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-8">PutForwards</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-55">extended attribute</a> can refer to an attribute that itself has that extended attribute.
 There must not exist a cycle in a
 chain of forwarded assignments.  A cycle exists if, when following
 the chain of forwarded assignments, a particular attribute on
 an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-74">interface</a> is
 encountered more than once.</p>
-   <p>An attribute with the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-8">PutForwards</a></code>]
+   <p>An attribute with the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-9">PutForwards</a></code>]
 extended attribute must not also be declared
 with the [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-8">LenientSetter</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-3">Replaceable</a></code>] extended attributes.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-9">PutForwards</a></code>]
+[<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-4">Replaceable</a></code>] extended attributes.</p>
+   <p>The [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-10">PutForwards</a></code>]
 extended attribute must not be used
 on an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-37">attribute</a> that
-is not <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-9">read only</a>.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-10">PutForwards</a></code>] extended attribute
-must not be used on a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-8">static attribute</a>.</p>
+is not <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-10">read only</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-11">PutForwards</a></code>] extended attribute
+must not be used on a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-8">static attribute</a>.</p>
+   <p>The [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-12">PutForwards</a></code>] extended attribute
 must not be used on an attribute declared on
 a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-21">callback interface</a>.</p>
    <p>See the <a href="#es-attributes">Attributes</a> section for how
-[<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-12">PutForwards</a></code>]
+[<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-13">PutForwards</a></code>]
 is to be implemented.</p>
    <div class="example" id="example-dda2a869">
     <a class="self-link" href="#example-dda2a869"></a> 
     <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-39">IDL fragment</a> defines interfaces for names and people.
-    The [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-13">PutForwards</a></code>] extended
+    The [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-14">PutForwards</a></code>] extended
     attribute is used on the <code class="idl">name</code> attribute
     of the <code class="idl">Person</code> interface to indicate
     that assignments to that attribute result in assignments to the <code class="idl">full</code> attribute of the <code class="idl">Person</code> object:</p>
@@ -8553,29 +8556,29 @@ p<span class="p">.</span>name <span class="o">=</span> <span class="s1">'John Ci
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.15" data-lt="Replaceable" id="Replaceable"><span class="secno">3.3.15. </span><span class="content">[Replaceable]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-4">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-55">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-10">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-9">regular attribute</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-5">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-56">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-11">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-9">regular attribute</a>,
 it indicates that setting the corresponding property on the <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-16">platform object</a> will result in
 an own property with the same name being created on the object
 which has the value being assigned.  This property will shadow
 the accessor property corresponding to the attribute, which
 exists on the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-6">interface prototype object</a>.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-5">Replaceable</a></code>]
+   <p>The [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-6">Replaceable</a></code>]
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-12">take no arguments</a>.</p>
-   <p>An attribute with the [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-6">Replaceable</a></code>]
+   <p>An attribute with the [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-7">Replaceable</a></code>]
 extended attribute must not also be declared
 with the [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-9">LenientSetter</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-14">PutForwards</a></code>] extended attributes.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-7">Replaceable</a></code>]
+[<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-15">PutForwards</a></code>] extended attributes.</p>
+   <p>The [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-8">Replaceable</a></code>]
 extended attribute must not be used
 on an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-38">attribute</a> that
-is not <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-11">read only</a>.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-8">Replaceable</a></code>] extended attribute
-must not be used on a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-9">static attribute</a>.</p>
+is not <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-12">read only</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-9">Replaceable</a></code>] extended attribute
+must not be used on a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-9">static attribute</a>.</p>
+   <p>The [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-10">Replaceable</a></code>] extended attribute
 must not be used on an attribute declared on
 a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-22">callback interface</a>.</p>
    <p>See <a href="#es-attributes">§3.6.6 Attributes</a> for the specific requirements that the use of
-[<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-10">Replaceable</a></code>] entails.</p>
+[<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-11">Replaceable</a></code>] entails.</p>
    <div class="example" id="example-8ded6a51">
     <a class="self-link" href="#example-8ded6a51"></a> 
     <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-40">IDL fragment</a> defines an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-75">interface</a> with an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-42">operation</a> that increments a counter, and an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-39">attribute</a> that exposes the counter’s value, which is initially 0:</p>
@@ -8609,15 +8612,15 @@ counter<span class="p">.</span>value<span class="p">;</span>                    
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.16" data-lt="SameObject" id="SameObject"><span class="secno">3.3.16. </span><span class="content">[SameObject]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-2">SameObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-56">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-12">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-41">attribute</a>, then it
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-3">SameObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-57">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-13">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-41">attribute</a>, then it
 indicates that when getting the value of the attribute on a given
 object, the same value must always
 be returned.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-3">SameObject</a></code>]
-extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-13">take no arguments</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-4">SameObject</a></code>]
+extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-13">take no arguments</a>.</p>
+   <p>The [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-5">SameObject</a></code>]
 extended attribute must not
-be used on anything other than a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-13">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-42">attribute</a> whose type is an <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-14">interface type</a> or <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-24">object</a></code>.</p>
+be used on anything other than a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-14">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-42">attribute</a> whose type is an <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-14">interface type</a> or <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-24">object</a></code>.</p>
    <div class="example" id="example-87c35b5d">
     <a class="self-link" href="#example-87c35b5d"></a> 
     <p>As an example, this extended attribute is suitable for use on
@@ -8630,7 +8633,7 @@ be used on anything other than a <a data-link-type="dfn" href="#dfn-read-only" i
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.17" data-lt="SecureContext" id="SecureContext"><span class="secno">3.3.17. </span><span class="content">[SecureContext]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-9">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-57">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-76">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-11">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-8">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-4">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-17">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-5">namespace member</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-9">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-58">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-76">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-11">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-8">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-4">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-17">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-5">namespace member</a>,
 it indicates that the construct is exposed
 only within a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-10">SecureContext</a></code>]
@@ -8638,12 +8641,12 @@ extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" i
    <p>The [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-11">SecureContext</a></code>]
 extended attribute must not
 be used on anything other than an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-77">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-12">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-9">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-5">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-18">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-6">namespace member</a>.</p>
-   <p>Whether a construct that the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-12">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-58">extended attribute</a> can be specified on is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-available-only-in-secure-contexts">available only in secure contexts</dfn> is defined as follows:</p>
+   <p>Whether a construct that the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-12">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-59">extended attribute</a> can be specified on is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-available-only-in-secure-contexts">available only in secure contexts</dfn> is defined as follows:</p>
    <ul>
     <li data-md="">
-     <p>If the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-13">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-59">extended attribute</a> is specified on the construct, then it is <a data-link-type="dfn" href="#dfn-available-only-in-secure-contexts" id="ref-for-dfn-available-only-in-secure-contexts-2">available only in secure contexts</a>.</p>
+     <p>If the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-13">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-60">extended attribute</a> is specified on the construct, then it is <a data-link-type="dfn" href="#dfn-available-only-in-secure-contexts" id="ref-for-dfn-available-only-in-secure-contexts-2">available only in secure contexts</a>.</p>
     <li data-md="">
-     <p>Otherwise, if the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-14">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-60">extended attribute</a> does not appear on a construct, then whether it is <a data-link-type="dfn" href="#dfn-available-only-in-secure-contexts" id="ref-for-dfn-available-only-in-secure-contexts-3">available only in secure contexts</a> depends on the type of construct:</p>
+     <p>Otherwise, if the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-14">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-61">extended attribute</a> does not appear on a construct, then whether it is <a data-link-type="dfn" href="#dfn-available-only-in-secure-contexts" id="ref-for-dfn-available-only-in-secure-contexts-3">available only in secure contexts</a> depends on the type of construct:</p>
      <dl class="switch">
       <dt data-md="">
        <p>interface</p>
@@ -8701,7 +8704,7 @@ that does specify [<code class="idl"><a data-link-type="idl" href="#SecureContex
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.18" data-lt="TreatNonObjectAsNull" id="TreatNonObjectAsNull"><span class="secno">3.3.18. </span><span class="content">[TreatNonObjectAsNull]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-5">TreatNonObjectAsNull</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-61">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-22">callback function</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-5">TreatNonObjectAsNull</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-62">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-22">callback function</a>,
 then it indicates that any value assigned to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-43">attribute</a> whose type is a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-25">nullable</a> <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-23">callback function</a> that is not an object will be converted to
 the <emu-val>null</emu-val> value.</p>
    <p class="advisement"> Specifications should not use [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-6">TreatNonObjectAsNull</a></code>]
@@ -8716,7 +8719,7 @@ the <emu-val>null</emu-val> value.</p>
    <div class="example" id="example-28226fc6">
     <a class="self-link" href="#example-28226fc6"></a> 
     <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-42">IDL fragment</a> defines an interface that has one
-    attribute whose type is a [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-9">TreatNonObjectAsNull</a></code>]-annotated <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-25">callback function</a> and another whose type is a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-26">callback function</a> without the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-62">extended attribute</a>:</p>
+    attribute whose type is a [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-9">TreatNonObjectAsNull</a></code>]-annotated <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-25">callback function</a> and another whose type is a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-26">callback function</a> without the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-63">extended attribute</a>:</p>
 <pre class="highlight"><span class="kt">callback</span> <span class="nv">OccurrenceHandler</span> = <span class="kt">void</span> (<span class="kt">DOMString</span> <span class="nv">details</span>);
 
 [<span class="nv">TreatNonObjectAsNull</span>]
@@ -8749,7 +8752,7 @@ manager<span class="p">.</span>handler2<span class="p">;</span>            <span
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.19" data-lt="TreatNullAs" id="TreatNullAs"><span class="secno">3.3.19. </span><span class="content">[TreatNullAs]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#TreatNullAs" id="ref-for-TreatNullAs-8">TreatNullAs</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-63">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-44">attribute</a> or <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-45">operation</a> argument whose type is <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-52">DOMString</a></code>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#TreatNullAs" id="ref-for-TreatNullAs-8">TreatNullAs</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-64">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-44">attribute</a> or <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-45">operation</a> argument whose type is <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-52">DOMString</a></code>,
 it indicates that a <emu-val>null</emu-val> value
 assigned to the attribute or passed as the operation argument will be
 handled differently from its default handling.  Instead of being stringified
@@ -8802,7 +8805,7 @@ d<span class="p">.</span>isMemberOfBreed<span class="p">(</span><span class="kc"
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.20" data-lt="Unforgeable" id="Unforgeable"><span class="secno">3.3.20. </span><span class="content">[Unforgeable]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-3">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-64">extended attribute</a> appears on a non-<a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-10">static</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-45">attribute</a> or non-<a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-10">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-46">operations</a>, it indicates
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-3">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-65">extended attribute</a> appears on a non-<a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-10">static</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-45">attribute</a> or non-<a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-10">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-46">operations</a>, it indicates
 that the attribute or operation will be reflected as an ECMAScript property in
 a way that means its behavior cannot be modified and that performing
 a property lookup on the object will always result in the attribute’s
@@ -8811,7 +8814,7 @@ non-configurable and will exist as an own property on the object
 itself rather than on its prototype.</p>
    <p>An attribute or operation is said to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-unforgeable-on-an-interface">unforgeable</dfn> on a given interface <var>A</var> if the
 attribute or operation is declared on <var>A</var> or one of <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-16">consequential interfaces</a>, and is
-annotated with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-4">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-65">extended attribute</a>.</p>
+annotated with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-4">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-66">extended attribute</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-5">Unforgeable</a></code>]
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-15">take no arguments</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-6">Unforgeable</a></code>]
@@ -8873,7 +8876,7 @@ system<span class="p">.</span>loginTime<span class="p">;</span>  <span class="c1
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.21" data-lt="Unscopable" id="Unscopable"><span class="secno">3.3.21. </span><span class="content">[Unscopable]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-1">Unscopable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-66">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-10">regular attribute</a> or <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-12">regular operation</a>, it
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-1">Unscopable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-67">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-10">regular attribute</a> or <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-12">regular operation</a>, it
 indicates that an object that implements an interface with the given
 interface member will not include its property name in any object
 environment record with it as its base object.  The result of this is
@@ -8923,7 +8926,7 @@ getter or setter function of an IDL attribute).</p>
    <h3 class="heading settled" data-level="3.5" id="es-overloads"><span class="secno">3.5. </span><span class="content">Overload resolution algorithm</span><a class="self-link" href="#es-overloads"></a></h3>
    <div class="algorithm" data-algorithm="overload resolution algorithm">
     <p>In order to define how overloaded function invocations are resolved, the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-overload-resolution-algorithm">overload resolution algorithm</dfn> is defined.  Its input is an <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-4">effective overload set</a>, <var>S</var>, and a list of ECMAScript values, <var>arg</var><sub>0..<var>n</var>−1</sub>.
-    Its output is a pair consisting of the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-50">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-67">extended attribute</a> of one of <var>S</var>’s entries
+    Its output is a pair consisting of the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-50">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-68">extended attribute</a> of one of <var>S</var>’s entries
     and a list of IDL values or the special value “missing”.  The algorithm behaves as follows:</p>
     <ol>
      <li data-md="">
@@ -9211,7 +9214,7 @@ that has one of the above types in its <a data-link-type="dfn" href="#dfn-flatte
         <p>Otherwise: <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-26">throw</a> a <emu-val>TypeError</emu-val>.</p>
       </ol>
      <li data-md="">
-      <p>Let <var>callable</var> be the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-51">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-68">extended attribute</a> of the single entry in <var>S</var>.</p>
+      <p>Let <var>callable</var> be the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-51">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-69">extended attribute</a> of the single entry in <var>S</var>.</p>
      <li data-md="">
       <p>If <var>i</var> = <var>d</var> and <var>method</var> is not <emu-val>undefined</emu-val>, then</p>
       <ol>
@@ -9323,7 +9326,7 @@ ECMAScript global environment and:</p>
     <li data-md="">
      <p>is a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-25">callback interface</a> that has <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-21">constants</a> declared on it, or</p>
     <li data-md="">
-     <p>is a non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-79">interface</a> that is not declared with the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-13">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-69">extended attribute</a>,</p>
+     <p>is a non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-79">interface</a> that is not declared with the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-13">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-70">extended attribute</a>,</p>
    </ul>
    <p>a corresponding property must exist on the
 ECMAScript environment’s global object.
@@ -9367,11 +9370,11 @@ the Function.prototype object.</p>
    <p class="note" role="note">Note: Remember that interface objects for callback interfaces only exist if they have <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-23">constants</a> declared on them;
 when they do exist, they are not <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-5">function objects</a>.</p>
    <h5 class="heading settled" data-level="3.6.1.1" id="es-constructible-interfaces"><span class="secno">3.6.1.1. </span><span class="content">Constructible Interfaces</span><span id="es-interface-call"></span><a class="self-link" href="#es-constructible-interfaces"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-81">interface</a> is declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-20">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-70">extended attribute</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-81">interface</a> is declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-20">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-71">extended attribute</a>,
 then the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-7">interface object</a> can be called as a constructor
 to create an object that implements that interface.
 Calling that interface as a function will throw an exception.</p>
-   <p>Interfaces that are not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-21">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-71">extended attribute</a> will throw when called,
+   <p>Interfaces that are not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-21">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-72">extended attribute</a> will throw when called,
 both as a function and as a constructor.</p>
    <div class="algorithm" data-algorithm="to construct an object implementing an interface">
     <p>When evaluating the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-6">function object</a> <var>F</var>,
@@ -9380,7 +9383,7 @@ both as a function and as a constructor.</p>
     the following steps must be taken:</p>
     <ol>
      <li data-md="">
-      <p>If <var>I</var> was not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-22">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-72">extended attribute</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-27">throw</a> a <emu-val>TypeError</emu-val>.</p>
+      <p>If <var>I</var> was not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-22">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-73">extended attribute</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-27">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-built-in-function-objects">NewTarget</a> is <emu-val>undefined</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-28">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
@@ -9403,7 +9406,7 @@ both as a function and as a constructor.</p>
    </div>
    <div class="algorithm" data-algorithm="determine value of length property of non-callback interfaces">
     <p>Interface objects for non-callback interfaces must have a property named “length” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> whose value is a <emu-val>Number</emu-val>.
-    If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-23">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-73">extended attribute</a> does not appear on the interface definition, then the value is 0.
+    If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-23">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-74">extended attribute</a> does not appear on the interface definition, then the value is 0.
     Otherwise, the value is determined as follows:</p>
     <ol>
      <li data-md="">
@@ -9447,7 +9450,7 @@ return <emu-val>true</emu-val>.</p>
    </div>
    <h4 class="heading settled" data-level="3.6.2" id="named-constructors"><span class="secno">3.6.2. </span><span class="content">Named constructors</span><a class="self-link" href="#named-constructors"></a></h4>
    <p>A <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-2">named constructor</a> that exists due to one or more
-[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-17">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-74">extended attributes</a> with a given <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-60">identifier</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-7">function object</a>.
+[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-17">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-75">extended attributes</a> with a given <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-60">identifier</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-7">function object</a>.
 It must have a [[Call]] internal property,
 which allows construction of objects that
 implement the interface on which the
@@ -9488,10 +9491,10 @@ with the <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-n
 with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> whose value is the identifier used for the named constructor.</p>
    <p>A named constructor must also have a property named
 “prototype” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span> whose value is the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-9">interface prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-88">interface</a> on which the
-[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-20">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-75">extended attribute</a> appears.</p>
+[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-20">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-76">extended attribute</a> appears.</p>
    <h4 class="heading settled" data-level="3.6.3" id="interface-prototype-object"><span class="secno">3.6.3. </span><span class="content">Interface prototype object</span><a class="self-link" href="#interface-prototype-object"></a></h4>
    <p>There must exist an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-10">interface prototype object</a> for every non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-89">interface</a> defined, regardless of whether the interface was declared with the
-[<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-14">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-76">extended attribute</a>.
+[<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-14">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-77">extended attribute</a>.
 The interface prototype object for a particular interface has
 properties that correspond to the <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-13">regular attributes</a> and <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-15">regular operations</a> defined on that interface.  These properties are described in more detail in
 sections <a href="#es-attributes">§3.6.6 Attributes</a> and <a href="#es-operations">§3.6.7 Operations</a>.</p>
@@ -9510,7 +9513,7 @@ is a reference to the interface object for the interface.</p>
     <ol>
      <li data-md="">
       <p>If <var>A</var> is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-33">Global</a></code>]
-or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-34">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-77">extended attribute</a>, and <var>A</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-6">supports named properties</a>, then
+or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-34">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-78">extended attribute</a>, and <var>A</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-6">supports named properties</a>, then
 return the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-4">named properties object</a> for <var>A</var>, as defined in <a href="#named-properties-object">§3.6.4 Named properties object</a>.</p>
      <li data-md="">
       <p>Otherwise, if <var>A</var> is declared to inherit from another
@@ -9524,7 +9527,7 @@ extended attribute, then return <a data-link-type="dfn" href="https://tc39.githu
    </div>
    <div class="note" role="note">
     <p>The <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-13">interface prototype object</a> of an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-90">interface</a> that is defined with
-    the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-16">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-78">extended attribute</a> will be accessible if the interface is used as a <a data-link-type="dfn" href="#dfn-supplemental-interface" id="ref-for-dfn-supplemental-interface-5">non-supplemental interface</a>.
+    the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-16">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-79">extended attribute</a> will be accessible if the interface is used as a <a data-link-type="dfn" href="#dfn-supplemental-interface" id="ref-for-dfn-supplemental-interface-5">non-supplemental interface</a>.
     For example, with the following IDL:</p>
 <pre class="highlight">[<span class="nv">NoInterfaceObject</span>]
 <span class="kt">interface</span> <span class="nv">Foo</span> {
@@ -9565,14 +9568,14 @@ interface member, <emu-val>true</emu-val>).</p>
     </ol>
    </div>
    <p>If the interface is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-35">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-36">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-79">extended attribute</a>, or the interface is in the set
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-36">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-80">extended attribute</a>, or the interface is in the set
 of <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces-16">inherited interfaces</a> for any
 other interface that is declared with one of these attributes, then the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-14">interface prototype object</a> must be an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">immutable prototype exotic object</a>.</p>
    <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-1">class string</a> of an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-15">interface prototype object</a> is the concatenation of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-91">interface</a>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-64">identifier</a> and the string
 “Prototype”.</p>
    <h4 class="heading settled" data-level="3.6.4" id="named-properties-object"><span class="secno">3.6.4. </span><span class="content">Named properties object</span><a class="self-link" href="#named-properties-object"></a></h4>
    <p>For every <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-92">interface</a> declared with the
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-37">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-38">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-80">extended attribute</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-7">supports named properties</a>,
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-37">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-38">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-81">extended attribute</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-7">supports named properties</a>,
 there must exist an object known as the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-named-properties-object">named properties object</dfn> for that interface on which named properties are exposed.</p>
    <div class="algorithm" data-algorithm="value of [[Prototype]] property of named properties objects">
     <p>The <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-5">named properties object</a> for a given interface <var>A</var> must have an internal
@@ -9619,7 +9622,7 @@ of performing the steps listed in the description of <var>operation</var> with <
         <p>Set <var>desc</var>.[[Value]] to the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-40">converting</a> <var>value</var> to an ECMAScript value.</p>
        <li data-md="">
         <p>If <var>A</var> implements an interface with the
-[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-5">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-81">extended attribute</a>,
+[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-5">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-82">extended attribute</a>,
 then set <var>desc</var>.[[Enumerable]] to <emu-val>false</emu-val>,
 otherwise set it to <emu-val>true</emu-val>.</p>
        <li data-md="">
@@ -9725,180 +9728,198 @@ where:</p>
        <p><var>configurable</var> is <emu-val>false</emu-val> if the attribute was
 declared with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-9">Unforgeable</a></code>] extended attribute and <emu-val>true</emu-val> otherwise;</p>
       <li data-md="">
-       <p><var>G</var> is the <a data-link-type="dfn" href="#dfn-attribute-getter" id="ref-for-dfn-attribute-getter-2">attribute getter</a>, defined below; and</p>
+       <p><var>G</var> is the <a data-link-type="dfn" href="#dfn-attribute-getter" id="ref-for-dfn-attribute-getter-2">attribute getter</a> created given the attribute, the interface (or the interface
+it’s being mixed in to, if the interface is actually a mixin), and the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">relevant Realm</a> of
+the object that is the location of the property; and</p>
       <li data-md="">
-       <p><var>S</var> is the <a data-link-type="dfn" href="#dfn-attribute-setter" id="ref-for-dfn-attribute-setter-2">attribute setter</a>, also defined below.</p>
+       <p><var>S</var> is the <a data-link-type="dfn" href="#dfn-attribute-setter" id="ref-for-dfn-attribute-setter-2">attribute setter</a> created given the attribute, the interface (or the interface
+it’s being mixed in to, if the interface is actually a mixin), and the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">relevant Realm</a> of
+the object that is the location of the property.</p>
      </ul>
-    <li data-md="">
-     <div class="algorithm" data-algorithm="attribute getter">
-      <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-attribute-getter">attribute getter</dfn> is a <emu-val>Function</emu-val> object whose behavior when invoked is as follows:</p>
+   </ul>
+   <div class="algorithm" data-algorithm="attribute getter">
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-attribute-getter">attribute getter</dfn> is created as follows, given an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-51">attribute</a> <var>attribute</var>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-98">interface</a> <var>target</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>:</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>steps</var> be the following series of steps:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>idlValue</var> be an IDL value determined as follows.</p>
-       <li data-md="">
-        <p>If the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-51">attribute</a> is a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-14">regular attribute</a>, then:</p>
+        <p>Try running the following steps:</p>
         <ol>
          <li data-md="">
-          <p>Let <var>I</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-98">interface</a> whose <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-21">interface prototype object</a> this property corresponding to the attribute appears on.</p>
-          <p class="note" role="note">Note: This means that even if an implements statement was used to make
-an attribute available on the interface, <var>I</var> is the interface
-on the left hand side of the implements statement, and not the one
-that the attribute was originally declared on.</p>
+          <p>Let <var>O</var> be <emu-val>null</emu-val>.</p>
          <li data-md="">
-          <p>Let <var>O</var> be the <emu-val>this</emu-val> value.</p>
-         <li data-md="">
-          <p>If <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-20">platform object</a>,
-then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-dfn-perform-a-security-check-1">perform a security check</a>, passing:</p>
-          <ul>
-           <li data-md="">
-            <p>the platform object <var>O</var>,</p>
-           <li data-md="">
-            <p>the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-69">identifier</a> of the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-52">attribute</a>, and</p>
-           <li data-md="">
-            <p>the type “getter”.</p>
-          </ul>
-         <li data-md="">
-          <p>If <var>O</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-21">platform object</a> that implements <var>I</var>, then:</p>
+          <p>If <var>attribute</var> is not a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-12">static attribute</a>:</p>
           <ol>
            <li data-md="">
-            <p>If the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-53">attribute</a> was specified with the
-[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-8">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-82">extended attribute</a>,
-then return <emu-val>undefined</emu-val>.</p>
+            <p>If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, set <var>O</var> to <var>realm</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global">global object</a>.
+(This will subsequently cause a <emu-val>TypeError</emu-val> in a few steps, if
+the global object does not implement <var>target</var> and [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-9">LenientThis</a></code>] is not
+specified.)</p>
            <li data-md="">
-            <p>Otherwise, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-30">throw</a> a <emu-val>TypeError</emu-val>.</p>
+            <p>Otherwise, set <var>O</var> to the <emu-val>this</emu-val> value.</p>
+           <li data-md="">
+            <p>If <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-20">platform object</a>, then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-dfn-perform-a-security-check-1">perform a security check</a>, passing <var>O</var>, <var>attribute</var>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-69">identifier</a>, and "getter".</p>
+           <li data-md="">
+            <p>If <var>O</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-21">platform object</a> that implements the interface <var>target</var>,
+then:</p>
+            <ol>
+             <li data-md="">
+              <p>If <var>attribute</var> was specified with the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-10">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-83">extended attribute</a>, then return <emu-val>undefined</emu-val>.</p>
+             <li data-md="">
+              <p>Otherwise, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-30">throw</a> a <emu-val>TypeError</emu-val>.</p>
+            </ol>
           </ol>
          <li data-md="">
-          <p>Set <var>idlValue</var> to be the result of performing the actions listed in the description of the attribute that occur when getting
-(or those listed in the description of the inherited attribute, if this attribute is declared to <a data-link-type="dfn" href="#dfn-inherit-getter" id="ref-for-dfn-inherit-getter-2">inherit its getter</a>),
-with <var>O</var> as the object.</p>
+          <p>Let <var>R</var> be the result of performing the actions listed in the
+description of <var>attribute</var> that occur on getting (or those listed in the description
+of the inherited attribute, if this attribute is declared to <a data-link-type="dfn" href="#dfn-inherit-getter" id="ref-for-dfn-inherit-getter-2">inherit its getter</a>), on <var>O</var> if <var>O</var> is not <emu-val>null</emu-val>.</p>
+         <li data-md="">
+          <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-42">converting</a> <var>R</var> to an
+ECMAScript value of the type <var>attribute</var> is declared as.</p>
         </ol>
-       <li data-md="">
-        <p>Otherwise, the attribute is a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-12">static attribute</a>.
-Set <var>idlValue</var> to be the result of performing the actions listed in the description of the attribute that occur when getting.</p>
-       <li data-md="">
-        <p>Let <var>V</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-42">converting</a> <var>idlValue</var> to an ECMAScript value.</p>
-       <li data-md="">
-        <p>Return <var>V</var>.</p>
       </ol>
-     </div>
-     <p>The value of the <emu-val>Function</emu-val> object’s “length”
-property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
-     <p>The value of the <emu-val>Function</emu-val> object’s “name”
-property is a <emu-val>String</emu-val> whose value is the
-concatenation of “get ” and the identifier of the attribute.</p>
-    <li data-md="">
-     <div class="algorithm" data-algorithm="attribute setter">
-      <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-attribute-setter">attribute setter</dfn> is <emu-val>undefined</emu-val> if the attribute is declared <code>readonly</code> and does not have a
-    [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-9">LenientThis</a></code>], [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-15">PutForwards</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-11">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-83">extended attribute</a> declared on it.
-    Otherwise, it is a <emu-val>Function</emu-val> object whose behavior when invoked is as follows:</p>
+      <p>And then, if an exception was thrown:</p>
       <ol>
        <li data-md="">
-        <p>If no arguments were passed to the <emu-val>Function</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-31">throw</a> a <emu-val>TypeError</emu-val>.</p>
-       <li data-md="">
-        <p>Let <var>V</var> be the value of the first argument passed to the <emu-val>Function</emu-val>.</p>
-       <li data-md="">
-        <p>If the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-54">attribute</a> is a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-15">regular attribute</a>, then:</p>
+        <p>If <var>attribute</var>’s type is a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-11">promise type</a>, then:</p>
         <ol>
          <li data-md="">
-          <p>Let <var>I</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-99">interface</a> whose <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-22">interface prototype object</a> this property corresponding to the attribute appears on.</p>
+          <p>Let <var>reject</var> be the initial value of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.</p>
          <li data-md="">
-          <p>Let <var>O</var> be the <emu-val>this</emu-val> value.</p>
+          <p>Return the result of calling <var>reject</var> with <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a> as the <emu-val>this</emu-val> object and the exception as the single argument value.</p>
+        </ol>
+       <li data-md="">
+        <p>Otherwise, end these steps and allow the exception to propagate.</p>
+      </ol>
+     <li data-md="">
+      <p>Let <var>F</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createbuiltinfunction">CreateBuiltinFunction</a>(<var>realm</var>, <var>steps</var>, the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-function-prototype-object">%FunctionPrototype%</a> of <var>realm</var>).</p>
+     <li data-md="">
+      <p>Let <var>name</var> be the string "get " prepended to <var>attribute</var>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-70">identifier</a>.</p>
+     <li data-md="">
+      <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-setfunctionname">SetFunctionName</a>(<var>F</var>, <var>name</var>).</p>
+     <li data-md="">
+      <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow">DefinePropertyOrThrow</a>(<var>F</var>, "length",
+PropertyDescriptor<span class="prop-desc">{[[Value]]: 0, [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val>}</span>).</p>
+     <li data-md="">
+      <p>Return <var>F</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="attribute setter">
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-attribute-setter">attribute setter</dfn> is created as follows, given an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-52">attribute</a> <var>attribute</var>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-99">interface</a> <var>target</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>:</p>
+    <ol>
+     <li data-md="">
+      <p>If <var>attribute</var> is <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-15">read only</a> and does not have a
+[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-11">LenientThis</a></code>], [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-16">PutForwards</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-12">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-84">extended attribute</a>, return <emu-val>undefined</emu-val>; there is no <a data-link-type="dfn" href="#dfn-attribute-setter" id="ref-for-dfn-attribute-setter-3">attribute setter</a> function.</p>
+     <li data-md="">
+      <p class="assertion">Assert: <var>attribute</var>’s type is not a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-12">promise type</a>.</p>
+     <li data-md="">
+      <p>Let <var>steps</var> be the following series of steps:</p>
+      <ol>
+       <li data-md="">
+        <p>If no arguments were passed, then</p>
+       <li data-md="">
+        <p>Let <var>V</var> be the value of the first argument passed.</p>
+       <li data-md="">
+        <p>Let <var>id</var> be <var>attribute</var>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-71">identifier</a>.</p>
+       <li data-md="">
+        <p>Let <var>O</var> be <emu-val>null</emu-val>.</p>
+       <li data-md="">
+        <p>If <var>attribute</var> is not a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-13">static attribute</a>:</p>
+        <ol>
          <li data-md="">
-          <p>If <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-22">platform object</a>,
-then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-dfn-perform-a-security-check-2">perform a security check</a>, passing:</p>
-          <ul>
-           <li data-md="">
-            <p>the platform object <var>O</var>,</p>
-           <li data-md="">
-            <p>the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-70">identifier</a> of the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-55">attribute</a>, and</p>
-           <li data-md="">
-            <p>the type “setter”.</p>
-          </ul>
+          <p>If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, set <var>O</var> to <var>realm</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global">global object</a>.
+(This will subsequently cause a <emu-val>TypeError</emu-val> in a few steps, if
+the global object does not implement <var>target</var> and [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-12">LenientThis</a></code>] is not
+specified.)</p>
          <li data-md="">
-          <p>Let <var>validThis</var> be <emu-val>true</emu-val> if <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-23">platform object</a> that implements <var>I</var>, or <emu-val>false</emu-val> otherwise.</p>
+          <p>Otherwise, set <var>O</var> to the <emu-val>this</emu-val> value.</p>
          <li data-md="">
-          <p>If <var>validThis</var> is <emu-val>false</emu-val> and the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-56">attribute</a> was not specified with the
-[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-10">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-84">extended attribute</a>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-32">throw</a> a <emu-val>TypeError</emu-val>.</p>
+          <p>If <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-22">platform object</a>, then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-dfn-perform-a-security-check-2">perform a security check</a>, passing <var>O</var>, <var>id</var>, and "setter".</p>
          <li data-md="">
-          <p>If the attribute is declared with a [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-12">Replaceable</a></code>]
-extended attribute, then:</p>
+          <p>Let <var>validThis</var> be <emu-val>true</emu-val> if <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-23">platform object</a> that
+implements the interface <var>target</var>, or <emu-val>false</emu-val> otherwise.</p>
+         <li data-md="">
+          <p>If <var>validThis</var> is <emu-val>false</emu-val> and <var>attribute</var> was not specified
+with the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-13">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-85">extended attribute</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-31">throw</a> a <emu-val>TypeError</emu-val>.</p>
+         <li data-md="">
+          <p>If <var>attribute</var> is declared with the [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-13">Replaceable</a></code>] extended attribute, then:</p>
           <ol>
            <li data-md="">
-            <p>Let <var>P</var> be the identifier of the attribute.</p>
-           <li data-md="">
-            <p>Call <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createdataproperty">CreateDataProperty</a>(<var>O</var>, <var>P</var>, <var>V</var>).</p>
+            <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createdataproperty">CreateDataProperty</a>(<var>O</var>, <var>id</var>, <var>V</var>).</p>
            <li data-md="">
             <p>Return <emu-val>undefined</emu-val>.</p>
           </ol>
          <li data-md="">
           <p>If <var>validThis</var> is <emu-val>false</emu-val>, then return <emu-val>undefined</emu-val>.</p>
          <li data-md="">
-          <p>If the attribute is declared with a [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-10">LenientSetter</a></code>]
-extended attribute, then return <emu-val>undefined</emu-val>.</p>
+          <p>If <var>attribute</var> is declared with a [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-10">LenientSetter</a></code>] extended attribute, then
+return <emu-val>undefined</emu-val>.</p>
          <li data-md="">
-          <p>If the attribute is declared with a [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-16">PutForwards</a></code>]
-extended attribute, then:</p>
+          <p>If <var>attribute</var> is declared with a [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-17">PutForwards</a></code>] extended attribute, then:</p>
           <ol>
            <li data-md="">
-            <p>Let <var>Q</var> be the result of calling the [[Get]] method
-on <var>O</var> using the identifier of the attribute as the property name.</p>
+            <p>Let <var>Q</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>O</var>, <var>id</var>).</p>
            <li data-md="">
-            <p>If <var>Q</var> is not an object, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-33">throw</a> a <emu-val>TypeError</emu-val>.</p>
+            <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>Q</var>) is not Object, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-32">throw</a> a <emu-val>TypeError</emu-val>.</p>
            <li data-md="">
-            <p>Let <var>A</var> be the attribute identified by the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-17">PutForwards</a></code>] extended attribute.</p>
+            <p>Let <var>forwardId</var> be the identifier argument of the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-18">PutForwards</a></code>] extended
+attribute.</p>
            <li data-md="">
-            <p>Call the [[Put]] method on <var>Q</var> using the identifier of <var>A</var> as the property name and <var>V</var> as the value.</p>
+            <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-set-o-p-v-throw">Set</a>(<var>Q</var>, <var>forwardId</var>, <var>V</var>).</p>
            <li data-md="">
             <p>Return <emu-val>undefined</emu-val>.</p>
           </ol>
         </ol>
        <li data-md="">
-        <p>Let <var>idlValue</var> be an IDL value determined as follows:</p>
-        <ul>
-         <li data-md="">
-          <p>If the type of the attribute is an <a data-link-type="dfn" href="#dfn-enumeration" id="ref-for-dfn-enumeration-20">enumeration</a>, then:</p>
+        <p>Let <var>idlValue</var> be determined as follows:</p>
+        <dl class="switch">
+         <dt><var>attribute</var>’s type is an <a data-link-type="dfn" href="#dfn-enumeration" id="ref-for-dfn-enumeration-20">enumeration</a>
+         <dd>
           <ol>
            <li data-md="">
-            <p>Let <var>S</var> be the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a>(<var>V</var>).</p>
+            <p>Let <var>S</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a>(<var>V</var>).</p>
            <li data-md="">
-            <p>If <var>S</var> is not one of the <a data-link-type="dfn" href="#dfn-enumeration-value" id="ref-for-dfn-enumeration-value-7">enumeration’s values</a>, then return <emu-val>undefined</emu-val>.</p>
+            <p>If <var>S</var> is not one of the <a data-link-type="dfn" href="#dfn-enumeration-value" id="ref-for-dfn-enumeration-value-7">enumeration’s values</a>, then
+return <emu-val>undefined</emu-val>.</p>
            <li data-md="">
-            <p>The value of <var>idlValue</var> is the enumeration value equal to <var>S</var>.</p>
+            <p>Otherwise, <var>idlValue</var> is the enumeration value equal to <var>S</var>.</p>
           </ol>
-         <li data-md="">
-          <p>Otherwise, the type of the attribute is not an <a data-link-type="dfn" href="#dfn-enumeration" id="ref-for-dfn-enumeration-21">enumeration</a>.
-The value of <var>idlValue</var> is the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-61">converting</a> <var>V</var> to an IDL value.</p>
-        </ul>
+         <dt>Otherwise
+         <dd> <var>idlValue</var> is the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-61">converting</a> <var>V</var> to an
+        IDL value of <var>attribute</var>’s type. 
+        </dl>
        <li data-md="">
-        <p>If the attribute is a regular attribute, then perform the actions listed in the description of the attribute that occur when setting,
-with <var>O</var> as the object and <var>idlValue</var> as the value.</p>
+        <p>Perform the actions listed in the description of <var>attribute</var> that occur on setting, on <var>O</var> if <var>O</var> is not <emu-val>null</emu-val>.</p>
        <li data-md="">
-        <p>Otherwise, the attribute is a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-13">static attribute</a>.
-Perform the actions listed in the description of the attribute that occur when setting with <var>idlValue</var> as the value.</p>
-       <li data-md="">
-        <p>Return <emu-val>undefined</emu-val>.</p>
+        <p>Return <emu-val>undefined</emu-val></p>
       </ol>
-     </div>
-     <p>The value of the <emu-val>Function</emu-val> object’s “length”
-property is the <emu-val>Number</emu-val> value <emu-val>1</emu-val>.</p>
-     <p>The value of the <emu-val>Function</emu-val> object’s “name”
-property is a <emu-val>String</emu-val> whose value is the
-concatenation of “set ” and the identifier of the attribute.</p>
-   </ul>
+     <li data-md="">
+      <p>Let <var>F</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createbuiltinfunction">CreateBuiltinFunction</a>(<var>realm</var>, <var>steps</var>, the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-function-prototype-object">%FunctionPrototype%</a> of <var>realm</var>).</p>
+     <li data-md="">
+      <p>Let <var>name</var> be the string "set " prepended to <var>id</var>.</p>
+     <li data-md="">
+      <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-setfunctionname">SetFunctionName</a>(<var>F</var>, <var>name</var>).</p>
+     <li data-md="">
+      <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow">DefinePropertyOrThrow</a>(<var>F</var>, "length",
+PropertyDescriptor<span class="prop-desc">{[[Value]]: 1, [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val>}</span>).</p>
+     <li data-md="">
+      <p>Return <var>F</var>.</p>
+    </ol>
+   </div>
    <p class="note" role="note">Note: Although there is only a single property for an IDL attribute, since
 accessor property getters and setters are passed a <emu-val>this</emu-val> value for the object on which property corresponding to the IDL attribute is
 accessed, they are able to expose instance-specific data.</p>
-   <p class="note" role="note">Note: Note that attempting to assign to a property corresponding to a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-14">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-57">attribute</a> results in different behavior depending on whether the script doing so is in strict mode.
+   <p class="note" role="note">Note: Attempting to assign to a property corresponding to a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-16">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-53">attribute</a> results in different behavior depending on whether the script doing so is in strict mode.
 When in strict mode, such an assignment will result in a <emu-val>TypeError</emu-val> being thrown.  When not in strict mode, the assignment attempt will be ignored.</p>
    <h4 class="heading settled" data-level="3.6.7" id="es-operations"><span class="secno">3.6.7. </span><span class="content">Operations</span><a class="self-link" href="#es-operations"></a></h4>
-   <p>For each unique <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-71">identifier</a> of an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-6">exposed</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-52">operation</a> defined on the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-100">interface</a>, there
+   <p>For each unique <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-72">identifier</a> of an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-6">exposed</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-52">operation</a> defined on the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-100">interface</a>, there
 must exist a corresponding property,
-unless the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-9">effective overload set</a> for that <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-72">identifier</a> and <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-53">operation</a> and with an argument count of 0 has no entries.</p>
+unless the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-9">effective overload set</a> for that <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-73">identifier</a> and <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-53">operation</a> and with an argument count of 0 has no entries.</p>
    <p>The characteristics of this property are as follows:</p>
    <ul>
     <li data-md="">
-     <p>The name of the property is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-73">identifier</a>.</p>
+     <p>The name of the property is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-74">identifier</a>.</p>
     <li data-md="">
      <p>The location of the property is determined as follows:</p>
      <ul>
@@ -9913,9 +9934,9 @@ then the property exists on every object that implements the interface.</p>
        <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-22">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-53">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-54">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-55">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-56">PrimaryGlobal</a></code>]-annotated interface as well as on
-the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-23">interface prototype object</a>.</p>
+the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-21">interface prototype object</a>.</p>
       <li data-md="">
-       <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-24">interface prototype object</a>.</p>
+       <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-22">interface prototype object</a>.</p>
      </ul>
     <li data-md="">
      <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <var>B</var>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <var>B</var> }</span>,
@@ -9937,7 +9958,7 @@ property-installation style as namespaces.)</p>
     given an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-54">operation</a> <var>op</var>, a <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-11">namespace</a> or <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-101">interface</a> <var>target</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>: 
     <ol>
      <li data-md="">
-      <p>Let <var>id</var> be <var>op</var>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-74">identifier</a>.</p>
+      <p>Let <var>id</var> be <var>op</var>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-75">identifier</a>.</p>
      <li data-md="">
       <p>Let <var>steps</var> be the following series of steps, given function argument
 values <var>arg</var><sub>0..<var>n</var>−1</sub>:</p>
@@ -9959,11 +9980,11 @@ object does not implement <var>target</var>.)</p>
            <li data-md="">
             <p>If <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-24">platform object</a>, then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-dfn-perform-a-security-check-3">perform a security check</a>, passing <var>O</var>, <var>id</var>, and "method".</p>
            <li data-md="">
-            <p>If <var>O</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-25">platform object</a> that implements the interface <var>target</var>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-34">throw</a> a <emu-val>TypeError</emu-val>.</p>
+            <p>If <var>O</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-25">platform object</a> that implements the interface <var>target</var>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-33">throw</a> a <emu-val>TypeError</emu-val>.</p>
           </ol>
          <li data-md="">
           <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-10">effective overload set</a> for <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-16">regular operations</a> (if <var>op</var> is a
-regular operation) or for <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-15">static operations</a> (if <var>op</var> is a static operation) with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-75">identifier</a> <var>id</var> on <var>target</var> and with argument count <var>n</var>.</p>
+regular operation) or for <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-15">static operations</a> (if <var>op</var> is a static operation) with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-76">identifier</a> <var>id</var> on <var>target</var> and with argument count <var>n</var>.</p>
          <li data-md="">
           <p>Let &lt;<var>operation</var>, <var>values</var>> be the result of passing <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to the <a data-link-type="dfn" href="#dfn-overload-resolution-algorithm" id="ref-for-dfn-overload-resolution-algorithm-3">overload resolution algorithm</a>.</p>
          <li data-md="">
@@ -9977,7 +9998,7 @@ an ECMAScript value of the type <var>op</var> is declared to return.</p>
       <p>And then, if an exception was thrown:</p>
       <ol>
        <li data-md="">
-        <p>If <var>op</var> has a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-5">return type</a> that is a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-9">promise type</a>, then:</p>
+        <p>If <var>op</var> has a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-5">return type</a> that is a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-13">promise type</a>, then:</p>
         <ol>
          <li data-md="">
           <p>Let <var>reject</var> be the initial value of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.</p>
@@ -9994,7 +10015,7 @@ and the exception as the single argument value.</p>
       <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-setfunctionname">SetFunctionName</a>(<var>F</var>, <var>id</var>).</p>
      <li data-md="">
       <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-11">effective overload set</a> for <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-17">regular operations</a> (if <var>op</var> is a regular
-operation) or for <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-16">static operations</a> (if <var>op</var> is a static operation) with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-76">identifier</a> <var>id</var> on <var>target</var> and with argument count 0.</p>
+operation) or for <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-16">static operations</a> (if <var>op</var> is a static operation) with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-77">identifier</a> <var>id</var> on <var>target</var> and with argument count 0.</p>
      <li data-md="">
       <p>Let <var>length</var> be the length of the shortest argument list in the entries in <var>S</var>.</p>
      <li data-md="">
@@ -10014,7 +10035,7 @@ then there must exist a property with the following characteristics:</p>
      <p>If the <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-4">stringifier</a> is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-5">unforgeable</a> on the interface
 or if the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-57">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-58">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on every object that implements the interface.
-Otherwise, the property exists on the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-25">interface prototype object</a>.</p>
+Otherwise, the property exists on the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-23">interface prototype object</a>.</p>
     <li data-md="">
      <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <var>B</var>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <var>B</var> }</span>,
 where <var>B</var> is <emu-val>false</emu-val> if the stringifier is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-6">unforgeable</a> on the interface,
@@ -10032,19 +10053,19 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
          <li data-md="">
           <p>the platform object <var>O</var>,</p>
          <li data-md="">
-          <p>the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-77">identifier</a> of the <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-5">stringifier</a>, and</p>
+          <p>the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-78">identifier</a> of the <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-5">stringifier</a>, and</p>
          <li data-md="">
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-104">interface</a> on which the stringifier was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-35">throw</a> a <emu-val>TypeError</emu-val>.</p>
+        <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-104">interface</a> on which the stringifier was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-34">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>V</var> be an uninitialized variable.</p>
        <li data-md="">
         <p>Depending on where <code>stringifier</code> was specified:</p>
         <dl class="switch">
          <dt data-md="">
-          <p>on an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-58">attribute</a></p>
+          <p>on an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-54">attribute</a></p>
          <dd data-md="">
           <p>Set <var>V</var> to the result of performing the actions listed in the description of the attribute that occur when getting
 (or those listed in the description of the inherited attribute, if this attribute is declared to <a data-link-type="dfn" href="#dfn-inherit-getter" id="ref-for-dfn-inherit-getter-3">inherit its getter</a>),
@@ -10083,9 +10104,9 @@ then the property exists on the single object that implements the interface.</p>
      <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-23">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-61">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-62">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-63">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-64">PrimaryGlobal</a></code>]-annotated interface as well as on
-the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-26">interface prototype object</a>.</p>
+the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-24">interface prototype object</a>.</p>
     <li data-md="">
-     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-27">interface prototype object</a>.</p>
+     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-25">interface prototype object</a>.</p>
    </ul>
    <div class="algorithm" data-algorithm="to invoke the toJSON method of interfaces">
     <p>The property’s <emu-val>Function</emu-val> object, when invoked,
@@ -10100,12 +10121,12 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
        <li data-md="">
         <p>the platform object <var>O</var>,</p>
        <li data-md="">
-        <p>the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-78">identifier</a> of the <a data-link-type="dfn" href="#dfn-serializer" id="ref-for-dfn-serializer-6">serializer</a>, and</p>
+        <p>the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-79">identifier</a> of the <a data-link-type="dfn" href="#dfn-serializer" id="ref-for-dfn-serializer-6">serializer</a>, and</p>
        <li data-md="">
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-106">interface</a> on which the serializer was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-36">throw</a> a <emu-val>TypeError</emu-val>.</p>
+      <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-106">interface</a> on which the serializer was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-35">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Depending on how <code>serializer</code> was specified:</p>
       <dl class="switch">
@@ -10201,7 +10222,7 @@ property is the <emu-val>String</emu-val> value “toJSON”.</p>
      <p>an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-9">iterable declaration</a></p>
     <li data-md="">
      <p>an <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-6">indexed property getter</a> and
-an <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-6">integer-typed</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-59">attribute</a> named “length”</p>
+an <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-6">integer-typed</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-55">attribute</a> named “length”</p>
     <li data-md="">
      <p>a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-7">maplike declaration</a></p>
     <li data-md="">
@@ -10218,9 +10239,9 @@ then the property exists on the single object that implements the interface.</p>
      <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-24">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-67">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-68">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-69">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-70">PrimaryGlobal</a></code>]-annotated interface as well as on
-the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-28">interface prototype object</a>.</p>
+the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-26">interface prototype object</a>.</p>
     <li data-md="">
-     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-29">interface prototype object</a>.</p>
+     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-27">interface prototype object</a>.</p>
    </ul>
    <p>If the interface defines an <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-7">indexed property getter</a>,
 then the <emu-val>Function</emu-val> object is <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ArrayProto_values%</a>.</p>
@@ -10245,7 +10266,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-109">interface</a> the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-10">iterable declaration</a> is on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-29">platform object</a> that implements <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-37">throw</a> a <emu-val>TypeError</emu-val>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-36">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>iterator</var> be a newly created <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-1">default iterator object</a> for <var>interface</var> with <var>object</var> as its target and iterator kind “key+value”.</p>
      <li data-md="">
@@ -10272,7 +10293,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       </ul>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-31">platform object</a> that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-110">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-9">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-9">setlike declaration</a> is defined,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-38">throw</a> a <emu-val>TypeError</emu-val>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-37">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>If the interface has a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-10">maplike declaration</a>, then:</p>
       <ol>
@@ -10317,9 +10338,9 @@ then the property exists on the single object that implements the interface.</p>
      <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-25">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-73">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-74">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-75">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-76">PrimaryGlobal</a></code>]-annotated interface as well as on
-the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-30">interface prototype object</a>.</p>
+the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-28">interface prototype object</a>.</p>
     <li data-md="">
-     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-31">interface prototype object</a>.</p>
+     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-29">interface prototype object</a>.</p>
    </ul>
    <p>If the interface defines an <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-8">indexed property getter</a>,
 then the <emu-val>Function</emu-val> object is
@@ -10381,11 +10402,11 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-112">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-14">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-13">setlike declaration</a> is declared.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-33">platform object</a> that implements <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-39">throw</a> a <emu-val>TypeError</emu-val>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-38">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>callbackFn</var> be the value of the first argument passed to the function, or <emu-val>undefined</emu-val> if the argument was not supplied.</p>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>callbackFn</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-40">throw</a> a <emu-val>TypeError</emu-val>.</p>
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>callbackFn</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-39">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>thisArg</var> be the value of the second argument passed to the function, or <emu-val>undefined</emu-val> if the argument was not supplied.</p>
      <li data-md="">
@@ -10409,7 +10430,7 @@ or the [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma2
      <li data-md="">
       <p>Let <var>forEach</var> be the result of calling the [[Get]] internal method of <var>backing</var> with “forEach” and <var>backing</var> as arguments.</p>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>forEach</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-41">throw</a> a <emu-val>TypeError</emu-val>.</p>
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>forEach</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-40">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-call">Call</a>(<var>forEach</var>, <var>backing</var>, «<var>callbackWrapper</var>, <var>thisArg</var>»).</p>
      <li data-md="">
@@ -10433,9 +10454,9 @@ then the property exists on the single object that implements the interface.</p>
      <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-26">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-79">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-80">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-81">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-82">PrimaryGlobal</a></code>]-annotated interface as well as on
-the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-32">interface prototype object</a>.</p>
+the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-30">interface prototype object</a>.</p>
     <li data-md="">
-     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-33">interface prototype object</a>.</p>
+     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-31">interface prototype object</a>.</p>
    </ul>
    <p>If the interface has a <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-7">value iterator</a>,
 then the <emu-val>Function</emu-val> object is
@@ -10455,9 +10476,9 @@ then the property exists on the single object that implements the interface.</p>
      <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-27">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-85">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-86">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-87">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-88">PrimaryGlobal</a></code>]-annotated interface as well as on
-the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-34">interface prototype object</a>.</p>
+the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-32">interface prototype object</a>.</p>
     <li data-md="">
-     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-35">interface prototype object</a>.</p>
+     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-33">interface prototype object</a>.</p>
    </ul>
    <p>If the interface has a <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-8">value iterator</a>,
 then the <emu-val>Function</emu-val> object is
@@ -10483,7 +10504,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-115">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-15">iterable declaration</a> is declared on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-35">platform object</a> that implements <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-42">throw</a> a <emu-val>TypeError</emu-val>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-41">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>iterator</var> be a newly created <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-2">default iterator object</a> for <var>interface</var> with <var>object</var> as its target and iterator kind “key”.</p>
      <li data-md="">
@@ -10505,9 +10526,9 @@ then the property exists on the single object that implements the interface.</p>
      <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-28">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-91">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-92">PrimaryGlobal</a></code>]-annotated interface, then
 the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-93">Global</a></code>]- or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-94">PrimaryGlobal</a></code>]-annotated interface as well as on
-the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-36">interface prototype object</a>.</p>
+the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-34">interface prototype object</a>.</p>
     <li data-md="">
-     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-37">interface prototype object</a>.</p>
+     <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-35">interface prototype object</a>.</p>
    </ul>
    <p>If the interface has a <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-9">value iterator</a>,
 then the <emu-val>Function</emu-val> object is
@@ -10533,7 +10554,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-117">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-17">iterable declaration</a> is declared on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-37">platform object</a> that implements <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-43">throw</a> a <emu-val>TypeError</emu-val>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-42">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>iterator</var> be a newly created <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-3">default iterator object</a> for <var>interface</var> with <var>object</var> as its target and iterator kind “value”.</p>
      <li data-md="">
@@ -10559,7 +10580,7 @@ restricted to iterating over an object’s <a data-link-type="dfn" href="#dfn-su
 use standard ECMAScript Array iterator objects.</p>
    <p>When a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-5">default iterator object</a> is first created,
 its index is set to 0.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-3">class string</a> of a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-6">default iterator object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-120">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-79">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-121">interface</a> and the string “Iterator”.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-3">class string</a> of a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-6">default iterator object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-120">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-80">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-121">interface</a> and the string “Iterator”.</p>
    <h5 class="heading settled" data-level="3.6.9.5" id="es-iterator-prototype-object"><span class="secno">3.6.9.5. </span><span class="content">Iterator prototype object</span><a class="self-link" href="#es-iterator-prototype-object"></a></h5>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-iterator-prototype-object">iterator prototype object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-122">interface</a> is an object that exists for every interface that has a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-11">pair iterator</a>.  It serves as the
 prototype for <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-7">default iterator objects</a> for the interface.</p>
@@ -10584,7 +10605,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       </ul>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-8">default iterator object</a> for <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-44">throw</a> a <emu-val>TypeError</emu-val>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-43">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>index</var> be <var>object</var>’s index.</p>
      <li data-md="">
@@ -10651,7 +10672,7 @@ return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createi
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createiterresultobject">CreateIterResultObject</a>(<var>result</var>, <emu-val>false</emu-val>).</p>
     </ol>
    </div>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-4">class string</a> of an <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-6">iterator prototype object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-124">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-80">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-125">interface</a> and the string “Iterator”.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-4">class string</a> of an <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-6">iterator prototype object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-124">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-81">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-125">interface</a> and the string “Iterator”.</p>
    <h4 class="heading settled" data-level="3.6.10" id="es-maplike"><span class="secno">3.6.10. </span><span class="content">Maplike declarations</span><a class="self-link" href="#es-maplike"></a></h4>
    <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-126">interface</a> that has a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-16">maplike declaration</a> must have a [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
 initially set to a newly created <emu-val>Map</emu-val> object.
@@ -10659,7 +10680,7 @@ This <emu-val>Map</emu-val> object’s [[MapData]] internal slot is
 the object’s <a data-link-type="dfn" href="#dfn-map-entries" id="ref-for-dfn-map-entries-3">map entries</a>.</p>
    <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-127">interface</a> <var>A</var> is declared with
 a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-17">maplike declaration</a>, then
-there exists a number of additional properties on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-38">interface prototype object</a>.
+there exists a number of additional properties on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-36">interface prototype object</a>.
 These additional properties are described in the sub-sections below.</p>
    <div class="algorithm" data-algorithm="forwards to the internal map object">
     <p>Some of the properties below are defined to have a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-14">function object</a> value that <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-forwards-to-the-internal-map-object">forwards to the internal map object</dfn> for a given function name.  Such functions behave as follows when invoked:</p>
@@ -10682,19 +10703,19 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-45">throw</a> a <emu-val>TypeError</emu-val>.</p>
+      <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-44">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
      <li data-md="">
       <p>Let <var>function</var> be the result of calling the [[Get]] internal method of <var>map</var> passing <var>name</var> and <var>map</var> as arguments.</p>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>function</var>) is <emu-val>false</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-46">throw</a> a <emu-val>TypeError</emu-val>.</p>
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>function</var>) is <emu-val>false</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-45">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-call">Call</a>(<var>function</var>, <var>map</var>, <var>arguments</var>).</p>
     </ol>
    </div>
    <h5 class="heading settled" data-level="3.6.10.1" id="es-map-size"><span class="secno">3.6.10.1. </span><span class="content">size</span><a class="self-link" href="#es-map-size"></a></h5>
-   <p>There must exist a property named “size” on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-39">interface prototype object</a> with the following characteristics:</p>
+   <p>There must exist a property named “size” on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-37">interface prototype object</a> with the following characteristics:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="prop-desc">{ [[Get]]: <var>G</var>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>,
@@ -10719,7 +10740,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “getter”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-47">throw</a> a <emu-val>TypeError</emu-val>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-46">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -10730,10 +10751,10 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
      <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “size”.</p>
    </ul>
    <h5 class="heading settled" data-level="3.6.10.2" id="es-map-entries"><span class="secno">3.6.10.2. </span><span class="content">entries</span><a class="self-link" href="#es-map-entries"></a></h5>
-   <p>A property named “entries” must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-40">interface prototype object</a> with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-15">function object</a> that is the value of
+   <p>A property named “entries” must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-38">interface prototype object</a> with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-15">function object</a> that is the value of
 the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> property.</p>
    <h5 class="heading settled" data-level="3.6.10.3" id="es-map-keys-values"><span class="secno">3.6.10.3. </span><span class="content">keys and values</span><a class="self-link" href="#es-map-keys-values"></a></h5>
-   <p>For both of “keys” and “values”, there must exist a property with that name on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-41">interface prototype object</a> with the following characteristics:</p>
+   <p>For both of “keys” and “values”, there must exist a property with that name on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-39">interface prototype object</a> with the following characteristics:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
@@ -10743,7 +10764,7 @@ the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known
    <p>The value of the <emu-val>Function</emu-val> objects’ “length” properties is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “keys” or “values”, correspondingly.</p>
    <h5 class="heading settled" data-level="3.6.10.4" id="es-map-get-has"><span class="secno">3.6.10.4. </span><span class="content">get and has</span><a class="self-link" href="#es-map-get-has"></a></h5>
-   <p>For both of “get” and “has”, there must exist a property with that name on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-42">interface prototype object</a> with the following characteristics:</p>
+   <p>For both of “get” and “has”, there must exist a property with that name on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-40">interface prototype object</a> with the following characteristics:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
@@ -10768,7 +10789,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-48">throw</a> a <emu-val>TypeError</emu-val>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-47">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -10791,7 +10812,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
    <h5 class="heading settled" data-level="3.6.10.5" id="es-map-clear"><span class="secno">3.6.10.5. </span><span class="content">clear</span><a class="self-link" href="#es-map-clear"></a></h5>
    <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-29">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-21">interface member</a> with identifier “clear”, and <var>A</var> was declared with a read–write maplike declaration,
 then a property named “clear” and the following characteristics
-must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-43">interface prototype object</a>:</p>
+must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-41">interface prototype object</a>:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
@@ -10803,7 +10824,7 @@ must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prot
    <h5 class="heading settled" data-level="3.6.10.6" id="es-map-delete"><span class="secno">3.6.10.6. </span><span class="content">delete</span><a class="self-link" href="#es-map-delete"></a></h5>
    <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-30">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-22">interface member</a> with identifier “delete”, and <var>A</var> was declared with a read–write maplike declaration,
 then a property named “delete” and the following characteristics
-must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-44">interface prototype object</a>:</p>
+must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-42">interface prototype object</a>:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
@@ -10825,7 +10846,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-49">throw</a> a <emu-val>TypeError</emu-val>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-48">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -10849,7 +10870,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
    <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-31">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-23">interface member</a> with identifier “set”,
 and <var>A</var> was declared with a read–write maplike declaration,
 then a property named “set” and the following characteristics
-must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-45">interface prototype object</a>:</p>
+must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-43">interface prototype object</a>:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
@@ -10871,7 +10892,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-50">throw</a> a <emu-val>TypeError</emu-val>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-49">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -10906,7 +10927,7 @@ This <emu-val>Set</emu-val> object’s [[SetData]] internal slot is
 the object’s <a data-link-type="dfn" href="#dfn-set-entries" id="ref-for-dfn-set-entries-3">set entries</a>.</p>
    <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-129">interface</a> <var>A</var> is declared with a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-15">setlike declaration</a>, then
 there exists a number of additional properties
-on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-46">interface prototype object</a>.
+on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-44">interface prototype object</a>.
 These additional properties are described in the sub-sections below.</p>
    <div class="algorithm" data-algorithm="forwards to the internal set object">
     <p>Some of the properties below are defined to have a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-16">function object</a> value that <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-forwards-to-the-internal-set-object">forwards to the internal set object</dfn> for a given function name. Such functions behave as follows when invoked:</p>
@@ -10930,7 +10951,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       </ul>
      <li data-md="">
       <p>If <var>O</var> is not an object that implements <var>A</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-51">throw</a> a <emu-val>TypeError</emu-val>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-50">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>set</var> be the <emu-val>Set</emu-val> object that is
 the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
@@ -10938,13 +10959,13 @@ the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https
       <p>Let <var>function</var> be the result of calling the [[Get]] internal method of <var>set</var> passing <var>name</var> and <var>set</var> as arguments.</p>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>function</var>) is <emu-val>false</emu-val>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-52">throw</a> a <emu-val>TypeError</emu-val>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-51">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-call">Call</a>(<var>function</var>, <var>set</var>, <var>arguments</var>).</p>
     </ol>
    </div>
    <h5 class="heading settled" data-level="3.6.11.1" id="es-set-size"><span class="secno">3.6.11.1. </span><span class="content">size</span><a class="self-link" href="#es-set-size"></a></h5>
-   <p>There must exist a property named “size” on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-47">interface prototype object</a> with the following characteristics:</p>
+   <p>There must exist a property named “size” on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-45">interface prototype object</a> with the following characteristics:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="prop-desc">{ [[Get]]: <var>G</var>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>,
@@ -10969,7 +10990,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “getter”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-53">throw</a> a <emu-val>TypeError</emu-val>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-52">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>set</var> be the <emu-val>Set</emu-val> object that is the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -10980,10 +11001,10 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
      <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “size”.</p>
    </ul>
    <h5 class="heading settled" data-level="3.6.11.2" id="es-set-values"><span class="secno">3.6.11.2. </span><span class="content">values</span><a class="self-link" href="#es-set-values"></a></h5>
-   <p>A property named “values” must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-48">interface prototype object</a> with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-17">function object</a> that is the value of
+   <p>A property named “values” must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-46">interface prototype object</a> with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-17">function object</a> that is the value of
 the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> property.</p>
    <h5 class="heading settled" data-level="3.6.11.3" id="es-set-entries-keys"><span class="secno">3.6.11.3. </span><span class="content">entries and keys</span><a class="self-link" href="#es-set-entries-keys"></a></h5>
-   <p>For both of “entries” and “keys”, there must exist a property with that name on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-49">interface prototype object</a> with the following characteristics:</p>
+   <p>For both of “entries” and “keys”, there must exist a property with that name on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-47">interface prototype object</a> with the following characteristics:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
@@ -10995,7 +11016,7 @@ the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is
 the <emu-val>String</emu-val> value “entries” or “keys”, correspondingly.</p>
    <h5 class="heading settled" data-level="3.6.11.4" id="es-set-has"><span class="secno">3.6.11.4. </span><span class="content">has</span><a class="self-link" href="#es-set-has"></a></h5>
-   <p>There must exist a property with named “has” on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-50">interface prototype object</a> with the following characteristics:</p>
+   <p>There must exist a property with named “has” on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-48">interface prototype object</a> with the following characteristics:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
@@ -11017,7 +11038,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-54">throw</a> a <emu-val>TypeError</emu-val>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-53">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>set</var> be the <emu-val>Set</emu-val> object that is the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -11046,7 +11067,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
      <p><var>A</var> was declared with a read–write setlike declaration,</p>
    </ul>
    <p>then a property with that name and the following characteristics
-must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-51">interface prototype object</a>:</p>
+must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-49">interface prototype object</a>:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
@@ -11070,7 +11091,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-55">throw</a> a <emu-val>TypeError</emu-val>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-54">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>set</var> be the <emu-val>Set</emu-val> object that is the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -11097,7 +11118,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
    <h5 class="heading settled" data-level="3.6.11.6" id="es-set-clear"><span class="secno">3.6.11.6. </span><span class="content">clear</span><a class="self-link" href="#es-set-clear"></a></h5>
    <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-33">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-25">interface member</a> with a matching identifier, and <var>A</var> was declared with a read–write setlike declaration,
 then a property named “clear” and the following characteristics
-must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-52">interface prototype object</a>:</p>
+must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-50">interface prototype object</a>:</p>
    <ul>
     <li data-md="">
      <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
@@ -11107,8 +11128,8 @@ must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prot
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “clear”.</p>
    <h3 class="heading settled" data-level="3.7" id="es-implements-statements"><span class="secno">3.7. </span><span class="content">Implements statements</span><a class="self-link" href="#es-implements-statements"></a></h3>
-   <p>The <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-53">interface prototype object</a> of an interface <var>A</var> must have a copy of
-each property that corresponds to one of the <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-28">constants</a>, <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-60">attributes</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-59">operations</a>, <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-18">iterable declarations</a>, <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-21">maplike declarations</a> and <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-18">setlike declarations</a> that exist on all of the interface prototype objects of <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-34">consequential interfaces</a>.
+   <p>The <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-51">interface prototype object</a> of an interface <var>A</var> must have a copy of
+each property that corresponds to one of the <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-28">constants</a>, <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-56">attributes</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-59">operations</a>, <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-18">iterable declarations</a>, <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-21">maplike declarations</a> and <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-18">setlike declarations</a> that exist on all of the interface prototype objects of <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-34">consequential interfaces</a>.
 For operations, where the property is a data property with a <emu-val>Function</emu-val> object value, each copy of the property must have
 distinct <emu-val>Function</emu-val> objects.  For attributes, each
 copy of the accessor property must have
@@ -11118,7 +11139,7 @@ and similarly with their setters.</p>
     <p>When invoking an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-60">operation</a> by calling
     a <emu-val>Function</emu-val> object that is the value of one of the copies that exists
     due to an implements statement, the <emu-val>this</emu-val> value is
-    checked to ensure that it is an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-130">interface</a> corresponding to the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-54">interface prototype object</a> that the property is on.</p>
+    checked to ensure that it is an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-130">interface</a> corresponding to the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-52">interface prototype object</a> that the property is on.</p>
     <p>For example, consider the following IDL:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">A</span> {
   <span class="kt">void</span> <span class="nv">f</span>();
@@ -11133,7 +11154,7 @@ and similarly with their setters.</p>
     <p>Attempting to call <code>B.prototype.f</code> on an object that implements <code class="idl">A</code> (but not <code class="idl">B</code>) or one
     that implements <code class="idl">C</code> will result in a <emu-val>TypeError</emu-val> being thrown.  However,
     calling <code>A.prototype.f</code> on an object that implements <code class="idl">B</code> or one that implements <code class="idl">C</code> would succeed.  This is handled by the algorithm in <a href="#es-operations">§3.6.7 Operations</a> that defines how IDL operation invocation works in ECMAScript.</p>
-    <p>Similar behavior is required for the getter and setter <emu-val>Function</emu-val> objects that correspond to an IDL <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-61">attributes</a>,
+    <p>Similar behavior is required for the getter and setter <emu-val>Function</emu-val> objects that correspond to an IDL <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-57">attributes</a>,
     and this is handled in <a href="#es-attributes">§3.6.6 Attributes</a>.</p>
    </div>
    <h3 class="heading settled" data-level="3.8" id="es-platform-objects"><span class="secno">3.8. </span><span class="content">Platform objects implementing interfaces</span><a class="self-link" href="#es-platform-objects"></a></h3>
@@ -11144,17 +11165,17 @@ which global environment (or, by proxy, which global object) each platform
 object is associated with.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-primary-interface">primary interface</dfn> of a platform object
 that implements one or more interfaces is the most-derived <a data-link-type="dfn" href="#dfn-supplemental-interface" id="ref-for-dfn-supplemental-interface-7">non-supplemental interface</a> that it implements.  The value of the internal [[Prototype]]
-property of the platform object is the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-55">interface prototype object</a> of the <a data-link-type="dfn" href="#dfn-primary-interface" id="ref-for-dfn-primary-interface-1">primary interface</a> from the <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-49">platform object</a>’s associated global environment.</p>
+property of the platform object is the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-53">interface prototype object</a> of the <a data-link-type="dfn" href="#dfn-primary-interface" id="ref-for-dfn-primary-interface-1">primary interface</a> from the <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-49">platform object</a>’s associated global environment.</p>
    <p>The global environment that a given <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-50">platform object</a> is associated with can <dfn data-dfn-for="global environment" data-dfn-type="dfn" data-export="" id="dfn-change-global-environment">change<a class="self-link" href="#dfn-change-global-environment"></a></dfn> after it has been created.  When
 the global environment associated with a platform object is changed, its internal
 [[Prototype]] property must be immediately
-updated to be the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-56">interface prototype object</a> of the <a data-link-type="dfn" href="#dfn-primary-interface" id="ref-for-dfn-primary-interface-2">primary interface</a> from the <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-51">platform object</a>’s newly associated global environment.</p>
+updated to be the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-54">interface prototype object</a> of the <a data-link-type="dfn" href="#dfn-primary-interface" id="ref-for-dfn-primary-interface-2">primary interface</a> from the <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-51">platform object</a>’s newly associated global environment.</p>
    <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-5">class string</a> of
 a platform object that implements one or more interfaces
-must be the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-81">identifier</a> of
+must be the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-82">identifier</a> of
 the <a data-link-type="dfn" href="#dfn-primary-interface" id="ref-for-dfn-primary-interface-3">primary interface</a> of the platform object.</p>
    <h4 class="heading settled" data-level="3.8.1" id="platform-object-setprototypeof"><span class="secno">3.8.1. </span><span class="content">[[SetPrototypeOf]]</span><span id="platformobjectsetprototypeof"></span><a class="self-link" href="#platform-object-setprototypeof"></a></h4>
-   <p>The internal [[SetPrototypeOf]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-52">platform object</a> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-131">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-95">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-96">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-85">extended attribute</a> must execute the same algorithm as is defined for the
+   <p>The internal [[SetPrototypeOf]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-52">platform object</a> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-131">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-95">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-96">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-86">extended attribute</a> must execute the same algorithm as is defined for the
 [[SetPrototypeOf]] internal method of an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">immutable prototype exotic object</a>.</p>
    <p class="note" role="note">Note: For <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> objects, it is unobservable whether this is implemented, since the presence of
 the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#windowproxy">WindowProxy</a></code> object ensures that [[SetPrototypeOf]] is never called on a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> object
@@ -11240,12 +11261,12 @@ and <var>O</var> implements an interface with a <a data-link-type="dfn" href="#d
       </ol>
      <li data-md="">
       <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-9">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-133">interface</a> with the
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-97">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-98">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-86">extended attribute</a> and <var>P</var> is not an <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-dfn-unforgeable-property-name-1">unforgeable property name</a> of <var>O</var>, then:</p>
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-97">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-98">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-87">extended attribute</a> and <var>P</var> is not an <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-dfn-unforgeable-property-name-1">unforgeable property name</a> of <var>O</var>, then:</p>
       <ol>
        <li data-md="">
         <p>Let <var>creating</var> be true if <var>P</var> is not a <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-4">supported property name</a>, and false otherwise.</p>
        <li data-md="">
-        <p>If <var>O</var> implements an interface with the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-8">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-87">extended attribute</a> or <var>O</var> does not have an own property
+        <p>If <var>O</var> implements an interface with the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-8">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-88">extended attribute</a> or <var>O</var> does not have an own property
 named <var>P</var>, then:</p>
         <ol>
          <li data-md="">
@@ -11266,7 +11287,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
      <li data-md="">
       <p>If <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-134">interface</a> with the
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-99">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-100">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-88">extended attribute</a>, then set <var>Desc</var>.[[Configurable]] to <emu-val>true</emu-val>.</p>
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-100">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-89">extended attribute</a>, then set <var>Desc</var>.[[Configurable]] to <emu-val>true</emu-val>.</p>
      <li data-md="">
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinarydefineownproperty">OrdinaryDefineOwnProperty</a>(<var>O</var>, <var>P</var>, <var>Desc</var>).</p>
     </ol>
@@ -11287,14 +11308,14 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
       </ol>
      <li data-md="">
       <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-10">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-135">interface</a> with the
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-101">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-102">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-89">extended attribute</a> and the result of calling the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-2">named property visibility algorithm</a> with property name <var>P</var> and object <var>O</var> is true, then:</p>
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-101">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-102">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-90">extended attribute</a> and the result of calling the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-2">named property visibility algorithm</a> with property name <var>P</var> and object <var>O</var> is true, then:</p>
       <ol>
        <li data-md="">
         <p>If <var>O</var> does not implement an interface with a <a data-link-type="dfn" href="#dfn-named-property-deleter" id="ref-for-dfn-named-property-deleter-5">named property deleter</a>, then return <emu-val>false</emu-val>.</p>
        <li data-md="">
         <p>Let <var>operation</var> be the operation used to declare the named property deleter.</p>
        <li data-md="">
-        <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-82">identifier</a>, then:</p>
+        <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-83">identifier</a>, then:</p>
         <ol>
          <li data-md="">
           <p>Perform the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-delete-an-existing-named-property" id="ref-for-dfn-delete-an-existing-named-property-1">delete an existing named property</a> with <var>P</var> as the name.</p>
@@ -11331,7 +11352,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
     assuming <var>arg</var><sub>0..<var>n</var>−1</sub> is the list of argument values passed to [[Call]]:</p>
     <ol>
      <li data-md="">
-      <p>If <var>I</var> has no <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-11">legacy callers</a>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-56">throw</a> a <emu-val>TypeError</emu-val>.</p>
+      <p>If <var>I</var> has no <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-11">legacy callers</a>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-55">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-12">effective overload set</a> for legacy callers on <var>I</var> and with argument count <var>n</var>.</p>
      <li data-md="">
@@ -11366,7 +11387,7 @@ the object’s <a data-link-type="dfn" href="#dfn-supported-property-indices" id
 enumerated first, in numerical order.</p>
     <li data-md="">
      <p>If the object <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-11">supports named properties</a> and doesn’t implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-138">interface</a> with the
-[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-6">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-90">extended attribute</a>, then
+[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-6">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-91">extended attribute</a>, then
 the object’s <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-5">supported property names</a> that
 are visible according to the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-3">named property visibility algorithm</a> are enumerated next, in the order given in the definition of the set of supported property names.</p>
     <li data-md="">
@@ -11394,7 +11415,7 @@ in no defined order.</p>
    <div class="algorithm" data-algorithm="named property visibility algorithm">
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-named-property-visibility">named property visibility algorithm</dfn> is used to determine if a given named property is exposed on an object.
     Some named properties are not exposed on an object depending on whether
-    the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-9">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-91">extended attribute</a> was used.
+    the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-9">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-92">extended attribute</a> was used.
     The algorithm operates as follows, with property name <var>P</var> and object <var>O</var>:</p>
     <ol>
      <li data-md="">
@@ -11405,7 +11426,7 @@ in no defined order.</p>
   because in practice those are always set up before objects have any supported property names,
   and once set up will make the corresponding named properties invisible.</p>
      <li data-md="">
-      <p>If <var>O</var> implements an interface that has the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-10">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-92">extended attribute</a>, then return true.</p>
+      <p>If <var>O</var> implements an interface that has the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-10">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-93">extended attribute</a>, then return true.</p>
      <li data-md="">
       <p>Initialize <var>prototype</var> to be the value of the internal [[Prototype]] property of <var>O</var>.</p>
      <li data-md="">
@@ -11461,7 +11482,7 @@ and false otherwise.</p>
      <li data-md="">
       <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-68">converting</a> <var>V</var> to an IDL value of type <var>T</var>.</p>
      <li data-md="">
-      <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-83">identifier</a>, then:</p>
+      <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-84">identifier</a>, then:</p>
       <ol>
        <li data-md="">
         <p>If <var>creating</var> is true, then perform the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-set-the-value-of-a-new-indexed-property" id="ref-for-dfn-set-the-value-of-a-new-indexed-property-1">set the value of a new indexed property</a> with <var>index</var> as the index and <var>value</var> as the value.</p>
@@ -11484,7 +11505,7 @@ and false otherwise.</p>
      <li data-md="">
       <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-69">converting</a> <var>V</var> to an IDL value of type <var>T</var>.</p>
      <li data-md="">
-      <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-84">identifier</a>, then:</p>
+      <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-85">identifier</a>, then:</p>
       <ol>
        <li data-md="">
         <p>If <var>creating</var> is true, then perform the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-set-the-value-of-a-new-named-property" id="ref-for-dfn-set-the-value-of-a-new-named-property-1">set the value of a new named property</a> with <var>P</var> as the name and <var>value</var> as the value.</p>
@@ -11512,7 +11533,7 @@ and false otherwise.</p>
          <li data-md="">
           <p>Let <var>value</var> be an uninitialized variable.</p>
          <li data-md="">
-          <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-85">identifier</a>, then
+          <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-86">identifier</a>, then
 set <var>value</var> to the result of performing the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-determine-the-value-of-an-indexed-property" id="ref-for-dfn-determine-the-value-of-an-indexed-property-1">determine the value of an indexed property</a> with <var>index</var> as the index.</p>
          <li data-md="">
           <p>Otherwise, <var>operation</var> was defined with an identifier.  Set <var>value</var> to the result
@@ -11541,7 +11562,7 @@ property name <var>P</var> and object <var>O</var> is true, and <var>ignoreNamed
        <li data-md="">
         <p>Let <var>value</var> be an uninitialized variable.</p>
        <li data-md="">
-        <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-86">identifier</a>, then
+        <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-87">identifier</a>, then
 set <var>value</var> to the result of performing the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-determine-the-value-of-a-named-property" id="ref-for-dfn-determine-the-value-of-a-named-property-2">determine the value of a named property</a> with <var>P</var> as the name.</p>
        <li data-md="">
         <p>Otherwise, <var>operation</var> was defined with an identifier.  Set <var>value</var> to the result
@@ -11554,7 +11575,7 @@ of performing the steps listed in the description of <var>operation</var> with <
         <p>If <var>O</var> implements an interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="ref-for-dfn-named-property-setter-7">named property setter</a>, then set <var>desc</var>.[[Writable]] to <emu-val>true</emu-val>, otherwise set it to <emu-val>false</emu-val>.</p>
        <li data-md="">
         <p>If <var>O</var> implements an interface with the
-[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-7">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-93">extended attribute</a>,
+[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-7">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-94">extended attribute</a>,
 then set <var>desc</var>.[[Enumerable]] to <emu-val>false</emu-val>,
 otherwise set it to <emu-val>true</emu-val>.</p>
        <li data-md="">
@@ -11585,12 +11606,12 @@ the callable object itself.</p>
        <p>Otherwise, the object is not <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">callable</a>.
 The implementation of the operation (or set of overloaded operations) is
 the result of invoking the internal [[Get]] method
-on the object with a property name that is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-87">identifier</a> of the operation.</p>
+on the object with a property name that is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-88">identifier</a> of the operation.</p>
      </ul>
     <li data-md="">
      <p>Otherwise, the interface is not a <a data-link-type="dfn" href="#dfn-single-operation-callback-interface" id="ref-for-dfn-single-operation-callback-interface-2">single operation callback interface</a>.
 Any object is considered to implement the interface.
-For each operation declared on the interface with a given <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-88">identifier</a>, the implementation
+For each operation declared on the interface with a given <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-89">identifier</a>, the implementation
 is the result of invoking [[Get]] on the object with a
 property name that is that identifier.</p>
    </ul>
@@ -11603,9 +11624,9 @@ a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callbac
     <li data-md="">
      <p>is not declared to <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-14">inherit</a> from another interface,</p>
     <li data-md="">
-     <p>has no <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-62">attributes</a>, and</p>
+     <p>has no <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-58">attributes</a>, and</p>
     <li data-md="">
-     <p>has one or more <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-18">regular operations</a> that all have the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-89">identifier</a>,
+     <p>has one or more <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-18">regular operations</a> that all have the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-90">identifier</a>,
 and no others.</p>
    </ul>
    <div class="algorithm" data-algorithm="to call a user object’s operation">
@@ -11707,7 +11728,7 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
        <li data-md="">
         <p>If <var>completion</var> is a normal completion, return <var>completion</var>.</p>
        <li data-md="">
-        <p>If <var>completion</var> is an abrupt completion and the operation has a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-7">return type</a> that is <em>not</em> a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-10">promise type</a>, return <var>completion</var>.</p>
+        <p>If <var>completion</var> is an abrupt completion and the operation has a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-7">return type</a> that is <em>not</em> a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-14">promise type</a>, return <var>completion</var>.</p>
        <li data-md="">
         <p>Let <var>reject</var> be the initial value of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.</p>
        <li data-md="">
@@ -11755,7 +11776,7 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
        <li data-md="">
         <p>If <var>completion</var> is a normal completion, return <var>completion</var>.</p>
        <li data-md="">
-        <p>If <var>completion</var> is an abrupt completion and the attribute’s type is <em>not</em> a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-11">promise type</a>, return <var>completion</var>.</p>
+        <p>If <var>completion</var> is an abrupt completion and the attribute’s type is <em>not</em> a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-15">promise type</a>, return <var>completion</var>.</p>
        <li data-md="">
         <p>Let <var>reject</var> be the initial value of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.</p>
        <li data-md="">
@@ -11894,7 +11915,7 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
        <li data-md="">
         <p>If <var>completion</var> is a normal completion, return <var>completion</var>.</p>
        <li data-md="">
-        <p>If <var>completion</var> is an abrupt completion and the callback function has a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-8">return type</a> that is <em>not</em> a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-12">promise type</a>, return <var>completion</var>.</p>
+        <p>If <var>completion</var> is an abrupt completion and the callback function has a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-8">return type</a> that is <em>not</em> a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-16">promise type</a>, return <var>completion</var>.</p>
        <li data-md="">
         <p>Let <var>reject</var> be the initial value of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.</p>
        <li data-md="">
@@ -11907,7 +11928,7 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
    <h3 class="heading settled" data-level="3.12" id="es-namespaces"><span class="secno">3.12. </span><span class="content">Namespaces</span><a class="self-link" href="#es-namespaces"></a></h3>
    <p>For every <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-12">namespace</a> that is <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-9">exposed</a> in a given ECMAScript global environment,
 a corresponding property must exist on the ECMAScript
-environment’s global object. The name of the property is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-90">identifier</a> of the namespace, and its value is an object
+environment’s global object. The name of the property is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-91">identifier</a> of the namespace, and its value is an object
 called the <dfn data-dfn-type="dfn" data-export="" id="dfn-namespace-object">namespace object<a class="self-link" href="#dfn-namespace-object"></a></dfn>.</p>
    <p>The property has the attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>,
 [[Configurable]]: <emu-val>true</emu-val> }</span>. The characteristics of a
@@ -11924,7 +11945,7 @@ namespace object are described in <a href="#namespace-object">§3.12.1 Namespace
        <li data-md="">
         <p>Let <var>F</var> be the result of <a data-link-type="dfn" href="#dfn-create-operation-function" id="ref-for-dfn-create-operation-function-2">creating an operation function</a> given <var>op</var>, <var>namespace</var>,  and <var>realm</var>.</p>
        <li data-md="">
-        <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createdataproperty">CreateDataProperty</a>(<var>namespaceObject</var>, <var>op</var>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-91">identifier</a>, <var>F</var>).</p>
+        <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createdataproperty">CreateDataProperty</a>(<var>namespaceObject</var>, <var>op</var>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-92">identifier</a>, <var>F</var>).</p>
       </ol>
     </ol>
    </div>
@@ -12018,7 +12039,7 @@ on exception objects too.</p>
      <li data-md="">
       <p>Let <var>F</var> be the <emu-val>Function</emu-val> object used
 as the <emu-val>this</emu-val> value in the top-most call
-on the ECMAScript call stack where <var>F</var> corresponds to an IDL <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-63">attribute</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-62">operation</a>, <a data-link-type="dfn" href="#idl-indexed-properties" id="ref-for-idl-indexed-properties-4">indexed property</a>, <a data-link-type="dfn" href="#idl-named-properties" id="ref-for-idl-named-properties-4">named property</a>, <a href="#Constructor" id="ref-for-Constructor-24">constructor</a>, <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-5">named constructor</a> or <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-6">stringifier</a>.</p>
+on the ECMAScript call stack where <var>F</var> corresponds to an IDL <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-59">attribute</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-62">operation</a>, <a data-link-type="dfn" href="#idl-indexed-properties" id="ref-for-idl-indexed-properties-4">indexed property</a>, <a data-link-type="dfn" href="#idl-named-properties" id="ref-for-idl-named-properties-4">named property</a>, <a href="#Constructor" id="ref-for-Constructor-24">constructor</a>, <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-5">named constructor</a> or <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-6">stringifier</a>.</p>
      <li data-md="">
       <p>If <var>F</var> corresponds to an attribute, operation or stringifier, then return
 the global environment associated with the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-140">interface</a> that definition appears on.</p>
@@ -12214,7 +12235,7 @@ return any value.</p>
    <h2 class="heading settled" data-level="5" id="extensibility"><span class="secno">5. </span><span class="content">Extensibility</span><a class="self-link" href="#extensibility"></a></h2>
    <p><i>This section is informative.</i></p>
    <p>Extensions to language binding requirements can be specified
-using <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-94">extended attributes</a> that do not conflict with those defined in this document.  Extensions for
+using <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-95">extended attributes</a> that do not conflict with those defined in this document.  Extensions for
 private, project-specific use should not be included in <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-46">IDL fragments</a> appearing in other specifications.  It is recommended that extensions
 that are required for use in other specifications be coordinated
 with the group responsible for work on <cite>Web IDL</cite>, which
@@ -12373,7 +12394,7 @@ and “<span class="input">.</span>” is tokenized as the quoted terminal symbo
 used in the grammar and the values used for <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> terminals.  Thus, for
 example, the input text “<span class="input">Const</span>” is tokenized as
 an <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> rather than the
-terminal symbol <emu-t>const</emu-t>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-142">interface</a> with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-92">identifier</a> “A” is distinct from one named “a”, and an <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-95">extended attribute</a> [<code class="idl">constructor</code>] will not be recognized as
+terminal symbol <emu-t>const</emu-t>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-142">interface</a> with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-93">identifier</a> “A” is distinct from one named “a”, and an <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-96">extended attribute</a> [<code class="idl">constructor</code>] will not be recognized as
 the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-25">Constructor</a></code>]
 extended attribute.</p>
    <p>Implicitly, any number of <emu-t class="regex"><a href="#prod-whitespace">whitespace</a></emu-t> and <emu-t class="regex"><a href="#prod-comment">comment</a></emu-t> terminals are allowed between every other terminal
@@ -12385,7 +12406,7 @@ matches an <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-
    <p>While the <emu-nt><a href="#prod-ExtendedAttribute">ExtendedAttribute</a></emu-nt> non-terminal matches any non-empty sequence of terminal symbols (as long as any
 parentheses, square brackets or braces are balanced, and the <emu-t>,</emu-t> token appears only within those balanced brackets),
 only a subset of those
-possible sequences are used by the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-96">extended attributes</a> defined in this specification — see <a href="#idl-extended-attributes">§2.12 Extended attributes</a> for the syntaxes that are used by these extended attributes.</p>
+possible sequences are used by the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-97">extended attributes</a> defined in this specification — see <a href="#idl-extended-attributes">§2.12 Extended attributes</a> for the syntaxes that are used by these extended attributes.</p>
    <h2 class="no-num heading settled" id="conventions"><span class="content">Document conventions</span><a class="self-link" href="#conventions"></a></h2>
    <p>The following typographic conventions are used in this document:</p>
    <ul>
@@ -13247,19 +13268,19 @@ language binding.</p>
     <li><a href="#ref-for-dfn-identifier-65">3.6.4. Named properties object</a>
     <li><a href="#ref-for-dfn-identifier-66">3.6.4.1. [[GetOwnProperty]]</a>
     <li><a href="#ref-for-dfn-identifier-67">3.6.5. Constants</a>
-    <li><a href="#ref-for-dfn-identifier-68">3.6.6. Attributes</a> <a href="#ref-for-dfn-identifier-69">(2)</a> <a href="#ref-for-dfn-identifier-70">(3)</a>
-    <li><a href="#ref-for-dfn-identifier-71">3.6.7. Operations</a> <a href="#ref-for-dfn-identifier-72">(2)</a> <a href="#ref-for-dfn-identifier-73">(3)</a> <a href="#ref-for-dfn-identifier-74">(4)</a> <a href="#ref-for-dfn-identifier-75">(5)</a> <a href="#ref-for-dfn-identifier-76">(6)</a>
-    <li><a href="#ref-for-dfn-identifier-77">3.6.7.1. Stringifiers</a>
-    <li><a href="#ref-for-dfn-identifier-78">3.6.7.2. Serializers</a>
-    <li><a href="#ref-for-dfn-identifier-79">3.6.9.4. Default iterator objects</a>
-    <li><a href="#ref-for-dfn-identifier-80">3.6.9.5. Iterator prototype object</a>
-    <li><a href="#ref-for-dfn-identifier-81">3.8. Platform objects implementing interfaces</a>
-    <li><a href="#ref-for-dfn-identifier-82">3.9.4. [[Delete]]</a>
-    <li><a href="#ref-for-dfn-identifier-83">3.9.8. Abstract operations</a> <a href="#ref-for-dfn-identifier-84">(2)</a> <a href="#ref-for-dfn-identifier-85">(3)</a> <a href="#ref-for-dfn-identifier-86">(4)</a>
-    <li><a href="#ref-for-dfn-identifier-87">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-identifier-88">(2)</a> <a href="#ref-for-dfn-identifier-89">(3)</a>
-    <li><a href="#ref-for-dfn-identifier-90">3.12. Namespaces</a>
-    <li><a href="#ref-for-dfn-identifier-91">3.12.1. Namespace object</a>
-    <li><a href="#ref-for-dfn-identifier-92">IDL grammar</a>
+    <li><a href="#ref-for-dfn-identifier-68">3.6.6. Attributes</a> <a href="#ref-for-dfn-identifier-69">(2)</a> <a href="#ref-for-dfn-identifier-70">(3)</a> <a href="#ref-for-dfn-identifier-71">(4)</a>
+    <li><a href="#ref-for-dfn-identifier-72">3.6.7. Operations</a> <a href="#ref-for-dfn-identifier-73">(2)</a> <a href="#ref-for-dfn-identifier-74">(3)</a> <a href="#ref-for-dfn-identifier-75">(4)</a> <a href="#ref-for-dfn-identifier-76">(5)</a> <a href="#ref-for-dfn-identifier-77">(6)</a>
+    <li><a href="#ref-for-dfn-identifier-78">3.6.7.1. Stringifiers</a>
+    <li><a href="#ref-for-dfn-identifier-79">3.6.7.2. Serializers</a>
+    <li><a href="#ref-for-dfn-identifier-80">3.6.9.4. Default iterator objects</a>
+    <li><a href="#ref-for-dfn-identifier-81">3.6.9.5. Iterator prototype object</a>
+    <li><a href="#ref-for-dfn-identifier-82">3.8. Platform objects implementing interfaces</a>
+    <li><a href="#ref-for-dfn-identifier-83">3.9.4. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-identifier-84">3.9.8. Abstract operations</a> <a href="#ref-for-dfn-identifier-85">(2)</a> <a href="#ref-for-dfn-identifier-86">(3)</a> <a href="#ref-for-dfn-identifier-87">(4)</a>
+    <li><a href="#ref-for-dfn-identifier-88">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-identifier-89">(2)</a> <a href="#ref-for-dfn-identifier-90">(3)</a>
+    <li><a href="#ref-for-dfn-identifier-91">3.12. Namespaces</a>
+    <li><a href="#ref-for-dfn-identifier-92">3.12.1. Namespace object</a>
+    <li><a href="#ref-for-dfn-identifier-93">IDL grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-reserved-identifier">
@@ -13482,12 +13503,12 @@ language binding.</p>
     <li><a href="#ref-for-dfn-attribute-44">3.3.19. [TreatNullAs]</a>
     <li><a href="#ref-for-dfn-attribute-45">3.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-attribute-46">(2)</a> <a href="#ref-for-dfn-attribute-47">(3)</a>
     <li><a href="#ref-for-dfn-attribute-48">3.4. Security</a>
-    <li><a href="#ref-for-dfn-attribute-49">3.6.6. Attributes</a> <a href="#ref-for-dfn-attribute-50">(2)</a> <a href="#ref-for-dfn-attribute-51">(3)</a> <a href="#ref-for-dfn-attribute-52">(4)</a> <a href="#ref-for-dfn-attribute-53">(5)</a> <a href="#ref-for-dfn-attribute-54">(6)</a> <a href="#ref-for-dfn-attribute-55">(7)</a> <a href="#ref-for-dfn-attribute-56">(8)</a> <a href="#ref-for-dfn-attribute-57">(9)</a>
-    <li><a href="#ref-for-dfn-attribute-58">3.6.7.1. Stringifiers</a>
-    <li><a href="#ref-for-dfn-attribute-59">3.6.8.1. @@iterator</a>
-    <li><a href="#ref-for-dfn-attribute-60">3.7. Implements statements</a> <a href="#ref-for-dfn-attribute-61">(2)</a>
-    <li><a href="#ref-for-dfn-attribute-62">3.10. User objects implementing callback interfaces</a>
-    <li><a href="#ref-for-dfn-attribute-63">3.15. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-attribute-49">3.6.6. Attributes</a> <a href="#ref-for-dfn-attribute-50">(2)</a> <a href="#ref-for-dfn-attribute-51">(3)</a> <a href="#ref-for-dfn-attribute-52">(4)</a> <a href="#ref-for-dfn-attribute-53">(5)</a>
+    <li><a href="#ref-for-dfn-attribute-54">3.6.7.1. Stringifiers</a>
+    <li><a href="#ref-for-dfn-attribute-55">3.6.8.1. @@iterator</a>
+    <li><a href="#ref-for-dfn-attribute-56">3.7. Implements statements</a> <a href="#ref-for-dfn-attribute-57">(2)</a>
+    <li><a href="#ref-for-dfn-attribute-58">3.10. User objects implementing callback interfaces</a>
+    <li><a href="#ref-for-dfn-attribute-59">3.15. Creating and throwing exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-regular-attribute">
@@ -13502,21 +13523,20 @@ language binding.</p>
     <li><a href="#ref-for-dfn-regular-attribute-10">3.3.21. [Unscopable]</a> <a href="#ref-for-dfn-regular-attribute-11">(2)</a>
     <li><a href="#ref-for-dfn-regular-attribute-12">3.6.1. Interface object</a>
     <li><a href="#ref-for-dfn-regular-attribute-13">3.6.3. Interface prototype object</a>
-    <li><a href="#ref-for-dfn-regular-attribute-14">3.6.6. Attributes</a> <a href="#ref-for-dfn-regular-attribute-15">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-read-only">
    <b><a href="#dfn-read-only">#dfn-read-only</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-read-only-1">2. Interface definition language</a>
-    <li><a href="#ref-for-dfn-read-only-2">2.2.2. Attributes</a> <a href="#ref-for-dfn-read-only-3">(2)</a>
-    <li><a href="#ref-for-dfn-read-only-4">3.3.1. [Clamp]</a>
-    <li><a href="#ref-for-dfn-read-only-5">3.3.3. [EnforceRange]</a>
-    <li><a href="#ref-for-dfn-read-only-6">3.3.8. [LenientSetter]</a> <a href="#ref-for-dfn-read-only-7">(2)</a>
-    <li><a href="#ref-for-dfn-read-only-8">3.3.14. [PutForwards]</a> <a href="#ref-for-dfn-read-only-9">(2)</a>
-    <li><a href="#ref-for-dfn-read-only-10">3.3.15. [Replaceable]</a> <a href="#ref-for-dfn-read-only-11">(2)</a>
-    <li><a href="#ref-for-dfn-read-only-12">3.3.16. [SameObject]</a> <a href="#ref-for-dfn-read-only-13">(2)</a>
-    <li><a href="#ref-for-dfn-read-only-14">3.6.6. Attributes</a>
+    <li><a href="#ref-for-dfn-read-only-2">2.2.2. Attributes</a> <a href="#ref-for-dfn-read-only-3">(2)</a> <a href="#ref-for-dfn-read-only-4">(3)</a>
+    <li><a href="#ref-for-dfn-read-only-5">3.3.1. [Clamp]</a>
+    <li><a href="#ref-for-dfn-read-only-6">3.3.3. [EnforceRange]</a>
+    <li><a href="#ref-for-dfn-read-only-7">3.3.8. [LenientSetter]</a> <a href="#ref-for-dfn-read-only-8">(2)</a>
+    <li><a href="#ref-for-dfn-read-only-9">3.3.14. [PutForwards]</a> <a href="#ref-for-dfn-read-only-10">(2)</a>
+    <li><a href="#ref-for-dfn-read-only-11">3.3.15. [Replaceable]</a> <a href="#ref-for-dfn-read-only-12">(2)</a>
+    <li><a href="#ref-for-dfn-read-only-13">3.3.16. [SameObject]</a> <a href="#ref-for-dfn-read-only-14">(2)</a>
+    <li><a href="#ref-for-dfn-read-only-15">3.6.6. Attributes</a> <a href="#ref-for-dfn-read-only-16">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-inherit-getter">
@@ -14289,7 +14309,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-enumeration-12">2.6. Enumerations</a> <a href="#ref-for-dfn-enumeration-13">(2)</a> <a href="#ref-for-dfn-enumeration-14">(3)</a>
     <li><a href="#ref-for-dfn-enumeration-15">2.11.21. Enumeration types</a> <a href="#ref-for-dfn-enumeration-16">(2)</a>
     <li><a href="#ref-for-dfn-enumeration-17">3.2.15. Enumeration types</a> <a href="#ref-for-dfn-enumeration-18">(2)</a> <a href="#ref-for-dfn-enumeration-19">(3)</a>
-    <li><a href="#ref-for-dfn-enumeration-20">3.6.6. Attributes</a> <a href="#ref-for-dfn-enumeration-21">(2)</a>
+    <li><a href="#ref-for-dfn-enumeration-20">3.6.6. Attributes</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-enumeration-value">
@@ -14912,14 +14932,16 @@ language binding.</p>
   <aside class="dfn-panel" data-for="dfn-promise-type">
    <b><a href="#dfn-promise-type">#dfn-promise-type</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-promise-type-1">2.2.4.1. Legacy callers</a>
-    <li><a href="#ref-for-dfn-promise-type-2">2.2.6. Overloading</a>
-    <li><a href="#ref-for-dfn-promise-type-3">2.11.23. Nullable types — T?</a>
-    <li><a href="#ref-for-dfn-promise-type-4">3.2.20. Promise types — Promise&lt;T></a> <a href="#ref-for-dfn-promise-type-5">(2)</a> <a href="#ref-for-dfn-promise-type-6">(3)</a> <a href="#ref-for-dfn-promise-type-7">(4)</a>
-    <li><a href="#ref-for-dfn-promise-type-8">3.3.11. [NewObject]</a>
-    <li><a href="#ref-for-dfn-promise-type-9">3.6.7. Operations</a>
-    <li><a href="#ref-for-dfn-promise-type-10">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-promise-type-11">(2)</a>
-    <li><a href="#ref-for-dfn-promise-type-12">3.11. Invoking callback functions</a>
+    <li><a href="#ref-for-dfn-promise-type-1">2.2.2. Attributes</a> <a href="#ref-for-dfn-promise-type-2">(2)</a>
+    <li><a href="#ref-for-dfn-promise-type-3">2.2.4.1. Legacy callers</a>
+    <li><a href="#ref-for-dfn-promise-type-4">2.2.6. Overloading</a>
+    <li><a href="#ref-for-dfn-promise-type-5">2.11.23. Nullable types — T?</a>
+    <li><a href="#ref-for-dfn-promise-type-6">3.2.20. Promise types — Promise&lt;T></a> <a href="#ref-for-dfn-promise-type-7">(2)</a> <a href="#ref-for-dfn-promise-type-8">(3)</a> <a href="#ref-for-dfn-promise-type-9">(4)</a>
+    <li><a href="#ref-for-dfn-promise-type-10">3.3.11. [NewObject]</a>
+    <li><a href="#ref-for-dfn-promise-type-11">3.6.6. Attributes</a> <a href="#ref-for-dfn-promise-type-12">(2)</a>
+    <li><a href="#ref-for-dfn-promise-type-13">3.6.7. Operations</a>
+    <li><a href="#ref-for-dfn-promise-type-14">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-promise-type-15">(2)</a>
+    <li><a href="#ref-for-dfn-promise-type-16">3.11. Invoking callback functions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-union-type">
@@ -15106,54 +15128,54 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-dfn-extended-attribute-1">2. Interface definition language</a> <a href="#ref-for-dfn-extended-attribute-2">(2)</a>
     <li><a href="#ref-for-dfn-extended-attribute-3">2.2. Interfaces</a> <a href="#ref-for-dfn-extended-attribute-4">(2)</a> <a href="#ref-for-dfn-extended-attribute-5">(3)</a> <a href="#ref-for-dfn-extended-attribute-6">(4)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-7">2.2.2. Attributes</a> <a href="#ref-for-dfn-extended-attribute-8">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-9">2.2.3. Operations</a> <a href="#ref-for-dfn-extended-attribute-10">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-11">2.2.6. Overloading</a> <a href="#ref-for-dfn-extended-attribute-12">(2)</a> <a href="#ref-for-dfn-extended-attribute-13">(3)</a> <a href="#ref-for-dfn-extended-attribute-14">(4)</a> <a href="#ref-for-dfn-extended-attribute-15">(5)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-16">2.2.8. Maplike declarations</a>
-    <li><a href="#ref-for-dfn-extended-attribute-17">2.2.9. Setlike declarations</a>
-    <li><a href="#ref-for-dfn-extended-attribute-18">2.6. Enumerations</a>
-    <li><a href="#ref-for-dfn-extended-attribute-19">2.8. Typedefs</a>
-    <li><a href="#ref-for-dfn-extended-attribute-20">2.9. Implements statements</a>
-    <li><a href="#ref-for-dfn-extended-attribute-21">2.10. Objects implementing interfaces</a>
-    <li><a href="#ref-for-dfn-extended-attribute-22">2.12. Extended attributes</a>
-    <li><a href="#ref-for-dfn-extended-attribute-23">3.2.4.9. Abstract operations</a> <a href="#ref-for-dfn-extended-attribute-24">(2)</a> <a href="#ref-for-dfn-extended-attribute-25">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-26">3.3. ECMAScript-specific extended attributes</a>
-    <li><a href="#ref-for-dfn-extended-attribute-27">3.3.1. [Clamp]</a> <a href="#ref-for-dfn-extended-attribute-28">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-29">3.3.2. [Constructor]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-30">3.3.3. [EnforceRange]</a> <a href="#ref-for-dfn-extended-attribute-31">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-32">3.3.4. [Exposed]</a> <a href="#ref-for-dfn-extended-attribute-33">(2)</a> <a href="#ref-for-dfn-extended-attribute-34">(3)</a> <a href="#ref-for-dfn-extended-attribute-35">(4)</a> <a href="#ref-for-dfn-extended-attribute-36">(5)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-37">3.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-extended-attribute-38">(2)</a> <a href="#ref-for-dfn-extended-attribute-39">(3)</a> <a href="#ref-for-dfn-extended-attribute-40">(4)</a> <a href="#ref-for-dfn-extended-attribute-41">(5)</a> <a href="#ref-for-dfn-extended-attribute-42">(6)</a> <a href="#ref-for-dfn-extended-attribute-43">(7)</a> <a href="#ref-for-dfn-extended-attribute-44">(8)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-45">3.3.6. [LegacyArrayClass]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-46">3.3.7. [LegacyUnenumerableNamedProperties]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-47">3.3.8. [LenientSetter]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-48">3.3.9. [LenientThis]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-49">3.3.10. [NamedConstructor]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-50">3.3.11. [NewObject]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-51">3.3.12. [NoInterfaceObject]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-52">3.3.13. [OverrideBuiltins]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-53">3.3.14. [PutForwards]</a> <a href="#ref-for-dfn-extended-attribute-54">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-55">3.3.15. [Replaceable]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-56">3.3.16. [SameObject]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-57">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-extended-attribute-58">(2)</a> <a href="#ref-for-dfn-extended-attribute-59">(3)</a> <a href="#ref-for-dfn-extended-attribute-60">(4)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-61">3.3.18. [TreatNonObjectAsNull]</a> <a href="#ref-for-dfn-extended-attribute-62">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-63">3.3.19. [TreatNullAs]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-64">3.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-extended-attribute-65">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-66">3.3.21. [Unscopable]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-67">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-extended-attribute-68">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-69">3.6. Interfaces</a>
-    <li><a href="#ref-for-dfn-extended-attribute-70">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-dfn-extended-attribute-71">(2)</a> <a href="#ref-for-dfn-extended-attribute-72">(3)</a> <a href="#ref-for-dfn-extended-attribute-73">(4)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-74">3.6.2. Named constructors</a> <a href="#ref-for-dfn-extended-attribute-75">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-76">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-extended-attribute-77">(2)</a> <a href="#ref-for-dfn-extended-attribute-78">(3)</a> <a href="#ref-for-dfn-extended-attribute-79">(4)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-80">3.6.4. Named properties object</a>
-    <li><a href="#ref-for-dfn-extended-attribute-81">3.6.4.1. [[GetOwnProperty]]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-82">3.6.6. Attributes</a> <a href="#ref-for-dfn-extended-attribute-83">(2)</a> <a href="#ref-for-dfn-extended-attribute-84">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-85">3.8.1. [[SetPrototypeOf]]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-86">3.9.3. [[DefineOwnProperty]]</a> <a href="#ref-for-dfn-extended-attribute-87">(2)</a> <a href="#ref-for-dfn-extended-attribute-88">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-89">3.9.4. [[Delete]]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-90">3.9.7. Property enumeration</a>
-    <li><a href="#ref-for-dfn-extended-attribute-91">3.9.8. Abstract operations</a> <a href="#ref-for-dfn-extended-attribute-92">(2)</a> <a href="#ref-for-dfn-extended-attribute-93">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-94">5. Extensibility</a>
-    <li><a href="#ref-for-dfn-extended-attribute-95">IDL grammar</a> <a href="#ref-for-dfn-extended-attribute-96">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-7">2.2.2. Attributes</a> <a href="#ref-for-dfn-extended-attribute-8">(2)</a> <a href="#ref-for-dfn-extended-attribute-9">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-10">2.2.3. Operations</a> <a href="#ref-for-dfn-extended-attribute-11">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-12">2.2.6. Overloading</a> <a href="#ref-for-dfn-extended-attribute-13">(2)</a> <a href="#ref-for-dfn-extended-attribute-14">(3)</a> <a href="#ref-for-dfn-extended-attribute-15">(4)</a> <a href="#ref-for-dfn-extended-attribute-16">(5)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-17">2.2.8. Maplike declarations</a>
+    <li><a href="#ref-for-dfn-extended-attribute-18">2.2.9. Setlike declarations</a>
+    <li><a href="#ref-for-dfn-extended-attribute-19">2.6. Enumerations</a>
+    <li><a href="#ref-for-dfn-extended-attribute-20">2.8. Typedefs</a>
+    <li><a href="#ref-for-dfn-extended-attribute-21">2.9. Implements statements</a>
+    <li><a href="#ref-for-dfn-extended-attribute-22">2.10. Objects implementing interfaces</a>
+    <li><a href="#ref-for-dfn-extended-attribute-23">2.12. Extended attributes</a>
+    <li><a href="#ref-for-dfn-extended-attribute-24">3.2.4.9. Abstract operations</a> <a href="#ref-for-dfn-extended-attribute-25">(2)</a> <a href="#ref-for-dfn-extended-attribute-26">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-27">3.3. ECMAScript-specific extended attributes</a>
+    <li><a href="#ref-for-dfn-extended-attribute-28">3.3.1. [Clamp]</a> <a href="#ref-for-dfn-extended-attribute-29">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-30">3.3.2. [Constructor]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-31">3.3.3. [EnforceRange]</a> <a href="#ref-for-dfn-extended-attribute-32">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-33">3.3.4. [Exposed]</a> <a href="#ref-for-dfn-extended-attribute-34">(2)</a> <a href="#ref-for-dfn-extended-attribute-35">(3)</a> <a href="#ref-for-dfn-extended-attribute-36">(4)</a> <a href="#ref-for-dfn-extended-attribute-37">(5)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-38">3.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-extended-attribute-39">(2)</a> <a href="#ref-for-dfn-extended-attribute-40">(3)</a> <a href="#ref-for-dfn-extended-attribute-41">(4)</a> <a href="#ref-for-dfn-extended-attribute-42">(5)</a> <a href="#ref-for-dfn-extended-attribute-43">(6)</a> <a href="#ref-for-dfn-extended-attribute-44">(7)</a> <a href="#ref-for-dfn-extended-attribute-45">(8)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-46">3.3.6. [LegacyArrayClass]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-47">3.3.7. [LegacyUnenumerableNamedProperties]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-48">3.3.8. [LenientSetter]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-49">3.3.9. [LenientThis]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-50">3.3.10. [NamedConstructor]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-51">3.3.11. [NewObject]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-52">3.3.12. [NoInterfaceObject]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-53">3.3.13. [OverrideBuiltins]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-54">3.3.14. [PutForwards]</a> <a href="#ref-for-dfn-extended-attribute-55">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-56">3.3.15. [Replaceable]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-57">3.3.16. [SameObject]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-58">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-extended-attribute-59">(2)</a> <a href="#ref-for-dfn-extended-attribute-60">(3)</a> <a href="#ref-for-dfn-extended-attribute-61">(4)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-62">3.3.18. [TreatNonObjectAsNull]</a> <a href="#ref-for-dfn-extended-attribute-63">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-64">3.3.19. [TreatNullAs]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-65">3.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-extended-attribute-66">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-67">3.3.21. [Unscopable]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-68">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-extended-attribute-69">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-70">3.6. Interfaces</a>
+    <li><a href="#ref-for-dfn-extended-attribute-71">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-dfn-extended-attribute-72">(2)</a> <a href="#ref-for-dfn-extended-attribute-73">(3)</a> <a href="#ref-for-dfn-extended-attribute-74">(4)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-75">3.6.2. Named constructors</a> <a href="#ref-for-dfn-extended-attribute-76">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-77">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-extended-attribute-78">(2)</a> <a href="#ref-for-dfn-extended-attribute-79">(3)</a> <a href="#ref-for-dfn-extended-attribute-80">(4)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-81">3.6.4. Named properties object</a>
+    <li><a href="#ref-for-dfn-extended-attribute-82">3.6.4.1. [[GetOwnProperty]]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-83">3.6.6. Attributes</a> <a href="#ref-for-dfn-extended-attribute-84">(2)</a> <a href="#ref-for-dfn-extended-attribute-85">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-86">3.8.1. [[SetPrototypeOf]]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-87">3.9.3. [[DefineOwnProperty]]</a> <a href="#ref-for-dfn-extended-attribute-88">(2)</a> <a href="#ref-for-dfn-extended-attribute-89">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-90">3.9.4. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-91">3.9.7. Property enumeration</a>
+    <li><a href="#ref-for-dfn-extended-attribute-92">3.9.8. Abstract operations</a> <a href="#ref-for-dfn-extended-attribute-93">(2)</a> <a href="#ref-for-dfn-extended-attribute-94">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-95">5. Extensibility</a>
+    <li><a href="#ref-for-dfn-extended-attribute-96">IDL grammar</a> <a href="#ref-for-dfn-extended-attribute-97">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-xattr-no-arguments">
@@ -15262,25 +15284,25 @@ language binding.</p>
     <li><a href="#ref-for-ecmascript-throw-25">3.5. Overload resolution algorithm</a> <a href="#ref-for-ecmascript-throw-26">(2)</a>
     <li><a href="#ref-for-ecmascript-throw-27">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-ecmascript-throw-28">(2)</a>
     <li><a href="#ref-for-ecmascript-throw-29">3.6.1.2. Interface object [[HasInstance]] method</a>
-    <li><a href="#ref-for-ecmascript-throw-30">3.6.6. Attributes</a> <a href="#ref-for-ecmascript-throw-31">(2)</a> <a href="#ref-for-ecmascript-throw-32">(3)</a> <a href="#ref-for-ecmascript-throw-33">(4)</a>
-    <li><a href="#ref-for-ecmascript-throw-34">3.6.7. Operations</a>
-    <li><a href="#ref-for-ecmascript-throw-35">3.6.7.1. Stringifiers</a>
-    <li><a href="#ref-for-ecmascript-throw-36">3.6.7.2. Serializers</a>
-    <li><a href="#ref-for-ecmascript-throw-37">3.6.8.1. @@iterator</a> <a href="#ref-for-ecmascript-throw-38">(2)</a>
-    <li><a href="#ref-for-ecmascript-throw-39">3.6.8.2. forEach</a> <a href="#ref-for-ecmascript-throw-40">(2)</a> <a href="#ref-for-ecmascript-throw-41">(3)</a>
-    <li><a href="#ref-for-ecmascript-throw-42">3.6.9.2. keys</a>
-    <li><a href="#ref-for-ecmascript-throw-43">3.6.9.3. values</a>
-    <li><a href="#ref-for-ecmascript-throw-44">3.6.9.5. Iterator prototype object</a>
-    <li><a href="#ref-for-ecmascript-throw-45">3.6.10. Maplike declarations</a> <a href="#ref-for-ecmascript-throw-46">(2)</a>
-    <li><a href="#ref-for-ecmascript-throw-47">3.6.10.1. size</a>
-    <li><a href="#ref-for-ecmascript-throw-48">3.6.10.4. get and has</a>
-    <li><a href="#ref-for-ecmascript-throw-49">3.6.10.6. delete</a>
-    <li><a href="#ref-for-ecmascript-throw-50">3.6.10.7. set</a>
-    <li><a href="#ref-for-ecmascript-throw-51">3.6.11. Setlike declarations</a> <a href="#ref-for-ecmascript-throw-52">(2)</a>
-    <li><a href="#ref-for-ecmascript-throw-53">3.6.11.1. size</a>
-    <li><a href="#ref-for-ecmascript-throw-54">3.6.11.4. has</a>
-    <li><a href="#ref-for-ecmascript-throw-55">3.6.11.5. add and delete</a>
-    <li><a href="#ref-for-ecmascript-throw-56">3.9.5. [[Call]]</a>
+    <li><a href="#ref-for-ecmascript-throw-30">3.6.6. Attributes</a> <a href="#ref-for-ecmascript-throw-31">(2)</a> <a href="#ref-for-ecmascript-throw-32">(3)</a>
+    <li><a href="#ref-for-ecmascript-throw-33">3.6.7. Operations</a>
+    <li><a href="#ref-for-ecmascript-throw-34">3.6.7.1. Stringifiers</a>
+    <li><a href="#ref-for-ecmascript-throw-35">3.6.7.2. Serializers</a>
+    <li><a href="#ref-for-ecmascript-throw-36">3.6.8.1. @@iterator</a> <a href="#ref-for-ecmascript-throw-37">(2)</a>
+    <li><a href="#ref-for-ecmascript-throw-38">3.6.8.2. forEach</a> <a href="#ref-for-ecmascript-throw-39">(2)</a> <a href="#ref-for-ecmascript-throw-40">(3)</a>
+    <li><a href="#ref-for-ecmascript-throw-41">3.6.9.2. keys</a>
+    <li><a href="#ref-for-ecmascript-throw-42">3.6.9.3. values</a>
+    <li><a href="#ref-for-ecmascript-throw-43">3.6.9.5. Iterator prototype object</a>
+    <li><a href="#ref-for-ecmascript-throw-44">3.6.10. Maplike declarations</a> <a href="#ref-for-ecmascript-throw-45">(2)</a>
+    <li><a href="#ref-for-ecmascript-throw-46">3.6.10.1. size</a>
+    <li><a href="#ref-for-ecmascript-throw-47">3.6.10.4. get and has</a>
+    <li><a href="#ref-for-ecmascript-throw-48">3.6.10.6. delete</a>
+    <li><a href="#ref-for-ecmascript-throw-49">3.6.10.7. set</a>
+    <li><a href="#ref-for-ecmascript-throw-50">3.6.11. Setlike declarations</a> <a href="#ref-for-ecmascript-throw-51">(2)</a>
+    <li><a href="#ref-for-ecmascript-throw-52">3.6.11.1. size</a>
+    <li><a href="#ref-for-ecmascript-throw-53">3.6.11.4. has</a>
+    <li><a href="#ref-for-ecmascript-throw-54">3.6.11.5. add and delete</a>
+    <li><a href="#ref-for-ecmascript-throw-55">3.9.5. [[Call]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-initial-object">
@@ -15593,10 +15615,10 @@ language binding.</p>
   <aside class="dfn-panel" data-for="LenientThis">
    <b><a href="#LenientThis">#LenientThis</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-LenientThis-1">2.2.2. Attributes</a>
-    <li><a href="#ref-for-LenientThis-2">3.3.8. [LenientSetter]</a>
-    <li><a href="#ref-for-LenientThis-3">3.3.9. [LenientThis]</a> <a href="#ref-for-LenientThis-4">(2)</a> <a href="#ref-for-LenientThis-5">(3)</a> <a href="#ref-for-LenientThis-6">(4)</a> <a href="#ref-for-LenientThis-7">(5)</a>
-    <li><a href="#ref-for-LenientThis-8">3.6.6. Attributes</a> <a href="#ref-for-LenientThis-9">(2)</a> <a href="#ref-for-LenientThis-10">(3)</a>
+    <li><a href="#ref-for-LenientThis-1">2.2.2. Attributes</a> <a href="#ref-for-LenientThis-2">(2)</a>
+    <li><a href="#ref-for-LenientThis-3">3.3.8. [LenientSetter]</a>
+    <li><a href="#ref-for-LenientThis-4">3.3.9. [LenientThis]</a> <a href="#ref-for-LenientThis-5">(2)</a> <a href="#ref-for-LenientThis-6">(3)</a> <a href="#ref-for-LenientThis-7">(4)</a> <a href="#ref-for-LenientThis-8">(5)</a>
+    <li><a href="#ref-for-LenientThis-9">3.6.6. Attributes</a> <a href="#ref-for-LenientThis-10">(2)</a> <a href="#ref-for-LenientThis-11">(3)</a> <a href="#ref-for-LenientThis-12">(4)</a> <a href="#ref-for-LenientThis-13">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="NamedConstructor">
@@ -15641,28 +15663,28 @@ language binding.</p>
   <aside class="dfn-panel" data-for="PutForwards">
    <b><a href="#PutForwards">#PutForwards</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-PutForwards-1">2.2.2. Attributes</a>
-    <li><a href="#ref-for-PutForwards-2">3.3.8. [LenientSetter]</a>
-    <li><a href="#ref-for-PutForwards-3">3.3.14. [PutForwards]</a> <a href="#ref-for-PutForwards-4">(2)</a> <a href="#ref-for-PutForwards-5">(3)</a> <a href="#ref-for-PutForwards-6">(4)</a> <a href="#ref-for-PutForwards-7">(5)</a> <a href="#ref-for-PutForwards-8">(6)</a> <a href="#ref-for-PutForwards-9">(7)</a> <a href="#ref-for-PutForwards-10">(8)</a> <a href="#ref-for-PutForwards-11">(9)</a> <a href="#ref-for-PutForwards-12">(10)</a> <a href="#ref-for-PutForwards-13">(11)</a>
-    <li><a href="#ref-for-PutForwards-14">3.3.15. [Replaceable]</a>
-    <li><a href="#ref-for-PutForwards-15">3.6.6. Attributes</a> <a href="#ref-for-PutForwards-16">(2)</a> <a href="#ref-for-PutForwards-17">(3)</a>
+    <li><a href="#ref-for-PutForwards-1">2.2.2. Attributes</a> <a href="#ref-for-PutForwards-2">(2)</a>
+    <li><a href="#ref-for-PutForwards-3">3.3.8. [LenientSetter]</a>
+    <li><a href="#ref-for-PutForwards-4">3.3.14. [PutForwards]</a> <a href="#ref-for-PutForwards-5">(2)</a> <a href="#ref-for-PutForwards-6">(3)</a> <a href="#ref-for-PutForwards-7">(4)</a> <a href="#ref-for-PutForwards-8">(5)</a> <a href="#ref-for-PutForwards-9">(6)</a> <a href="#ref-for-PutForwards-10">(7)</a> <a href="#ref-for-PutForwards-11">(8)</a> <a href="#ref-for-PutForwards-12">(9)</a> <a href="#ref-for-PutForwards-13">(10)</a> <a href="#ref-for-PutForwards-14">(11)</a>
+    <li><a href="#ref-for-PutForwards-15">3.3.15. [Replaceable]</a>
+    <li><a href="#ref-for-PutForwards-16">3.6.6. Attributes</a> <a href="#ref-for-PutForwards-17">(2)</a> <a href="#ref-for-PutForwards-18">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="Replaceable">
    <b><a href="#Replaceable">#Replaceable</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-Replaceable-1">2.2.2. Attributes</a>
-    <li><a href="#ref-for-Replaceable-2">3.3.8. [LenientSetter]</a>
-    <li><a href="#ref-for-Replaceable-3">3.3.14. [PutForwards]</a>
-    <li><a href="#ref-for-Replaceable-4">3.3.15. [Replaceable]</a> <a href="#ref-for-Replaceable-5">(2)</a> <a href="#ref-for-Replaceable-6">(3)</a> <a href="#ref-for-Replaceable-7">(4)</a> <a href="#ref-for-Replaceable-8">(5)</a> <a href="#ref-for-Replaceable-9">(6)</a> <a href="#ref-for-Replaceable-10">(7)</a>
-    <li><a href="#ref-for-Replaceable-11">3.6.6. Attributes</a> <a href="#ref-for-Replaceable-12">(2)</a>
+    <li><a href="#ref-for-Replaceable-1">2.2.2. Attributes</a> <a href="#ref-for-Replaceable-2">(2)</a>
+    <li><a href="#ref-for-Replaceable-3">3.3.8. [LenientSetter]</a>
+    <li><a href="#ref-for-Replaceable-4">3.3.14. [PutForwards]</a>
+    <li><a href="#ref-for-Replaceable-5">3.3.15. [Replaceable]</a> <a href="#ref-for-Replaceable-6">(2)</a> <a href="#ref-for-Replaceable-7">(3)</a> <a href="#ref-for-Replaceable-8">(4)</a> <a href="#ref-for-Replaceable-9">(5)</a> <a href="#ref-for-Replaceable-10">(6)</a> <a href="#ref-for-Replaceable-11">(7)</a>
+    <li><a href="#ref-for-Replaceable-12">3.6.6. Attributes</a> <a href="#ref-for-Replaceable-13">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="SameObject">
    <b><a href="#SameObject">#SameObject</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-SameObject-1">2.2.2. Attributes</a>
-    <li><a href="#ref-for-SameObject-2">3.3.16. [SameObject]</a> <a href="#ref-for-SameObject-3">(2)</a> <a href="#ref-for-SameObject-4">(3)</a>
+    <li><a href="#ref-for-SameObject-1">2.2.2. Attributes</a> <a href="#ref-for-SameObject-2">(2)</a>
+    <li><a href="#ref-for-SameObject-3">3.3.16. [SameObject]</a> <a href="#ref-for-SameObject-4">(2)</a> <a href="#ref-for-SameObject-5">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="SecureContext">
@@ -15801,32 +15823,32 @@ language binding.</p>
     <li><a href="#ref-for-dfn-interface-prototype-object-10">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-interface-prototype-object-11">(2)</a> <a href="#ref-for-dfn-interface-prototype-object-12">(3)</a> <a href="#ref-for-dfn-interface-prototype-object-13">(4)</a> <a href="#ref-for-dfn-interface-prototype-object-14">(5)</a> <a href="#ref-for-dfn-interface-prototype-object-15">(6)</a>
     <li><a href="#ref-for-dfn-interface-prototype-object-16">3.6.4. Named properties object</a>
     <li><a href="#ref-for-dfn-interface-prototype-object-17">3.6.5. Constants</a> <a href="#ref-for-dfn-interface-prototype-object-18">(2)</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-19">3.6.6. Attributes</a> <a href="#ref-for-dfn-interface-prototype-object-20">(2)</a> <a href="#ref-for-dfn-interface-prototype-object-21">(3)</a> <a href="#ref-for-dfn-interface-prototype-object-22">(4)</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-23">3.6.7. Operations</a> <a href="#ref-for-dfn-interface-prototype-object-24">(2)</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-25">3.6.7.1. Stringifiers</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-26">3.6.7.2. Serializers</a> <a href="#ref-for-dfn-interface-prototype-object-27">(2)</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-28">3.6.8.1. @@iterator</a> <a href="#ref-for-dfn-interface-prototype-object-29">(2)</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-30">3.6.8.2. forEach</a> <a href="#ref-for-dfn-interface-prototype-object-31">(2)</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-32">3.6.9.1. entries</a> <a href="#ref-for-dfn-interface-prototype-object-33">(2)</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-34">3.6.9.2. keys</a> <a href="#ref-for-dfn-interface-prototype-object-35">(2)</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-36">3.6.9.3. values</a> <a href="#ref-for-dfn-interface-prototype-object-37">(2)</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-38">3.6.10. Maplike declarations</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-39">3.6.10.1. size</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-40">3.6.10.2. entries</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-41">3.6.10.3. keys and values</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-42">3.6.10.4. get and has</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-43">3.6.10.5. clear</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-44">3.6.10.6. delete</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-45">3.6.10.7. set</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-46">3.6.11. Setlike declarations</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-47">3.6.11.1. size</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-48">3.6.11.2. values</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-49">3.6.11.3. entries and keys</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-50">3.6.11.4. has</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-51">3.6.11.5. add and delete</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-52">3.6.11.6. clear</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-53">3.7. Implements statements</a> <a href="#ref-for-dfn-interface-prototype-object-54">(2)</a>
-    <li><a href="#ref-for-dfn-interface-prototype-object-55">3.8. Platform objects implementing interfaces</a> <a href="#ref-for-dfn-interface-prototype-object-56">(2)</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-19">3.6.6. Attributes</a> <a href="#ref-for-dfn-interface-prototype-object-20">(2)</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-21">3.6.7. Operations</a> <a href="#ref-for-dfn-interface-prototype-object-22">(2)</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-23">3.6.7.1. Stringifiers</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-24">3.6.7.2. Serializers</a> <a href="#ref-for-dfn-interface-prototype-object-25">(2)</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-26">3.6.8.1. @@iterator</a> <a href="#ref-for-dfn-interface-prototype-object-27">(2)</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-28">3.6.8.2. forEach</a> <a href="#ref-for-dfn-interface-prototype-object-29">(2)</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-30">3.6.9.1. entries</a> <a href="#ref-for-dfn-interface-prototype-object-31">(2)</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-32">3.6.9.2. keys</a> <a href="#ref-for-dfn-interface-prototype-object-33">(2)</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-34">3.6.9.3. values</a> <a href="#ref-for-dfn-interface-prototype-object-35">(2)</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-36">3.6.10. Maplike declarations</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-37">3.6.10.1. size</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-38">3.6.10.2. entries</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-39">3.6.10.3. keys and values</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-40">3.6.10.4. get and has</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-41">3.6.10.5. clear</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-42">3.6.10.6. delete</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-43">3.6.10.7. set</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-44">3.6.11. Setlike declarations</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-45">3.6.11.1. size</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-46">3.6.11.2. values</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-47">3.6.11.3. entries and keys</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-48">3.6.11.4. has</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-49">3.6.11.5. add and delete</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-50">3.6.11.6. clear</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-51">3.7. Implements statements</a> <a href="#ref-for-dfn-interface-prototype-object-52">(2)</a>
+    <li><a href="#ref-for-dfn-interface-prototype-object-53">3.8. Platform objects implementing interfaces</a> <a href="#ref-for-dfn-interface-prototype-object-54">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-named-properties-object">
@@ -15855,7 +15877,7 @@ language binding.</p>
    <b><a href="#dfn-attribute-setter">#dfn-attribute-setter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-attribute-setter-1">3.1. ECMAScript environment</a>
-    <li><a href="#ref-for-dfn-attribute-setter-2">3.6.6. Attributes</a>
+    <li><a href="#ref-for-dfn-attribute-setter-2">3.6.6. Attributes</a> <a href="#ref-for-dfn-attribute-setter-3">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-create-operation-function">

--- a/index.html
+++ b/index.html
@@ -1557,7 +1557,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web IDL</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-10">10 January 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-19">19 January 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2704,9 +2704,9 @@ ignored or an exception is thrown.</p>
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="n">type</span> <span class="nv">identifier</span>;
 };
 </pre>
-   <p>The type of an attribute that is not <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-2">read only</a> must not be a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-1">promise type</a>. Additionally,
-the type of an attribute with any of the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-7">extended attributes</a> [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-1">LenientThis</a></code>],
-[<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-1">PutForwards</a></code>], [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-1">Replaceable</a></code>], or [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-1">SameObject</a></code>] must not be a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-2">promise type</a>.</p>
+   <p>Attributes whose type is a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-1">promise type</a> must be <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-2">read only</a>. Additionally, they cannot have
+any of the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-7">extended attributes</a> [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-1">LenientThis</a></code>], [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-1">PutForwards</a></code>], [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-1">Replaceable</a></code>], or
+[<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-1">SameObject</a></code>].</p>
    <p>A <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-2">regular attribute</a> that is not <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-3">read only</a> can be declared to <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-inherit-getter">inherit its getter</dfn> from an ancestor interface.  This can be used to make a read only attribute
 in an ancestor interface be writable on a derived interface.  An attribute <a data-link-type="dfn" href="#dfn-inherit-getter" id="ref-for-dfn-inherit-getter-1">inherits its getter</a> if
 its declaration includes <emu-t>inherit</emu-t> in the declaration.
@@ -3235,7 +3235,7 @@ as if it were a function.</p>
    <p class="note" role="note">Note: This artificial restriction allows bundling all interfaces with exotic object behavior
 into a single <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-2">platform object</a> category: <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-1">legacy platform objects</a>.
 This is possible because all existing interfaces which have a <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-3">legacy caller</a> also <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-2">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-2">named properties</a>.</p>
-   <p>Legacy callers must not be defined to return a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-3">promise type</a>.</p>
+   <p>Legacy callers must not be defined to return a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-2">promise type</a>.</p>
    <p class="advisement"> Legacy callers are universally recognised as an undesirable feature.  They exist
     only so that legacy Web platform features can be specified.  Legacy callers
     should not be used in specifications unless required to
@@ -4454,7 +4454,7 @@ and it is not the case that both are <a data-link-type="dfn" href="#dfn-callback
       <p><code>CBIface</code> is distinguishable from <code>Iface</code> because the pair satisfies note (a),
     but it is not distinguishable from <code>Dict</code> because that pair does not satisfy note (b).</p>
      </div>
-     <div class="example" id="example-distinguishability-promises"><a class="self-link" href="#example-distinguishability-promises"></a> <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-4">Promise types</a> do not appear in the above table, and as a consequence are
+     <div class="example" id="example-distinguishability-promises"><a class="self-link" href="#example-distinguishability-promises"></a> <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-3">Promise types</a> do not appear in the above table, and as a consequence are
     not distinguishable with any other type. </div>
    </ol>
    <p>If there is more than one entry in an <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-3">effective overload set</a> that has a given type list length, then for those entries there
@@ -5854,7 +5854,7 @@ The inner type must not be:</p>
     <li data-md="">
      <p><code class="idl"><a data-link-type="idl" href="#idl-any" id="ref-for-idl-any-6">any</a></code>,</p>
     <li data-md="">
-     <p>a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-5">Promise type</a>,</p>
+     <p>a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-4">Promise type</a>,</p>
     <li data-md="">
      <p>another nullable type, or</p>
     <li data-md="">
@@ -7313,7 +7313,7 @@ console<span class="p">.</span>assert<span class="p">(</span>entries<span class=
     </table>
    </div>
    <h4 class="heading settled" data-level="3.2.20" id="es-promise"><span class="secno">3.2.20. </span><span class="content">Promise types — Promise&lt;<var>T</var>></span><a class="self-link" href="#es-promise"></a></h4>
-   <p>IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-6">promise type</a> values are
+   <p>IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-5">promise type</a> values are
 represented by ECMAScript <emu-val>Promise</emu-val> objects.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to promise" id="es-to-promise">
     <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-32">converted</a> to an IDL <a class="idl-code" data-link-type="interface" href="#idl-promise" id="ref-for-idl-promise-1">Promise<var>T</var></a> value as follows:</p>
@@ -7324,13 +7324,13 @@ represented by ECMAScript <emu-val>Promise</emu-val> objects.</p>
      <li data-md="">
       <p>Let <var>promise</var> be the result of calling <var>resolve</var> with <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a> as the <emu-val>this</emu-val> value and <var>V</var> as the single argument value.</p>
      <li data-md="">
-      <p>Return the IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-7">promise type</a> value that is a reference to the
+      <p>Return the IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-6">promise type</a> value that is a reference to the
 same object as <var>promise</var>.</p>
     </ol>
    </div>
-   <p id="promise-to-es"> The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-31">converting</a> an IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-8">promise type</a> value to an ECMAScript
+   <p id="promise-to-es"> The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-31">converting</a> an IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-7">promise type</a> value to an ECMAScript
     value is the <emu-val>Promise</emu-val> value that represents a reference to the same object that the
-    IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-9">promise type</a> represents. </p>
+    IDL <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-8">promise type</a> represents. </p>
    <div class="algorithm" data-algorithm="perform some steps once a promise is settled">
     <p>One can <dfn data-dfn-type="dfn" data-export="" data-lt="upon settling" id="dfn-perform-steps-once-promise-is-settled">perform some steps once a promise is settled<a class="self-link" href="#dfn-perform-steps-once-promise-is-settled"></a></dfn>.
     There can be one or two sets of steps to perform,
@@ -8346,7 +8346,7 @@ extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" i
    <p>The [<code class="idl"><a data-link-type="idl" href="#NewObject" id="ref-for-NewObject-4">NewObject</a></code>]
 extended attribute must not
 be used on anything other than a <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-10">regular</a> or <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-8">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-41">operation</a> whose <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-4">return type</a> is an <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-11">interface type</a> or
-a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-10">promise type</a>.</p>
+a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-9">promise type</a>.</p>
    <div class="example" id="example-245e5507">
     <a class="self-link" href="#example-245e5507"></a> 
     <p>As an example, this extended attribute is suitable for use on
@@ -9749,7 +9749,7 @@ the object that is the location of the property.</p>
          <li data-md="">
           <p>Let <var>O</var> be <emu-val>null</emu-val>.</p>
          <li data-md="">
-          <p>If <var>attribute</var> is not a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-12">static attribute</a>:</p>
+          <p>If <var>attribute</var> is a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-14">regular attribute</a>:</p>
           <ol>
            <li data-md="">
             <p>If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, set <var>O</var> to <var>realm</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global">global object</a>.
@@ -9782,7 +9782,7 @@ ECMAScript value of the type <var>attribute</var> is declared as.</p>
       <p>And then, if an exception was thrown:</p>
       <ol>
        <li data-md="">
-        <p>If <var>attribute</var>’s type is a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-11">promise type</a>, then:</p>
+        <p>If <var>attribute</var>’s type is a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-10">promise type</a>, then:</p>
         <ol>
          <li data-md="">
           <p>Let <var>reject</var> be the initial value of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.</p>
@@ -9812,12 +9812,12 @@ PropertyDescriptor<span class="prop-desc">{[[Value]]: 0, [[Writable]]: <emu-val>
       <p>If <var>attribute</var> is <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-15">read only</a> and does not have a
 [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-11">LenientThis</a></code>], [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-16">PutForwards</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-12">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-84">extended attribute</a>, return <emu-val>undefined</emu-val>; there is no <a data-link-type="dfn" href="#dfn-attribute-setter" id="ref-for-dfn-attribute-setter-3">attribute setter</a> function.</p>
      <li data-md="">
-      <p class="assertion">Assert: <var>attribute</var>’s type is not a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-12">promise type</a>.</p>
+      <p class="assertion">Assert: <var>attribute</var>’s type is not a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-11">promise type</a>.</p>
      <li data-md="">
       <p>Let <var>steps</var> be the following series of steps:</p>
       <ol>
        <li data-md="">
-        <p>If no arguments were passed, then</p>
+        <p>If no arguments were passed, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-31">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>V</var> be the value of the first argument passed.</p>
        <li data-md="">
@@ -9825,7 +9825,7 @@ PropertyDescriptor<span class="prop-desc">{[[Value]]: 0, [[Writable]]: <emu-val>
        <li data-md="">
         <p>Let <var>O</var> be <emu-val>null</emu-val>.</p>
        <li data-md="">
-        <p>If <var>attribute</var> is not a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-13">static attribute</a>:</p>
+        <p>If <var>attribute</var> is a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-15">regular attribute</a>:</p>
         <ol>
          <li data-md="">
           <p>If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, set <var>O</var> to <var>realm</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global">global object</a>.
@@ -9837,11 +9837,10 @@ specified.)</p>
          <li data-md="">
           <p>If <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-22">platform object</a>, then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-dfn-perform-a-security-check-2">perform a security check</a>, passing <var>O</var>, <var>id</var>, and "setter".</p>
          <li data-md="">
-          <p>Let <var>validThis</var> be <emu-val>true</emu-val> if <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-23">platform object</a> that
-implements the interface <var>target</var>, or <emu-val>false</emu-val> otherwise.</p>
+          <p>Let <var>validThis</var> be true if <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-23">platform object</a> that implements the
+interface <var>target</var>, or false otherwise.</p>
          <li data-md="">
-          <p>If <var>validThis</var> is <emu-val>false</emu-val> and <var>attribute</var> was not specified
-with the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-13">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-85">extended attribute</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-31">throw</a> a <emu-val>TypeError</emu-val>.</p>
+          <p>If <var>validThis</var> is false and <var>attribute</var> was not specified with the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-13">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-85">extended attribute</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-32">throw</a> a <emu-val>TypeError</emu-val>.</p>
          <li data-md="">
           <p>If <var>attribute</var> is declared with the [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-13">Replaceable</a></code>] extended attribute, then:</p>
           <ol>
@@ -9851,7 +9850,7 @@ with the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-
             <p>Return <emu-val>undefined</emu-val>.</p>
           </ol>
          <li data-md="">
-          <p>If <var>validThis</var> is <emu-val>false</emu-val>, then return <emu-val>undefined</emu-val>.</p>
+          <p>If <var>validThis</var> is false, then return <emu-val>undefined</emu-val>.</p>
          <li data-md="">
           <p>If <var>attribute</var> is declared with a [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-10">LenientSetter</a></code>] extended attribute, then
 return <emu-val>undefined</emu-val>.</p>
@@ -9861,7 +9860,7 @@ return <emu-val>undefined</emu-val>.</p>
            <li data-md="">
             <p>Let <var>Q</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>O</var>, <var>id</var>).</p>
            <li data-md="">
-            <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>Q</var>) is not Object, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-32">throw</a> a <emu-val>TypeError</emu-val>.</p>
+            <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>Q</var>) is not Object, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-33">throw</a> a <emu-val>TypeError</emu-val>.</p>
            <li data-md="">
             <p>Let <var>forwardId</var> be the identifier argument of the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-18">PutForwards</a></code>] extended
 attribute.</p>
@@ -9980,7 +9979,7 @@ object does not implement <var>target</var>.)</p>
            <li data-md="">
             <p>If <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-24">platform object</a>, then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-dfn-perform-a-security-check-3">perform a security check</a>, passing <var>O</var>, <var>id</var>, and "method".</p>
            <li data-md="">
-            <p>If <var>O</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-25">platform object</a> that implements the interface <var>target</var>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-33">throw</a> a <emu-val>TypeError</emu-val>.</p>
+            <p>If <var>O</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-25">platform object</a> that implements the interface <var>target</var>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-34">throw</a> a <emu-val>TypeError</emu-val>.</p>
           </ol>
          <li data-md="">
           <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-10">effective overload set</a> for <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-16">regular operations</a> (if <var>op</var> is a
@@ -9998,7 +9997,7 @@ an ECMAScript value of the type <var>op</var> is declared to return.</p>
       <p>And then, if an exception was thrown:</p>
       <ol>
        <li data-md="">
-        <p>If <var>op</var> has a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-5">return type</a> that is a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-13">promise type</a>, then:</p>
+        <p>If <var>op</var> has a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-5">return type</a> that is a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-12">promise type</a>, then:</p>
         <ol>
          <li data-md="">
           <p>Let <var>reject</var> be the initial value of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.</p>
@@ -10058,7 +10057,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-104">interface</a> on which the stringifier was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-34">throw</a> a <emu-val>TypeError</emu-val>.</p>
+        <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-104">interface</a> on which the stringifier was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-35">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>V</var> be an uninitialized variable.</p>
        <li data-md="">
@@ -10126,7 +10125,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-106">interface</a> on which the serializer was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-35">throw</a> a <emu-val>TypeError</emu-val>.</p>
+      <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-106">interface</a> on which the serializer was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-36">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Depending on how <code>serializer</code> was specified:</p>
       <dl class="switch">
@@ -10266,7 +10265,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-109">interface</a> the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-10">iterable declaration</a> is on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-29">platform object</a> that implements <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-36">throw</a> a <emu-val>TypeError</emu-val>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-37">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>iterator</var> be a newly created <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-1">default iterator object</a> for <var>interface</var> with <var>object</var> as its target and iterator kind “key+value”.</p>
      <li data-md="">
@@ -10293,7 +10292,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       </ul>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-31">platform object</a> that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-110">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-9">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-9">setlike declaration</a> is defined,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-37">throw</a> a <emu-val>TypeError</emu-val>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-38">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>If the interface has a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-10">maplike declaration</a>, then:</p>
       <ol>
@@ -10402,11 +10401,11 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-112">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-14">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-13">setlike declaration</a> is declared.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-33">platform object</a> that implements <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-38">throw</a> a <emu-val>TypeError</emu-val>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-39">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>callbackFn</var> be the value of the first argument passed to the function, or <emu-val>undefined</emu-val> if the argument was not supplied.</p>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>callbackFn</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-39">throw</a> a <emu-val>TypeError</emu-val>.</p>
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>callbackFn</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-40">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>thisArg</var> be the value of the second argument passed to the function, or <emu-val>undefined</emu-val> if the argument was not supplied.</p>
      <li data-md="">
@@ -10430,7 +10429,7 @@ or the [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma2
      <li data-md="">
       <p>Let <var>forEach</var> be the result of calling the [[Get]] internal method of <var>backing</var> with “forEach” and <var>backing</var> as arguments.</p>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>forEach</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-40">throw</a> a <emu-val>TypeError</emu-val>.</p>
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>forEach</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-41">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-call">Call</a>(<var>forEach</var>, <var>backing</var>, «<var>callbackWrapper</var>, <var>thisArg</var>»).</p>
      <li data-md="">
@@ -10504,7 +10503,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-115">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-15">iterable declaration</a> is declared on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-35">platform object</a> that implements <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-41">throw</a> a <emu-val>TypeError</emu-val>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-42">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>iterator</var> be a newly created <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-2">default iterator object</a> for <var>interface</var> with <var>object</var> as its target and iterator kind “key”.</p>
      <li data-md="">
@@ -10554,7 +10553,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-117">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-17">iterable declaration</a> is declared on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-37">platform object</a> that implements <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-42">throw</a> a <emu-val>TypeError</emu-val>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-43">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>iterator</var> be a newly created <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-3">default iterator object</a> for <var>interface</var> with <var>object</var> as its target and iterator kind “value”.</p>
      <li data-md="">
@@ -10605,7 +10604,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       </ul>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-8">default iterator object</a> for <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-43">throw</a> a <emu-val>TypeError</emu-val>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-44">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>index</var> be <var>object</var>’s index.</p>
      <li data-md="">
@@ -10703,13 +10702,13 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-44">throw</a> a <emu-val>TypeError</emu-val>.</p>
+      <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-45">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
      <li data-md="">
       <p>Let <var>function</var> be the result of calling the [[Get]] internal method of <var>map</var> passing <var>name</var> and <var>map</var> as arguments.</p>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>function</var>) is <emu-val>false</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-45">throw</a> a <emu-val>TypeError</emu-val>.</p>
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>function</var>) is <emu-val>false</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-46">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-call">Call</a>(<var>function</var>, <var>map</var>, <var>arguments</var>).</p>
     </ol>
@@ -10740,7 +10739,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “getter”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-46">throw</a> a <emu-val>TypeError</emu-val>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-47">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -10789,7 +10788,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-47">throw</a> a <emu-val>TypeError</emu-val>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-48">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -10846,7 +10845,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-48">throw</a> a <emu-val>TypeError</emu-val>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-49">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -10892,7 +10891,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-49">throw</a> a <emu-val>TypeError</emu-val>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-50">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -10951,7 +10950,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       </ul>
      <li data-md="">
       <p>If <var>O</var> is not an object that implements <var>A</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-50">throw</a> a <emu-val>TypeError</emu-val>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-51">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>set</var> be the <emu-val>Set</emu-val> object that is
 the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
@@ -10959,7 +10958,7 @@ the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https
       <p>Let <var>function</var> be the result of calling the [[Get]] internal method of <var>set</var> passing <var>name</var> and <var>set</var> as arguments.</p>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>function</var>) is <emu-val>false</emu-val>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-51">throw</a> a <emu-val>TypeError</emu-val>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-52">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-call">Call</a>(<var>function</var>, <var>set</var>, <var>arguments</var>).</p>
     </ol>
@@ -10990,7 +10989,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “getter”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-52">throw</a> a <emu-val>TypeError</emu-val>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-53">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>set</var> be the <emu-val>Set</emu-val> object that is the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -11038,7 +11037,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-53">throw</a> a <emu-val>TypeError</emu-val>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-54">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>set</var> be the <emu-val>Set</emu-val> object that is the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -11091,7 +11090,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-54">throw</a> a <emu-val>TypeError</emu-val>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-55">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>set</var> be the <emu-val>Set</emu-val> object that is the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -11352,7 +11351,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
     assuming <var>arg</var><sub>0..<var>n</var>−1</sub> is the list of argument values passed to [[Call]]:</p>
     <ol>
      <li data-md="">
-      <p>If <var>I</var> has no <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-11">legacy callers</a>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-55">throw</a> a <emu-val>TypeError</emu-val>.</p>
+      <p>If <var>I</var> has no <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-11">legacy callers</a>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-56">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-12">effective overload set</a> for legacy callers on <var>I</var> and with argument count <var>n</var>.</p>
      <li data-md="">
@@ -11728,7 +11727,7 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
        <li data-md="">
         <p>If <var>completion</var> is a normal completion, return <var>completion</var>.</p>
        <li data-md="">
-        <p>If <var>completion</var> is an abrupt completion and the operation has a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-7">return type</a> that is <em>not</em> a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-14">promise type</a>, return <var>completion</var>.</p>
+        <p>If <var>completion</var> is an abrupt completion and the operation has a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-7">return type</a> that is <em>not</em> a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-13">promise type</a>, return <var>completion</var>.</p>
        <li data-md="">
         <p>Let <var>reject</var> be the initial value of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.</p>
        <li data-md="">
@@ -11776,7 +11775,7 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
        <li data-md="">
         <p>If <var>completion</var> is a normal completion, return <var>completion</var>.</p>
        <li data-md="">
-        <p>If <var>completion</var> is an abrupt completion and the attribute’s type is <em>not</em> a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-15">promise type</a>, return <var>completion</var>.</p>
+        <p>If <var>completion</var> is an abrupt completion and the attribute’s type is <em>not</em> a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-14">promise type</a>, return <var>completion</var>.</p>
        <li data-md="">
         <p>Let <var>reject</var> be the initial value of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.</p>
        <li data-md="">
@@ -11915,7 +11914,7 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
        <li data-md="">
         <p>If <var>completion</var> is a normal completion, return <var>completion</var>.</p>
        <li data-md="">
-        <p>If <var>completion</var> is an abrupt completion and the callback function has a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-8">return type</a> that is <em>not</em> a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-16">promise type</a>, return <var>completion</var>.</p>
+        <p>If <var>completion</var> is an abrupt completion and the callback function has a <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-8">return type</a> that is <em>not</em> a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-15">promise type</a>, return <var>completion</var>.</p>
        <li data-md="">
         <p>Let <var>reject</var> be the initial value of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a>.reject.</p>
        <li data-md="">
@@ -13523,6 +13522,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-regular-attribute-10">3.3.21. [Unscopable]</a> <a href="#ref-for-dfn-regular-attribute-11">(2)</a>
     <li><a href="#ref-for-dfn-regular-attribute-12">3.6.1. Interface object</a>
     <li><a href="#ref-for-dfn-regular-attribute-13">3.6.3. Interface prototype object</a>
+    <li><a href="#ref-for-dfn-regular-attribute-14">3.6.6. Attributes</a> <a href="#ref-for-dfn-regular-attribute-15">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-read-only">
@@ -13933,7 +13933,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-static-attribute-8">3.3.14. [PutForwards]</a>
     <li><a href="#ref-for-dfn-static-attribute-9">3.3.15. [Replaceable]</a>
     <li><a href="#ref-for-dfn-static-attribute-10">3.3.20. [Unforgeable]</a>
-    <li><a href="#ref-for-dfn-static-attribute-11">3.6.6. Attributes</a> <a href="#ref-for-dfn-static-attribute-12">(2)</a> <a href="#ref-for-dfn-static-attribute-13">(3)</a>
+    <li><a href="#ref-for-dfn-static-attribute-11">3.6.6. Attributes</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-static-operation">
@@ -14932,16 +14932,16 @@ language binding.</p>
   <aside class="dfn-panel" data-for="dfn-promise-type">
    <b><a href="#dfn-promise-type">#dfn-promise-type</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-promise-type-1">2.2.2. Attributes</a> <a href="#ref-for-dfn-promise-type-2">(2)</a>
-    <li><a href="#ref-for-dfn-promise-type-3">2.2.4.1. Legacy callers</a>
-    <li><a href="#ref-for-dfn-promise-type-4">2.2.6. Overloading</a>
-    <li><a href="#ref-for-dfn-promise-type-5">2.11.23. Nullable types — T?</a>
-    <li><a href="#ref-for-dfn-promise-type-6">3.2.20. Promise types — Promise&lt;T></a> <a href="#ref-for-dfn-promise-type-7">(2)</a> <a href="#ref-for-dfn-promise-type-8">(3)</a> <a href="#ref-for-dfn-promise-type-9">(4)</a>
-    <li><a href="#ref-for-dfn-promise-type-10">3.3.11. [NewObject]</a>
-    <li><a href="#ref-for-dfn-promise-type-11">3.6.6. Attributes</a> <a href="#ref-for-dfn-promise-type-12">(2)</a>
-    <li><a href="#ref-for-dfn-promise-type-13">3.6.7. Operations</a>
-    <li><a href="#ref-for-dfn-promise-type-14">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-promise-type-15">(2)</a>
-    <li><a href="#ref-for-dfn-promise-type-16">3.11. Invoking callback functions</a>
+    <li><a href="#ref-for-dfn-promise-type-1">2.2.2. Attributes</a>
+    <li><a href="#ref-for-dfn-promise-type-2">2.2.4.1. Legacy callers</a>
+    <li><a href="#ref-for-dfn-promise-type-3">2.2.6. Overloading</a>
+    <li><a href="#ref-for-dfn-promise-type-4">2.11.23. Nullable types — T?</a>
+    <li><a href="#ref-for-dfn-promise-type-5">3.2.20. Promise types — Promise&lt;T></a> <a href="#ref-for-dfn-promise-type-6">(2)</a> <a href="#ref-for-dfn-promise-type-7">(3)</a> <a href="#ref-for-dfn-promise-type-8">(4)</a>
+    <li><a href="#ref-for-dfn-promise-type-9">3.3.11. [NewObject]</a>
+    <li><a href="#ref-for-dfn-promise-type-10">3.6.6. Attributes</a> <a href="#ref-for-dfn-promise-type-11">(2)</a>
+    <li><a href="#ref-for-dfn-promise-type-12">3.6.7. Operations</a>
+    <li><a href="#ref-for-dfn-promise-type-13">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-promise-type-14">(2)</a>
+    <li><a href="#ref-for-dfn-promise-type-15">3.11. Invoking callback functions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-union-type">
@@ -15284,25 +15284,25 @@ language binding.</p>
     <li><a href="#ref-for-ecmascript-throw-25">3.5. Overload resolution algorithm</a> <a href="#ref-for-ecmascript-throw-26">(2)</a>
     <li><a href="#ref-for-ecmascript-throw-27">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-ecmascript-throw-28">(2)</a>
     <li><a href="#ref-for-ecmascript-throw-29">3.6.1.2. Interface object [[HasInstance]] method</a>
-    <li><a href="#ref-for-ecmascript-throw-30">3.6.6. Attributes</a> <a href="#ref-for-ecmascript-throw-31">(2)</a> <a href="#ref-for-ecmascript-throw-32">(3)</a>
-    <li><a href="#ref-for-ecmascript-throw-33">3.6.7. Operations</a>
-    <li><a href="#ref-for-ecmascript-throw-34">3.6.7.1. Stringifiers</a>
-    <li><a href="#ref-for-ecmascript-throw-35">3.6.7.2. Serializers</a>
-    <li><a href="#ref-for-ecmascript-throw-36">3.6.8.1. @@iterator</a> <a href="#ref-for-ecmascript-throw-37">(2)</a>
-    <li><a href="#ref-for-ecmascript-throw-38">3.6.8.2. forEach</a> <a href="#ref-for-ecmascript-throw-39">(2)</a> <a href="#ref-for-ecmascript-throw-40">(3)</a>
-    <li><a href="#ref-for-ecmascript-throw-41">3.6.9.2. keys</a>
-    <li><a href="#ref-for-ecmascript-throw-42">3.6.9.3. values</a>
-    <li><a href="#ref-for-ecmascript-throw-43">3.6.9.5. Iterator prototype object</a>
-    <li><a href="#ref-for-ecmascript-throw-44">3.6.10. Maplike declarations</a> <a href="#ref-for-ecmascript-throw-45">(2)</a>
-    <li><a href="#ref-for-ecmascript-throw-46">3.6.10.1. size</a>
-    <li><a href="#ref-for-ecmascript-throw-47">3.6.10.4. get and has</a>
-    <li><a href="#ref-for-ecmascript-throw-48">3.6.10.6. delete</a>
-    <li><a href="#ref-for-ecmascript-throw-49">3.6.10.7. set</a>
-    <li><a href="#ref-for-ecmascript-throw-50">3.6.11. Setlike declarations</a> <a href="#ref-for-ecmascript-throw-51">(2)</a>
-    <li><a href="#ref-for-ecmascript-throw-52">3.6.11.1. size</a>
-    <li><a href="#ref-for-ecmascript-throw-53">3.6.11.4. has</a>
-    <li><a href="#ref-for-ecmascript-throw-54">3.6.11.5. add and delete</a>
-    <li><a href="#ref-for-ecmascript-throw-55">3.9.5. [[Call]]</a>
+    <li><a href="#ref-for-ecmascript-throw-30">3.6.6. Attributes</a> <a href="#ref-for-ecmascript-throw-31">(2)</a> <a href="#ref-for-ecmascript-throw-32">(3)</a> <a href="#ref-for-ecmascript-throw-33">(4)</a>
+    <li><a href="#ref-for-ecmascript-throw-34">3.6.7. Operations</a>
+    <li><a href="#ref-for-ecmascript-throw-35">3.6.7.1. Stringifiers</a>
+    <li><a href="#ref-for-ecmascript-throw-36">3.6.7.2. Serializers</a>
+    <li><a href="#ref-for-ecmascript-throw-37">3.6.8.1. @@iterator</a> <a href="#ref-for-ecmascript-throw-38">(2)</a>
+    <li><a href="#ref-for-ecmascript-throw-39">3.6.8.2. forEach</a> <a href="#ref-for-ecmascript-throw-40">(2)</a> <a href="#ref-for-ecmascript-throw-41">(3)</a>
+    <li><a href="#ref-for-ecmascript-throw-42">3.6.9.2. keys</a>
+    <li><a href="#ref-for-ecmascript-throw-43">3.6.9.3. values</a>
+    <li><a href="#ref-for-ecmascript-throw-44">3.6.9.5. Iterator prototype object</a>
+    <li><a href="#ref-for-ecmascript-throw-45">3.6.10. Maplike declarations</a> <a href="#ref-for-ecmascript-throw-46">(2)</a>
+    <li><a href="#ref-for-ecmascript-throw-47">3.6.10.1. size</a>
+    <li><a href="#ref-for-ecmascript-throw-48">3.6.10.4. get and has</a>
+    <li><a href="#ref-for-ecmascript-throw-49">3.6.10.6. delete</a>
+    <li><a href="#ref-for-ecmascript-throw-50">3.6.10.7. set</a>
+    <li><a href="#ref-for-ecmascript-throw-51">3.6.11. Setlike declarations</a> <a href="#ref-for-ecmascript-throw-52">(2)</a>
+    <li><a href="#ref-for-ecmascript-throw-53">3.6.11.1. size</a>
+    <li><a href="#ref-for-ecmascript-throw-54">3.6.11.4. has</a>
+    <li><a href="#ref-for-ecmascript-throw-55">3.6.11.5. add and delete</a>
+    <li><a href="#ref-for-ecmascript-throw-56">3.9.5. [[Call]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-initial-object">


### PR DESCRIPTION
- Fixes getters on the global when no explicit `this` is passed, similarly to what was already done for operations in a2b4599631fe0fa254a7a4993dd7f00b74c8ad20. Closes https://www.w3.org/Bugs/Public/show_bug.cgi?id=29421.
- Make promise getters reject in case of an error. Disallow promise types on attributes that will generate setters. Fixes #186 and fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=25048.
- Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=27905 by more clearly specifying the target (as was done previously for operations).
- Updated to use modern ES Get/Set abstract operations instead of [[Get]] and [[Put]].
- Also made minor fixes to the operations definition, e.g. wrapping it in `<div algorithm>` and remembering to actually return F.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
    
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://cdn.rawgit.com/heycam/webidl/9962a71/index.html) | [Diff w/ current ED](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fheycam.github.io%2Fwebidl%2F&doc2=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2F9962a71%2Findex.html) | [Diff w/ base](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2F0c5f48b%2Findex.html&doc2=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2F9962a71%2Findex.html)