### PR TITLE
Fix typo in sequence type conversion example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7528,7 +7528,7 @@ ECMAScript <emu-val>Array</emu-val> values.
         a = [false, '',
              { valueOf: function() { alert('hi'); return 100; } }, 0,
              '50', new Number(62.5)];
-        canvas.drawPolygon(s);
+        canvas.drawPolygon(a);
 
         // Modifying an Array that was passed to drawPolygon() is guaranteed not to
         // have an effect on the Canvas, since the Array is effectively passed by value.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
    
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://cdn.rawgit.com/TimothyGu/webidl/f324d60/index.html) | [Diff w/ current ED](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fheycam.github.io%2Fwebidl%2F&doc2=https%3A%2F%2Fcdn.rawgit.com%2FTimothyGu%2Fwebidl%2Ff324d60%2Findex.html) | [Diff w/ base](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2Fbbb2bde%2Findex.html&doc2=https%3A%2F%2Fcdn.rawgit.com%2FTimothyGu%2Fwebidl%2Ff324d60%2Findex.html)