### PR TITLE
Add legacy platform objects.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8461,9 +8461,7 @@ extended attribute must be declared on
 at most one interface.  The interface [{{PrimaryGlobal}}]
 is declared on, if any, is known as the <dfn id="dfn-primary-global-interface" export>primary global interface</dfn>.
 
-See [[#named-properties-object]],
-[[#legacy-platform-object-getownproperty]] and
-[[#legacy-platform-object-defineownproperty]]
+See [[#named-properties-object]]
 for the specific requirements that the use of
 [{{Global}}] and [{{PrimaryGlobal}}]
 entails for named properties,
@@ -11777,6 +11775,18 @@ the [=primary interface=]
 of the platform object.
 
 
+<h4 id="platform-object-setprototypeof" oldids="platformobjectsetprototypeof">\[[SetPrototypeOf]]</h4>
+
+The internal \[[SetPrototypeOf]] method of every [=platform object=]
+that implements an [=interface=] with the [{{Global}}] or [{{PrimaryGlobal}}]
+[=extended attribute=] must execute the same algorithm as is defined for the
+\[[SetPrototypeOf]] internal method of an [=immutable prototype exotic object=].
+
+Note: For {{Window}} objects, it is unobservable whether this is implemented, since the presence of
+the {{WindowProxy}} object ensures that \[[SetPrototypeOf]] is never called on a {{Window}} object
+directly. For other global objects, however, this is necessary.
+
+
 <h3 id="es-legacy-platform-objects" oldids="indexed-and-named-properties">Legacy platform objects</h3>
 
 [=Legacy platform objects=] will appear to have additional properties that correspond to their
@@ -11806,9 +11816,9 @@ has an [=interface member=] with that identifier
 and that interface member is [=unforgeable=] on any of
 the interfaces that |O| implements.
 
-Support for [=getters=] is handled by the <a href="#legacy-platform-object-getownproperty">legacy platform object \[[GetOwnProperty]] method</a>,
-and for [=setters=] by the <a href="#legacy-platform-object-defineownproperty">legacy platform object \[[DefineOwnProperty]] method</a>
-and the <a href="#legacy-platform-object-set">legacy platform object \[[Set]] method</a>.
+Support for [=getters=] is handled in [[#legacy-platform-object-getownproperty]],
+and for [=setters=] in [[#legacy-platform-object-defineownproperty]]
+and [[#legacy-platform-object-set]].
 
 
 <h4 id="legacy-platform-object-getownproperty" dfn oldids="getownproperty" lt=GetOwnProperty for="legacy platform object">\[[GetOwnProperty]]</h4>
@@ -11843,19 +11853,8 @@ and the <a href="#legacy-platform-object-set">legacy platform object \[[Set]] me
     1.  Perform steps 3-11 of the [=default [[Set]] internal method=].
 </div>
 
-<h4 id="legacy-platform-object-setprototypeof" oldids="platformobjectsetprototypeof">\[[SetPrototypeOf]]</h4>
 
-The internal \[[SetPrototypeOf]] method of every [=legacy platform object=]
-that implements an [=interface=] with the [{{Global}}] or [{{PrimaryGlobal}}]
-[=extended attribute=] must execute the same algorithm as is defined for the
-\[[SetPrototypeOf]] internal method of an [=immutable prototype exotic object=].
-
-Note: For {{Window}} objects, it is unobservable whether this is implemented, since the presence of
-the {{WindowProxy}} object ensures that \[[SetPrototypeOf]] is never called on a {{Window}} object
-directly. For other global objects, however, this is necessary.
-
-
-<h4 id="legacy-platform-object-defineownproperty" oldids="defineownproperty" algorithm>\[[DefineOwnProperty]]</h4>
+<h4 id="legacy-platform-object-defineownproperty" oldids="defineownproperty">\[[DefineOwnProperty]]</h4>
 
 <div algorithm="to invoke the internal [[DefineOwnProperty]] method of legacy platform objects">
 

--- a/index.bs
+++ b/index.bs
@@ -2131,8 +2131,18 @@ If multiple legacy callers are specified on an interface, overload resolution
 is used to determine which legacy caller is invoked when the object is called
 as if it were a function.
 
-Legacy callers must not be defined to return a
-[=promise type=].
+[=Legacy callers=] can only be defined on interfaces that also
+[=support indexed properties|supports indexed=] or
+[=support named properties|named properties=].
+
+Note: This artificial restriction allows bundling all the interfaces
+which support these various legacy [=extended attributes=]
+into a single [=platform object=] category: [=legacy platform objects=].
+This is possible because all existing interfaces which have a [=legacy caller=]
+also [=support indexed properties|supports indexed=] or
+[=support named properties|named properties=].
+
+Legacy callers must not be defined to return a [=promise type=].
 
 <p class="advisement">
     Legacy callers are universally recognised as an undesirable feature.  They exist
@@ -2855,9 +2865,9 @@ The following requirements apply to the definitions of indexed property getters 
 
     </blockquote>
 
-    As described in [[#es-platform-objects]],
+    As described in [[#es-legacy-platform-objects]],
     an ECMAScript implementation would create
-    properties on a [=platform object=] implementing
+    properties on a [=legacy platform object=] implementing
     <code class="idl">OrderedMap</code> that correspond to
     entries in both the named and indexed property sets.
     These properties can then be used to interact
@@ -2865,7 +2875,7 @@ The following requirements apply to the definitions of indexed property getters 
     methods, as demonstrated below:
 
     <pre highlight="js">
-        // Assume map is a platform object implementing the OrderedMap interface.
+        // Assume map is a legacy platform object implementing the OrderedMap interface.
         var map = getOrderedMap();
         var x, y;
 
@@ -5076,6 +5086,13 @@ object that are considered to be platform objects:
 
 *   objects that implement a non-[=callback interface|callback=] [=interface=];
 *   objects representing IDL {{DOMException|DOMExceptions}}.
+
+<dfn id="dfn-legacy-platform-object" export>Legacy platform objects</dfn> are
+[=platform objects=] that implement an [=interface=] which
+does not have a [{{Global}}] or [{{PrimaryGlobal}}] [=extended attribute=],
+[=support indexed properties|supports indexed=] or
+[=support named properties|named properties=],
+and may have one or multiple [=legacy callers=].
 
 In a browser, for example,
 the browser-implemented DOM objects (implementing interfaces such as <code class="idl">Node</code> and
@@ -8368,12 +8385,11 @@ interfaces. Specifically:
 
 </div>
 
-If the [{{Global}}] or
-[{{PrimaryGlobal}}]
-[=extended attributes=]
-is used on an [=interface=], then:
+If the [{{Global}}] or [{{PrimaryGlobal}}] [=extended attributes=] is
+used on an [=interface=], then:
 
 *   The interface must not define a [=named property setter=].
+*   The interface must not define an [=indexed property getter=].
 *   The interface must not also be declared with the [{{OverrideBuiltins}}]
     extended attribute.
 *   The interface must not [=interface/inherit=] from another interface with the
@@ -8447,8 +8463,8 @@ at most one interface.  The interface [{{PrimaryGlobal}}]
 is declared on, if any, is known as the <dfn id="dfn-primary-global-interface" export>primary global interface</dfn>.
 
 See [[#named-properties-object]],
-[[#getownproperty]] and
-[[#defineownproperty]]
+[[#legacy-platform-object-getownproperty]] and
+[[#legacy-platform-object-defineownproperty]]
 for the specific requirements that the use of
 [{{Global}}] and [{{PrimaryGlobal}}]
 entails for named properties,
@@ -8942,7 +8958,7 @@ for the specific requirements that the use of
 If the [{{OverrideBuiltins}}]
 [=extended attribute=]
 appears on an [=interface=],
-it indicates that for a [=platform object=] implementing the interface,
+it indicates that for a [=legacy platform object=] implementing the interface,
 properties corresponding to all of
 the object’s [=supported property names=]
 will appear to be on the object,
@@ -8966,8 +8982,8 @@ definition, then that partial interface definition must
 be the part of the interface definition that defines
 the [=named property getter=].
 
-See [[#indexed-and-named-properties]]
-and [[#defineownproperty]]
+See [[#es-legacy-platform-objects]]
+and [[#legacy-platform-object-defineownproperty]]
 for the specific requirements that the use of
 [{{OverrideBuiltins}}] entails.
 
@@ -9571,8 +9587,8 @@ must not have a non-static attribute or
 See [[#es-attributes]],
 [[#es-operations]],
 [[#es-platform-objects]],
-[[#indexed-and-named-properties]] and
-[[#defineownproperty]]
+[[#es-legacy-platform-objects]] and
+[[#legacy-platform-object-defineownproperty]]
 for the specific requirements that the use of
 [{{Unforgeable}}] entails.
 
@@ -10338,7 +10354,7 @@ For every [=interface=] declared with the
 that [=support named properties|supports named properties=],
 there must exist an object known as the
 <dfn id="dfn-named-properties-object" export>named properties object</dfn>
-for that interface.
+for that interface on which named properties are exposed.
 
 <div algorithm="value of [[Prototype]] property of named properties objects">
 
@@ -11762,33 +11778,24 @@ the [=primary interface=]
 of the platform object.
 
 
-<h4 id="indexed-and-named-properties">Indexed and named properties</h4>
+<h3 id="es-legacy-platform-objects" oldids="indexed-and-named-properties">Legacy platform objects</h3>
 
-If a [=platform object=] implements an [=interface=] that
-[=support indexed properties|supports indexed=] or
-[=support named properties|named properties=],
-the object will appear to have additional properties that correspond to the
-object’s indexed and named properties.  These properties are not “real” own
+[=Legacy platform objects=] will appear to have additional properties that correspond to the
+[=indexed properties|indexed=] and [=named properties=].  These properties are not “real” own
 properties on the object, but are made to look like they are by being exposed
 by the \[[GetOwnProperty]] internal method.
-
-However, when the [{{Global}}] or
-[{{PrimaryGlobal}}]
-[=extended attribute=] has been used,
-named properties are not exposed on the object but on another object
-in the prototype chain, the [=named properties object=].
 
 It is permissible for an object to implement multiple interfaces that support indexed properties.
 However, if so, and there are conflicting definitions as to the object’s
 [=supported property indices=],
 or if one of the interfaces is a [=supplemental interface=] for the
-platform object, then it is undefined what additional properties the object will appear to
+legacy platform object, then it is undefined what additional properties the object will appear to
 have, or what its exact behavior will be with regard to its indexed properties.
 The same applies for named properties.
 
 The [=indexed property getter=]
 that is defined on the derived-most interface that the
-platform object implements is the one that defines the behavior
+legacy platform object implements is the one that defines the behavior
 when indexing the object with an array index.  Similarly for
 [=indexed property setters=].
 This way, the definitions of these special operations from
@@ -11821,11 +11828,12 @@ the interfaces that |O| implements.
     the [{{OverrideBuiltins}}] [=extended attribute=] was used.
     The algorithm operates as follows, with property name |P| and object |O|:
 
-    1.  If |P| is not a [=supported property name=]
-        of |O|, then return false.
+    1.  If |P| is not a [=supported property name=] of |O|, then return false.
     1.  If |O| has an own property named |P|, then return false.
 
-          Note: This will include cases in which |O| has unforgeable properties, because in practice those are always set up before objects have any supported property names, and once set up will make the corresponding named properties invisible.
+          Note: This will include cases in which |O| has unforgeable properties,
+          because in practice those are always set up before objects have any supported property names,
+          and once set up will make the corresponding named properties invisible.
 
     1.  If |O| implements an interface that has the [{{OverrideBuiltins}}]
         [=extended attribute=], then return true.
@@ -11835,37 +11843,32 @@ the interfaces that |O| implements.
             and |prototype| has an own property named |P|, then return false.
         1.  Set |prototype| to be the value of the internal \[[Prototype]] property of |prototype|.
     1.  Return true.
+
+    <div class="note">
+
+        This should ensure that for objects with named properties, property resolution is done in the following order:
+
+        1.  Indexed properties.
+        1.  Own properties, including unforgeable attributes and operations.
+        1.  Then, if [{{OverrideBuiltins}}]:
+            1.  Named properties.
+            1.  Properties from the prototype chain.
+        1.  Otherwise, if not [{{OverrideBuiltins}}]:
+            1.  Properties from the prototype chain.
+            1.  Named properties.
+    </div>
 </div>
 
-<div class="note">
-
-    This should ensure that for objects with named properties, property resolution is done in the following order:
-
-    1.  Indexed properties.
-    1.  Own properties, including unforgeable attributes and operations.
-    1.  Then, if [{{OverrideBuiltins}}]:
-        1.  Named properties.
-        1.  Properties from the prototype chain.
-    1.  Otherwise, if not [{{OverrideBuiltins}}]:
-        1.  Properties from the prototype chain.
-        1.  Named properties.
-
-</div>
-
-Support for [=getters=] is
-handled by the <a href="#getownproperty">platform object \[[GetOwnProperty]] method</a>
-defined in section [[#getownproperty]], and
-for [=setters=]
-by the <a href="#defineownproperty">platform object \[[DefineOwnProperty]] method</a>
-defined in section [[#defineownproperty]] and the <a href="#platformobjectset">platform object \[[Set]] method</a>
-defined in section [[#platformobjectset]].
+Support for [=getters=] is handled by the <a href="#legacy-platform-object-getownproperty">legacy platform object \[[GetOwnProperty]] method</a>,
+and for [=setters=] by the <a href="#legacy-platform-object-defineownproperty">legacy platform object \[[DefineOwnProperty]] method</a>,
+and the <a href="#legacy-platform-object-set">legacy platform object \[[Set]] method</a>.
 
 
-<h4 id="getownproperty-guts" dfn>The PlatformObjectGetOwnProperty abstract operation</h4>
+<h4 id="getownproperty-guts" lt="LegacyPlatformObjectGetOwnProperty|The PlatformObjectGetOwnProperty abstract operation" dfn>The LegacyPlatformObjectGetOwnProperty abstract operation</h4>
 
-<div algorithm="PlatformObjectGetOwnProperty abstract operation">
+<div algorithm="LegacyPlatformObjectGetOwnProperty abstract operation">
 
-    The PlatformObjectGetOwnProperty abstract operation performs the following steps when
+    The LegacyPlatformObjectGetOwnProperty abstract operation performs the following steps when
     called with an object |O|, a property name |P|, and a boolean |ignoreNamedProps| value:
 
     1.  If |O| [=support indexed properties|supports indexed properties=]
@@ -11889,9 +11892,8 @@ defined in section [[#platformobjectset]].
             1.  Set |desc|.\[[Enumerable]] and |desc|.\[[Configurable]] to <emu-val>true</emu-val>.
             1.  Return |desc|.
         1.  Set |ignoreNamedProps| to true.
-    1.  If |O| [=support named properties|supports named properties=], |O| does not
-        implement an [=interface=] with the [{{Global}}] or [{{PrimaryGlobal}}]
-        [=extended attribute=], the result of running the [=named property visibility algorithm=] with
+    1.  If |O| [=support named properties|supports named properties=],
+        the result of running the [=named property visibility algorithm=] with
         property name |P| and object |O| is true, and |ignoreNamedProps| is false, then:
         1.  Let |operation| be the operation used to declare the named property getter.
         1.  Let |value| be an uninitialized variable.
@@ -11918,22 +11920,18 @@ defined in section [[#platformobjectset]].
 </div>
 
 
-<h4 id="getownproperty">Platform object \[[GetOwnProperty]] method</h4>
+<h4 id="legacy-platform-object-getownproperty" oldis="getownproperty">Legacy platform object \[[GetOwnProperty]] method</h4>
 
 <div algorithm="to invoke the internal [[GetOwnProperty]] method of platform objects">
 
-    The internal \[[GetOwnProperty]] method of every [=platform object=] |O|
-    that implements an [=interface=] which
-    [=support indexed properties|supports indexed=] or
-    [=support named properties|named properties=]
+    The internal \[[GetOwnProperty]] method of every [=legacy platform object=] |O|
     must behave as follows when called with property name |P|:
 
-    1.  Return the result of invoking the [=The PlatformObjectGetOwnProperty abstract operation|PlatformObjectGetOwnProperty=]
-        abstract operation with |O|, |P|, and <emu-val>false</emu-val> as arguments.
+    1. Return [=LegacyPlatformObjectGetOwnProperty=](|O|, |P|, <emu-val>false</emu-val>).
 </div>
 
 
-<h4 id="invoking-indexed-setter">Invoking a platform object indexed property setter</h4>
+<h4 id="invoking-indexed-setter">Invoking a legacy platform object indexed property setter</h4>
 
 <div algorithm>
 
@@ -11958,7 +11956,7 @@ defined in section [[#platformobjectset]].
 </div>
 
 
-<h4 id="invoking-named-setter">Invoking a platform object named property setter</h4>
+<h4 id="invoking-named-setter">Invoking a legacy platform object named property setter</h4>
 
 <div algorithm>
 
@@ -11981,14 +11979,11 @@ defined in section [[#platformobjectset]].
 </div>
 
 
-<h4 id="platformobjectset">Platform object \[[Set]] method</h4>
+<h4 id="legacy-platform-object-set" oldis="platformobjectset">Legacy platform object \[[Set]] method</h4>
 
-<div algorithm="to invoke the internal [[Set]] method of platform objects">
+<div algorithm="to invoke the internal [[Set]] method of legacy platform objects">
 
-    The internal \[[Set]] method of every [=platform object=] |O|
-    that implements an [=interface=] which
-    [=support indexed properties|supports indexed=] or
-    [=support named properties|named properties=]
+    The internal \[[Set]] method of every [=legacy platform object=] |O|
     must behave as follows when called with
     property name |P|, value |V|, and ECMAScript language value |Receiver|:
 
@@ -12001,17 +11996,15 @@ defined in section [[#platformobjectset]].
             and |O| implements an interface with a [=named property setter=], then:
             1.  [=Invoke the named property setter=] with |P| and |V|.
             1.  Return <emu-val>true</emu-val>.
-    1.  Let |ownDesc| be the result of invoking the
-        [=The PlatformObjectGetOwnProperty abstract operation|PlatformObjectGetOwnProperty=]
-        abstract operation with |O|, |P|, and <emu-val>true</emu-val> as arguments.
+    1.  Let |ownDesc| be [=LegacyPlatformObjectGetOwnProperty=](|O|, |P|, <emu-val>true</emu-val>).
     1.  Perform steps 3-11 of the [=default [[Set]] internal method=].
 </div>
 
-<h4 id="platformobjectsetprototypeof">Platform object \[[SetPrototypeOf]] method</h4>
+<h4 id="legacy-platform-object-setprototypeof" oldis="platformobjectsetprototypeof">Legacy platform object \[[SetPrototypeOf]] method</h4>
 
-<div algorithm="to invoke the internal [[SetPrototypeOf]] method of platform objects">
+<div algorithm="to invoke the internal [[SetPrototypeOf]] method of legacy platform objects">
 
-    The internal \[[SetPrototypeOf]] method of every [=platform object=]
+    The internal \[[SetPrototypeOf]] method of every [=legacy platform object=]
     that implements an [=interface=] with the [{{Global}}] or [{{PrimaryGlobal}}]
     [=extended attribute=] must execute the same algorithm as is defined for the
     \[[SetPrototypeOf]] internal method of an [=immutable prototype exotic object=].
@@ -12022,15 +12015,12 @@ the {{WindowProxy}} object ensures that \[[SetPrototypeOf]] is never called on a
 directly. For other global objects, however, this is necessary.
 
 
-<h4 id="defineownproperty">Platform object \[[DefineOwnProperty]] method</h4>
+<h4 id="legacy-platform-object-defineownproperty" oldis="defineownproperty">Legacy platform object \[[DefineOwnProperty]] method</h4>
 
-<div algorithm="to invoke the internal [[DefineOwnProperty]] method of platform objects">
+<div algorithm="to invoke the internal [[DefineOwnProperty]] method of legacy platform objects">
 
-    When the internal \[[DefineOwnProperty]] method of a [=platform object=] |O|
-    that implements an [=interface=] which
-    [=support indexed properties|supports indexed=] or
-    [=support named properties|named properties=] is called with
-    property key |P| and [=Property Descriptor=] |Desc|,
+    When the internal \[[DefineOwnProperty]] method of a [=legacy platform object=] |O|
+    is called with property key |P| and [=Property Descriptor=] |Desc|,
     the following steps must be taken:
 
     1.  If |O| [=support indexed properties|supports indexed properties=] and
@@ -12071,13 +12061,11 @@ directly. For other global objects, however, this is necessary.
 </div>
 
 
-<h4 id="delete">Platform object \[[Delete]] method</h4>
+<h4 id="legacy-platform-object-delete" oldis="delete">Legacy platform object \[[Delete]] method</h4>
 
-<div algorithm="to invoke the internal [[Delete]] method of platform objects">
+<div algorithm="to invoke the internal [[Delete]] method of legacy platform objects">
 
-    The internal \[[Delete]] method of every [=platform object=] |O|
-    that implements an [=interface=] which
-    [=support indexed properties|supports indexed=] or [=support named properties|named properties=]
+    The internal \[[Delete]] method of every [=legacy platform object=] |O|
     must behave as follows when called with property name |P|.
 
     1.  If |O| [=support indexed properties|supports indexed properties=] and
@@ -12109,14 +12097,16 @@ directly. For other global objects, however, this is necessary.
 </div>
 
 
-<h4 id="call">Platform object \[[Call]] method</h4>
+<h4 id="legacy-platform-object-call" oldis="call">Legacy platform object \[[Call]] method</h4>
 
-<div algorithm="to invoke the internal [[Call]] method of platform objects">
+<div algorithm="to invoke the internal [[Call]] method of legacy platform objects">
 
-    The internal \[[Call]] method of every [=platform object=] that implements
-    an [=interface=] |I| with at least one [=legacy caller=] must behave as follows,
+    The internal \[[Call]] method of [=legacy platform object=] that implements
+    an [=interface=] |I| must behave as follows,
     assuming |arg|<sub>0..|n|−1</sub> is the list of argument values passed to \[[Call]]:
 
+    1.  If |I| has no [=legacy callers=],
+        <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
     1.  Initialize |S| to the [=effective overload set=]
         for legacy callers on |I| and with argument count |n|.
     1.  Let &lt;|operation|, |values|&gt; be the result of passing |S| and
@@ -12130,21 +12120,16 @@ directly. For other global objects, however, this is necessary.
 </div>
 
 
-<h4 id="preventextensions">Platform object \[[PreventExtensions]] method</h4>
+<h4 id="legacy-platform-object-preventextensions" oldis="preventextensions">Legacy platform object \[[PreventExtensions]] method</h4>
 
-<div algorithm="to invoke the internal [[PreventExtensions]] method of platform objects">
+<div algorithm="to invoke the internal [[PreventExtensions]] method of legacy platform objects">
 
-    When the \[[PreventExtensions]] internal method of a [=platform object=] |O| is called,
+    When the \[[PreventExtensions]] internal method of a [=legacy platform object=] is called,
     the following steps are taken:
 
-    1.  If |O| [=support indexed properties|supports indexed properties=] or
-        |O| [=support named properties|supports named properties=],
-        return <emu-val>false</emu-val>.
-    1.  Return [=OrdinaryPreventExtensions=](|O|).
+    1.  return <emu-val>false</emu-val>.
 
-    Note: this keeps [=platform objects=] which
-    [=support indexed properties|support indexed=] or
-    [=support named properties|named properties=] extensible by
+    Note: this keeps [=legacy platform objects=] extensible by
     making \[[PreventExtensions]] fail for them.
 </div>
 
@@ -12152,11 +12137,9 @@ directly. For other global objects, however, this is necessary.
 <h4 id="property-enumeration">Property enumeration</h4>
 
 This document does not define a complete property enumeration order
-for all [=platform objects=] implementing [=interfaces=]
+for [=platform objects=] implementing [=interfaces=]
 (or for <a href="#es-exception-objects">platform objects representing exceptions</a>).
-However, if a platform object implements an interface that
-[=support indexed properties|supports indexed=] or
-[=support named properties|named properties=], then
+However, for [=legacy platform objects=],
 properties on the object must be
 enumerated in the following order:
 

--- a/index.bs
+++ b/index.bs
@@ -2135,8 +2135,7 @@ as if it were a function.
 [=support indexed properties|supports indexed=] or
 [=support named properties|named properties=].
 
-Note: This artificial restriction allows bundling all the interfaces
-which support these various legacy [=extended attributes=]
+Note: This artificial restriction allows bundling all interfaces with exotic object behavior
 into a single [=platform object=] category: [=legacy platform objects=].
 This is possible because all existing interfaces which have a [=legacy caller=]
 also [=support indexed properties|supports indexed=] or
@@ -8389,7 +8388,7 @@ If the [{{Global}}] or [{{PrimaryGlobal}}] [=extended attributes=] is
 used on an [=interface=], then:
 
 *   The interface must not define a [=named property setter=].
-*   The interface must not define an [=indexed property getter=].
+*   The interface must not define [=indexed property getters=] or [=indexed property setter|setters=].
 *   The interface must not also be declared with the [{{OverrideBuiltins}}]
     extended attribute.
 *   The interface must not [=interface/inherit=] from another interface with the
@@ -8619,7 +8618,7 @@ If the [{{LegacyUnenumerableNamedProperties}}]
 extended attribute is specified on an interface, then it applies to all its derived interfaces and
 must not be specified on any of them.
 
-See [[#property-enumeration]]
+See [[#legacy-platform-object-property-enumeration]]
 for the specific requirements that the use of
 [{{LegacyUnenumerableNamedProperties}}]
 entails.
@@ -10376,7 +10375,7 @@ is the concatenation of the [=interface=]’s
 [=identifier=] and the string “Properties”.
 
 
-<h5 id="named-properties-object-getownproperty">Named properties object \[[GetOwnProperty]] method</h5>
+<h5 id="named-properties-object-getownproperty">\[[GetOwnProperty]]</h5>
 
 <div algorithm="to invoke the internal [[GetOwnProperty]] method of named properties object">
 
@@ -10417,7 +10416,7 @@ is the concatenation of the [=interface=]’s
 </div>
 
 
-<h5 id="named-properties-object-defineownproperty">Named properties object \[[DefineOwnProperty]] method</h5>
+<h5 id="named-properties-object-defineownproperty">\[[DefineOwnProperty]]</h5>
 
 <div algorithm="to invoke the internal [[DefineOwnProperty]] method of named properties object">
 
@@ -10427,7 +10426,7 @@ is the concatenation of the [=interface=]’s
     1.  Return <emu-val>false</emu-val>.
 </div>
 
-<h5 id="named-properties-object-delete">Named properties object \[[Delete]] method</h5>
+<h5 id="named-properties-object-delete">\[[Delete]]</h5>
 
 <div algorithm="to invoke the internal [[Delete]] method of named properties object">
 
@@ -10438,14 +10437,14 @@ is the concatenation of the [=interface=]’s
 </div>
 
 
-<h5 id="named-properties-object-setprototypeof">Named properties object \[[SetPrototypeOf]] method</h5>
+<h5 id="named-properties-object-setprototypeof">\[[SetPrototypeOf]]</h5>
 
 When the \[[SetPrototypeOf]] internal method of a [=named properties object=] is
 called, the same algorithm must be executed as is defined for the \[[SetPrototypeOf]] internal method of an
 [=immutable prototype exotic object=].
 
 
-<h5 id="named-properties-object-preventextensions">Named properties object \[[PreventExtensions]] method</h5>
+<h5 id="named-properties-object-preventextensions">\[[PreventExtensions]]</h5>
 
 <div algorithm="to invoke the internal [[PreventExtensions]] method of named properties object">
 
@@ -11780,10 +11779,10 @@ of the platform object.
 
 <h3 id="es-legacy-platform-objects" oldids="indexed-and-named-properties">Legacy platform objects</h3>
 
-[=Legacy platform objects=] will appear to have additional properties that correspond to the
+[=Legacy platform objects=] will appear to have additional properties that correspond to their
 [=indexed properties|indexed=] and [=named properties=].  These properties are not “real” own
 properties on the object, but are made to look like they are by being exposed
-by the \[[GetOwnProperty]] internal method.
+by the <a href="#legacy-platform-object-getownproperty">\[[GetOwnProperty]] internal method</a> .
 
 It is permissible for an object to implement multiple interfaces that support indexed properties.
 However, if so, and there are conflicting definitions as to the object’s
@@ -11801,6 +11800,205 @@ when indexing the object with an array index.  Similarly for
 This way, the definitions of these special operations from
 ancestor interfaces can be overridden.
 
+A property name is an <dfn id="dfn-unforgeable-property-name" export>unforgeable property name</dfn> on a
+given platform object if the object implements an [=interface=] that
+has an [=interface member=] with that identifier
+and that interface member is [=unforgeable=] on any of
+the interfaces that |O| implements.
+
+Support for [=getters=] is handled by the <a href="#legacy-platform-object-getownproperty">legacy platform object \[[GetOwnProperty]] method</a>,
+and for [=setters=] by the <a href="#legacy-platform-object-defineownproperty">legacy platform object \[[DefineOwnProperty]] method</a>
+and the <a href="#legacy-platform-object-set">legacy platform object \[[Set]] method</a>.
+
+
+<h4 id="legacy-platform-object-getownproperty" dfn oldids="getownproperty" lt=GetOwnProperty for="legacy platform object">\[[GetOwnProperty]]</h4>
+
+<div algorithm="to invoke the internal [[GetOwnProperty]] method of platform objects">
+
+    The internal \[[GetOwnProperty]] method of every [=legacy platform object=] |O|
+    must behave as follows when called with property name |P|:
+
+    1. Return <a abstract-op>LegacyPlatformObjectGetOwnProperty</a>(|O|, |P|, <emu-val>false</emu-val>).
+</div>
+
+
+<h4 id="legacy-platform-object-set" oldids="platformobjectset">\[[Set]]</h4>
+
+<div algorithm="to invoke the internal [[Set]] method of legacy platform objects">
+
+    The internal \[[Set]] method of every [=legacy platform object=] |O|
+    must behave as follows when called with
+    property name |P|, value |V|, and ECMAScript language value |Receiver|:
+
+    1.  If |O| and |Receiver| are the same object, then:
+        1.  If |O| [=support indexed properties|supports indexed properties=], |P| is an [=array index property name=], and |O| implements an interface with an [=indexed property setter=], then:
+            1.  [=Invoke the indexed property setter=] with |P| and |V|.
+            1.  Return <emu-val>true</emu-val>.
+        1.  If |O| [=support named properties|supports named properties=], [=Type=](|P|) is String,
+            |P| is not an [=array index property name=],
+            and |O| implements an interface with a [=named property setter=], then:
+            1.  [=Invoke the named property setter=] with |P| and |V|.
+            1.  Return <emu-val>true</emu-val>.
+    1.  Let |ownDesc| be <a abstract-op>LegacyPlatformObjectGetOwnProperty</a>(|O|, |P|, <emu-val>true</emu-val>).
+    1.  Perform steps 3-11 of the [=default [[Set]] internal method=].
+</div>
+
+<h4 id="legacy-platform-object-setprototypeof" oldids="platformobjectsetprototypeof">\[[SetPrototypeOf]]</h4>
+
+The internal \[[SetPrototypeOf]] method of every [=legacy platform object=]
+that implements an [=interface=] with the [{{Global}}] or [{{PrimaryGlobal}}]
+[=extended attribute=] must execute the same algorithm as is defined for the
+\[[SetPrototypeOf]] internal method of an [=immutable prototype exotic object=].
+
+Note: For {{Window}} objects, it is unobservable whether this is implemented, since the presence of
+the {{WindowProxy}} object ensures that \[[SetPrototypeOf]] is never called on a {{Window}} object
+directly. For other global objects, however, this is necessary.
+
+
+<h4 id="legacy-platform-object-defineownproperty" oldids="defineownproperty" algorithm>\[[DefineOwnProperty]]</h4>
+
+<div algorithm="to invoke the internal [[DefineOwnProperty]] method of legacy platform objects">
+
+    When the internal \[[DefineOwnProperty]] method of a [=legacy platform object=] |O|
+    is called with property key |P| and [=Property Descriptor=] |Desc|,
+    the following steps must be taken:
+
+    1.  If |O| [=support indexed properties|supports indexed properties=] and
+        |P| is an [=array index property name=], then:
+        1.  If the result of calling [=IsDataDescriptor=](|Desc|) is
+            <emu-val>false</emu-val>, then return
+            <emu-val>false</emu-val>.
+        1.  If |O| does not implement an interface with an
+            [=indexed property setter=], then return <emu-val>false</emu-val>.
+        1.  [=Invoke the indexed property setter=] with |P| and |Desc|.\[[Value]].
+        1.  Return <emu-val>true</emu-val>.
+    1.  If |O| [=support named properties|supports named properties=],
+        |O| does not implement an [=interface=] with the
+        [{{Global}}] or [{{PrimaryGlobal}}] [=extended attribute=]
+        and |P| is not an [=unforgeable property name=]
+        of |O|, then:
+        1.  Let |creating| be true if |P| is not a [=supported property name=], and false otherwise.
+        1.  If |O| implements an interface with the [{{OverrideBuiltins}}]
+            [=extended attribute=] or |O| does not have an own property
+            named |P|, then:
+            1.  If |creating| is false and |O| does not implement an
+                interface with a [=named property setter=], then return <emu-val>false</emu-val>.
+            1.  If |O| implements an interface with a
+                [=named property setter=], then:
+                1.  If the result of calling [=IsDataDescriptor=](|Desc|) is
+                    <emu-val>false</emu-val>, then return
+                    <emu-val>false</emu-val>.
+                1.  [=Invoke the named property setter=] with |P| and |Desc|.\[[Value]].
+                1.  Return <emu-val>true</emu-val>.
+    1.  If |O| does not implement an
+        [=interface=] with the
+        [{{Global}}] or
+        [{{PrimaryGlobal}}]
+        [=extended attribute=], then set
+        |Desc|.\[[Configurable]] to
+        <emu-val>true</emu-val>.
+    1.  Return [=OrdinaryDefineOwnProperty=](|O|, |P|, |Desc|).
+</div>
+
+
+<h4 id="legacy-platform-object-delete" oldids="delete">\[[Delete]]</h4>
+
+<div algorithm="to invoke the internal [[Delete]] method of legacy platform objects">
+
+    The internal \[[Delete]] method of every [=legacy platform object=] |O|
+    must behave as follows when called with property name |P|.
+
+    1.  If |O| [=support indexed properties|supports indexed properties=] and
+        |P| is an [=array index property name=], then:
+        1.  Let |index| be the result of calling [=ToUint32=](|P|).
+        1.  If |index| is not a [=supported property indices|supported property index=], then return <emu-val>true</emu-val>.
+        1.  Return <emu-val>false</emu-val>.
+    1.  If |O| [=support named properties|supports named properties=],
+        |O| does not implement an [=interface=] with the
+        [{{Global}}] or [{{PrimaryGlobal}}] [=extended attribute=]
+        and the result of calling the [=named property visibility algorithm=]
+        with property name |P| and object |O| is true, then:
+        1.  If |O| does not implement an interface with a [=named property deleter=], then return <emu-val>false</emu-val>.
+        1.  Let |operation| be the operation used to declare the named property deleter.
+        1.  If |operation| was defined without an [=identifier=], then:
+            1.  Perform the steps listed in the interface description to
+                [=delete an existing named property=]
+                with |P| as the name.
+            1.  If the steps indicated that the deletion failed, then return <emu-val>false</emu-val>.
+        1.  Otherwise, |operation| was defined with an identifier:
+            1.  Perform the steps listed in the description of |operation| with |P| as the only argument value.
+            1.  If |operation| was declared with a [=return type=] of {{boolean}}
+                and the steps returned <emu-val>false</emu-val>, then return <emu-val>false</emu-val>.
+        1.  Return <emu-val>true</emu-val>.
+    1.  If |O| has an own property with name |P|, then:
+        1.  If the property is not configurable, then return <emu-val>false</emu-val>.
+        1.  Otherwise, remove the property from |O|.
+    1.  Return <emu-val>true</emu-val>.
+</div>
+
+
+<h4 id="legacy-platform-object-call" oldids="call">\[[Call]]</h4>
+
+<div algorithm="to invoke the internal [[Call]] method of legacy platform objects">
+
+    The internal \[[Call]] method of [=legacy platform object=] that implements
+    an [=interface=] |I| must behave as follows,
+    assuming |arg|<sub>0..|n|−1</sub> is the list of argument values passed to \[[Call]]:
+
+    1.  If |I| has no [=legacy callers=],
+        <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+    1.  Initialize |S| to the [=effective overload set=]
+        for legacy callers on |I| and with argument count |n|.
+    1.  Let &lt;|operation|, |values|&gt; be the result of passing |S| and
+        |arg|<sub>0..|n|−1</sub> to the [=overload resolution algorithm=].
+    1.  Perform the actions listed in the description of the legacy caller |operation| with
+        |values| as the argument values.
+    1.  Return the result of [=converted to an ECMAScript value|converting=]
+        the return value from those actions to an ECMAScript value of the type
+        |operation| is declared to return (or <emu-val>undefined</emu-val>
+        if |operation| is declared to return {{void}}).
+</div>
+
+
+<h4 id="legacy-platform-object-preventextensions" oldids="preventextensions">\[[PreventExtensions]]</h4>
+
+<div algorithm="to invoke the internal [[PreventExtensions]] method of legacy platform objects">
+
+    When the \[[PreventExtensions]] internal method of a [=legacy platform object=] is called,
+    the following steps are taken:
+
+    1.  Return <emu-val>false</emu-val>.
+
+    Note: this keeps [=legacy platform objects=] extensible by
+    making \[[PreventExtensions]] fail for them.
+</div>
+
+
+<h4 id="legacy-platform-object-property-enumeration" oldids="property-enumeration">Property enumeration</h4>
+
+This document does not define a complete property enumeration order
+for [=platform objects=] implementing [=interfaces=]
+(or for <a href="#es-exception-objects">platform objects representing exceptions</a>).
+However, for [=legacy platform objects=],
+properties on the object must be
+enumerated in the following order:
+
+1.  If the object [=support indexed properties|supports indexed properties=], then
+    the object’s [=supported property indices=] are
+    enumerated first, in numerical order.
+1.  If the object [=support named properties|supports named properties=] and doesn't implement an [=interface=] with the
+    [{{LegacyUnenumerableNamedProperties}}]
+    [=extended attribute=], then
+    the object’s [=supported property names=] that
+    are visible according to the [=named property visibility algorithm=]
+    are enumerated next, in the order given in the definition of the set of supported property names.
+1.  Finally, any enumerable own properties or properties from the object’s prototype chain are then enumerated,
+    in no defined order.
+
+Note: Future versions of the ECMAScript specification may define a total order for property enumeration.
+
+<h4 id="legacy-platform-object-abstract-ops">Abstract operations</h4>
+
 <div algorithm>
 
     The name of each property that appears to exist due to an object supporting indexed properties
@@ -11813,12 +12011,6 @@ ancestor interfaces can be overridden.
     1.  If |s| ≠ |P| or |i| = 2<sup>32</sup> − 1, then return <emu-val>false</emu-val>.
     1.  Return <emu-val>true</emu-val>.
 </div>
-
-A property name is an <dfn id="dfn-unforgeable-property-name" export>unforgeable property name</dfn> on a
-given platform object if the object implements an [=interface=] that
-has an [=interface member=] with that identifier
-and that interface member is [=unforgeable=] on any of
-the interfaces that |O| implements.
 
 <div algorithm>
 
@@ -11843,33 +12035,69 @@ the interfaces that |O| implements.
             and |prototype| has an own property named |P|, then return false.
         1.  Set |prototype| to be the value of the internal \[[Prototype]] property of |prototype|.
     1.  Return true.
-
-    <div class="note">
-
-        This should ensure that for objects with named properties, property resolution is done in the following order:
-
-        1.  Indexed properties.
-        1.  Own properties, including unforgeable attributes and operations.
-        1.  Then, if [{{OverrideBuiltins}}]:
-            1.  Named properties.
-            1.  Properties from the prototype chain.
-        1.  Otherwise, if not [{{OverrideBuiltins}}]:
-            1.  Properties from the prototype chain.
-            1.  Named properties.
-    </div>
 </div>
 
-Support for [=getters=] is handled by the <a href="#legacy-platform-object-getownproperty">legacy platform object \[[GetOwnProperty]] method</a>,
-and for [=setters=] by the <a href="#legacy-platform-object-defineownproperty">legacy platform object \[[DefineOwnProperty]] method</a>,
-and the <a href="#legacy-platform-object-set">legacy platform object \[[Set]] method</a>.
+<div class="note">
 
+    This should ensure that for objects with named properties, property resolution is done in the following order:
 
-<h4 id="getownproperty-guts" lt="LegacyPlatformObjectGetOwnProperty" dfn>The LegacyPlatformObjectGetOwnProperty abstract operation</h4>
+    1.  Indexed properties.
+    1.  Own properties, including unforgeable attributes and operations.
+    1.  Then, if [{{OverrideBuiltins}}]:
+        1.  Named properties.
+        1.  Properties from the prototype chain.
+    1.  Otherwise, if not [{{OverrideBuiltins}}]:
+        1.  Properties from the prototype chain.
+        1.  Named properties.
+</div>
 
-<div algorithm="LegacyPlatformObjectGetOwnProperty abstract operation">
+<div algorithm>
 
-    The LegacyPlatformObjectGetOwnProperty abstract operation performs the following steps when
-    called with an object |O|, a property name |P|, and a boolean |ignoreNamedProps| value:
+    To <dfn id="invoke-indexed-setter" oldids="invoking-indexed-setter" export lt="invoke the indexed property setter">invoke an indexed property setter</dfn>
+    with property name |P| and ECMAScript value |V|, the following steps must be performed:
+
+    1.  Let |index| be the result of calling [=ToUint32=](|P|).
+    1.  Let |creating| be true if |index| is not a [=supported property indices|supported property index=],
+        and false otherwise.
+    1.  Let |operation| be the operation used to declare the indexed property setter.
+    1.  Let |T| be the type of the second argument of |operation|.
+    1.  Let |value| be the result of [=converted to an IDL value|converting=] |V| to an IDL value of type |T|.
+    1.  If |operation| was defined without an [=identifier=], then:
+        1.  If |creating| is true, then perform the steps listed in the interface description to
+            [=set the value of a new indexed property=]
+            with |index| as the index and |value| as the value.
+        1.  Otherwise, |creating| is false.  Perform the steps listed in the interface description to
+            [=set the value of an existing indexed property=]
+            with |index| as the index and |value| as the value.
+    1.  Otherwise, |operation| was defined with an identifier.  Perform the steps listed in the description of
+        |operation| with |index| and |value| as the two argument values.
+</div>
+
+<div algorithm>
+
+    To <dfn id="invoke-named-setter" oldids="invoking-named-setter" export lt="invoke the named property setter">invoke a named property setter</dfn>
+    with property name |P| and ECMAScript value |V|, the following steps must be performed:
+
+    1.  Let |creating| be true if |P| is not a [=supported property name=], and false otherwise.
+    1.  Let |operation| be the operation used to declare the named property setter.
+    1.  Let |T| be the type of the second argument of |operation|.
+    1.  Let |value| be the result of [=converted to an IDL value|converting=] |V| to an IDL value of type |T|.
+    1.  If |operation| was defined without an [=identifier=], then:
+        1.  If |creating| is true, then perform the steps listed in the interface description to
+            [=set the value of a new named property=]
+            with |P| as the name and |value| as the value.
+        1.  Otherwise, |creating| is false.  Perform the steps listed in the interface description to
+            [=set the value of an existing named property=]
+            with |P| as the name and |value| as the value.
+    1.  Otherwise, |operation| was defined with an identifier.  Perform the steps listed in the description of
+        |operation| with |P| and |value| as the two argument values.
+</div>
+
+<div algorithm>
+
+    The <dfn id="LegacyPlatformObjectGetOwnProperty" oldids="getownproperty-guts" abstract-op>LegacyPlatformObjectGetOwnProperty</dfn>
+    abstract operation performs the following steps when called with
+    an object |O|, a property name |P|, and a boolean |ignoreNamedProps| value:
 
     1.  If |O| [=support indexed properties|supports indexed properties=]
         and |P| is an [=array index property name=], then:
@@ -11918,245 +12146,6 @@ and the <a href="#legacy-platform-object-set">legacy platform object \[[Set]] me
         1.  Return |desc|.
     1.  Return [=OrdinaryGetOwnProperty=](|O|, |P|).
 </div>
-
-
-<h4 id="legacy-platform-object-getownproperty" oldids="getownproperty">Legacy platform object \[[GetOwnProperty]] method</h4>
-
-<div algorithm="to invoke the internal [[GetOwnProperty]] method of platform objects">
-
-    The internal \[[GetOwnProperty]] method of every [=legacy platform object=] |O|
-    must behave as follows when called with property name |P|:
-
-    1. Return [=LegacyPlatformObjectGetOwnProperty=](|O|, |P|, <emu-val>false</emu-val>).
-</div>
-
-
-<h4 id="invoking-indexed-setter">Invoking a legacy platform object indexed property setter</h4>
-
-<div algorithm>
-
-    To <dfn id="invoke-indexed-setter" export lt="invoke the indexed property setter">invoke an indexed property setter</dfn>
-    with property name |P| and ECMAScript value |V|, the following steps must be performed:
-
-    1.  Let |index| be the result of calling [=ToUint32=](|P|).
-    1.  Let |creating| be true if |index| is not a [=supported property indices|supported property index=],
-        and false otherwise.
-    1.  Let |operation| be the operation used to declare the indexed property setter.
-    1.  Let |T| be the type of the second argument of |operation|.
-    1.  Let |value| be the result of [=converted to an IDL value|converting=] |V| to an IDL value of type |T|.
-    1.  If |operation| was defined without an [=identifier=], then:
-        1.  If |creating| is true, then perform the steps listed in the interface description to
-            [=set the value of a new indexed property=]
-            with |index| as the index and |value| as the value.
-        1.  Otherwise, |creating| is false.  Perform the steps listed in the interface description to
-            [=set the value of an existing indexed property=]
-            with |index| as the index and |value| as the value.
-    1.  Otherwise, |operation| was defined with an identifier.  Perform the steps listed in the description of
-        |operation| with |index| and |value| as the two argument values.
-</div>
-
-
-<h4 id="invoking-named-setter">Invoking a legacy platform object named property setter</h4>
-
-<div algorithm>
-
-    To <dfn id="invoke-named-setter" export lt="invoke the named property setter">invoke a named property setter</dfn>
-    with property name |P| and ECMAScript value |V|, the following steps must be performed:
-
-    1.  Let |creating| be true if |P| is not a [=supported property name=], and false otherwise.
-    1.  Let |operation| be the operation used to declare the named property setter.
-    1.  Let |T| be the type of the second argument of |operation|.
-    1.  Let |value| be the result of [=converted to an IDL value|converting=] |V| to an IDL value of type |T|.
-    1.  If |operation| was defined without an [=identifier=], then:
-        1.  If |creating| is true, then perform the steps listed in the interface description to
-            [=set the value of a new named property=]
-            with |P| as the name and |value| as the value.
-        1.  Otherwise, |creating| is false.  Perform the steps listed in the interface description to
-            [=set the value of an existing named property=]
-            with |P| as the name and |value| as the value.
-    1.  Otherwise, |operation| was defined with an identifier.  Perform the steps listed in the description of
-        |operation| with |P| and |value| as the two argument values.
-</div>
-
-
-<h4 id="legacy-platform-object-set" oldids="platformobjectset">Legacy platform object \[[Set]] method</h4>
-
-<div algorithm="to invoke the internal [[Set]] method of legacy platform objects">
-
-    The internal \[[Set]] method of every [=legacy platform object=] |O|
-    must behave as follows when called with
-    property name |P|, value |V|, and ECMAScript language value |Receiver|:
-
-    1.  If |O| and |Receiver| are the same object, then:
-        1.  If |O| [=support indexed properties|supports indexed properties=], |P| is an [=array index property name=], and |O| implements an interface with an [=indexed property setter=], then:
-            1.  [=Invoke the indexed property setter=] with |P| and |V|.
-            1.  Return <emu-val>true</emu-val>.
-        1.  If |O| [=support named properties|supports named properties=], [=Type=](|P|) is String,
-            |P| is not an [=array index property name=],
-            and |O| implements an interface with a [=named property setter=], then:
-            1.  [=Invoke the named property setter=] with |P| and |V|.
-            1.  Return <emu-val>true</emu-val>.
-    1.  Let |ownDesc| be [=LegacyPlatformObjectGetOwnProperty=](|O|, |P|, <emu-val>true</emu-val>).
-    1.  Perform steps 3-11 of the [=default [[Set]] internal method=].
-</div>
-
-<h4 id="legacy-platform-object-setprototypeof" oldids="platformobjectsetprototypeof">Legacy platform object \[[SetPrototypeOf]] method</h4>
-
-<div algorithm="to invoke the internal [[SetPrototypeOf]] method of legacy platform objects">
-
-    The internal \[[SetPrototypeOf]] method of every [=legacy platform object=]
-    that implements an [=interface=] with the [{{Global}}] or [{{PrimaryGlobal}}]
-    [=extended attribute=] must execute the same algorithm as is defined for the
-    \[[SetPrototypeOf]] internal method of an [=immutable prototype exotic object=].
-</div>
-
-Note: For {{Window}} objects, it is unobservable whether this is implemented, since the presence of
-the {{WindowProxy}} object ensures that \[[SetPrototypeOf]] is never called on a {{Window}} object
-directly. For other global objects, however, this is necessary.
-
-
-<h4 id="legacy-platform-object-defineownproperty" oldids="defineownproperty">Legacy platform object \[[DefineOwnProperty]] method</h4>
-
-<div algorithm="to invoke the internal [[DefineOwnProperty]] method of legacy platform objects">
-
-    When the internal \[[DefineOwnProperty]] method of a [=legacy platform object=] |O|
-    is called with property key |P| and [=Property Descriptor=] |Desc|,
-    the following steps must be taken:
-
-    1.  If |O| [=support indexed properties|supports indexed properties=] and
-        |P| is an [=array index property name=], then:
-        1.  If the result of calling [=IsDataDescriptor=](|Desc|) is
-            <emu-val>false</emu-val>, then return
-            <emu-val>false</emu-val>.
-        1.  If |O| does not implement an interface with an
-            [=indexed property setter=], then return <emu-val>false</emu-val>.
-        1.  [=Invoke the indexed property setter=] with |P| and |Desc|.\[[Value]].
-        1.  Return <emu-val>true</emu-val>.
-    1.  If |O| [=support named properties|supports named properties=],
-        |O| does not implement an [=interface=] with the
-        [{{Global}}] or [{{PrimaryGlobal}}] [=extended attribute=]
-        and |P| is not an [=unforgeable property name=]
-        of |O|, then:
-        1.  Let |creating| be true if |P| is not a [=supported property name=], and false otherwise.
-        1.  If |O| implements an interface with the [{{OverrideBuiltins}}]
-            [=extended attribute=] or |O| does not have an own property
-            named |P|, then:
-            1.  If |creating| is false and |O| does not implement an
-                interface with a [=named property setter=], then return <emu-val>false</emu-val>.
-            1.  If |O| implements an interface with a
-                [=named property setter=], then:
-                1.  If the result of calling [=IsDataDescriptor=](|Desc|) is
-                    <emu-val>false</emu-val>, then return
-                    <emu-val>false</emu-val>.
-                1.  [=Invoke the named property setter=] with |P| and |Desc|.\[[Value]].
-                1.  Return <emu-val>true</emu-val>.
-    1.  If |O| does not implement an
-        [=interface=] with the
-        [{{Global}}] or
-        [{{PrimaryGlobal}}]
-        [=extended attribute=], then set
-        |Desc|.\[[Configurable]] to
-        <emu-val>true</emu-val>.
-    1.  Return [=OrdinaryDefineOwnProperty=](|O|, |P|, |Desc|).
-</div>
-
-
-<h4 id="legacy-platform-object-delete" oldids="delete">Legacy platform object \[[Delete]] method</h4>
-
-<div algorithm="to invoke the internal [[Delete]] method of legacy platform objects">
-
-    The internal \[[Delete]] method of every [=legacy platform object=] |O|
-    must behave as follows when called with property name |P|.
-
-    1.  If |O| [=support indexed properties|supports indexed properties=] and
-        |P| is an [=array index property name=], then:
-        1.  Let |index| be the result of calling [=ToUint32=](|P|).
-        1.  If |index| is not a [=supported property indices|supported property index=], then return <emu-val>true</emu-val>.
-        1.  Return <emu-val>false</emu-val>.
-    1.  If |O| [=support named properties|supports named properties=],
-        |O| does not implement an [=interface=] with the
-        [{{Global}}] or [{{PrimaryGlobal}}] [=extended attribute=]
-        and the result of calling the [=named property visibility algorithm=]
-        with property name |P| and object |O| is true, then:
-        1.  If |O| does not implement an interface with a [=named property deleter=], then return <emu-val>false</emu-val>.
-        1.  Let |operation| be the operation used to declare the named property deleter.
-        1.  If |operation| was defined without an [=identifier=], then:
-            1.  Perform the steps listed in the interface description to
-                [=delete an existing named property=]
-                with |P| as the name.
-            1.  If the steps indicated that the deletion failed, then return <emu-val>false</emu-val>.
-        1.  Otherwise, |operation| was defined with an identifier:
-            1.  Perform the steps listed in the description of |operation| with |P| as the only argument value.
-            1.  If |operation| was declared with a [=return type=] of {{boolean}}
-                and the steps returned <emu-val>false</emu-val>, then return <emu-val>false</emu-val>.
-        1.  Return <emu-val>true</emu-val>.
-    1.  If |O| has an own property with name |P|, then:
-        1.  If the property is not configurable, then return <emu-val>false</emu-val>.
-        1.  Otherwise, remove the property from |O|.
-    1.  Return <emu-val>true</emu-val>.
-</div>
-
-
-<h4 id="legacy-platform-object-call" oldids="call">Legacy platform object \[[Call]] method</h4>
-
-<div algorithm="to invoke the internal [[Call]] method of legacy platform objects">
-
-    The internal \[[Call]] method of [=legacy platform object=] that implements
-    an [=interface=] |I| must behave as follows,
-    assuming |arg|<sub>0..|n|−1</sub> is the list of argument values passed to \[[Call]]:
-
-    1.  If |I| has no [=legacy callers=],
-        <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
-    1.  Initialize |S| to the [=effective overload set=]
-        for legacy callers on |I| and with argument count |n|.
-    1.  Let &lt;|operation|, |values|&gt; be the result of passing |S| and
-        |arg|<sub>0..|n|−1</sub> to the [=overload resolution algorithm=].
-    1.  Perform the actions listed in the description of the legacy caller |operation| with
-        |values| as the argument values.
-    1.  Return the result of [=converted to an ECMAScript value|converting=]
-        the return value from those actions to an ECMAScript value of the type
-        |operation| is declared to return (or <emu-val>undefined</emu-val>
-        if |operation| is declared to return {{void}}).
-</div>
-
-
-<h4 id="legacy-platform-object-preventextensions" oldids="preventextensions">Legacy platform object \[[PreventExtensions]] method</h4>
-
-<div algorithm="to invoke the internal [[PreventExtensions]] method of legacy platform objects">
-
-    When the \[[PreventExtensions]] internal method of a [=legacy platform object=] is called,
-    the following steps are taken:
-
-    1.  return <emu-val>false</emu-val>.
-
-    Note: this keeps [=legacy platform objects=] extensible by
-    making \[[PreventExtensions]] fail for them.
-</div>
-
-
-<h4 id="property-enumeration">Property enumeration</h4>
-
-This document does not define a complete property enumeration order
-for [=platform objects=] implementing [=interfaces=]
-(or for <a href="#es-exception-objects">platform objects representing exceptions</a>).
-However, for [=legacy platform objects=],
-properties on the object must be
-enumerated in the following order:
-
-1.  If the object [=support indexed properties|supports indexed properties=], then
-    the object’s [=supported property indices=] are
-    enumerated first, in numerical order.
-1.  If the object [=support named properties|supports named properties=] and doesn't implement an [=interface=] with the
-    [{{LegacyUnenumerableNamedProperties}}]
-    [=extended attribute=], then
-    the object’s [=supported property names=] that
-    are visible according to the [=named property visibility algorithm=]
-    are enumerated next, in the order given in the definition of the set of supported property names.
-1.  Finally, any enumerable own properties or properties from the object’s prototype chain are then enumerated,
-    in no defined order.
-
-Note: Future versions of the ECMAScript specification may define a total order for property enumeration.
-
 
 <h3 id="es-user-objects">User objects implementing callback interfaces</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -11864,7 +11864,7 @@ and for [=setters=] by the <a href="#legacy-platform-object-defineownproperty">l
 and the <a href="#legacy-platform-object-set">legacy platform object \[[Set]] method</a>.
 
 
-<h4 id="getownproperty-guts" lt="LegacyPlatformObjectGetOwnProperty|The PlatformObjectGetOwnProperty abstract operation" dfn>The LegacyPlatformObjectGetOwnProperty abstract operation</h4>
+<h4 id="getownproperty-guts" lt="LegacyPlatformObjectGetOwnProperty" dfn>The LegacyPlatformObjectGetOwnProperty abstract operation</h4>
 
 <div algorithm="LegacyPlatformObjectGetOwnProperty abstract operation">
 

--- a/index.bs
+++ b/index.bs
@@ -11920,7 +11920,7 @@ and the <a href="#legacy-platform-object-set">legacy platform object \[[Set]] me
 </div>
 
 
-<h4 id="legacy-platform-object-getownproperty" oldis="getownproperty">Legacy platform object \[[GetOwnProperty]] method</h4>
+<h4 id="legacy-platform-object-getownproperty" oldids="getownproperty">Legacy platform object \[[GetOwnProperty]] method</h4>
 
 <div algorithm="to invoke the internal [[GetOwnProperty]] method of platform objects">
 
@@ -11979,7 +11979,7 @@ and the <a href="#legacy-platform-object-set">legacy platform object \[[Set]] me
 </div>
 
 
-<h4 id="legacy-platform-object-set" oldis="platformobjectset">Legacy platform object \[[Set]] method</h4>
+<h4 id="legacy-platform-object-set" oldids="platformobjectset">Legacy platform object \[[Set]] method</h4>
 
 <div algorithm="to invoke the internal [[Set]] method of legacy platform objects">
 
@@ -12000,7 +12000,7 @@ and the <a href="#legacy-platform-object-set">legacy platform object \[[Set]] me
     1.  Perform steps 3-11 of the [=default [[Set]] internal method=].
 </div>
 
-<h4 id="legacy-platform-object-setprototypeof" oldis="platformobjectsetprototypeof">Legacy platform object \[[SetPrototypeOf]] method</h4>
+<h4 id="legacy-platform-object-setprototypeof" oldids="platformobjectsetprototypeof">Legacy platform object \[[SetPrototypeOf]] method</h4>
 
 <div algorithm="to invoke the internal [[SetPrototypeOf]] method of legacy platform objects">
 
@@ -12015,7 +12015,7 @@ the {{WindowProxy}} object ensures that \[[SetPrototypeOf]] is never called on a
 directly. For other global objects, however, this is necessary.
 
 
-<h4 id="legacy-platform-object-defineownproperty" oldis="defineownproperty">Legacy platform object \[[DefineOwnProperty]] method</h4>
+<h4 id="legacy-platform-object-defineownproperty" oldids="defineownproperty">Legacy platform object \[[DefineOwnProperty]] method</h4>
 
 <div algorithm="to invoke the internal [[DefineOwnProperty]] method of legacy platform objects">
 
@@ -12061,7 +12061,7 @@ directly. For other global objects, however, this is necessary.
 </div>
 
 
-<h4 id="legacy-platform-object-delete" oldis="delete">Legacy platform object \[[Delete]] method</h4>
+<h4 id="legacy-platform-object-delete" oldids="delete">Legacy platform object \[[Delete]] method</h4>
 
 <div algorithm="to invoke the internal [[Delete]] method of legacy platform objects">
 
@@ -12097,7 +12097,7 @@ directly. For other global objects, however, this is necessary.
 </div>
 
 
-<h4 id="legacy-platform-object-call" oldis="call">Legacy platform object \[[Call]] method</h4>
+<h4 id="legacy-platform-object-call" oldids="call">Legacy platform object \[[Call]] method</h4>
 
 <div algorithm="to invoke the internal [[Call]] method of legacy platform objects">
 
@@ -12120,7 +12120,7 @@ directly. For other global objects, however, this is necessary.
 </div>
 
 
-<h4 id="legacy-platform-object-preventextensions" oldis="preventextensions">Legacy platform object \[[PreventExtensions]] method</h4>
+<h4 id="legacy-platform-object-preventextensions" oldids="preventextensions">Legacy platform object \[[PreventExtensions]] method</h4>
 
 <div algorithm="to invoke the internal [[PreventExtensions]] method of legacy platform objects">
 

--- a/index.html
+++ b/index.html
@@ -11300,7 +11300,7 @@ otherwise set it to <emu-val>true</emu-val>.</p>
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinarygetownproperty">OrdinaryGetOwnProperty</a>(<var>O</var>, <var>P</var>).</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.9.2" id="legacy-platform-object-getownproperty" oldis="getownproperty"><span class="secno">3.9.2. </span><span class="content">Legacy platform object [[GetOwnProperty]] method</span><a class="self-link" href="#legacy-platform-object-getownproperty"></a></h4>
+   <h4 class="heading settled" data-level="3.9.2" id="legacy-platform-object-getownproperty"><span class="secno">3.9.2. </span><span class="content">Legacy platform object [[GetOwnProperty]] method</span><span id="getownproperty"></span><a class="self-link" href="#legacy-platform-object-getownproperty"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[GetOwnProperty]] method of platform objects">
     <p>The internal [[GetOwnProperty]] method of every <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-5">legacy platform object</a> <var>O</var> must behave as follows when called with property name <var>P</var>:</p>
     <ol>
@@ -11359,7 +11359,7 @@ and false otherwise.</p>
       <p>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of <var>operation</var> with <var>P</var> and <var>value</var> as the two argument values.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.9.5" id="legacy-platform-object-set" oldis="platformobjectset"><span class="secno">3.9.5. </span><span class="content">Legacy platform object [[Set]] method</span><a class="self-link" href="#legacy-platform-object-set"></a></h4>
+   <h4 class="heading settled" data-level="3.9.5" id="legacy-platform-object-set"><span class="secno">3.9.5. </span><span class="content">Legacy platform object [[Set]] method</span><span id="platformobjectset"></span><a class="self-link" href="#legacy-platform-object-set"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[Set]] method of legacy platform objects">
     <p>The internal [[Set]] method of every <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-6">legacy platform object</a> <var>O</var> must behave as follows when called with
     property name <var>P</var>, value <var>V</var>, and ECMAScript language value <var>Receiver</var>:</p>
@@ -11391,7 +11391,7 @@ and <var>O</var> implements an interface with a <a data-link-type="dfn" href="#d
       <p>Perform steps 3-11 of the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver">default [[Set]] internal method</a>.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.9.6" id="legacy-platform-object-setprototypeof" oldis="platformobjectsetprototypeof"><span class="secno">3.9.6. </span><span class="content">Legacy platform object [[SetPrototypeOf]] method</span><a class="self-link" href="#legacy-platform-object-setprototypeof"></a></h4>
+   <h4 class="heading settled" data-level="3.9.6" id="legacy-platform-object-setprototypeof"><span class="secno">3.9.6. </span><span class="content">Legacy platform object [[SetPrototypeOf]] method</span><span id="platformobjectsetprototypeof"></span><a class="self-link" href="#legacy-platform-object-setprototypeof"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[SetPrototypeOf]] method of legacy platform objects">
     <p>The internal [[SetPrototypeOf]] method of every <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-7">legacy platform object</a> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-132">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-95">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-96">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-89">extended attribute</a> must execute the same algorithm as is defined for the
     [[SetPrototypeOf]] internal method of an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">immutable prototype exotic object</a>.</p>
@@ -11399,7 +11399,7 @@ and <var>O</var> implements an interface with a <a data-link-type="dfn" href="#d
    <p class="note" role="note">Note: For <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> objects, it is unobservable whether this is implemented, since the presence of
 the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#windowproxy">WindowProxy</a></code> object ensures that [[SetPrototypeOf]] is never called on a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> object
 directly. For other global objects, however, this is necessary.</p>
-   <h4 class="heading settled" data-level="3.9.7" id="legacy-platform-object-defineownproperty" oldis="defineownproperty"><span class="secno">3.9.7. </span><span class="content">Legacy platform object [[DefineOwnProperty]] method</span><a class="self-link" href="#legacy-platform-object-defineownproperty"></a></h4>
+   <h4 class="heading settled" data-level="3.9.7" id="legacy-platform-object-defineownproperty"><span class="secno">3.9.7. </span><span class="content">Legacy platform object [[DefineOwnProperty]] method</span><span id="defineownproperty"></span><a class="self-link" href="#legacy-platform-object-defineownproperty"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[DefineOwnProperty]] method of legacy platform objects">
     <p>When the internal [[DefineOwnProperty]] method of a <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-8">legacy platform object</a> <var>O</var> is called with property key <var>P</var> and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">Property Descriptor</a> <var>Desc</var>,
     the following steps must be taken:</p>
@@ -11449,7 +11449,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinarydefineownproperty">OrdinaryDefineOwnProperty</a>(<var>O</var>, <var>P</var>, <var>Desc</var>).</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.9.8" id="legacy-platform-object-delete" oldis="delete"><span class="secno">3.9.8. </span><span class="content">Legacy platform object [[Delete]] method</span><a class="self-link" href="#legacy-platform-object-delete"></a></h4>
+   <h4 class="heading settled" data-level="3.9.8" id="legacy-platform-object-delete"><span class="secno">3.9.8. </span><span class="content">Legacy platform object [[Delete]] method</span><span id="delete"></span><a class="self-link" href="#legacy-platform-object-delete"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[Delete]] method of legacy platform objects">
     <p>The internal [[Delete]] method of every <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-9">legacy platform object</a> <var>O</var> must behave as follows when called with property name <var>P</var>.</p>
     <ol>
@@ -11502,7 +11502,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
       <p>Return <emu-val>true</emu-val>.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.9.9" id="legacy-platform-object-call" oldis="call"><span class="secno">3.9.9. </span><span class="content">Legacy platform object [[Call]] method</span><a class="self-link" href="#legacy-platform-object-call"></a></h4>
+   <h4 class="heading settled" data-level="3.9.9" id="legacy-platform-object-call"><span class="secno">3.9.9. </span><span class="content">Legacy platform object [[Call]] method</span><span id="call"></span><a class="self-link" href="#legacy-platform-object-call"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[Call]] method of legacy platform objects">
     <p>The internal [[Call]] method of <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-10">legacy platform object</a> that implements
     an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-136">interface</a> <var>I</var> must behave as follows,
@@ -11520,7 +11520,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
       <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-58">converting</a> the return value from those actions to an ECMAScript value of the type <var>operation</var> is declared to return (or <emu-val>undefined</emu-val> if <var>operation</var> is declared to return <code class="idl"><a data-link-type="idl" href="#idl-void" id="ref-for-idl-void-6">void</a></code>).</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.9.10" id="legacy-platform-object-preventextensions" oldis="preventextensions"><span class="secno">3.9.10. </span><span class="content">Legacy platform object [[PreventExtensions]] method</span><a class="self-link" href="#legacy-platform-object-preventextensions"></a></h4>
+   <h4 class="heading settled" data-level="3.9.10" id="legacy-platform-object-preventextensions"><span class="secno">3.9.10. </span><span class="content">Legacy platform object [[PreventExtensions]] method</span><span id="preventextensions"></span><a class="self-link" href="#legacy-platform-object-preventextensions"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[PreventExtensions]] method of legacy platform objects">
     <p>When the [[PreventExtensions]] internal method of a <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-11">legacy platform object</a> is called,
     the following steps are taken:</p>

--- a/index.html
+++ b/index.html
@@ -1833,19 +1833,22 @@ are interoperable.</p>
          </ol>
        </ol>
       <li><a href="#es-implements-statements"><span class="secno">3.7</span> <span class="content">Implements statements</span></a>
-      <li><a href="#es-platform-objects"><span class="secno">3.8</span> <span class="content">Platform objects implementing interfaces</span></a>
+      <li>
+       <a href="#es-platform-objects"><span class="secno">3.8</span> <span class="content">Platform objects implementing interfaces</span></a>
+       <ol class="toc">
+        <li><a href="#platform-object-setprototypeof"><span class="secno">3.8.1</span> <span class="content">[[SetPrototypeOf]]</span></a>
+       </ol>
       <li>
        <a href="#es-legacy-platform-objects"><span class="secno">3.9</span> <span class="content">Legacy platform objects</span></a>
        <ol class="toc">
         <li><a href="#legacy-platform-object-getownproperty"><span class="secno">3.9.1</span> <span class="content">[[GetOwnProperty]]</span></a>
         <li><a href="#legacy-platform-object-set"><span class="secno">3.9.2</span> <span class="content">[[Set]]</span></a>
-        <li><a href="#legacy-platform-object-setprototypeof"><span class="secno">3.9.3</span> <span class="content">[[SetPrototypeOf]]</span></a>
-        <li><a href="#legacy-platform-object-defineownproperty"><span class="secno">3.9.4</span> <span class="content">[[DefineOwnProperty]]</span></a>
-        <li><a href="#legacy-platform-object-delete"><span class="secno">3.9.5</span> <span class="content">[[Delete]]</span></a>
-        <li><a href="#legacy-platform-object-call"><span class="secno">3.9.6</span> <span class="content">[[Call]]</span></a>
-        <li><a href="#legacy-platform-object-preventextensions"><span class="secno">3.9.7</span> <span class="content">[[PreventExtensions]]</span></a>
-        <li><a href="#legacy-platform-object-property-enumeration"><span class="secno">3.9.8</span> <span class="content">Property enumeration</span></a>
-        <li><a href="#legacy-platform-object-abstract-ops"><span class="secno">3.9.9</span> <span class="content">Abstract operations</span></a>
+        <li><a href="#legacy-platform-object-defineownproperty"><span class="secno">3.9.3</span> <span class="content">[[DefineOwnProperty]]</span></a>
+        <li><a href="#legacy-platform-object-delete"><span class="secno">3.9.4</span> <span class="content">[[Delete]]</span></a>
+        <li><a href="#legacy-platform-object-call"><span class="secno">3.9.5</span> <span class="content">[[Call]]</span></a>
+        <li><a href="#legacy-platform-object-preventextensions"><span class="secno">3.9.6</span> <span class="content">[[PreventExtensions]]</span></a>
+        <li><a href="#legacy-platform-object-property-enumeration"><span class="secno">3.9.7</span> <span class="content">Property enumeration</span></a>
+        <li><a href="#legacy-platform-object-abstract-ops"><span class="secno">3.9.8</span> <span class="content">Abstract operations</span></a>
        </ol>
       <li><a href="#es-user-objects"><span class="secno">3.10</span> <span class="content">User objects implementing callback interfaces</span></a>
       <li><a href="#es-invoking-callback-functions"><span class="secno">3.11</span> <span class="content">Invoking callback functions</span></a>
@@ -8061,7 +8064,7 @@ interface.  The [<code class="idl"><a data-link-type="idl" href="#Global" id="re
 extended attribute must be declared on
 at most one interface.  The interface [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-26">PrimaryGlobal</a></code>]
 is declared on, if any, is known as the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-primary-global-interface">primary global interface</dfn>.</p>
-   <p>See <a href="#named-properties-object">§3.6.4 Named properties object</a>, <a href="#legacy-platform-object-getownproperty" id="ref-for-legacy-platform-object-getownproperty-1">§3.9.1 [[GetOwnProperty]]</a> and <a href="#legacy-platform-object-defineownproperty">§3.9.4 [[DefineOwnProperty]]</a> for the specific requirements that the use of
+   <p>See <a href="#named-properties-object">§3.6.4 Named properties object</a> for the specific requirements that the use of
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-27">Global</a></code>] and [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-28">PrimaryGlobal</a></code>]
 entails for named properties,
 and <a href="#es-constants">§3.6.5 Constants</a>, <a href="#es-attributes">§3.6.6 Attributes</a> and <a href="#es-operations">§3.6.7 Operations</a> for the requirements relating to the location of properties
@@ -8166,7 +8169,7 @@ that does not define a <a data-link-type="dfn" href="#dfn-named-property-getter"
    <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-3">LegacyUnenumerableNamedProperties</a></code>]
 extended attribute is specified on an interface, then it applies to all its derived interfaces and
 must not be specified on any of them.</p>
-   <p>See <a href="#legacy-platform-object-property-enumeration">§3.9.8 Property enumeration</a> for the specific requirements that the use of
+   <p>See <a href="#legacy-platform-object-property-enumeration">§3.9.7 Property enumeration</a> for the specific requirements that the use of
 [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-4">LegacyUnenumerableNamedProperties</a></code>]
 entails.</p>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.8" data-lt="LenientSetter" id="LenientSetter"><span class="secno">3.3.8. </span><span class="content">[LenientSetter]</span></h4>
@@ -8407,7 +8410,7 @@ extended attribute.  If the extended attribute is specified on
 a <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-10">partial interface</a> definition, then that partial interface definition must
 be the part of the interface definition that defines
 the <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-named-property-getter-8">named property getter</a>.</p>
-   <p>See <a href="#es-legacy-platform-objects">§3.9 Legacy platform objects</a> and <a href="#legacy-platform-object-defineownproperty">§3.9.4 [[DefineOwnProperty]]</a> for the specific requirements that the use of
+   <p>See <a href="#es-legacy-platform-objects">§3.9 Legacy platform objects</a> and <a href="#legacy-platform-object-defineownproperty">§3.9.3 [[DefineOwnProperty]]</a> for the specific requirements that the use of
 [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-7">OverrideBuiltins</a></code>] entails.</p>
    <div class="example" id="example-1f93745b">
     <a class="self-link" href="#example-1f93745b"></a> 
@@ -8815,7 +8818,7 @@ the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifi
 };
 </pre>
    </div>
-   <p>See <a href="#es-attributes">§3.6.6 Attributes</a>, <a href="#es-operations">§3.6.7 Operations</a>, <a href="#es-platform-objects">§3.8 Platform objects implementing interfaces</a>, <a href="#es-legacy-platform-objects">§3.9 Legacy platform objects</a> and <a href="#legacy-platform-object-defineownproperty">§3.9.4 [[DefineOwnProperty]]</a> for the specific requirements that the use of
+   <p>See <a href="#es-attributes">§3.6.6 Attributes</a>, <a href="#es-operations">§3.6.7 Operations</a>, <a href="#es-platform-objects">§3.8 Platform objects implementing interfaces</a>, <a href="#es-legacy-platform-objects">§3.9 Legacy platform objects</a> and <a href="#legacy-platform-object-defineownproperty">§3.9.3 [[DefineOwnProperty]]</a> for the specific requirements that the use of
 [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-7">Unforgeable</a></code>] entails.</p>
    <div class="example" id="example-8fe6c799">
     <a class="self-link" href="#example-8fe6c799"></a> 
@@ -11132,10 +11135,16 @@ updated to be the <a data-link-type="dfn" href="#dfn-interface-prototype-object"
 a platform object that implements one or more interfaces
 must be the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-81">identifier</a> of
 the <a data-link-type="dfn" href="#dfn-primary-interface" id="ref-for-dfn-primary-interface-3">primary interface</a> of the platform object.</p>
+   <h4 class="heading settled" data-level="3.8.1" id="platform-object-setprototypeof"><span class="secno">3.8.1. </span><span class="content">[[SetPrototypeOf]]</span><span id="platformobjectsetprototypeof"></span><a class="self-link" href="#platform-object-setprototypeof"></a></h4>
+   <p>The internal [[SetPrototypeOf]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-52">platform object</a> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-131">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-95">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-96">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-85">extended attribute</a> must execute the same algorithm as is defined for the
+[[SetPrototypeOf]] internal method of an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">immutable prototype exotic object</a>.</p>
+   <p class="note" role="note">Note: For <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> objects, it is unobservable whether this is implemented, since the presence of
+the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#windowproxy">WindowProxy</a></code> object ensures that [[SetPrototypeOf]] is never called on a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> object
+directly. For other global objects, however, this is necessary.</p>
    <h3 class="heading settled" data-level="3.9" id="es-legacy-platform-objects"><span class="secno">3.9. </span><span class="content">Legacy platform objects</span><span id="indexed-and-named-properties"></span><a class="self-link" href="#es-legacy-platform-objects"></a></h3>
    <p><a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-4">Legacy platform objects</a> will appear to have additional properties that correspond to their <a data-link-type="dfn" href="#idl-indexed-properties" id="ref-for-idl-indexed-properties-3">indexed</a> and <a data-link-type="dfn" href="#idl-named-properties" id="ref-for-idl-named-properties-3">named properties</a>.  These properties are not “real” own
 properties on the object, but are made to look like they are by being exposed
-by the <a href="#legacy-platform-object-getownproperty" id="ref-for-legacy-platform-object-getownproperty-2">[[GetOwnProperty]] internal method</a> .</p>
+by the <a href="#legacy-platform-object-getownproperty" id="ref-for-legacy-platform-object-getownproperty-1">[[GetOwnProperty]] internal method</a> .</p>
    <p>It is permissible for an object to implement multiple interfaces that support indexed properties.
 However, if so, and there are conflicting definitions as to the object’s <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-4">supported property indices</a>,
 or if one of the interfaces is a <a data-link-type="dfn" href="#dfn-supplemental-interface" id="ref-for-dfn-supplemental-interface-8">supplemental interface</a> for the
@@ -11148,12 +11157,12 @@ when indexing the object with an array index.  Similarly for <a data-link-type="
 This way, the definitions of these special operations from
 ancestor interfaces can be overridden.</p>
    <p>A property name is an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-unforgeable-property-name">unforgeable property name</dfn> on a
-given platform object if the object implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-131">interface</a> that
+given platform object if the object implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-132">interface</a> that
 has an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-26">interface member</a> with that identifier
 and that interface member is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-7">unforgeable</a> on any of
 the interfaces that <var>O</var> implements.</p>
-   <p>Support for <a data-link-type="dfn" href="#dfn-getter" id="ref-for-dfn-getter-1">getters</a> is handled by the <a href="#legacy-platform-object-getownproperty" id="ref-for-legacy-platform-object-getownproperty-3">legacy platform object [[GetOwnProperty]] method</a>,
-and for <a data-link-type="dfn" href="#dfn-setter" id="ref-for-dfn-setter-1">setters</a> by the <a href="#legacy-platform-object-defineownproperty">legacy platform object [[DefineOwnProperty]] method</a> and the <a href="#legacy-platform-object-set">legacy platform object [[Set]] method</a>.</p>
+   <p>Support for <a data-link-type="dfn" href="#dfn-getter" id="ref-for-dfn-getter-1">getters</a> is handled in <a href="#legacy-platform-object-getownproperty" id="ref-for-legacy-platform-object-getownproperty-2">§3.9.1 [[GetOwnProperty]]</a>,
+and for <a data-link-type="dfn" href="#dfn-setter" id="ref-for-dfn-setter-1">setters</a> in <a href="#legacy-platform-object-defineownproperty">§3.9.3 [[DefineOwnProperty]]</a> and <a href="#legacy-platform-object-set">§3.9.2 [[Set]]</a>.</p>
    <h4 class="heading settled dfn-paneled" data-dfn-for="legacy platform object" data-dfn-type="dfn" data-level="3.9.1" data-lt="GetOwnProperty" data-noexport="" id="legacy-platform-object-getownproperty"><span class="secno">3.9.1. </span><span class="content">[[GetOwnProperty]]</span><span id="getownproperty"></span></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[GetOwnProperty]] method of platform objects">
     <p>The internal [[GetOwnProperty]] method of every <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-5">legacy platform object</a> <var>O</var> must behave as follows when called with property name <var>P</var>:</p>
@@ -11194,15 +11203,9 @@ and <var>O</var> implements an interface with a <a data-link-type="dfn" href="#d
       <p>Perform steps 3-11 of the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver">default [[Set]] internal method</a>.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.9.3" id="legacy-platform-object-setprototypeof"><span class="secno">3.9.3. </span><span class="content">[[SetPrototypeOf]]</span><span id="platformobjectsetprototypeof"></span><a class="self-link" href="#legacy-platform-object-setprototypeof"></a></h4>
-   <p>The internal [[SetPrototypeOf]] method of every <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-7">legacy platform object</a> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-132">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-95">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-96">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-85">extended attribute</a> must execute the same algorithm as is defined for the
-[[SetPrototypeOf]] internal method of an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">immutable prototype exotic object</a>.</p>
-   <p class="note" role="note">Note: For <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> objects, it is unobservable whether this is implemented, since the presence of
-the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#windowproxy">WindowProxy</a></code> object ensures that [[SetPrototypeOf]] is never called on a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> object
-directly. For other global objects, however, this is necessary.</p>
-   <h4 class="heading settled algorithm" data-algorithm="[[DefineOwnProperty]]" data-level="3.9.4" id="legacy-platform-object-defineownproperty"><span class="secno">3.9.4. </span><span class="content">[[DefineOwnProperty]]</span><span id="defineownproperty"></span><a class="self-link" href="#legacy-platform-object-defineownproperty"></a></h4>
+   <h4 class="heading settled" data-level="3.9.3" id="legacy-platform-object-defineownproperty"><span class="secno">3.9.3. </span><span class="content">[[DefineOwnProperty]]</span><span id="defineownproperty"></span><a class="self-link" href="#legacy-platform-object-defineownproperty"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[DefineOwnProperty]] method of legacy platform objects">
-    <p>When the internal [[DefineOwnProperty]] method of a <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-8">legacy platform object</a> <var>O</var> is called with property key <var>P</var> and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">Property Descriptor</a> <var>Desc</var>,
+    <p>When the internal [[DefineOwnProperty]] method of a <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-7">legacy platform object</a> <var>O</var> is called with property key <var>P</var> and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">Property Descriptor</a> <var>Desc</var>,
     the following steps must be taken:</p>
     <ol>
      <li data-md="">
@@ -11250,9 +11253,9 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinarydefineownproperty">OrdinaryDefineOwnProperty</a>(<var>O</var>, <var>P</var>, <var>Desc</var>).</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.9.5" id="legacy-platform-object-delete"><span class="secno">3.9.5. </span><span class="content">[[Delete]]</span><span id="delete"></span><a class="self-link" href="#legacy-platform-object-delete"></a></h4>
+   <h4 class="heading settled" data-level="3.9.4" id="legacy-platform-object-delete"><span class="secno">3.9.4. </span><span class="content">[[Delete]]</span><span id="delete"></span><a class="self-link" href="#legacy-platform-object-delete"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[Delete]] method of legacy platform objects">
-    <p>The internal [[Delete]] method of every <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-9">legacy platform object</a> <var>O</var> must behave as follows when called with property name <var>P</var>.</p>
+    <p>The internal [[Delete]] method of every <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-8">legacy platform object</a> <var>O</var> must behave as follows when called with property name <var>P</var>.</p>
     <ol>
      <li data-md="">
       <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-14">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-4">array index property name</a>, then:</p>
@@ -11303,9 +11306,9 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
       <p>Return <emu-val>true</emu-val>.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.9.6" id="legacy-platform-object-call"><span class="secno">3.9.6. </span><span class="content">[[Call]]</span><span id="call"></span><a class="self-link" href="#legacy-platform-object-call"></a></h4>
+   <h4 class="heading settled" data-level="3.9.5" id="legacy-platform-object-call"><span class="secno">3.9.5. </span><span class="content">[[Call]]</span><span id="call"></span><a class="self-link" href="#legacy-platform-object-call"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[Call]] method of legacy platform objects">
-    <p>The internal [[Call]] method of <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-10">legacy platform object</a> that implements
+    <p>The internal [[Call]] method of <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-9">legacy platform object</a> that implements
     an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-136">interface</a> <var>I</var> must behave as follows,
     assuming <var>arg</var><sub>0..<var>n</var>−1</sub> is the list of argument values passed to [[Call]]:</p>
     <ol>
@@ -11321,21 +11324,21 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
       <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-56">converting</a> the return value from those actions to an ECMAScript value of the type <var>operation</var> is declared to return (or <emu-val>undefined</emu-val> if <var>operation</var> is declared to return <code class="idl"><a data-link-type="idl" href="#idl-void" id="ref-for-idl-void-6">void</a></code>).</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.9.7" id="legacy-platform-object-preventextensions"><span class="secno">3.9.7. </span><span class="content">[[PreventExtensions]]</span><span id="preventextensions"></span><a class="self-link" href="#legacy-platform-object-preventextensions"></a></h4>
+   <h4 class="heading settled" data-level="3.9.6" id="legacy-platform-object-preventextensions"><span class="secno">3.9.6. </span><span class="content">[[PreventExtensions]]</span><span id="preventextensions"></span><a class="self-link" href="#legacy-platform-object-preventextensions"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[PreventExtensions]] method of legacy platform objects">
-    <p>When the [[PreventExtensions]] internal method of a <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-11">legacy platform object</a> is called,
+    <p>When the [[PreventExtensions]] internal method of a <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-10">legacy platform object</a> is called,
     the following steps are taken:</p>
     <ol>
      <li data-md="">
       <p>Return <emu-val>false</emu-val>.</p>
     </ol>
-    <p class="note" role="note">Note: this keeps <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-12">legacy platform objects</a> extensible by
+    <p class="note" role="note">Note: this keeps <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-11">legacy platform objects</a> extensible by
     making [[PreventExtensions]] fail for them.</p>
    </div>
-   <h4 class="heading settled" data-level="3.9.8" id="legacy-platform-object-property-enumeration"><span class="secno">3.9.8. </span><span class="content">Property enumeration</span><span id="property-enumeration"></span><a class="self-link" href="#legacy-platform-object-property-enumeration"></a></h4>
+   <h4 class="heading settled" data-level="3.9.7" id="legacy-platform-object-property-enumeration"><span class="secno">3.9.7. </span><span class="content">Property enumeration</span><span id="property-enumeration"></span><a class="self-link" href="#legacy-platform-object-property-enumeration"></a></h4>
    <p>This document does not define a complete property enumeration order
-for <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-52">platform objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-137">interfaces</a> (or for <a href="#es-exception-objects" id="ref-for-es-exception-objects-1">platform objects representing exceptions</a>).
-However, for <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-13">legacy platform objects</a>,
+for <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-53">platform objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-137">interfaces</a> (or for <a href="#es-exception-objects" id="ref-for-es-exception-objects-1">platform objects representing exceptions</a>).
+However, for <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-12">legacy platform objects</a>,
 properties on the object must be
 enumerated in the following order:</p>
    <ol>
@@ -11353,7 +11356,7 @@ are visible according to the <a data-link-type="dfn" href="#dfn-named-property-v
 in no defined order.</p>
    </ol>
    <p class="note" role="note">Note: Future versions of the ECMAScript specification may define a total order for property enumeration.</p>
-   <h4 class="heading settled" data-level="3.9.9" id="legacy-platform-object-abstract-ops"><span class="secno">3.9.9. </span><span class="content">Abstract operations</span><a class="self-link" href="#legacy-platform-object-abstract-ops"></a></h4>
+   <h4 class="heading settled" data-level="3.9.8" id="legacy-platform-object-abstract-ops"><span class="secno">3.9.8. </span><span class="content">Abstract operations</span><a class="self-link" href="#legacy-platform-object-abstract-ops"></a></h4>
    <div class="algorithm" data-algorithm="array index property name">
     <p>The name of each property that appears to exist due to an object supporting indexed properties
     is an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-array-index-property-name">array index property name</dfn>,
@@ -11972,7 +11975,7 @@ attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[E
    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="3.14" data-lt="Exception objects" data-noexport="" id="es-exception-objects"><span class="secno">3.14. </span><span class="content">Exception objects</span></h3>
    <p><a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-5">Simple exceptions</a> are represented
 by native ECMAScript objects of the corresponding type.</p>
-   <p><code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-28">DOMExceptions</a></code> are represented by <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-53">platform objects</a> that inherit from
+   <p><code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-28">DOMExceptions</a></code> are represented by <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-54">platform objects</a> that inherit from
 the <a data-link-type="dfn" href="#dfn-DOMException-prototype-object" id="ref-for-dfn-DOMException-prototype-object-3">DOMException prototype object</a>.</p>
    <p>Every platform object representing a DOMException in ECMAScript is associated with a global environment, just
 as the <a data-link-type="dfn" href="#dfn-initial-object" id="ref-for-dfn-initial-object-5">initial objects</a> are.
@@ -12640,7 +12643,7 @@ language binding.</p>
    <li><a href="#idl-any">any</a><span>, in §2.11</span>
    <li><a href="#idl-ArrayBuffer">ArrayBuffer</a><span>, in §2.11.30</span>
    <li><a href="#ArrayBufferView">ArrayBufferView</a><span>, in §4</span>
-   <li><a href="#dfn-array-index-property-name">array index property name</a><span>, in §3.9.9</span>
+   <li><a href="#dfn-array-index-property-name">array index property name</a><span>, in §3.9.8</span>
    <li><a href="#dfn-associated-realm">associated Realm</a><span>, in §3.1</span>
    <li><a href="#dfn-attribute">attribute</a><span>, in §2.2.2</span>
    <li><a href="#dfn-attribute-getter">attribute getter</a><span>, in §3.6.6</span>
@@ -12799,15 +12802,15 @@ language binding.</p>
    <li><a href="#dom-domexception-invalid_state_err">INVALID_STATE_ERR</a><span>, in §2.5.1</span>
    <li><a href="#invalidstateerror">InvalidStateError</a><span>, in §2.5.1</span>
    <li><a href="#invoke-a-callback-function">invoke</a><span>, in §3.11</span>
-   <li><a href="#invoke-indexed-setter">invoke the indexed property setter</a><span>, in §3.9.9</span>
-   <li><a href="#invoke-named-setter">invoke the named property setter</a><span>, in §3.9.9</span>
+   <li><a href="#invoke-indexed-setter">invoke the indexed property setter</a><span>, in §3.9.8</span>
+   <li><a href="#invoke-named-setter">invoke the named property setter</a><span>, in §3.9.8</span>
    <li><a href="#dfn-iterable">iterable</a><span>, in §2.2.7</span>
    <li><a href="#dfn-iterable-declaration">iterable declaration</a><span>, in §2.2.7</span>
    <li><a href="#dfn-iterator-prototype-object">iterator prototype object</a><span>, in §3.6.9.5</span>
    <li><a href="#dfn-legacy-caller">legacy</a><span>, in §2.2.4</span>
    <li><a href="#LegacyArrayClass">LegacyArrayClass</a><span>, in §3.3.5</span>
    <li><a href="#idl-legacy-callers">Legacy callers</a><span>, in §2.2.4</span>
-   <li><a href="#LegacyPlatformObjectGetOwnProperty">LegacyPlatformObjectGetOwnProperty</a><span>, in §3.9.9</span>
+   <li><a href="#LegacyPlatformObjectGetOwnProperty">LegacyPlatformObjectGetOwnProperty</a><span>, in §3.9.8</span>
    <li><a href="#dfn-legacy-platform-object">Legacy platform objects</a><span>, in §2.10</span>
    <li><a href="#LegacyUnenumerableNamedProperties">LegacyUnenumerableNamedProperties</a><span>, in §3.3.6</span>
    <li><a href="#LenientSetter">LenientSetter</a><span>, in §3.3.7</span>
@@ -12829,7 +12832,7 @@ language binding.</p>
    <li><a href="#dfn-named-property-deleter">named property deleter</a><span>, in §2.2.4</span>
    <li><a href="#dfn-named-property-getter">named property getter</a><span>, in §2.2.4</span>
    <li><a href="#dfn-named-property-setter">named property setter</a><span>, in §2.2.4</span>
-   <li><a href="#dfn-named-property-visibility">named property visibility algorithm</a><span>, in §3.9.9</span>
+   <li><a href="#dfn-named-property-visibility">named property visibility algorithm</a><span>, in §3.9.8</span>
    <li><a href="#dfn-namespace">namespace</a><span>, in §2.3</span>
    <li><a href="#dom-domexception-namespace_err">NAMESPACE_ERR</a><span>, in §2.5.1</span>
    <li><a href="#namespaceerror">NamespaceError</a><span>, in §2.5.1</span>
@@ -13227,8 +13230,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-identifier-79">3.6.9.4. Default iterator objects</a>
     <li><a href="#ref-for-dfn-identifier-80">3.6.9.5. Iterator prototype object</a>
     <li><a href="#ref-for-dfn-identifier-81">3.8. Platform objects implementing interfaces</a>
-    <li><a href="#ref-for-dfn-identifier-82">3.9.5. [[Delete]]</a>
-    <li><a href="#ref-for-dfn-identifier-83">3.9.9. Abstract operations</a> <a href="#ref-for-dfn-identifier-84">(2)</a> <a href="#ref-for-dfn-identifier-85">(3)</a> <a href="#ref-for-dfn-identifier-86">(4)</a>
+    <li><a href="#ref-for-dfn-identifier-82">3.9.4. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-identifier-83">3.9.8. Abstract operations</a> <a href="#ref-for-dfn-identifier-84">(2)</a> <a href="#ref-for-dfn-identifier-85">(3)</a> <a href="#ref-for-dfn-identifier-86">(4)</a>
     <li><a href="#ref-for-dfn-identifier-87">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-identifier-88">(2)</a> <a href="#ref-for-dfn-identifier-89">(3)</a>
     <li><a href="#ref-for-dfn-identifier-90">3.12. Namespaces</a>
     <li><a href="#ref-for-dfn-identifier-91">3.12.1. Namespace object</a>
@@ -13303,12 +13306,12 @@ language binding.</p>
     <li><a href="#ref-for-dfn-interface-126">3.6.10. Maplike declarations</a> <a href="#ref-for-dfn-interface-127">(2)</a>
     <li><a href="#ref-for-dfn-interface-128">3.6.11. Setlike declarations</a> <a href="#ref-for-dfn-interface-129">(2)</a>
     <li><a href="#ref-for-dfn-interface-130">3.7. Implements statements</a>
-    <li><a href="#ref-for-dfn-interface-131">3.9. Legacy platform objects</a>
-    <li><a href="#ref-for-dfn-interface-132">3.9.3. [[SetPrototypeOf]]</a>
-    <li><a href="#ref-for-dfn-interface-133">3.9.4. [[DefineOwnProperty]]</a> <a href="#ref-for-dfn-interface-134">(2)</a>
-    <li><a href="#ref-for-dfn-interface-135">3.9.5. [[Delete]]</a>
-    <li><a href="#ref-for-dfn-interface-136">3.9.6. [[Call]]</a>
-    <li><a href="#ref-for-dfn-interface-137">3.9.8. Property enumeration</a> <a href="#ref-for-dfn-interface-138">(2)</a>
+    <li><a href="#ref-for-dfn-interface-131">3.8.1. [[SetPrototypeOf]]</a>
+    <li><a href="#ref-for-dfn-interface-132">3.9. Legacy platform objects</a>
+    <li><a href="#ref-for-dfn-interface-133">3.9.3. [[DefineOwnProperty]]</a> <a href="#ref-for-dfn-interface-134">(2)</a>
+    <li><a href="#ref-for-dfn-interface-135">3.9.4. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-interface-136">3.9.5. [[Call]]</a>
+    <li><a href="#ref-for-dfn-interface-137">3.9.7. Property enumeration</a> <a href="#ref-for-dfn-interface-138">(2)</a>
     <li><a href="#ref-for-dfn-interface-139">3.10. User objects implementing callback interfaces</a>
     <li><a href="#ref-for-dfn-interface-140">3.15. Creating and throwing exceptions</a>
     <li><a href="#ref-for-dfn-interface-141">3.16. Handling exceptions</a>
@@ -13566,7 +13569,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-return-type-3">3.2.2. void</a>
     <li><a href="#ref-for-dfn-return-type-4">3.3.11. [NewObject]</a>
     <li><a href="#ref-for-dfn-return-type-5">3.6.7. Operations</a>
-    <li><a href="#ref-for-dfn-return-type-6">3.9.5. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-return-type-6">3.9.4. [[Delete]]</a>
     <li><a href="#ref-for-dfn-return-type-7">3.10. User objects implementing callback interfaces</a>
     <li><a href="#ref-for-dfn-return-type-8">3.11. Invoking callback functions</a>
    </ul>
@@ -13576,7 +13579,7 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-idl-void-1">3.2.2. void</a> <a href="#ref-for-idl-void-2">(2)</a> <a href="#ref-for-idl-void-3">(3)</a>
     <li><a href="#ref-for-idl-void-4">3.2.20. Promise types — Promise&lt;T></a> <a href="#ref-for-idl-void-5">(2)</a>
-    <li><a href="#ref-for-idl-void-6">3.9.6. [[Call]]</a>
+    <li><a href="#ref-for-idl-void-6">3.9.5. [[Call]]</a>
     <li><a href="#ref-for-idl-void-7">3.10. User objects implementing callback interfaces</a>
     <li><a href="#ref-for-idl-void-8">3.11. Invoking callback functions</a>
    </ul>
@@ -13679,8 +13682,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-named-property-setter-1">2.2.4.5. Named properties</a> <a href="#ref-for-dfn-named-property-setter-2">(2)</a>
     <li><a href="#ref-for-dfn-named-property-setter-3">3.3.5. [Global] and [PrimaryGlobal]</a>
     <li><a href="#ref-for-dfn-named-property-setter-4">3.9.2. [[Set]]</a>
-    <li><a href="#ref-for-dfn-named-property-setter-5">3.9.4. [[DefineOwnProperty]]</a> <a href="#ref-for-dfn-named-property-setter-6">(2)</a>
-    <li><a href="#ref-for-dfn-named-property-setter-7">3.9.9. Abstract operations</a>
+    <li><a href="#ref-for-dfn-named-property-setter-5">3.9.3. [[DefineOwnProperty]]</a> <a href="#ref-for-dfn-named-property-setter-6">(2)</a>
+    <li><a href="#ref-for-dfn-named-property-setter-7">3.9.8. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-indexed-property-getter">
@@ -13702,8 +13705,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-indexed-property-setter-4">3.3.6. [LegacyArrayClass]</a>
     <li><a href="#ref-for-dfn-indexed-property-setter-5">3.9. Legacy platform objects</a>
     <li><a href="#ref-for-dfn-indexed-property-setter-6">3.9.2. [[Set]]</a>
-    <li><a href="#ref-for-dfn-indexed-property-setter-7">3.9.4. [[DefineOwnProperty]]</a>
-    <li><a href="#ref-for-dfn-indexed-property-setter-8">3.9.9. Abstract operations</a>
+    <li><a href="#ref-for-dfn-indexed-property-setter-7">3.9.3. [[DefineOwnProperty]]</a>
+    <li><a href="#ref-for-dfn-indexed-property-setter-8">3.9.8. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-named-property-deleter">
@@ -13711,7 +13714,7 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-dfn-named-property-deleter-1">2.2.4. Special operations</a> <a href="#ref-for-dfn-named-property-deleter-2">(2)</a>
     <li><a href="#ref-for-dfn-named-property-deleter-3">2.2.4.5. Named properties</a> <a href="#ref-for-dfn-named-property-deleter-4">(2)</a>
-    <li><a href="#ref-for-dfn-named-property-deleter-5">3.9.5. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-named-property-deleter-5">3.9.4. [[Delete]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="idl-legacy-callers">
@@ -13720,7 +13723,7 @@ language binding.</p>
     <li><a href="#ref-for-idl-legacy-callers-1">2.2.4.1. Legacy callers</a> <a href="#ref-for-idl-legacy-callers-2">(2)</a> <a href="#ref-for-idl-legacy-callers-3">(3)</a> <a href="#ref-for-idl-legacy-callers-4">(4)</a>
     <li><a href="#ref-for-idl-legacy-callers-5">2.2.6. Overloading</a> <a href="#ref-for-idl-legacy-callers-6">(2)</a> <a href="#ref-for-idl-legacy-callers-7">(3)</a> <a href="#ref-for-idl-legacy-callers-8">(4)</a> <a href="#ref-for-idl-legacy-callers-9">(5)</a>
     <li><a href="#ref-for-idl-legacy-callers-10">2.10. Objects implementing interfaces</a>
-    <li><a href="#ref-for-idl-legacy-callers-11">3.9.6. [[Call]]</a>
+    <li><a href="#ref-for-idl-legacy-callers-11">3.9.5. [[Call]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-stringification-behavior">
@@ -13781,10 +13784,10 @@ language binding.</p>
     <li><a href="#ref-for-dfn-support-indexed-properties-10">3.3.6. [LegacyArrayClass]</a>
     <li><a href="#ref-for-dfn-support-indexed-properties-11">3.6.9.4. Default iterator objects</a>
     <li><a href="#ref-for-dfn-support-indexed-properties-12">3.9.2. [[Set]]</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-13">3.9.4. [[DefineOwnProperty]]</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-14">3.9.5. [[Delete]]</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-15">3.9.8. Property enumeration</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-16">3.9.9. Abstract operations</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-13">3.9.3. [[DefineOwnProperty]]</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-14">3.9.4. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-15">3.9.7. Property enumeration</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-16">3.9.8. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-supported-property-indices">
@@ -13792,27 +13795,27 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-dfn-supported-property-indices-1">2.2.4.4. Indexed properties</a> <a href="#ref-for-dfn-supported-property-indices-2">(2)</a> <a href="#ref-for-dfn-supported-property-indices-3">(3)</a>
     <li><a href="#ref-for-dfn-supported-property-indices-4">3.9. Legacy platform objects</a>
-    <li><a href="#ref-for-dfn-supported-property-indices-5">3.9.5. [[Delete]]</a>
-    <li><a href="#ref-for-dfn-supported-property-indices-6">3.9.8. Property enumeration</a>
-    <li><a href="#ref-for-dfn-supported-property-indices-7">3.9.9. Abstract operations</a> <a href="#ref-for-dfn-supported-property-indices-8">(2)</a>
+    <li><a href="#ref-for-dfn-supported-property-indices-5">3.9.4. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-supported-property-indices-6">3.9.7. Property enumeration</a>
+    <li><a href="#ref-for-dfn-supported-property-indices-7">3.9.8. Abstract operations</a> <a href="#ref-for-dfn-supported-property-indices-8">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-determine-the-value-of-an-indexed-property">
    <b><a href="#dfn-determine-the-value-of-an-indexed-property">#dfn-determine-the-value-of-an-indexed-property</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-determine-the-value-of-an-indexed-property-1">3.9.9. Abstract operations</a>
+    <li><a href="#ref-for-dfn-determine-the-value-of-an-indexed-property-1">3.9.8. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-set-the-value-of-an-existing-indexed-property">
    <b><a href="#dfn-set-the-value-of-an-existing-indexed-property">#dfn-set-the-value-of-an-existing-indexed-property</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-set-the-value-of-an-existing-indexed-property-1">3.9.9. Abstract operations</a>
+    <li><a href="#ref-for-dfn-set-the-value-of-an-existing-indexed-property-1">3.9.8. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-set-the-value-of-a-new-indexed-property">
    <b><a href="#dfn-set-the-value-of-a-new-indexed-property">#dfn-set-the-value-of-a-new-indexed-property</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-set-the-value-of-a-new-indexed-property-1">3.9.9. Abstract operations</a>
+    <li><a href="#ref-for-dfn-set-the-value-of-a-new-indexed-property-1">3.9.8. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="idl-named-properties">
@@ -13834,10 +13837,10 @@ language binding.</p>
     <li><a href="#ref-for-dfn-support-named-properties-6">3.6.3. Interface prototype object</a>
     <li><a href="#ref-for-dfn-support-named-properties-7">3.6.4. Named properties object</a>
     <li><a href="#ref-for-dfn-support-named-properties-8">3.9.2. [[Set]]</a>
-    <li><a href="#ref-for-dfn-support-named-properties-9">3.9.4. [[DefineOwnProperty]]</a>
-    <li><a href="#ref-for-dfn-support-named-properties-10">3.9.5. [[Delete]]</a>
-    <li><a href="#ref-for-dfn-support-named-properties-11">3.9.8. Property enumeration</a>
-    <li><a href="#ref-for-dfn-support-named-properties-12">3.9.9. Abstract operations</a>
+    <li><a href="#ref-for-dfn-support-named-properties-9">3.9.3. [[DefineOwnProperty]]</a>
+    <li><a href="#ref-for-dfn-support-named-properties-10">3.9.4. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-support-named-properties-11">3.9.7. Property enumeration</a>
+    <li><a href="#ref-for-dfn-support-named-properties-12">3.9.8. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-supported-property-names">
@@ -13845,34 +13848,34 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-dfn-supported-property-names-1">2.2.4.5. Named properties</a> <a href="#ref-for-dfn-supported-property-names-2">(2)</a>
     <li><a href="#ref-for-dfn-supported-property-names-3">3.3.13. [OverrideBuiltins]</a>
-    <li><a href="#ref-for-dfn-supported-property-names-4">3.9.4. [[DefineOwnProperty]]</a>
-    <li><a href="#ref-for-dfn-supported-property-names-5">3.9.8. Property enumeration</a>
-    <li><a href="#ref-for-dfn-supported-property-names-6">3.9.9. Abstract operations</a> <a href="#ref-for-dfn-supported-property-names-7">(2)</a>
+    <li><a href="#ref-for-dfn-supported-property-names-4">3.9.3. [[DefineOwnProperty]]</a>
+    <li><a href="#ref-for-dfn-supported-property-names-5">3.9.7. Property enumeration</a>
+    <li><a href="#ref-for-dfn-supported-property-names-6">3.9.8. Abstract operations</a> <a href="#ref-for-dfn-supported-property-names-7">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-determine-the-value-of-a-named-property">
    <b><a href="#dfn-determine-the-value-of-a-named-property">#dfn-determine-the-value-of-a-named-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-determine-the-value-of-a-named-property-1">3.6.4.1. [[GetOwnProperty]]</a>
-    <li><a href="#ref-for-dfn-determine-the-value-of-a-named-property-2">3.9.9. Abstract operations</a>
+    <li><a href="#ref-for-dfn-determine-the-value-of-a-named-property-2">3.9.8. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-set-the-value-of-an-existing-named-property">
    <b><a href="#dfn-set-the-value-of-an-existing-named-property">#dfn-set-the-value-of-an-existing-named-property</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-set-the-value-of-an-existing-named-property-1">3.9.9. Abstract operations</a>
+    <li><a href="#ref-for-dfn-set-the-value-of-an-existing-named-property-1">3.9.8. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-set-the-value-of-a-new-named-property">
    <b><a href="#dfn-set-the-value-of-a-new-named-property">#dfn-set-the-value-of-a-new-named-property</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-set-the-value-of-a-new-named-property-1">3.9.9. Abstract operations</a>
+    <li><a href="#ref-for-dfn-set-the-value-of-a-new-named-property-1">3.9.8. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-delete-an-existing-named-property">
    <b><a href="#dfn-delete-an-existing-named-property">#dfn-delete-an-existing-named-property</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-delete-an-existing-named-property-1">3.9.5. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-delete-an-existing-named-property-1">3.9.4. [[Delete]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-static-attribute">
@@ -13918,7 +13921,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-effective-overload-set-5">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-dfn-effective-overload-set-6">(2)</a>
     <li><a href="#ref-for-dfn-effective-overload-set-7">3.6.2. Named constructors</a> <a href="#ref-for-dfn-effective-overload-set-8">(2)</a>
     <li><a href="#ref-for-dfn-effective-overload-set-9">3.6.7. Operations</a> <a href="#ref-for-dfn-effective-overload-set-10">(2)</a> <a href="#ref-for-dfn-effective-overload-set-11">(3)</a>
-    <li><a href="#ref-for-dfn-effective-overload-set-12">3.9.6. [[Call]]</a>
+    <li><a href="#ref-for-dfn-effective-overload-set-12">3.9.5. [[Call]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-optionality-value">
@@ -14381,8 +14384,9 @@ language binding.</p>
     <li><a href="#ref-for-dfn-platform-object-46">3.6.11.4. has</a>
     <li><a href="#ref-for-dfn-platform-object-47">3.6.11.5. add and delete</a>
     <li><a href="#ref-for-dfn-platform-object-48">3.8. Platform objects implementing interfaces</a> <a href="#ref-for-dfn-platform-object-49">(2)</a> <a href="#ref-for-dfn-platform-object-50">(3)</a> <a href="#ref-for-dfn-platform-object-51">(4)</a>
-    <li><a href="#ref-for-dfn-platform-object-52">3.9.8. Property enumeration</a>
-    <li><a href="#ref-for-dfn-platform-object-53">3.14. Exception objects</a>
+    <li><a href="#ref-for-dfn-platform-object-52">3.8.1. [[SetPrototypeOf]]</a>
+    <li><a href="#ref-for-dfn-platform-object-53">3.9.7. Property enumeration</a>
+    <li><a href="#ref-for-dfn-platform-object-54">3.14. Exception objects</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-user-object">
@@ -14406,12 +14410,11 @@ language binding.</p>
     <li><a href="#ref-for-dfn-legacy-platform-object-4">3.9. Legacy platform objects</a>
     <li><a href="#ref-for-dfn-legacy-platform-object-5">3.9.1. [[GetOwnProperty]]</a>
     <li><a href="#ref-for-dfn-legacy-platform-object-6">3.9.2. [[Set]]</a>
-    <li><a href="#ref-for-dfn-legacy-platform-object-7">3.9.3. [[SetPrototypeOf]]</a>
-    <li><a href="#ref-for-dfn-legacy-platform-object-8">3.9.4. [[DefineOwnProperty]]</a>
-    <li><a href="#ref-for-dfn-legacy-platform-object-9">3.9.5. [[Delete]]</a>
-    <li><a href="#ref-for-dfn-legacy-platform-object-10">3.9.6. [[Call]]</a>
-    <li><a href="#ref-for-dfn-legacy-platform-object-11">3.9.7. [[PreventExtensions]]</a> <a href="#ref-for-dfn-legacy-platform-object-12">(2)</a>
-    <li><a href="#ref-for-dfn-legacy-platform-object-13">3.9.8. Property enumeration</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-7">3.9.3. [[DefineOwnProperty]]</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-8">3.9.4. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-9">3.9.5. [[Call]]</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-10">3.9.6. [[PreventExtensions]]</a> <a href="#ref-for-dfn-legacy-platform-object-11">(2)</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-12">3.9.7. Property enumeration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-integer-type">
@@ -14540,7 +14543,7 @@ language binding.</p>
     <li><a href="#ref-for-idl-boolean-11">3.2.3. boolean</a> <a href="#ref-for-idl-boolean-12">(2)</a> <a href="#ref-for-idl-boolean-13">(3)</a> <a href="#ref-for-idl-boolean-14">(4)</a>
     <li><a href="#ref-for-idl-boolean-15">3.2.21. Union types</a> <a href="#ref-for-idl-boolean-16">(2)</a> <a href="#ref-for-idl-boolean-17">(3)</a> <a href="#ref-for-idl-boolean-18">(4)</a>
     <li><a href="#ref-for-idl-boolean-19">3.5. Overload resolution algorithm</a> <a href="#ref-for-idl-boolean-20">(2)</a> <a href="#ref-for-idl-boolean-21">(3)</a> <a href="#ref-for-idl-boolean-22">(4)</a>
-    <li><a href="#ref-for-idl-boolean-23">3.9.5. [[Delete]]</a>
+    <li><a href="#ref-for-idl-boolean-23">3.9.4. [[Delete]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="idl-byte">
@@ -15106,11 +15109,11 @@ language binding.</p>
     <li><a href="#ref-for-dfn-extended-attribute-80">3.6.4. Named properties object</a>
     <li><a href="#ref-for-dfn-extended-attribute-81">3.6.4.1. [[GetOwnProperty]]</a>
     <li><a href="#ref-for-dfn-extended-attribute-82">3.6.6. Attributes</a> <a href="#ref-for-dfn-extended-attribute-83">(2)</a> <a href="#ref-for-dfn-extended-attribute-84">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-85">3.9.3. [[SetPrototypeOf]]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-86">3.9.4. [[DefineOwnProperty]]</a> <a href="#ref-for-dfn-extended-attribute-87">(2)</a> <a href="#ref-for-dfn-extended-attribute-88">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-89">3.9.5. [[Delete]]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-90">3.9.8. Property enumeration</a>
-    <li><a href="#ref-for-dfn-extended-attribute-91">3.9.9. Abstract operations</a> <a href="#ref-for-dfn-extended-attribute-92">(2)</a> <a href="#ref-for-dfn-extended-attribute-93">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-85">3.8.1. [[SetPrototypeOf]]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-86">3.9.3. [[DefineOwnProperty]]</a> <a href="#ref-for-dfn-extended-attribute-87">(2)</a> <a href="#ref-for-dfn-extended-attribute-88">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-89">3.9.4. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-90">3.9.7. Property enumeration</a>
+    <li><a href="#ref-for-dfn-extended-attribute-91">3.9.8. Abstract operations</a> <a href="#ref-for-dfn-extended-attribute-92">(2)</a> <a href="#ref-for-dfn-extended-attribute-93">(3)</a>
     <li><a href="#ref-for-dfn-extended-attribute-94">5. Extensibility</a>
     <li><a href="#ref-for-dfn-extended-attribute-95">IDL grammar</a> <a href="#ref-for-dfn-extended-attribute-96">(2)</a>
    </ul>
@@ -15239,7 +15242,7 @@ language binding.</p>
     <li><a href="#ref-for-ecmascript-throw-53">3.6.11.1. size</a>
     <li><a href="#ref-for-ecmascript-throw-54">3.6.11.4. has</a>
     <li><a href="#ref-for-ecmascript-throw-55">3.6.11.5. add and delete</a>
-    <li><a href="#ref-for-ecmascript-throw-56">3.9.6. [[Call]]</a>
+    <li><a href="#ref-for-ecmascript-throw-56">3.9.5. [[Call]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-initial-object">
@@ -15306,7 +15309,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-64">3.6.10.7. set</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-65">(2)</a>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-66">3.6.11.4. has</a>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-67">3.6.11.5. add and delete</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-68">3.9.9. Abstract operations</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-69">(2)</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-68">3.9.8. Abstract operations</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-69">(2)</a>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-70">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-71">(2)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-72">(3)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-73">(4)</a>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-74">3.11. Invoking callback functions</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-75">(2)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-76">(3)</a>
    </ul>
@@ -15359,8 +15362,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-52">3.6.10.7. set</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-53">(2)</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-54">3.6.11.4. has</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-55">3.6.11.5. add and delete</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-56">3.9.6. [[Call]]</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-57">3.9.9. Abstract operations</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-58">(2)</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-56">3.9.5. [[Call]]</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-57">3.9.8. Abstract operations</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-58">(2)</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-59">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-60">(2)</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-61">3.11. Invoking callback functions</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-62">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-63">(2)</a>
@@ -15504,9 +15507,9 @@ language binding.</p>
     <li><a href="#ref-for-Global-77">3.6.9.1. entries</a> <a href="#ref-for-Global-78">(2)</a> <a href="#ref-for-Global-79">(3)</a> <a href="#ref-for-Global-80">(4)</a> <a href="#ref-for-Global-81">(5)</a> <a href="#ref-for-Global-82">(6)</a>
     <li><a href="#ref-for-Global-83">3.6.9.2. keys</a> <a href="#ref-for-Global-84">(2)</a> <a href="#ref-for-Global-85">(3)</a> <a href="#ref-for-Global-86">(4)</a> <a href="#ref-for-Global-87">(5)</a> <a href="#ref-for-Global-88">(6)</a>
     <li><a href="#ref-for-Global-89">3.6.9.3. values</a> <a href="#ref-for-Global-90">(2)</a> <a href="#ref-for-Global-91">(3)</a> <a href="#ref-for-Global-92">(4)</a> <a href="#ref-for-Global-93">(5)</a> <a href="#ref-for-Global-94">(6)</a>
-    <li><a href="#ref-for-Global-95">3.9.3. [[SetPrototypeOf]]</a> <a href="#ref-for-Global-96">(2)</a>
-    <li><a href="#ref-for-Global-97">3.9.4. [[DefineOwnProperty]]</a> <a href="#ref-for-Global-98">(2)</a> <a href="#ref-for-Global-99">(3)</a> <a href="#ref-for-Global-100">(4)</a>
-    <li><a href="#ref-for-Global-101">3.9.5. [[Delete]]</a> <a href="#ref-for-Global-102">(2)</a>
+    <li><a href="#ref-for-Global-95">3.8.1. [[SetPrototypeOf]]</a> <a href="#ref-for-Global-96">(2)</a>
+    <li><a href="#ref-for-Global-97">3.9.3. [[DefineOwnProperty]]</a> <a href="#ref-for-Global-98">(2)</a> <a href="#ref-for-Global-99">(3)</a> <a href="#ref-for-Global-100">(4)</a>
+    <li><a href="#ref-for-Global-101">3.9.4. [[Delete]]</a> <a href="#ref-for-Global-102">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-global-name">
@@ -15535,8 +15538,8 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-LegacyUnenumerableNamedProperties-1">3.3.7. [LegacyUnenumerableNamedProperties]</a> <a href="#ref-for-LegacyUnenumerableNamedProperties-2">(2)</a> <a href="#ref-for-LegacyUnenumerableNamedProperties-3">(3)</a> <a href="#ref-for-LegacyUnenumerableNamedProperties-4">(4)</a>
     <li><a href="#ref-for-LegacyUnenumerableNamedProperties-5">3.6.4.1. [[GetOwnProperty]]</a>
-    <li><a href="#ref-for-LegacyUnenumerableNamedProperties-6">3.9.8. Property enumeration</a>
-    <li><a href="#ref-for-LegacyUnenumerableNamedProperties-7">3.9.9. Abstract operations</a>
+    <li><a href="#ref-for-LegacyUnenumerableNamedProperties-6">3.9.7. Property enumeration</a>
+    <li><a href="#ref-for-LegacyUnenumerableNamedProperties-7">3.9.8. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="LenientSetter">
@@ -15593,8 +15596,8 @@ language binding.</p>
     <li><a href="#ref-for-OverrideBuiltins-1">2.2. Interfaces</a> <a href="#ref-for-OverrideBuiltins-2">(2)</a>
     <li><a href="#ref-for-OverrideBuiltins-3">3.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-OverrideBuiltins-4">(2)</a>
     <li><a href="#ref-for-OverrideBuiltins-5">3.3.13. [OverrideBuiltins]</a> <a href="#ref-for-OverrideBuiltins-6">(2)</a> <a href="#ref-for-OverrideBuiltins-7">(3)</a>
-    <li><a href="#ref-for-OverrideBuiltins-8">3.9.4. [[DefineOwnProperty]]</a>
-    <li><a href="#ref-for-OverrideBuiltins-9">3.9.9. Abstract operations</a> <a href="#ref-for-OverrideBuiltins-10">(2)</a> <a href="#ref-for-OverrideBuiltins-11">(3)</a> <a href="#ref-for-OverrideBuiltins-12">(4)</a>
+    <li><a href="#ref-for-OverrideBuiltins-8">3.9.3. [[DefineOwnProperty]]</a>
+    <li><a href="#ref-for-OverrideBuiltins-9">3.9.8. Abstract operations</a> <a href="#ref-for-OverrideBuiltins-10">(2)</a> <a href="#ref-for-OverrideBuiltins-11">(3)</a> <a href="#ref-for-OverrideBuiltins-12">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="PutForwards">
@@ -15718,7 +15721,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-overload-resolution-algorithm-1">3.6.1.1. Constructible Interfaces</a>
     <li><a href="#ref-for-dfn-overload-resolution-algorithm-2">3.6.2. Named constructors</a>
     <li><a href="#ref-for-dfn-overload-resolution-algorithm-3">3.6.7. Operations</a>
-    <li><a href="#ref-for-dfn-overload-resolution-algorithm-4">3.9.6. [[Call]]</a>
+    <li><a href="#ref-for-dfn-overload-resolution-algorithm-4">3.9.5. [[Call]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-interface-object">
@@ -15800,7 +15803,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-named-properties-object-10">3.6.4.3. [[Delete]]</a>
     <li><a href="#ref-for-dfn-named-properties-object-11">3.6.4.4. [[SetPrototypeOf]]</a>
     <li><a href="#ref-for-dfn-named-properties-object-12">3.6.4.5. [[PreventExtensions]]</a> <a href="#ref-for-dfn-named-properties-object-13">(2)</a>
-    <li><a href="#ref-for-dfn-named-properties-object-14">3.9.9. Abstract operations</a>
+    <li><a href="#ref-for-dfn-named-properties-object-14">3.9.8. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-attribute-getter">
@@ -15884,46 +15887,45 @@ language binding.</p>
   <aside class="dfn-panel" data-for="dfn-unforgeable-property-name">
    <b><a href="#dfn-unforgeable-property-name">#dfn-unforgeable-property-name</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-unforgeable-property-name-1">3.9.4. [[DefineOwnProperty]]</a>
+    <li><a href="#ref-for-dfn-unforgeable-property-name-1">3.9.3. [[DefineOwnProperty]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="legacy-platform-object-getownproperty">
    <b><a href="#legacy-platform-object-getownproperty">#legacy-platform-object-getownproperty</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-legacy-platform-object-getownproperty-1">3.3.5. [Global] and [PrimaryGlobal]</a>
-    <li><a href="#ref-for-legacy-platform-object-getownproperty-2">3.9. Legacy platform objects</a> <a href="#ref-for-legacy-platform-object-getownproperty-3">(2)</a>
+    <li><a href="#ref-for-legacy-platform-object-getownproperty-1">3.9. Legacy platform objects</a> <a href="#ref-for-legacy-platform-object-getownproperty-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-array-index-property-name">
    <b><a href="#dfn-array-index-property-name">#dfn-array-index-property-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-array-index-property-name-1">3.9.2. [[Set]]</a> <a href="#ref-for-dfn-array-index-property-name-2">(2)</a>
-    <li><a href="#ref-for-dfn-array-index-property-name-3">3.9.4. [[DefineOwnProperty]]</a>
-    <li><a href="#ref-for-dfn-array-index-property-name-4">3.9.5. [[Delete]]</a>
-    <li><a href="#ref-for-dfn-array-index-property-name-5">3.9.9. Abstract operations</a>
+    <li><a href="#ref-for-dfn-array-index-property-name-3">3.9.3. [[DefineOwnProperty]]</a>
+    <li><a href="#ref-for-dfn-array-index-property-name-4">3.9.4. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-array-index-property-name-5">3.9.8. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-named-property-visibility">
    <b><a href="#dfn-named-property-visibility">#dfn-named-property-visibility</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-named-property-visibility-1">3.6.4.1. [[GetOwnProperty]]</a>
-    <li><a href="#ref-for-dfn-named-property-visibility-2">3.9.5. [[Delete]]</a>
-    <li><a href="#ref-for-dfn-named-property-visibility-3">3.9.8. Property enumeration</a>
-    <li><a href="#ref-for-dfn-named-property-visibility-4">3.9.9. Abstract operations</a>
+    <li><a href="#ref-for-dfn-named-property-visibility-2">3.9.4. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-named-property-visibility-3">3.9.7. Property enumeration</a>
+    <li><a href="#ref-for-dfn-named-property-visibility-4">3.9.8. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="invoke-indexed-setter">
    <b><a href="#invoke-indexed-setter">#invoke-indexed-setter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invoke-indexed-setter-1">3.9.2. [[Set]]</a>
-    <li><a href="#ref-for-invoke-indexed-setter-2">3.9.4. [[DefineOwnProperty]]</a>
+    <li><a href="#ref-for-invoke-indexed-setter-2">3.9.3. [[DefineOwnProperty]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="invoke-named-setter">
    <b><a href="#invoke-named-setter">#invoke-named-setter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invoke-named-setter-1">3.9.2. [[Set]]</a>
-    <li><a href="#ref-for-invoke-named-setter-2">3.9.4. [[DefineOwnProperty]]</a>
+    <li><a href="#ref-for-invoke-named-setter-2">3.9.3. [[DefineOwnProperty]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="LegacyPlatformObjectGetOwnProperty">
@@ -15972,7 +15974,7 @@ language binding.</p>
   <aside class="dfn-panel" data-for="es-exception-objects">
    <b><a href="#es-exception-objects">#es-exception-objects</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-es-exception-objects-1">3.9.8. Property enumeration</a>
+    <li><a href="#ref-for-es-exception-objects-1">3.9.7. Property enumeration</a>
     <li><a href="#ref-for-es-exception-objects-2">3.15. Creating and throwing exceptions</a>
    </ul>
   </aside>

--- a/index.html
+++ b/index.html
@@ -11228,7 +11228,7 @@ and <var>prototype</var> has an own property named <var>P</var>, then return fal
    <p>Support for <a data-link-type="dfn" href="#dfn-getter" id="ref-for-dfn-getter-1">getters</a> is handled by the <a href="#legacy-platform-object-getownproperty">legacy platform object [[GetOwnProperty]] method</a>,
 and for <a data-link-type="dfn" href="#dfn-setter" id="ref-for-dfn-setter-1">setters</a> by the <a href="#legacy-platform-object-defineownproperty">legacy platform object [[DefineOwnProperty]] method</a>,
 and the <a href="#legacy-platform-object-set">legacy platform object [[Set]] method</a>.</p>
-   <h4 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="3.9.1" data-lt="LegacyPlatformObjectGetOwnProperty|The PlatformObjectGetOwnProperty abstract operation" data-noexport="" id="getownproperty-guts"><span class="secno">3.9.1. </span><span class="content">The LegacyPlatformObjectGetOwnProperty abstract operation</span></h4>
+   <h4 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="3.9.1" data-lt="LegacyPlatformObjectGetOwnProperty" data-noexport="" id="getownproperty-guts"><span class="secno">3.9.1. </span><span class="content">The LegacyPlatformObjectGetOwnProperty abstract operation</span></h4>
    <div class="algorithm" data-algorithm="LegacyPlatformObjectGetOwnProperty abstract operation">
     <p>The LegacyPlatformObjectGetOwnProperty abstract operation performs the following steps when
     called with an object <var>O</var>, a property name <var>P</var>, and a boolean <var>ignoreNamedProps</var> value:</p>
@@ -12942,7 +12942,6 @@ language binding.</p>
    <li><a href="#dfn-xattr-identifier">takes an identifier</a><span>, in §2.12</span>
    <li><a href="#dfn-xattr-identifier-list">takes an identifier list</a><span>, in §2.12</span>
    <li><a href="#dfn-xattr-no-arguments">takes no arguments</a><span>, in §2.12</span>
-   <li><a href="#getownproperty-guts">The PlatformObjectGetOwnProperty abstract operation</a><span>, in §3.9</span>
    <li><a href="#dfn-throw">throw</a><span>, in §2.5</span>
    <li><a href="#dfn-throw">thrown</a><span>, in §2.5</span>
    <li><a href="#dom-domexception-timeout_err">TIMEOUT_ERR</a><span>, in §2.5.1</span>

--- a/index.html
+++ b/index.html
@@ -1833,42 +1833,42 @@ are interoperable.</p>
          </ol>
        </ol>
       <li><a href="#es-implements-statements"><span class="secno">3.7</span> <span class="content">Implements statements</span></a>
+      <li><a href="#es-platform-objects"><span class="secno">3.8</span> <span class="content">Platform objects implementing interfaces</span></a>
       <li>
-       <a href="#es-platform-objects"><span class="secno">3.8</span> <span class="content">Platform objects implementing interfaces</span></a>
+       <a href="#es-legacy-platform-objects"><span class="secno">3.9</span> <span class="content">Legacy platform objects</span></a>
        <ol class="toc">
-        <li><a href="#indexed-and-named-properties"><span class="secno">3.8.1</span> <span class="content">Indexed and named properties</span></a>
-        <li><a href="#getownproperty-guts"><span class="secno">3.8.2</span> <span class="content">The PlatformObjectGetOwnProperty abstract operation</span></a>
-        <li><a href="#getownproperty"><span class="secno">3.8.3</span> <span class="content">Platform object [[GetOwnProperty]] method</span></a>
-        <li><a href="#invoking-indexed-setter"><span class="secno">3.8.4</span> <span class="content">Invoking a platform object indexed property setter</span></a>
-        <li><a href="#invoking-named-setter"><span class="secno">3.8.5</span> <span class="content">Invoking a platform object named property setter</span></a>
-        <li><a href="#platformobjectset"><span class="secno">3.8.6</span> <span class="content">Platform object [[Set]] method</span></a>
-        <li><a href="#platformobjectsetprototypeof"><span class="secno">3.8.7</span> <span class="content">Platform object [[SetPrototypeOf]] method</span></a>
-        <li><a href="#defineownproperty"><span class="secno">3.8.8</span> <span class="content">Platform object [[DefineOwnProperty]] method</span></a>
-        <li><a href="#delete"><span class="secno">3.8.9</span> <span class="content">Platform object [[Delete]] method</span></a>
-        <li><a href="#call"><span class="secno">3.8.10</span> <span class="content">Platform object [[Call]] method</span></a>
-        <li><a href="#preventextensions"><span class="secno">3.8.11</span> <span class="content">Platform object [[PreventExtensions]] method</span></a>
-        <li><a href="#property-enumeration"><span class="secno">3.8.12</span> <span class="content">Property enumeration</span></a>
+        <li><a href="#getownproperty-guts"><span class="secno">3.9.1</span> <span class="content">The LegacyPlatformObjectGetOwnProperty abstract operation</span></a>
+        <li><a href="#legacy-platform-object-getownproperty"><span class="secno">3.9.2</span> <span class="content">Legacy platform object [[GetOwnProperty]] method</span></a>
+        <li><a href="#invoking-indexed-setter"><span class="secno">3.9.3</span> <span class="content">Invoking a legacy platform object indexed property setter</span></a>
+        <li><a href="#invoking-named-setter"><span class="secno">3.9.4</span> <span class="content">Invoking a legacy platform object named property setter</span></a>
+        <li><a href="#legacy-platform-object-set"><span class="secno">3.9.5</span> <span class="content">Legacy platform object [[Set]] method</span></a>
+        <li><a href="#legacy-platform-object-setprototypeof"><span class="secno">3.9.6</span> <span class="content">Legacy platform object [[SetPrototypeOf]] method</span></a>
+        <li><a href="#legacy-platform-object-defineownproperty"><span class="secno">3.9.7</span> <span class="content">Legacy platform object [[DefineOwnProperty]] method</span></a>
+        <li><a href="#legacy-platform-object-delete"><span class="secno">3.9.8</span> <span class="content">Legacy platform object [[Delete]] method</span></a>
+        <li><a href="#legacy-platform-object-call"><span class="secno">3.9.9</span> <span class="content">Legacy platform object [[Call]] method</span></a>
+        <li><a href="#legacy-platform-object-preventextensions"><span class="secno">3.9.10</span> <span class="content">Legacy platform object [[PreventExtensions]] method</span></a>
+        <li><a href="#property-enumeration"><span class="secno">3.9.11</span> <span class="content">Property enumeration</span></a>
        </ol>
-      <li><a href="#es-user-objects"><span class="secno">3.9</span> <span class="content">User objects implementing callback interfaces</span></a>
-      <li><a href="#es-invoking-callback-functions"><span class="secno">3.10</span> <span class="content">Invoking callback functions</span></a>
+      <li><a href="#es-user-objects"><span class="secno">3.10</span> <span class="content">User objects implementing callback interfaces</span></a>
+      <li><a href="#es-invoking-callback-functions"><span class="secno">3.11</span> <span class="content">Invoking callback functions</span></a>
       <li>
-       <a href="#es-namespaces"><span class="secno">3.11</span> <span class="content">Namespaces</span></a>
+       <a href="#es-namespaces"><span class="secno">3.12</span> <span class="content">Namespaces</span></a>
        <ol class="toc">
-        <li><a href="#namespace-object"><span class="secno">3.11.1</span> <span class="content">Namespace object</span></a>
+        <li><a href="#namespace-object"><span class="secno">3.12.1</span> <span class="content">Namespace object</span></a>
        </ol>
       <li>
-       <a href="#es-exceptions"><span class="secno">3.12</span> <span class="content">Exceptions</span></a>
+       <a href="#es-exceptions"><span class="secno">3.13</span> <span class="content">Exceptions</span></a>
        <ol class="toc">
         <li>
-         <a href="#es-DOMException-constructor-object"><span class="secno">3.12.1</span> <span class="content">DOMException constructor object</span></a>
+         <a href="#es-DOMException-constructor-object"><span class="secno">3.13.1</span> <span class="content">DOMException constructor object</span></a>
          <ol class="toc">
-          <li><a href="#es-DOMException-call"><span class="secno">3.12.1.1</span> <span class="content">DOMException(message, name)</span></a>
+          <li><a href="#es-DOMException-call"><span class="secno">3.13.1.1</span> <span class="content">DOMException(message, name)</span></a>
          </ol>
-        <li><a href="#es-DOMException-prototype-object"><span class="secno">3.12.2</span> <span class="content">DOMException prototype object</span></a>
+        <li><a href="#es-DOMException-prototype-object"><span class="secno">3.13.2</span> <span class="content">DOMException prototype object</span></a>
        </ol>
-      <li><a href="#es-exception-objects"><span class="secno">3.13</span> <span class="content">Exception objects</span></a>
-      <li><a href="#es-creating-throwing-exceptions"><span class="secno">3.14</span> <span class="content">Creating and throwing exceptions</span></a>
-      <li><a href="#es-handling-exceptions"><span class="secno">3.15</span> <span class="content">Handling exceptions</span></a>
+      <li><a href="#es-exception-objects"><span class="secno">3.14</span> <span class="content">Exception objects</span></a>
+      <li><a href="#es-creating-throwing-exceptions"><span class="secno">3.15</span> <span class="content">Creating and throwing exceptions</span></a>
+      <li><a href="#es-handling-exceptions"><span class="secno">3.16</span> <span class="content">Handling exceptions</span></a>
      </ol>
     <li>
      <a href="#common"><span class="secno">4</span> <span class="content">Common definitions</span></a>
@@ -3227,6 +3227,10 @@ legacy callers can be specified using an <a data-link-type="dfn" href="#dfn-oper
    <p>If multiple legacy callers are specified on an interface, overload resolution
 is used to determine which legacy caller is invoked when the object is called
 as if it were a function.</p>
+   <p><a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-2">Legacy callers</a> can only be defined on interfaces that also <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-1">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-1">named properties</a>.</p>
+   <p class="note" role="note">Note: This artificial restriction allows bundling all the interfaces
+which support these various legacy <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-11">extended attributes</a> into a single <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-2">platform object</a> category: <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-1">legacy platform objects</a>.
+This is possible because all existing interfaces which have a <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-3">legacy caller</a> also <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-2">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-2">named properties</a>.</p>
    <p>Legacy callers must not be defined to return a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-1">promise type</a>.</p>
    <p class="advisement"> Legacy callers are universally recognised as an undesirable feature.  They exist
     only so that legacy Web platform features can be specified.  Legacy callers
@@ -3235,14 +3239,14 @@ as if it were a function.</p>
     the <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a> mailing list before proceeding. </p>
    <div class="example" id="example-bd88c721">
     <a class="self-link" href="#example-bd88c721"></a> 
-    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-18">IDL fragment</a> defines an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-29">interface</a> with a <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-2">legacy caller</a>.</p>
+    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-18">IDL fragment</a> defines an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-29">interface</a> with a <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-4">legacy caller</a>.</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">NumberQuadrupler</span> {
   // This operation simply returns four times the given number x.
   <span class="kt">legacycaller</span> <span class="kt">double</span> <span class="nv">compute</span>(<span class="kt">double</span> <span class="nv">x</span>);
 };
 </pre>
     <p>An ECMAScript implementation supporting this interface would
-    allow a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-2">platform object</a> that implements <code class="idl">NumberQuadrupler</code> to be called as a function:</p>
+    allow a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-3">platform object</a> that implements <code class="idl">NumberQuadrupler</code> to be called as a function:</p>
 <pre class="highlight"><span class="kd">var</span> f <span class="o">=</span> getNumberQuadrupler<span class="p">(</span><span class="p">)</span><span class="p">;</span>  <span class="c1">// Obtain an instance of NumberQuadrupler.
 </span>
 f<span class="p">.</span>compute<span class="p">(</span><span class="mi">3</span><span class="p">)</span><span class="p">;</span>                   <span class="c1">// This evaluates to 12.
@@ -3754,7 +3758,7 @@ and whose value is the <a data-link-type="dfn" href="#dfn-serialized-value" id="
    <h5 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="2.2.4.4" data-lt="Indexed properties" id="idl-indexed-properties"><span class="secno">2.2.4.4. </span><span class="content">Indexed properties</span></h5>
    <p>An <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-32">interface</a> that defines
 an <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-1">indexed property getter</a> is said to <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-support-indexed-properties">support indexed properties</dfn>.</p>
-   <p>If an interface <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-1">supports indexed properties</a>,
+   <p>If an interface <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-3">supports indexed properties</a>,
 then the interface definition must be accompanied by
 a description of what indices the object can be indexed with at
 any given time. These indices are called the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-supported-property-indices">supported property indices</dfn>.</p>
@@ -3808,8 +3812,8 @@ a<span class="p">.</span>toWord<span class="p">(</span><span class="mi">5</span>
 </span>a<span class="p">[</span><span class="mi">5</span><span class="p">]</span><span class="p">;</span>         <span class="c1">// Evaluates to undefined, since there is no property "5".
 </span></pre>
    </div>
-   <div class="example" id="example-120b3f16">
-    <a class="self-link" href="#example-120b3f16"></a> 
+   <div class="example" id="example-ebf31526">
+    <a class="self-link" href="#example-ebf31526"></a> 
     <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-22">IDL fragment</a> defines an interface <code class="idl">OrderedMap</code> which allows
     retrieving and setting values by name or by index number:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">OrderedMap</span> {
@@ -3835,14 +3839,14 @@ a<span class="p">.</span>toWord<span class="p">(</span><span class="mi">5</span>
      <p>Such objects also support a named property for every name that,
         if passed to <code>get()</code>, would return a non-null value.</p>
     </blockquote>
-    <p>As described in <a href="#es-platform-objects">§3.8 Platform objects implementing interfaces</a>,
+    <p>As described in <a href="#es-legacy-platform-objects">§3.9 Legacy platform objects</a>,
     an ECMAScript implementation would create
-    properties on a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-3">platform object</a> implementing <code class="idl">OrderedMap</code> that correspond to
+    properties on a <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-2">legacy platform object</a> implementing <code class="idl">OrderedMap</code> that correspond to
     entries in both the named and indexed property sets.
     These properties can then be used to interact
     with the object in the same way as invoking the object’s
     methods, as demonstrated below:</p>
-<pre class="highlight"><span class="c1">// Assume map is a platform object implementing the OrderedMap interface.
+<pre class="highlight"><span class="c1">// Assume map is a legacy platform object implementing the OrderedMap interface.
 </span><span class="kd">var</span> map <span class="o">=</span> getOrderedMap<span class="p">(</span><span class="p">)</span><span class="p">;</span>
 <span class="kd">var</span> x<span class="p">,</span> y<span class="p">;</span>
 
@@ -3881,7 +3885,7 @@ map<span class="p">.</span>berry <span class="o">=</span> <span class="mi">123</
    <h5 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="2.2.4.5" data-lt="Named properties" id="idl-named-properties"><span class="secno">2.2.4.5. </span><span class="content">Named properties</span></h5>
    <p>An <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-33">interface</a> that defines
 a <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-named-property-getter-2">named property getter</a> is said to <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-support-named-properties">support named properties</dfn>.</p>
-   <p>If an interface <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-1">supports named properties</a>,
+   <p>If an interface <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-3">supports named properties</a>,
 then the interface definition must be accompanied by
 a description of the ordered set of names that can be used to index the object
 at any given time.  These names are called the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-supported-property-names">supported property names</dfn>.</p>
@@ -3983,13 +3987,13 @@ of an overloaded operation is used to invoke one of the
 operations on an object that implements the interface, the
 number and types of the arguments passed to the operation
 determine which of the overloaded operations is actually
-invoked.  If an interface has multiple <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-3">legacy callers</a> defined on it,
+invoked.  If an interface has multiple <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-5">legacy callers</a> defined on it,
 then those legacy callers are also said to be overloaded.
 In the ECMAScript language binding, <a href="#Constructor" id="ref-for-Constructor-5">constructors</a> can be overloaded too.  There are some restrictions on the arguments
 that overloaded operations, legacy callers and constructors can be
 specified to take, and in order to describe these restrictions,
 the notion of an <em>effective overload set</em> is used.</p>
-   <p><a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-17">Operations</a> and <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-4">legacy callers</a> must not be overloaded across <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-36">interface</a> and <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-6">partial interface</a> definitions.</p>
+   <p><a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-17">Operations</a> and <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-6">legacy callers</a> must not be overloaded across <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-36">interface</a> and <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-6">partial interface</a> definitions.</p>
    <div class="note" role="note">
     <p>For example, the overloads for both <var>f</var> and <var>g</var> are disallowed:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">A</span> {
@@ -4006,13 +4010,13 @@ the notion of an <em>effective overload set</em> is used.</p>
 };
 </pre>
     <p>Note that the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-6">Constructor</a></code>] and
-    [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-4">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-11">extended attributes</a> are disallowed from appearing
+    [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-4">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-12">extended attributes</a> are disallowed from appearing
     on <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-7">partial interface</a> definitions,
     so there is no need to also disallow overloading for constructors.</p>
    </div>
    <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-effective-overload-set">effective overload set</dfn> represents the allowable invocations for a particular <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-18">operation</a>,
 constructor (specified with [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-7">Constructor</a></code>]
-or [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-5">NamedConstructor</a></code>]), <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-5">legacy caller</a> or <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-11">callback function</a>.
+or [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-5">NamedConstructor</a></code>]), <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-7">legacy caller</a> or <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-11">callback function</a>.
 The algorithm to compute an <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-1">effective overload set</a> operates on one of the following six types of IDL constructs, and listed with them below are
 the inputs to the algorithm needed to compute the set.</p>
    <dl>
@@ -4034,7 +4038,7 @@ the inputs to the algorithm needed to compute the set.</p>
     <dd data-md="">
      <ul>
       <li data-md="">
-       <p>the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-38">interface</a> on which the <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-6">legacy callers</a> are to be found</p>
+       <p>the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-38">interface</a> on which the <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-8">legacy callers</a> are to be found</p>
       <li data-md="">
        <p>the number of arguments to be passed</p>
      </ul>
@@ -4043,7 +4047,7 @@ the inputs to the algorithm needed to compute the set.</p>
     <dd data-md="">
      <ul>
       <li data-md="">
-       <p>the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-39">interface</a> on which the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-8">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-12">extended attributes</a> are to be found</p>
+       <p>the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-39">interface</a> on which the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-8">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-13">extended attributes</a> are to be found</p>
       <li data-md="">
        <p>the number of arguments to be passed</p>
      </ul>
@@ -4052,7 +4056,7 @@ the inputs to the algorithm needed to compute the set.</p>
     <dd data-md="">
      <ul>
       <li data-md="">
-       <p>the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-40">interface</a> on which the [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-6">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-13">extended attributes</a> are to be found</p>
+       <p>the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-40">interface</a> on which the [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-6">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-14">extended attributes</a> are to be found</p>
       <li data-md="">
        <p>the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-31">identifier</a> of the named constructors</p>
       <li data-md="">
@@ -4119,16 +4123,16 @@ identifier <var>A</var> defined on interface <var>I</var>.</p>
         <p>For constructors</p>
        <dd data-md="">
         <p>The elements of <var>F</var> are the
-[<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-9">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-14">extended attributes</a> on interface <var>I</var>.</p>
+[<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-9">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-15">extended attributes</a> on interface <var>I</var>.</p>
        <dt data-md="">
         <p>For named constructors</p>
        <dd data-md="">
         <p>The elements of <var>F</var> are the
-[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-7">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-15">extended attributes</a> on interface <var>I</var> whose <a data-link-type="dfn" href="#dfn-xattr-named-argument-list" id="ref-for-dfn-xattr-named-argument-list-2">named argument lists’</a> identifiers are <var>A</var>.</p>
+[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-7">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-16">extended attributes</a> on interface <var>I</var> whose <a data-link-type="dfn" href="#dfn-xattr-named-argument-list" id="ref-for-dfn-xattr-named-argument-list-2">named argument lists’</a> identifiers are <var>A</var>.</p>
        <dt data-md="">
         <p>For legacy callers</p>
        <dd data-md="">
-        <p>The elements of <var>F</var> are the <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-7">legacy callers</a> defined on interface <var>I</var>.</p>
+        <p>The elements of <var>F</var> are the <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-9">legacy callers</a> defined on interface <var>I</var>.</p>
        <dt data-md="">
         <p>For callback functions</p>
        <dd data-md="">
@@ -4505,26 +4509,26 @@ If two type parameters are given, then the interface has a <dfn class="dfn-panel
 value pairs, where the first value is a key and the second is the
 value associated with the key.</p>
    <p>A <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-1">value iterator</a> must only be declared on an interface
-that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-2">supports indexed properties</a> and has an <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-2">integer-typed</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-11">attribute</a> named “length”.
+that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-4">supports indexed properties</a> and has an <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-2">integer-typed</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-11">attribute</a> named “length”.
 The value-type of the <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-2">value iterator</a> must be the same as the type returned by
 the <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-4">indexed property getter</a>.
 A <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-3">value iterator</a> is implicitly
 defined to iterate over the object’s indexed properties.</p>
    <p>A <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-1">pair iterator</a> must not be declared on an interface
-that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-3">supports indexed properties</a>.
+that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-5">supports indexed properties</a>.
 Prose accompanying an interface with a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-2">pair iterator</a> must define what the list of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-value-pairs-to-iterate-over">value pairs to iterate over</dfn> is.</p>
    <div class="note" role="note">
     <p>The ECMAScript forEach method that is generated for a <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-4">value iterator</a> invokes its callback like Array.prototype.forEach does, and the forEach
     method for a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-3">pair iterator</a> invokes its callback like Map.prototype.forEach does.</p>
-    <p>Since <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-5">value iterators</a> are currently allowed only on interfaces that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-4">support indexed properties</a>,
+    <p>Since <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-5">value iterators</a> are currently allowed only on interfaces that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-6">support indexed properties</a>,
     it makes sense to use an Array-like forEach method.
-    There may be a need for <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-6">value iterators</a> (a) on interfaces that do not <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-5">support indexed properties</a>,
+    There may be a need for <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-6">value iterators</a> (a) on interfaces that do not <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-7">support indexed properties</a>,
     or (b) with a forEach method that instead invokes its callback like
     Set.protoype.forEach (where the key is the same as the value).
     If you’re creating an API that needs such a forEach method, please send a request to <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>.</p>
    </div>
    <p class="note" role="note">Note: This is how <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-iterator-objects">array iterator objects</a> work.
-For interfaces that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-6">support indexed properties</a>,
+For interfaces that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-8">support indexed properties</a>,
 the iterator objects returned by “entries”, “keys”, “values” and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> are
 actual <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-iterator-objects">array iterator objects</a>.</p>
    <p>Interfaces with iterable declarations must not
@@ -4640,7 +4644,7 @@ A maplike interface and its <a data-link-type="dfn" href="#dfn-inherited-interfa
 <pre class="grammar" id="prod-MaplikeRest">MaplikeRest :
     "maplike" "&lt;" Type "," Type ">" ";"
 </pre>
-   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-16">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-4">maplike declarations</a>.</p>
+   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-17">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-4">maplike declarations</a>.</p>
    <p class="issue" id="issue-dbe4d1af"><a class="self-link" href="#issue-dbe4d1af"></a> Add example. </p>
    <h4 class="heading settled" data-level="2.2.9" id="idl-setlike"><span class="secno">2.2.9. </span><span class="content">Setlike declarations</span><a class="self-link" href="#idl-setlike"></a></h4>
    <p>An <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-46">interface</a> can be declared to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-setlike">setlike</dfn> by using a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-setlike-declaration">setlike declaration</dfn> (matching <emu-nt><a href="#prod-ReadWriteSetlike">ReadWriteSetlike</a></emu-nt> or <emu-t>readonly</emu-t> <emu-nt><a href="#prod-SetlikeRest">SetlikeRest</a></emu-nt>) in the body of the interface.</p>
@@ -4686,7 +4690,7 @@ A setlike interface and its <a data-link-type="dfn" href="#dfn-inherited-interfa
 <pre class="grammar" id="prod-SetlikeRest">SetlikeRest :
     "setlike" "&lt;" Type ">" ";"
 </pre>
-   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-17">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-5">setlike declarations</a>.</p>
+   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-18">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-5">setlike declarations</a>.</p>
    <p class="issue" id="issue-dbe4d1af0"><a class="self-link" href="#issue-dbe4d1af0"></a> Add example. </p>
    <h3 class="heading settled" data-level="2.3" id="idl-namespaces"><span class="secno">2.3. </span><span class="content">Namespaces</span><a class="self-link" href="#idl-namespaces"></a></h3>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-namespace">namespace</dfn> is a definition (matching <emu-nt><a href="#prod-Namespace">Namespace</a></emu-nt>) that declares a global singleton with
@@ -5030,7 +5034,7 @@ This allows for example an <a data-link-type="dfn" href="#dfn-operation" id="ref
 Exceptions can also be <dfn class="dfn-paneled" data-dfn-for="exception" data-dfn-type="dfn" data-export="" data-lt="throw|thrown" id="dfn-throw">thrown</dfn>, by providing the
 same details required to <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-1">create</a> one.</p>
    <p>The resulting behavior from creating and throwing an exception is language binding-specific.</p>
-   <p class="note" role="note">Note: See <a href="#es-creating-throwing-exceptions">§3.14 Creating and throwing exceptions</a> for details on what creating and throwing an exception
+   <p class="note" role="note">Note: See <a href="#es-creating-throwing-exceptions">§3.15 Creating and throwing exceptions</a> for details on what creating and throwing an exception
 entails in the ECMAScript language binding.</p>
    <div class="example" id="example-e7863d09">
     <a class="self-link" href="#example-e7863d09"></a> 
@@ -5208,7 +5212,7 @@ whose type is the enumeration, is language binding specific.</p>
    <p class="note" role="note">Note: In the ECMAScript binding, assignment of an invalid string value to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-18">attribute</a> is ignored, while
 passing such a value as an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-25">operation</a> argument
 results in an exception being thrown.</p>
-   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-18">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-enumeration" id="ref-for-dfn-enumeration-12">enumerations</a>.</p>
+   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-19">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-enumeration" id="ref-for-dfn-enumeration-12">enumerations</a>.</p>
 <pre class="grammar" id="prod-Enum">Enum :
     "enum" identifier "{" EnumValueList "}" ";"
 </pre>
@@ -5301,7 +5305,7 @@ the type in the IDL.</p>
 type gives the name.</p>
    <p>The <emu-nt><a href="#prod-Type">Type</a></emu-nt> must not
 identify the same or another <a data-link-type="dfn" href="#dfn-typedef" id="ref-for-dfn-typedef-11">typedef</a>.</p>
-   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-19">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-typedef" id="ref-for-dfn-typedef-12">typedefs</a>.</p>
+   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-20">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-typedef" id="ref-for-dfn-typedef-12">typedefs</a>.</p>
 <pre class="grammar" id="prod-Typedef">Typedef :
     "typedef" Type identifier ";"
 </pre>
@@ -5401,7 +5405,7 @@ of those consequential interfaces or on the original interface itself.</p>
 <span class="n">F</span> <span class="kt">implements</span> <span class="n">I</span>;  // H::z and I::z would clash when mixed in to F
 </pre>
    </div>
-   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-20">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-implements-statement" id="ref-for-dfn-implements-statement-6">implements statements</a>.</p>
+   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-21">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-implements-statement" id="ref-for-dfn-implements-statement-6">implements statements</a>.</p>
 <pre class="grammar" id="prod-ImplementsStatement">ImplementsStatement :
     identifier "implements" identifier ";"
 </pre>
@@ -5440,6 +5444,9 @@ object that are considered to be platform objects:</p>
     <li data-md="">
      <p>objects representing IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-9">DOMExceptions</a></code>.</p>
    </ul>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-legacy-platform-object">Legacy platform objects</dfn> are <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-7">platform objects</a> that implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-50">interface</a> which
+does not have a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-5">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-6">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-22">extended attribute</a>, <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-9">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-4">named properties</a>,
+and may have one or multiple <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-10">legacy callers</a>.</p>
    <p>In a browser, for example,
 the browser-implemented DOM objects (implementing interfaces such as <code class="idl">Node</code> and <code class="idl">Document</code>) that provide access to a web page’s contents
 to ECMAScript running in the page would be platform objects.  These objects might be exotic objects,
@@ -5777,7 +5784,7 @@ all possible non-null object references.</p>
    <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-18">type name</a> of the <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-4">object</a></code> type is “Object”.</p>
    <h4 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="2.11.19" data-lt="Interface types" data-noexport="" id="idl-interface"><span class="secno">2.11.19. </span><span class="content">Interface types</span></h4>
    <p>An <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-41">identifier</a> that
-identifies an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-50">interface</a> is used to refer to
+identifies an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-51">interface</a> is used to refer to
 a type that corresponds to the set of all possible non-null references to objects that
 implement that interface.</p>
    <p>For non-callback interfaces, an IDL value of the interface type is represented just
@@ -5844,7 +5851,7 @@ the string “OrNull”.</p>
   <span class="kt">const</span> <span class="kt">boolean</span>? <span class="nv">ARE_WE_THERE_YET</span> = <span class="kt">false</span>;
 };
 </pre>
-    <p>The following <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-51">interface</a> has two <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-21">attributes</a>: one whose value can
+    <p>The following <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-52">interface</a> has two <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-21">attributes</a>: one whose value can
     be a <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-43">DOMString</a></code> or the <emu-val>null</emu-val> value, and another whose value can be a reference to a <code class="idl">Node</code> object or the <emu-val>null</emu-val> value:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Node</span> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span>? <span class="nv">namespaceURI</span>;
@@ -5858,7 +5865,7 @@ the string “OrNull”.</p>
 values of type <var>T</var>.</p>
    <p>Sequences are always passed by value.  In
 language bindings where a sequence is represented by an object of
-some kind, passing a sequence to a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-7">platform object</a> will not result in a reference to the sequence being kept by that object.
+some kind, passing a sequence to a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-8">platform object</a> will not result in a reference to the sequence being kept by that object.
 Similarly, any sequence returned from a platform object
 will be a copy and modifications made to it will not be visible to the platform object.</p>
    <p>There is no way to represent a constant sequence value in IDL.</p>
@@ -5883,7 +5890,7 @@ In a specification, a record’s value can be written:</p>
    <p><var>K</var> must be one of <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-44">DOMString</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-USVString" id="ref-for-idl-USVString-10">USVString</a></code>, or <code class="idl"><a data-link-type="idl" href="#idl-ByteString" id="ref-for-idl-ByteString-10">ByteString</a></code>.</p>
    <p>Records are always passed by value. In language bindings where a record
 is represented by an object of some kind, passing a record
-to a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-8">platform object</a> will not result in a reference to the record
+to a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-9">platform object</a> will not result in a reference to the record
 being kept by that object. Similarly, any record returned from a
 platform object will be a copy and modifications made to it will not be visible
 to the platform object.</p>
@@ -6095,7 +6102,7 @@ and <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-29">
 is used to control how language bindings will handle those constructs.
 Extended attributes are specified with an <emu-nt><a href="#prod-ExtendedAttributeList">ExtendedAttributeList</a></emu-nt>,
 which is a square bracket enclosed, comma separated list of <emu-nt><a href="#prod-ExtendedAttribute">ExtendedAttribute</a></emu-nt>s.</p>
-   <p>The <emu-nt><a href="#prod-ExtendedAttribute">ExtendedAttribute</a></emu-nt> grammar symbol matches nearly any sequence of tokens, however the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-21">extended attributes</a> defined in this document only accept a more restricted syntax.
+   <p>The <emu-nt><a href="#prod-ExtendedAttribute">ExtendedAttribute</a></emu-nt> grammar symbol matches nearly any sequence of tokens, however the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-23">extended attributes</a> defined in this document only accept a more restricted syntax.
 Any extended attribute encountered in an <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-31">IDL fragment</a> is
 matched against the following six grammar symbols to determine
 which form (or forms) it is in:</p>
@@ -6233,7 +6240,7 @@ more of the following are redefined in accordance with the rules for exotic obje
 [[Delete]] and
 [[HasInstance]].</p>
    <p>Other specifications may override the definitions
-of any internal method of a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-9">platform object</a> that is an instance of an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-52">interface</a>.</p>
+of any internal method of a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-10">platform object</a> that is an instance of an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-53">interface</a>.</p>
    <p class="advisement"> As overriding internal ECMAScript object methods is a low level operation and
     can result in objects that behave differently from ordinary objects,
     this facility should not be used unless necessary
@@ -6356,7 +6363,7 @@ Object <span class="o">==</span> w<span class="p">.</span>Object<span class="p">
 </span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
 </pre>
    </div>
-   <p>Unless otherwise specified, each ECMAScript global environment <dfn class="dfn-paneled" data-dfn-for="ECMAScript global environment" data-dfn-type="dfn" data-export="" id="dfn-expose">exposes</dfn> all <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-53">interfaces</a> that the implementation supports.  If a given ECMAScript global environment does not
+   <p>Unless otherwise specified, each ECMAScript global environment <dfn class="dfn-paneled" data-dfn-for="ECMAScript global environment" data-dfn-type="dfn" data-export="" id="dfn-expose">exposes</dfn> all <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-54">interfaces</a> that the implementation supports.  If a given ECMAScript global environment does not
 expose an interface, then the requirements given in <a href="#es-interfaces">§3.6 Interfaces</a> are
 not followed for that interface.</p>
    <p class="note" role="note">Note: This allows, for example, ECMAScript global environments for Web Workers to <a data-link-type="dfn" href="#dfn-expose" id="ref-for-dfn-expose-1">expose</a> different sets of supported interfaces from those exposed in environments
@@ -6364,7 +6371,7 @@ for Web pages.</p>
    <p>Although at the time of this writing the ECMAScript specification does not reflect this,
 every ECMAScript object must have an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-associated-realm">associated <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a></dfn>. The mechanisms
 for associating objects with Realms are, for now, underspecified. However, we note that
-in the case of <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-10">platform objects</a>, the
+in the case of <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-11">platform objects</a>, the
 associated Realm is equal to the object’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">relevant Realm</a>, and
 for non-exotic function objects (i.e. not callable proxies, and not bound functions)
 the associated Realm is equal to the value of the function object’s [[Realm]] internal
@@ -6372,7 +6379,7 @@ slot.</p>
    <h3 class="heading settled" data-level="3.2" id="es-type-mapping"><span class="secno">3.2. </span><span class="content">ECMAScript type mapping</span><a class="self-link" href="#es-type-mapping"></a></h3>
    <p>This section describes how types in the IDL map to types in ECMAScript.</p>
    <p>Each sub-section below describes how values of a given IDL type are represented
-in ECMAScript.  For each IDL type, it is described how ECMAScript values are <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="converted to an IDL value|converted to IDL values" id="dfn-convert-ecmascript-to-idl-value">converted to an IDL value</dfn> when passed to a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-11">platform object</a> expecting that type, and how IDL values
+in ECMAScript.  For each IDL type, it is described how ECMAScript values are <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="converted to an IDL value|converted to IDL values" id="dfn-convert-ecmascript-to-idl-value">converted to an IDL value</dfn> when passed to a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-12">platform object</a> expecting that type, and how IDL values
 of that type are <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="converted to an ECMAScript value|converted to ECMAScript values" id="dfn-convert-idl-to-ecmascript-value">converted to ECMAScript values</dfn> when returned from a platform object.</p>
    <h4 class="heading settled" data-level="3.2.1" id="es-any"><span class="secno">3.2.1. </span><span class="content">any</span><a class="self-link" href="#es-any"></a></h4>
    <p>Since the IDL <code class="idl"><a data-link-type="idl" href="#idl-any" id="ref-for-idl-any-9">any</a></code> type
@@ -6417,7 +6424,7 @@ references the same object.</p>
     as described in the remainder of this section are performed. </p>
    <h4 class="heading settled" data-level="3.2.2" id="es-void"><span class="secno">3.2.2. </span><span class="content">void</span><a class="self-link" href="#es-void"></a></h4>
    <p>The only place that the <code class="idl"><a data-link-type="idl" href="#idl-void" id="ref-for-idl-void-1">void</a></code> type may appear
-in IDL is as the <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-3">return type</a> of an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-30">operation</a>.  Functions on <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-12">platform objects</a> that implement an operation whose IDL specifies a <code class="idl"><a data-link-type="idl" href="#idl-void" id="ref-for-idl-void-2">void</a></code> return type must return the <emu-val>undefined</emu-val> value.</p>
+in IDL is as the <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-3">return type</a> of an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-30">operation</a>.  Functions on <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-13">platform objects</a> that implement an operation whose IDL specifies a <code class="idl"><a data-link-type="idl" href="#idl-void" id="ref-for-idl-void-2">void</a></code> return type must return the <emu-val>undefined</emu-val> value.</p>
    <p>ECMAScript functions that implement an operation whose IDL
 specifies a <code class="idl"><a data-link-type="idl" href="#idl-void" id="ref-for-idl-void-3">void</a></code> return type
 may return any value, which will be discarded.</p>
@@ -6580,7 +6587,7 @@ ECMAScript <emu-val>Boolean</emu-val> value <var>x</var>.</p>
        <li data-md="">
         <p>Otherwise let <var>lowerBound</var> be −2<sup>53</sup> + 1.</p>
         <p class="note" role="note">Note: this ensures <code class="idl"><a data-link-type="idl" href="#idl-long-long" id="ref-for-idl-long-long-11">long long</a></code> types annotated with
-[<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-4">EnforceRange</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-4">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-22">extended attributes</a> are representable in ECMAScript’s <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">Number type</a> as unambiguous integers.</p>
+[<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-4">EnforceRange</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-4">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-24">extended attributes</a> are representable in ECMAScript’s <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">Number type</a> as unambiguous integers.</p>
       </ol>
      <li data-md="">
       <p>Otherwise, if <var>signedness</var> is "unsigned", then:</p>
@@ -6604,7 +6611,7 @@ ECMAScript <emu-val>Boolean</emu-val> value <var>x</var>.</p>
       <p>If the conversion to an IDL value is being performed due to any of the following:</p>
       <ul>
        <li data-md="">
-        <p><var>V</var> is being assigned to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-25">attribute</a> annotated with the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-5">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-23">extended attribute</a>,</p>
+        <p><var>V</var> is being assigned to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-25">attribute</a> annotated with the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-5">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-25">extended attribute</a>,</p>
        <li data-md="">
         <p><var>V</var> is being passed as an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-31">operation</a> argument annotated with the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-6">EnforceRange</a></code>] extended attribute, or</p>
        <li data-md="">
@@ -6627,7 +6634,7 @@ then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-thr
       <p>If <var>x</var> is not <emu-val>NaN</emu-val> and the conversion to an IDL value is being performed due to any of the following:</p>
       <ul>
        <li data-md="">
-        <p><var>V</var> is being assigned to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-26">attribute</a> annotated with the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-5">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-24">extended attribute</a>,</p>
+        <p><var>V</var> is being assigned to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-26">attribute</a> annotated with the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-5">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-26">extended attribute</a>,</p>
        <li data-md="">
         <p><var>V</var> is being passed as an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-32">operation</a> argument annotated with the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-6">Clamp</a></code>] extended attribute, or</p>
        <li data-md="">
@@ -6859,14 +6866,14 @@ the value of the corresponding element of <var>x</var>.</p>
    <h4 class="heading settled" data-level="3.2.13" id="es-interface"><span class="secno">3.2.13. </span><span class="content">Interface types</span><a class="self-link" href="#es-interface"></a></h4>
    <p>IDL <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-4">interface type</a> values are represented by ECMAScript <emu-val>Object</emu-val> or <emu-val>Function</emu-val> values.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to interface" id="es-to-interface">
-    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-20">converted</a> to an IDL <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-5">interface type</a> value by running the following algorithm (where <var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-54">interface</a>):</p>
+    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-20">converted</a> to an IDL <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-5">interface type</a> value by running the following algorithm (where <var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-55">interface</a>):</p>
     <ol>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-8">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
-      <p>If <var>V</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-13">platform object</a> that implements <var>I</var>, then return the IDL <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-6">interface type</a> value that represents a reference to that platform object.</p>
+      <p>If <var>V</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-14">platform object</a> that implements <var>I</var>, then return the IDL <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-6">interface type</a> value that represents a reference to that platform object.</p>
      <li data-md="">
-      <p>If <var>V</var> is a <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-8">user object</a> that is considered to implement <var>I</var> according to the rules in <a href="#es-user-objects">§3.9 User objects implementing callback interfaces</a>, then return the IDL <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-7">interface type</a> value that represents a reference to that
+      <p>If <var>V</var> is a <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-8">user object</a> that is considered to implement <var>I</var> according to the rules in <a href="#es-user-objects">§3.10 User objects implementing callback interfaces</a>, then return the IDL <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-7">interface type</a> value that represents a reference to that
 user object, with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a> as the <a data-link-type="dfn" href="#dfn-callback-context" id="ref-for-dfn-callback-context-5">callback context</a>.</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-9">Throw a <emu-val>TypeError</emu-val></a>.</p>
@@ -7115,7 +7122,7 @@ at index <var>j</var> is <var>S</var><sub><var>j</var></sub>.</p>
    </div>
    <div class="example" id="example-520e0ef6">
     <a class="self-link" href="#example-520e0ef6"></a> 
-    <p>The following <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-55">interface</a> defines
+    <p>The following <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-56">interface</a> defines
     an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-30">attribute</a> of a sequence
     type as well as an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-34">operation</a> with an argument of a sequence type.</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Canvas</span> {
@@ -7380,7 +7387,7 @@ result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id
 result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-37">converting</a> <var>V</var> to that record type.</p>
       </ol>
      <li data-md="">
-      <p>If <var>V</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-14">platform object</a>, then:</p>
+      <p>If <var>V</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-15">platform object</a>, then:</p>
       <ol>
        <li data-md="">
         <p>If <var>types</var> includes an <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-10">interface type</a> that <var>V</var> implements, then return the IDL value that is a reference to the object <var>V</var>.</p>
@@ -7673,9 +7680,9 @@ to the same object that the IDL <a class="idl-code" data-link-type="interface" h
     </ol>
    </div>
    <h3 class="heading settled" data-level="3.3" id="es-extended-attributes"><span class="secno">3.3. </span><span class="content">ECMAScript-specific extended attributes</span><a class="self-link" href="#es-extended-attributes"></a></h3>
-   <p>This section defines a number of <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-25">extended attributes</a> whose presence affects only the ECMAScript binding.</p>
+   <p>This section defines a number of <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-27">extended attributes</a> whose presence affects only the ECMAScript binding.</p>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.1" data-lt="Clamp" id="Clamp"><span class="secno">3.3.1. </span><span class="content">[Clamp]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-8">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-26">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-35">operation</a> argument,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-8">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-28">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-35">operation</a> argument,
 writable <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-31">attribute</a> or <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-19">dictionary member</a> whose type is one of the <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-4">integer types</a>,
 it indicates that when an ECMAScript <emu-val>Number</emu-val> is
 converted to the IDL type, out of range values will be clamped to the range
@@ -7696,7 +7703,7 @@ types in <a href="#es-type-mapping">§3.2 ECMAScript type mapping</a> for the sp
     <p>In the following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-34">IDL fragment</a>,
     two <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-36">operations</a> are declared that
     take three <code class="idl"><a data-link-type="idl" href="#idl-octet" id="ref-for-idl-octet-10">octet</a></code> arguments; one uses
-    the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-12">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-27">extended attribute</a> on all three arguments, while the other does not:</p>
+    the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-12">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-29">extended attribute</a> on all three arguments, while the other does not:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">GraphicsContext</span> {
   <span class="kt">void</span> <span class="nv">setColor</span>(<span class="kt">octet</span> <span class="nv">red</span>, <span class="kt">octet</span> <span class="nv">green</span>, <span class="kt">octet</span> <span class="nv">blue</span>);
   <span class="kt">void</span> <span class="nv">setColorClamped</span>([<span class="nv">Clamp</span>] <span class="kt">octet</span> <span class="nv">red</span>, [<span class="nv">Clamp</span>] <span class="kt">octet</span> <span class="nv">green</span>, [<span class="nv">Clamp</span>] <span class="kt">octet</span> <span class="nv">blue</span>);
@@ -7716,7 +7723,7 @@ types in <a href="#es-type-mapping">§3.2 ECMAScript type mapping</a> for the sp
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.2" data-lt="Constructor" id="Constructor"><span class="secno">3.3.2. </span><span class="content">[Constructor]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-11">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-28">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-56">interface</a>, it indicates that
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-11">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-30">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-57">interface</a>, it indicates that
 the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-3">interface object</a> for this interface
 will have an [[Construct]] internal method,
 allowing objects implementing the interface to be constructed.</p>
@@ -7776,7 +7783,7 @@ for an interface is to be implemented.</p>
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.3" data-lt="EnforceRange" id="EnforceRange"><span class="secno">3.3.3. </span><span class="content">[EnforceRange]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-9">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-29">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-37">operation</a> argument,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-9">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-31">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-37">operation</a> argument,
 writable <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-4">regular attribute</a> or <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-20">dictionary member</a> whose type is one of the <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-5">integer types</a>,
 it indicates that when an ECMAScript <emu-val>Number</emu-val> is
 converted to the IDL type, out of range values will cause an exception to
@@ -7798,7 +7805,7 @@ types in <a href="#es-type-mapping">§3.2 ECMAScript type mapping</a> for the sp
     <p>In the following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-35">IDL fragment</a>,
     two <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-38">operations</a> are declared that
     take three <code class="idl"><a data-link-type="idl" href="#idl-octet" id="ref-for-idl-octet-12">octet</a></code> arguments; one uses
-    the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-13">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-30">extended attribute</a> on all three arguments, while the other does not:</p>
+    the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-13">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-32">extended attribute</a> on all three arguments, while the other does not:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">GraphicsContext</span> {
   <span class="kt">void</span> <span class="nv">setColor</span>(<span class="kt">octet</span> <span class="nv">red</span>, <span class="kt">octet</span> <span class="nv">green</span>, <span class="kt">octet</span> <span class="nv">blue</span>);
   <span class="kt">void</span> <span class="nv">setColorEnforcedRange</span>([<span class="nv">EnforceRange</span>] <span class="kt">octet</span> <span class="nv">red</span>, [<span class="nv">EnforceRange</span>] <span class="kt">octet</span> <span class="nv">green</span>, [<span class="nv">EnforceRange</span>] <span class="kt">octet</span> <span class="nv">blue</span>);
@@ -7823,22 +7830,22 @@ types in <a href="#es-type-mapping">§3.2 ECMAScript type mapping</a> for the sp
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.4" data-lt="Exposed" id="Exposed"><span class="secno">3.3.4. </span><span class="content">[Exposed]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-9">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-31">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-57">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-8">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-6">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-3">partial namespace</a>, or
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-9">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-33">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-58">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-8">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-6">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-3">partial namespace</a>, or
 an individual <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-11">interface member</a> or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-3">namespace member</a>,
 it indicates that the construct is exposed
 on a particular set of global interfaces, rather than the default of
 being exposed only on the <a data-link-type="dfn" href="#dfn-primary-global-interface" id="ref-for-dfn-primary-global-interface-1">primary global interface</a>.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-10">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-32">extended attribute</a> must either <a data-link-type="dfn" href="#dfn-xattr-identifier" id="ref-for-dfn-xattr-identifier-1">take an identifier</a> or <a data-link-type="dfn" href="#dfn-xattr-identifier-list" id="ref-for-dfn-xattr-identifier-list-1">take an identifier list</a>.
+   <p>The [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-10">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-34">extended attribute</a> must either <a data-link-type="dfn" href="#dfn-xattr-identifier" id="ref-for-dfn-xattr-identifier-1">take an identifier</a> or <a data-link-type="dfn" href="#dfn-xattr-identifier-list" id="ref-for-dfn-xattr-identifier-list-1">take an identifier list</a>.
 Each of the identifiers mentioned must be
 a <a data-link-type="dfn" href="#dfn-global-name" id="ref-for-dfn-global-name-1">global name</a>.</p>
-   <p>Every construct that the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-11">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-33">extended attribute</a> can be specified on has an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exposure-set">exposure set</dfn>,
-which is a set of <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-58">interfaces</a> defining which global environments the construct can be used in.
+   <p>Every construct that the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-11">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-35">extended attribute</a> can be specified on has an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exposure-set">exposure set</dfn>,
+which is a set of <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-59">interfaces</a> defining which global environments the construct can be used in.
 The <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-1">exposure set</a> for a given construct is defined as follows:</p>
    <ul>
     <li data-md="">
-     <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-12">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-34">extended attribute</a> is specified on the construct, then the <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-2">exposure set</a> is the set of all interfaces that have a <a data-link-type="dfn" href="#dfn-global-name" id="ref-for-dfn-global-name-2">global name</a> that is listed in the extended attribute’s argument.</p>
+     <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-12">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-36">extended attribute</a> is specified on the construct, then the <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-2">exposure set</a> is the set of all interfaces that have a <a data-link-type="dfn" href="#dfn-global-name" id="ref-for-dfn-global-name-2">global name</a> that is listed in the extended attribute’s argument.</p>
     <li data-md="">
-     <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-13">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-35">extended attribute</a> does not appear on a construct, then its <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-3">exposure set</a> is defined
+     <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-13">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-37">extended attribute</a> does not appear on a construct, then its <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-3">exposure set</a> is defined
 implicitly, depending on the type of construct:</p>
      <dl class="switch">
       <dt data-md="">
@@ -7885,7 +7892,7 @@ namespace or partial namespace it’s a member of.</p>
    <p>An interface’s <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-15">exposure set</a> must be a subset of the <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-16">exposure set</a> of all
 of the interface’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-13">consequential interfaces</a>.</p>
    <p>If an interface <var>X</var> <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-9">inherits</a> from another interface <var>Y</var> then the <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-17">exposure set</a> of <var>X</var> must be a subset of the <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-18">exposure set</a> of <var>Y</var>.</p>
-   <p>An <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-59">interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-7">namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-12">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-4">namespace member</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exposed">exposed</dfn> in a given ECMAScript global environment if the
+   <p>An <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-60">interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-7">namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-12">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-4">namespace member</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exposed">exposed</dfn> in a given ECMAScript global environment if the
 ECMAScript global object implements an interface that is in the construct’s <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-19">exposure set</a>, and either:</p>
    <ul>
     <li data-md="">
@@ -7965,8 +7972,8 @@ can be made once, at the time the <a data-link-type="dfn" href="#dfn-initial-obj
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.5" data-lt="Global|PrimaryGlobal" dfn="" id="Global"><span class="secno">3.3.5. </span><span class="content">[Global] and [PrimaryGlobal]</span><span id="PrimaryGlobal"></span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-5">Global</a></code>]
-or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-6">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-36">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-60">interface</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-7">Global</a></code>]
+or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-8">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-38">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-61">interface</a>,
 it indicates that objects implementing this interface can
 be used as the global object in an ECMAScript environment,
 and that the structure of the prototype chain and how
@@ -7977,7 +7984,7 @@ interfaces. Specifically:</p>
      <p>Any <a data-link-type="dfn" href="#idl-named-properties" id="ref-for-idl-named-properties-2">named properties</a> will be exposed on an object in the prototype chain – the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-2">named properties object</a> –
 rather than on the object itself.</p>
     <li data-md="">
-     <p><a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-14">Interface members</a> from the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-61">interface</a> (or <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-14">consequential interfaces</a>)
+     <p><a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-14">Interface members</a> from the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-62">interface</a> (or <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-14">consequential interfaces</a>)
 will correspond to properties on the object itself rather than on <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-4">interface prototype objects</a>.</p>
    </ol>
    <div class="note" role="note">
@@ -8000,11 +8007,13 @@ will correspond to properties on the object itself rather than on <a data-link-t
     property would already have been created before the
     assignment is evaluated.</p>
    </div>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-7">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-8">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-37">extended attributes</a> is used on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-62">interface</a>, then:</p>
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-9">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-10">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-39">extended attributes</a> is
+used on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-63">interface</a>, then:</p>
    <ul>
     <li data-md="">
      <p>The interface must not define a <a data-link-type="dfn" href="#dfn-named-property-setter" id="ref-for-dfn-named-property-setter-3">named property setter</a>.</p>
+    <li data-md="">
+     <p>The interface must not define an <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-5">indexed property getter</a>.</p>
     <li data-md="">
      <p>The interface must not also be declared with the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-3">OverrideBuiltins</a></code>]
 extended attribute.</p>
@@ -8014,19 +8023,19 @@ extended attribute.</p>
     <li data-md="">
      <p>Any other interface must not <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-11">inherit</a> from it.</p>
    </ul>
-   <p>If [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-9">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-10">PrimaryGlobal</a></code>] is specified on
+   <p>If [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-11">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-12">PrimaryGlobal</a></code>] is specified on
 a <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-9">partial interface</a> definition, then that partial interface definition must
 be the part of the interface definition that defines
 the <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-named-property-getter-5">named property getter</a>.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-11">Global</a></code>] and [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-12">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-38">extended attribute</a> must not
-be used on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-63">interface</a> that can have more
+   <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-13">Global</a></code>] and [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-14">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-40">extended attribute</a> must not
+be used on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-64">interface</a> that can have more
 than one object implementing it in the same ECMAScript global environment.</p>
    <p class="note" role="note">Note: This is because the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-3">named properties object</a>,
 which exposes the named properties, is in the prototype chain, and it would not make
 sense for more than one object’s named properties to be exposed on an object that
 all of those objects inherit from.</p>
-   <p>If an interface is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-13">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-14">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-39">extended attribute</a>, then
+   <p>If an interface is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-15">Global</a></code>] or
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-16">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-41">extended attribute</a>, then
 there must not be more than one <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-15">interface member</a> across
 the interface and its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-15">consequential interfaces</a> with the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-51">identifier</a>.
 There also must not be more than
@@ -8035,35 +8044,35 @@ more than one <a data-link-type="dfn" href="#dfn-serializer" id="ref-for-dfn-ser
 or more than one <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-8">iterable declaration</a>, <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-6">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-6">setlike declaration</a> across those interfaces.</p>
    <p class="note" role="note">Note: This is because all of the members of the interface and its consequential
 interfaces get flattened down on to the object that implements the interface.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-15">Global</a></code>] and
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-16">PrimaryGlobal</a></code>] extended attributes
+   <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-17">Global</a></code>] and
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-18">PrimaryGlobal</a></code>] extended attributes
 can also be used to give a name to one or more global interfaces,
 which can then be referenced by the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-21">Exposed</a></code>]
 extended attribute.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-17">Global</a></code>] and
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-18">PrimaryGlobal</a></code>]
+   <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-19">Global</a></code>] and
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-20">PrimaryGlobal</a></code>]
 extended attributes must either <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-4">take no arguments</a> or <a data-link-type="dfn" href="#dfn-xattr-identifier-list" id="ref-for-dfn-xattr-identifier-list-2">take an identifier list</a>.</p>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-19">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-20">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-40">extended attribute</a> is declared with an identifier list argument, then those identifiers are the interface’s <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-global-name">global names</dfn>; otherwise, the interface has
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-21">Global</a></code>] or
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-22">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-42">extended attribute</a> is declared with an identifier list argument, then those identifiers are the interface’s <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-global-name">global names</dfn>; otherwise, the interface has
 a single global name, which is the interface’s identifier.</p>
    <p class="note" role="note">Note: The identifier argument list exists so that more than one global interface can
-be addressed with a single name in an [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-22">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-41">extended attribute</a>.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-21">Global</a></code>] and
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-22">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-42">extended attributes</a> must not be declared on the same
-interface.  The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-23">PrimaryGlobal</a></code>]
+be addressed with a single name in an [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-22">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-43">extended attribute</a>.</p>
+   <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-23">Global</a></code>] and
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-24">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-44">extended attributes</a> must not be declared on the same
+interface.  The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-25">PrimaryGlobal</a></code>]
 extended attribute must be declared on
-at most one interface.  The interface [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-24">PrimaryGlobal</a></code>]
+at most one interface.  The interface [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-26">PrimaryGlobal</a></code>]
 is declared on, if any, is known as the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-primary-global-interface">primary global interface</dfn>.</p>
-   <p>See <a href="#named-properties-object">§3.6.4 Named properties object</a>, <a href="#getownproperty">§3.8.3 Platform object [[GetOwnProperty]] method</a> and <a href="#defineownproperty">§3.8.8 Platform object [[DefineOwnProperty]] method</a> for the specific requirements that the use of
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-25">Global</a></code>] and [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-26">PrimaryGlobal</a></code>]
+   <p>See <a href="#named-properties-object">§3.6.4 Named properties object</a>, <a href="#legacy-platform-object-getownproperty">§3.9.2 Legacy platform object [[GetOwnProperty]] method</a> and <a href="#legacy-platform-object-defineownproperty">§3.9.7 Legacy platform object [[DefineOwnProperty]] method</a> for the specific requirements that the use of
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-27">Global</a></code>] and [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-28">PrimaryGlobal</a></code>]
 entails for named properties,
 and <a href="#es-constants">§3.6.5 Constants</a>, <a href="#es-attributes">§3.6.6 Attributes</a> and <a href="#es-operations">§3.6.7 Operations</a> for the requirements relating to the location of properties
 corresponding to <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-16">interface members</a>.</p>
    <div class="example" id="example-2b45d97a">
     <a class="self-link" href="#example-2b45d97a"></a> 
-    <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-27">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-43">extended attribute</a> is intended
+    <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-29">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-45">extended attribute</a> is intended
     to be used by the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> interface.
-    ([<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-28">Global</a></code>] is intended to be used by worker global interfaces.)
+    ([<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-30">Global</a></code>] is intended to be used by worker global interfaces.)
     The <code class="idl">Window</code> interface exposes frames as properties on the <code class="idl">Window</code> object.  Since the <code class="idl">Window</code> object also serves as the
     ECMAScript global object, variable declarations or assignments to the named properties
     will result in them being replaced by the new value.  Variable declarations for
@@ -8104,7 +8113,7 @@ corresponding to <a data-link-type="dfn" href="#dfn-interface-member" id="ref-fo
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.6" data-lt="LegacyArrayClass" id="LegacyArrayClass"><span class="secno">3.3.6. </span><span class="content">[LegacyArrayClass]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-3">LegacyArrayClass</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-44">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-64">interface</a> that is not defined to <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-12">inherit</a> from another, it indicates that the internal [[Prototype]]
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-3">LegacyArrayClass</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-46">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-65">interface</a> that is not defined to <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-12">inherit</a> from another, it indicates that the internal [[Prototype]]
 property of its <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-5">interface prototype object</a> will be the <emu-val>Array</emu-val> prototype object rather than
 the <emu-val>Object</emu-val> prototype object.  This allows <emu-val>Array</emu-val> methods to be used more easily
 with objects implementing the interface.</p>
@@ -8114,14 +8123,14 @@ It must not be used on an interface that
 has any <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces-14">inherited interfaces</a>.</p>
    <p class="note" role="note">Note: Interfaces using [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-5">LegacyArrayClass</a></code>] will
 need to define a “length” <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-32">attribute</a> of type <code class="idl"><a data-link-type="idl" href="#idl-unsigned-long" id="ref-for-idl-unsigned-long-13">unsigned long</a></code> that exposes the length
-of the array-like object, in order for the inherited <emu-val>Array</emu-val> methods to operate correctly.  Such interfaces would typically also <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-7">support indexed properties</a>,
+of the array-like object, in order for the inherited <emu-val>Array</emu-val> methods to operate correctly.  Such interfaces would typically also <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-10">support indexed properties</a>,
 which would provide access to the array elements.</p>
    <p>See <a href="#interface-prototype-object">§3.6.3 Interface prototype object</a> for the
 specific requirements that the use of [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-6">LegacyArrayClass</a></code>]
 entails.</p>
    <div class="example" id="example-2664cf61">
     <a class="self-link" href="#example-2664cf61"></a> 
-    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-36">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-65">interfaces</a> that use [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-7">LegacyArrayClass</a></code>].</p>
+    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-36">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-66">interfaces</a> that use [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-7">LegacyArrayClass</a></code>].</p>
 <pre class="highlight">[<span class="nv">LegacyArrayClass</span>]
 <span class="kt">interface</span> <span class="nv">ItemList</span> {
   <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <span class="nv">length</span>;
@@ -8151,7 +8160,7 @@ list<span class="p">.</span>concat<span class="p">(</span><span class="p">)</spa
     The exact behavior depends on the definition of the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-array-prototype-object">Array methods</a> themselves.</p>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.7" data-lt="LegacyUnenumerableNamedProperties" id="LegacyUnenumerableNamedProperties"><span class="secno">3.3.7. </span><span class="content">[LegacyUnenumerableNamedProperties]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-1">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-45">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-66">interface</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-2">supports named properties</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-1">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-47">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-67">interface</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-5">supports named properties</a>,
 it indicates that all the interface’s named properties are unenumerable.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-2">LegacyUnenumerableNamedProperties</a></code>]
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-6">take no arguments</a> and must not appear on an interface
@@ -8159,11 +8168,11 @@ that does not define a <a data-link-type="dfn" href="#dfn-named-property-getter"
    <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-3">LegacyUnenumerableNamedProperties</a></code>]
 extended attribute is specified on an interface, then it applies to all its derived interfaces and
 must not be specified on any of them.</p>
-   <p>See <a href="#property-enumeration">§3.8.12 Property enumeration</a> for the specific requirements that the use of
+   <p>See <a href="#property-enumeration">§3.9.11 Property enumeration</a> for the specific requirements that the use of
 [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-4">LegacyUnenumerableNamedProperties</a></code>]
 entails.</p>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.8" data-lt="LenientSetter" id="LenientSetter"><span class="secno">3.3.8. </span><span class="content">[LenientSetter]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-2">LenientSetter</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-46">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-6">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-5">regular attribute</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-2">LenientSetter</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-48">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-6">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-5">regular attribute</a>,
 it indicates that a no-op setter will be generated for the attribute’s
 accessor property.  This results in erroneous assignments to the property
 in strict mode to be ignored rather than causing an exception to be thrown.</p>
@@ -8213,10 +8222,10 @@ or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Re
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.9" data-lt="LenientThis" id="LenientThis"><span class="secno">3.3.9. </span><span class="content">[LenientThis]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-3">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-47">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-7">regular attribute</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-3">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-49">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-7">regular attribute</a>,
 it indicates that invocations of the attribute’s getter or setter
 with a <emu-val>this</emu-val> value that is not an
-object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-67">interface</a> on which the attribute appears will be ignored.</p>
+object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-68">interface</a> on which the attribute appears will be ignored.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-4">LenientThis</a></code>] extended attribute
 must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-8">take no arguments</a>.
 It must not be used on a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-7">static attribute</a>.</p>
@@ -8256,7 +8265,7 @@ is to be implemented.</p>
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.10" data-lt="NamedConstructor" id="NamedConstructor"><span class="secno">3.3.10. </span><span class="content">[NamedConstructor]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-8">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-48">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-68">interface</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-8">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-50">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-69">interface</a>,
 it indicates that the ECMAScript global object will have a property with the
 specified name whose value is a constructor function that can
 create objects that implement the interface.
@@ -8304,7 +8313,7 @@ are to be implemented.</p>
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.11" data-lt="NewObject" id="NewObject"><span class="secno">3.3.11. </span><span class="content">[NewObject]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#NewObject" id="ref-for-NewObject-2">NewObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-49">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-9">regular</a> or <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-7">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-40">operation</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#NewObject" id="ref-for-NewObject-2">NewObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-51">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-9">regular</a> or <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-7">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-40">operation</a>,
 then it indicates that when calling the operation,
 a reference to a newly created object
 must always be returned.</p>
@@ -8327,7 +8336,7 @@ a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.12" data-lt="NoInterfaceObject" id="NoInterfaceObject"><span class="secno">3.3.12. </span><span class="content">[NoInterfaceObject]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-4">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-50">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-69">interface</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-4">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-52">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-70">interface</a>,
 it indicates that an <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-5">interface object</a> will not exist for the interface in the ECMAScript binding.</p>
    <p class="advisement"> The [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-5">NoInterfaceObject</a></code>] extended attribute
     should not be used on interfaces that are not
@@ -8382,8 +8391,8 @@ Storage<span class="p">.</span>prototype<span class="p">.</span>addEntry <span c
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.13" data-lt="OverrideBuiltins" id="OverrideBuiltins"><span class="secno">3.3.13. </span><span class="content">[OverrideBuiltins]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-5">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-51">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-70">interface</a>,
-it indicates that for a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-15">platform object</a> implementing the interface,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-5">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-53">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-71">interface</a>,
+it indicates that for a <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-3">legacy platform object</a> implementing the interface,
 properties corresponding to all of
 the object’s <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-3">supported property names</a> will appear to be on the object,
 regardless of what other properties exist on the object or its
@@ -8394,17 +8403,17 @@ to be exposed only if there is no property with the
 same name on the object itself or somewhere on its prototype chain.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-6">OverrideBuiltins</a></code>]
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-11">take no arguments</a> and must not appear on an interface
-that does not define a <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-named-property-getter-7">named property getter</a> or that also is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-29">Global</a></code>]
-or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-30">PrimaryGlobal</a></code>]
+that does not define a <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-named-property-getter-7">named property getter</a> or that also is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-31">Global</a></code>]
+or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-32">PrimaryGlobal</a></code>]
 extended attribute.  If the extended attribute is specified on
 a <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-10">partial interface</a> definition, then that partial interface definition must
 be the part of the interface definition that defines
 the <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-named-property-getter-8">named property getter</a>.</p>
-   <p>See <a href="#indexed-and-named-properties">§3.8.1 Indexed and named properties</a> and <a href="#defineownproperty">§3.8.8 Platform object [[DefineOwnProperty]] method</a> for the specific requirements that the use of
+   <p>See <a href="#es-legacy-platform-objects">§3.9 Legacy platform objects</a> and <a href="#legacy-platform-object-defineownproperty">§3.9.7 Legacy platform object [[DefineOwnProperty]] method</a> for the specific requirements that the use of
 [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-7">OverrideBuiltins</a></code>] entails.</p>
    <div class="example" id="example-1f93745b">
     <a class="self-link" href="#example-1f93745b"></a> 
-    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-38">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-71">interfaces</a>,
+    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-38">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-72">interfaces</a>,
     one that has a <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-named-property-getter-9">named property getter</a> and one that does not.</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">StringMap</span> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <span class="nv">length</span>;
@@ -8451,7 +8460,7 @@ the <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-na
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.14" data-lt="PutForwards" id="PutForwards"><span class="secno">3.3.14. </span><span class="content">[PutForwards]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-3">PutForwards</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-52">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-8">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-8">regular attribute</a> declaration whose type is
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-3">PutForwards</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-54">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-8">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-8">regular attribute</a> declaration whose type is
 an <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-12">interface type</a>,
 it indicates that assigning to the attribute will have specific behavior.
 Namely, the assignment is “forwarded” to the attribute (specified by
@@ -8465,7 +8474,7 @@ Assuming that:</p>
      <p><var>A</var> is the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-34">attribute</a> on which the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-5">PutForwards</a></code>]
 extended attribute appears,</p>
     <li data-md="">
-     <p><var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-72">interface</a> on which <var>A</var> is declared,</p>
+     <p><var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-73">interface</a> on which <var>A</var> is declared,</p>
     <li data-md="">
      <p><var>J</var> is the <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-13">interface type</a> that <var>A</var> is declared to be of, and</p>
     <li data-md="">
@@ -8474,11 +8483,11 @@ extended attribute appears,</p>
    <p>then there must be another <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-35">attribute</a> <var>B</var> declared on <var>J</var> whose <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-53">identifier</a> is <var>N</var>.  Assignment of a value to the attribute <var>A</var> on an object implementing <var>I</var> will result in that value
 being assigned to attribute <var>B</var> of the object that <var>A</var> references, instead.</p>
    <p>Note that [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-6">PutForwards</a></code>]-annotated <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-36">attributes</a> can be
-chained.  That is, an attribute with the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-7">PutForwards</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-53">extended attribute</a> can refer to an attribute that itself has that extended attribute.
+chained.  That is, an attribute with the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-7">PutForwards</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-55">extended attribute</a> can refer to an attribute that itself has that extended attribute.
 There must not exist a cycle in a
 chain of forwarded assignments.  A cycle exists if, when following
 the chain of forwarded assignments, a particular attribute on
-an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-73">interface</a> is
+an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-74">interface</a> is
 encountered more than once.</p>
    <p>An attribute with the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-8">PutForwards</a></code>]
 extended attribute must not also be declared
@@ -8523,7 +8532,7 @@ p<span class="p">.</span>name <span class="o">=</span> <span class="s1">'John Ci
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.15" data-lt="Replaceable" id="Replaceable"><span class="secno">3.3.15. </span><span class="content">[Replaceable]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-4">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-54">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-10">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-9">regular attribute</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-4">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-56">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-10">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-9">regular attribute</a>,
 it indicates that setting the corresponding property on the <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-16">platform object</a> will result in
 an own property with the same name being created on the object
 which has the value being assigned.  This property will shadow
@@ -8548,7 +8557,7 @@ a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callbac
 [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-10">Replaceable</a></code>] entails.</p>
    <div class="example" id="example-8ded6a51">
     <a class="self-link" href="#example-8ded6a51"></a> 
-    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-40">IDL fragment</a> defines an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-74">interface</a> with an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-42">operation</a> that increments a counter, and an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-39">attribute</a> that exposes the counter’s value, which is initially 0:</p>
+    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-40">IDL fragment</a> defines an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-75">interface</a> with an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-42">operation</a> that increments a counter, and an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-39">attribute</a> that exposes the counter’s value, which is initially 0:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Counter</span> {
   [<span class="nv">Replaceable</span>] <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <span class="nv">value</span>;
   <span class="kt">void</span> <span class="nv">increment</span>();
@@ -8579,7 +8588,7 @@ counter<span class="p">.</span>value<span class="p">;</span>                    
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.16" data-lt="SameObject" id="SameObject"><span class="secno">3.3.16. </span><span class="content">[SameObject]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-2">SameObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-55">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-12">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-41">attribute</a>, then it
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-2">SameObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-57">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-12">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-41">attribute</a>, then it
 indicates that when getting the value of the attribute on a given
 object, the same value must always
 be returned.</p>
@@ -8600,20 +8609,20 @@ be used on anything other than a <a data-link-type="dfn" href="#dfn-read-only" i
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.17" data-lt="SecureContext" id="SecureContext"><span class="secno">3.3.17. </span><span class="content">[SecureContext]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-9">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-56">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-75">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-11">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-8">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-4">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-17">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-5">namespace member</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-9">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-58">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-76">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-11">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-8">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-4">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-17">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-5">namespace member</a>,
 it indicates that the construct is exposed
 only within a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-10">SecureContext</a></code>]
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-14">take no arguments</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-11">SecureContext</a></code>]
 extended attribute must not
-be used on anything other than an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-76">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-12">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-9">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-5">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-18">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-6">namespace member</a>.</p>
-   <p>Whether a construct that the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-12">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-57">extended attribute</a> can be specified on is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-available-only-in-secure-contexts">available only in secure contexts</dfn> is defined as follows:</p>
+be used on anything other than an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-77">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-12">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-9">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-5">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-18">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-6">namespace member</a>.</p>
+   <p>Whether a construct that the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-12">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-59">extended attribute</a> can be specified on is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-available-only-in-secure-contexts">available only in secure contexts</dfn> is defined as follows:</p>
    <ul>
     <li data-md="">
-     <p>If the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-13">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-58">extended attribute</a> is specified on the construct, then it is <a data-link-type="dfn" href="#dfn-available-only-in-secure-contexts" id="ref-for-dfn-available-only-in-secure-contexts-2">available only in secure contexts</a>.</p>
+     <p>If the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-13">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-60">extended attribute</a> is specified on the construct, then it is <a data-link-type="dfn" href="#dfn-available-only-in-secure-contexts" id="ref-for-dfn-available-only-in-secure-contexts-2">available only in secure contexts</a>.</p>
     <li data-md="">
-     <p>Otherwise, if the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-14">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-59">extended attribute</a> does not appear on a construct, then whether it is <a data-link-type="dfn" href="#dfn-available-only-in-secure-contexts" id="ref-for-dfn-available-only-in-secure-contexts-3">available only in secure contexts</a> depends on the type of construct:</p>
+     <p>Otherwise, if the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-14">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-61">extended attribute</a> does not appear on a construct, then whether it is <a data-link-type="dfn" href="#dfn-available-only-in-secure-contexts" id="ref-for-dfn-available-only-in-secure-contexts-3">available only in secure contexts</a> depends on the type of construct:</p>
      <dl class="switch">
       <dt data-md="">
        <p>interface</p>
@@ -8671,7 +8680,7 @@ that does specify [<code class="idl"><a data-link-type="idl" href="#SecureContex
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.18" data-lt="TreatNonObjectAsNull" id="TreatNonObjectAsNull"><span class="secno">3.3.18. </span><span class="content">[TreatNonObjectAsNull]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-5">TreatNonObjectAsNull</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-60">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-22">callback function</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-5">TreatNonObjectAsNull</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-62">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-22">callback function</a>,
 then it indicates that any value assigned to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-43">attribute</a> whose type is a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-25">nullable</a> <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-23">callback function</a> that is not an object will be converted to
 the <emu-val>null</emu-val> value.</p>
    <p class="advisement"> Specifications should not use [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-6">TreatNonObjectAsNull</a></code>]
@@ -8686,7 +8695,7 @@ the <emu-val>null</emu-val> value.</p>
    <div class="example" id="example-28226fc6">
     <a class="self-link" href="#example-28226fc6"></a> 
     <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-42">IDL fragment</a> defines an interface that has one
-    attribute whose type is a [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-9">TreatNonObjectAsNull</a></code>]-annotated <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-25">callback function</a> and another whose type is a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-26">callback function</a> without the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-61">extended attribute</a>:</p>
+    attribute whose type is a [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-9">TreatNonObjectAsNull</a></code>]-annotated <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-25">callback function</a> and another whose type is a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-26">callback function</a> without the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-63">extended attribute</a>:</p>
 <pre class="highlight"><span class="kt">callback</span> <span class="nv">OccurrenceHandler</span> = <span class="kt">void</span> (<span class="kt">DOMString</span> <span class="nv">details</span>);
 
 [<span class="nv">TreatNonObjectAsNull</span>]
@@ -8719,7 +8728,7 @@ manager<span class="p">.</span>handler2<span class="p">;</span>            <span
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.19" data-lt="TreatNullAs" id="TreatNullAs"><span class="secno">3.3.19. </span><span class="content">[TreatNullAs]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#TreatNullAs" id="ref-for-TreatNullAs-8">TreatNullAs</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-62">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-44">attribute</a> or <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-45">operation</a> argument whose type is <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-52">DOMString</a></code>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#TreatNullAs" id="ref-for-TreatNullAs-8">TreatNullAs</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-64">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-44">attribute</a> or <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-45">operation</a> argument whose type is <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-52">DOMString</a></code>,
 it indicates that a <emu-val>null</emu-val> value
 assigned to the attribute or passed as the operation argument will be
 handled differently from its default handling.  Instead of being stringified
@@ -8772,7 +8781,7 @@ d<span class="p">.</span>isMemberOfBreed<span class="p">(</span><span class="kc"
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.20" data-lt="Unforgeable" id="Unforgeable"><span class="secno">3.3.20. </span><span class="content">[Unforgeable]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-3">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-63">extended attribute</a> appears on a non-<a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-10">static</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-45">attribute</a> or non-<a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-10">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-46">operations</a>, it indicates
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-3">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-65">extended attribute</a> appears on a non-<a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-10">static</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-45">attribute</a> or non-<a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-10">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-46">operations</a>, it indicates
 that the attribute or operation will be reflected as an ECMAScript property in
 a way that means its behavior cannot be modified and that performing
 a property lookup on the object will always result in the attribute’s
@@ -8781,7 +8790,7 @@ non-configurable and will exist as an own property on the object
 itself rather than on its prototype.</p>
    <p>An attribute or operation is said to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-unforgeable-on-an-interface">unforgeable</dfn> on a given interface <var>A</var> if the
 attribute or operation is declared on <var>A</var> or one of <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-16">consequential interfaces</a>, and is
-annotated with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-4">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-64">extended attribute</a>.</p>
+annotated with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-4">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-66">extended attribute</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-5">Unforgeable</a></code>]
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-15">take no arguments</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-6">Unforgeable</a></code>]
@@ -8808,7 +8817,7 @@ the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifi
 };
 </pre>
    </div>
-   <p>See <a href="#es-attributes">§3.6.6 Attributes</a>, <a href="#es-operations">§3.6.7 Operations</a>, <a href="#es-platform-objects">§3.8 Platform objects implementing interfaces</a>, <a href="#indexed-and-named-properties">§3.8.1 Indexed and named properties</a> and <a href="#defineownproperty">§3.8.8 Platform object [[DefineOwnProperty]] method</a> for the specific requirements that the use of
+   <p>See <a href="#es-attributes">§3.6.6 Attributes</a>, <a href="#es-operations">§3.6.7 Operations</a>, <a href="#es-platform-objects">§3.8 Platform objects implementing interfaces</a>, <a href="#es-legacy-platform-objects">§3.9 Legacy platform objects</a> and <a href="#legacy-platform-object-defineownproperty">§3.9.7 Legacy platform object [[DefineOwnProperty]] method</a> for the specific requirements that the use of
 [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-7">Unforgeable</a></code>] entails.</p>
    <div class="example" id="example-8fe6c799">
     <a class="self-link" href="#example-8fe6c799"></a> 
@@ -8843,7 +8852,7 @@ system<span class="p">.</span>loginTime<span class="p">;</span>  <span class="c1
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.21" data-lt="Unscopable" id="Unscopable"><span class="secno">3.3.21. </span><span class="content">[Unscopable]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-1">Unscopable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-65">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-10">regular attribute</a> or <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-12">regular operation</a>, it
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-1">Unscopable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-67">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-10">regular attribute</a> or <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-12">regular operation</a>, it
 indicates that an object that implements an interface with the given
 interface member will not include its property name in any object
 environment record with it as its base object.  The result of this is
@@ -8893,7 +8902,7 @@ getter or setter function of an IDL attribute).</p>
    <h3 class="heading settled" data-level="3.5" id="es-overloads"><span class="secno">3.5. </span><span class="content">Overload resolution algorithm</span><a class="self-link" href="#es-overloads"></a></h3>
    <div class="algorithm" data-algorithm="overload resolution algorithm">
     <p>In order to define how overloaded function invocations are resolved, the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-overload-resolution-algorithm">overload resolution algorithm</dfn> is defined.  Its input is an <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-4">effective overload set</a>, <var>S</var>, and a list of ECMAScript values, <var>arg</var><sub>0..<var>n</var>−1</sub>.
-    Its output is a pair consisting of the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-50">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-66">extended attribute</a> of one of <var>S</var>’s entries
+    Its output is a pair consisting of the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-50">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-68">extended attribute</a> of one of <var>S</var>’s entries
     and a list of IDL values or the special value “missing”.  The algorithm behaves as follows:</p>
     <ol>
      <li data-md="">
@@ -9181,7 +9190,7 @@ that has one of the above types in its <a data-link-type="dfn" href="#dfn-flatte
         <p>Otherwise: <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-26">throw a <emu-val>TypeError</emu-val></a>.</p>
       </ol>
      <li data-md="">
-      <p>Let <var>callable</var> be the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-51">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-67">extended attribute</a> of the single entry in <var>S</var>.</p>
+      <p>Let <var>callable</var> be the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-51">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-69">extended attribute</a> of the single entry in <var>S</var>.</p>
      <li data-md="">
       <p>If <var>i</var> = <var>d</var> and <var>method</var> is not <emu-val>undefined</emu-val>, then</p>
       <ol>
@@ -9286,14 +9295,14 @@ If there are none, then a <emu-val>TypeError</emu-val> is thrown.</p>
     of variadic argument as would be done for a non-optional argument.</p>
    </div>
    <h3 class="heading settled" data-level="3.6" id="es-interfaces"><span class="secno">3.6. </span><span class="content">Interfaces</span><a class="self-link" href="#es-interfaces"></a></h3>
-   <p>For every <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-77">interface</a> that
+   <p>For every <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-78">interface</a> that
 is <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-2">exposed</a> in a given
 ECMAScript global environment and:</p>
    <ul>
     <li data-md="">
      <p>is a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-25">callback interface</a> that has <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-21">constants</a> declared on it, or</p>
     <li data-md="">
-     <p>is a non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-78">interface</a> that is not declared with the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-13">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-68">extended attribute</a>,</p>
+     <p>is a non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-79">interface</a> that is not declared with the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-13">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-70">extended attribute</a>,</p>
    </ul>
    <p>a corresponding property must exist on the
 ECMAScript environment’s global object.
@@ -9309,7 +9318,7 @@ construction of objects that implement the interface.  The property has the
 attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.
 The characteristics of a named constructor are described in <a href="#named-constructors">§3.6.2 Named constructors</a>.</p>
    <h4 class="heading settled" data-level="3.6.1" id="interface-object"><span class="secno">3.6.1. </span><span class="content">Interface object</span><a class="self-link" href="#interface-object"></a></h4>
-   <p>The interface object for a given non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-79">interface</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-3">function object</a>.
+   <p>The interface object for a given non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-80">interface</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-3">function object</a>.
 It has properties that correspond to
 the <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-22">constants</a> and <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-12">static operations</a> defined on that interface, as described in sections <a href="#es-constants">§3.6.5 Constants</a> and <a href="#es-operations">§3.6.7 Operations</a>.</p>
    <p>The [[Prototype]] internal property of
@@ -9337,26 +9346,26 @@ the Function.prototype object.</p>
    <p class="note" role="note">Note: Remember that interface objects for callback interfaces only exist if they have <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-23">constants</a> declared on them;
 when they do exist, they are not <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-5">function objects</a>.</p>
    <h5 class="heading settled" data-level="3.6.1.1" id="es-constructible-interfaces"><span class="secno">3.6.1.1. </span><span class="content">Constructible Interfaces</span><span id="es-interface-call"></span><a class="self-link" href="#es-constructible-interfaces"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-80">interface</a> is declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-20">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-69">extended attribute</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-81">interface</a> is declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-20">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-71">extended attribute</a>,
 then the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-7">interface object</a> can be called as a constructor
 to create an object that implements that interface.
 Calling that interface as a function will throw an exception.</p>
-   <p>Interfaces that are not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-21">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-70">extended attribute</a> will throw when called,
+   <p>Interfaces that are not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-21">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-72">extended attribute</a> will throw when called,
 both as a function and as a constructor.</p>
    <div class="algorithm" data-algorithm="to construct an object implementing an interface">
     <p>When evaluating the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-6">function object</a> <var>F</var>,
-    which is the interface object for a given non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-81">interface</a> <var>I</var>,
+    which is the interface object for a given non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-82">interface</a> <var>I</var>,
     assuming <var>arg</var><sub>0..<var>n</var>−1</sub> as the list of argument values passed <var>F</var>,
     the following steps must be taken:</p>
     <ol>
      <li data-md="">
-      <p>If <var>I</var> was not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-22">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-71">extended attribute</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-27">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <var>I</var> was not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-22">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-73">extended attribute</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-27">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-built-in-function-objects">NewTarget</a> is <emu-val>undefined</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-28">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>Let <var>id</var> be the identifier of interface <var>I</var>.</p>
      <li data-md="">
-      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-5">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-58">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-82">interface</a> <var>I</var> and with argument count <var>n</var>.</p>
+      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-5">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-58">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-83">interface</a> <var>I</var> and with argument count <var>n</var>.</p>
      <li data-md="">
       <p>Let &lt;<var>constructor</var>, <var>values</var>> be the result of passing <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to the <a data-link-type="dfn" href="#dfn-overload-resolution-algorithm" id="ref-for-dfn-overload-resolution-algorithm-1">overload resolution algorithm</a>.</p>
      <li data-md="">
@@ -9373,13 +9382,13 @@ both as a function and as a constructor.</p>
    </div>
    <div class="algorithm" data-algorithm="determine value of length property of non-callback interfaces">
     <p>Interface objects for non-callback interfaces must have a property named “length” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> whose value is a <emu-val>Number</emu-val>.
-    If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-23">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-72">extended attribute</a> does not appear on the interface definition, then the value is 0.
+    If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-23">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-74">extended attribute</a> does not appear on the interface definition, then the value is 0.
     Otherwise, the value is determined as follows:</p>
     <ol>
      <li data-md="">
       <p>Let <var>id</var> be the identifier of interface <var>I</var>.</p>
      <li data-md="">
-      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-6">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-59">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-83">interface</a> <var>I</var> and with argument count 0.</p>
+      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-6">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-59">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-84">interface</a> <var>I</var> and with argument count 0.</p>
      <li data-md="">
       <p>Return the length of the shortest argument list of the entries in <var>S</var>.</p>
     </ol>
@@ -9417,7 +9426,7 @@ return <emu-val>true</emu-val>.</p>
    </div>
    <h4 class="heading settled" data-level="3.6.2" id="named-constructors"><span class="secno">3.6.2. </span><span class="content">Named constructors</span><a class="self-link" href="#named-constructors"></a></h4>
    <p>A <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-2">named constructor</a> that exists due to one or more
-[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-17">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-73">extended attributes</a> with a given <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-60">identifier</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-7">function object</a>.
+[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-17">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-75">extended attributes</a> with a given <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-60">identifier</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-7">function object</a>.
 It must have a [[Call]] internal property,
 which allows construction of objects that
 implement the interface on which the
@@ -9426,11 +9435,11 @@ implement the interface on which the
     <p>It behaves as follows, assuming <var>arg</var><sub>0..<var>n</var>−1</sub> is the list
     of argument values passed to the constructor, <var>id</var> is the identifier of the constructor specified in the
     extended attribute <a data-link-type="dfn" href="#dfn-xattr-named-argument-list" id="ref-for-dfn-xattr-named-argument-list-4">named argument list</a>,
-    and <var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-84">interface</a> on which the
+    and <var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-85">interface</a> on which the
     [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-19">NamedConstructor</a></code>] extended attribute appears:</p>
     <ol>
      <li data-md="">
-      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-7">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-61">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-85">interface</a> <var>I</var> and with argument count <var>n</var>.</p>
+      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-7">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-61">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-86">interface</a> <var>I</var> and with argument count <var>n</var>.</p>
      <li data-md="">
       <p>Let &lt;<var>constructor</var>, <var>values</var>> be the result of passing <var>S</var> and <var>arg</var><sub>0..<var>n</var>−1</sub> to the <a data-link-type="dfn" href="#dfn-overload-resolution-algorithm" id="ref-for-dfn-overload-resolution-algorithm-2">overload resolution algorithm</a>.</p>
      <li data-md="">
@@ -9449,7 +9458,7 @@ with the <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-n
     <p>A named constructor must have a property named “length” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> whose value is a <emu-val>Number</emu-val> determined as follows:</p>
     <ol>
      <li data-md="">
-      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-8">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-62">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-86">interface</a> <var>I</var> and with argument count 0.</p>
+      <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-8">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-62">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-87">interface</a> <var>I</var> and with argument count 0.</p>
      <li data-md="">
       <p>Return the length of the shortest argument list of the entries in <var>S</var>.</p>
     </ol>
@@ -9457,11 +9466,11 @@ with the <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-n
    <p>A named constructor must have a property named “name”
 with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> whose value is the identifier used for the named constructor.</p>
    <p>A named constructor must also have a property named
-“prototype” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span> whose value is the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-9">interface prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-87">interface</a> on which the
-[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-20">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-74">extended attribute</a> appears.</p>
+“prototype” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span> whose value is the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-9">interface prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-88">interface</a> on which the
+[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-20">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-76">extended attribute</a> appears.</p>
    <h4 class="heading settled" data-level="3.6.3" id="interface-prototype-object"><span class="secno">3.6.3. </span><span class="content">Interface prototype object</span><a class="self-link" href="#interface-prototype-object"></a></h4>
-   <p>There must exist an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-10">interface prototype object</a> for every non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-88">interface</a> defined, regardless of whether the interface was declared with the
-[<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-14">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-75">extended attribute</a>.
+   <p>There must exist an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-10">interface prototype object</a> for every non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-89">interface</a> defined, regardless of whether the interface was declared with the
+[<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-14">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-77">extended attribute</a>.
 The interface prototype object for a particular interface has
 properties that correspond to the <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-13">regular attributes</a> and <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-15">regular operations</a> defined on that interface.  These properties are described in more detail in
 sections <a href="#es-attributes">§3.6.6 Attributes</a> and <a href="#es-operations">§3.6.7 Operations</a>.</p>
@@ -9479,8 +9488,8 @@ is a reference to the interface object for the interface.</p>
     the following steps:</p>
     <ol>
      <li data-md="">
-      <p>If <var>A</var> is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-31">Global</a></code>]
-or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-32">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-76">extended attribute</a>, and <var>A</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-3">supports named properties</a>, then
+      <p>If <var>A</var> is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-33">Global</a></code>]
+or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-34">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-78">extended attribute</a>, and <var>A</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-6">supports named properties</a>, then
 return the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-4">named properties object</a> for <var>A</var>, as defined in <a href="#named-properties-object">§3.6.4 Named properties object</a>.</p>
      <li data-md="">
       <p>Otherwise, if <var>A</var> is declared to inherit from another
@@ -9493,8 +9502,8 @@ extended attribute, then return <a data-link-type="dfn" href="https://tc39.githu
     </ol>
    </div>
    <div class="note" role="note">
-    <p>The <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-13">interface prototype object</a> of an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-89">interface</a> that is defined with
-    the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-16">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-77">extended attribute</a> will be accessible if the interface is used as a <a data-link-type="dfn" href="#dfn-supplemental-interface" id="ref-for-dfn-supplemental-interface-5">non-supplemental interface</a>.
+    <p>The <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-13">interface prototype object</a> of an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-90">interface</a> that is defined with
+    the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-16">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-79">extended attribute</a> will be accessible if the interface is used as a <a data-link-type="dfn" href="#dfn-supplemental-interface" id="ref-for-dfn-supplemental-interface-5">non-supplemental interface</a>.
     For example, with the following IDL:</p>
 <pre class="highlight">[<span class="nv">NoInterfaceObject</span>]
 <span class="kt">interface</span> <span class="nv">Foo</span> {
@@ -9534,16 +9543,16 @@ interface member, <emu-val>true</emu-val>).</p>
       <p>Return <var>object</var>.</p>
     </ol>
    </div>
-   <p>If the interface is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-33">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-34">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-78">extended attribute</a>, or the interface is in the set
+   <p>If the interface is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-35">Global</a></code>] or
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-36">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-80">extended attribute</a>, or the interface is in the set
 of <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces-16">inherited interfaces</a> for any
 other interface that is declared with one of these attributes, then the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-14">interface prototype object</a> must be an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">immutable prototype exotic object</a>.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-1">class string</a> of an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-15">interface prototype object</a> is the concatenation of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-90">interface</a>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-64">identifier</a> and the string
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-1">class string</a> of an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-15">interface prototype object</a> is the concatenation of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-91">interface</a>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-64">identifier</a> and the string
 “Prototype”.</p>
    <h4 class="heading settled" data-level="3.6.4" id="named-properties-object"><span class="secno">3.6.4. </span><span class="content">Named properties object</span><a class="self-link" href="#named-properties-object"></a></h4>
-   <p>For every <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-91">interface</a> declared with the
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-35">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-36">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-79">extended attribute</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-4">supports named properties</a>,
-there must exist an object known as the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-named-properties-object">named properties object</dfn> for that interface.</p>
+   <p>For every <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-92">interface</a> declared with the
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-37">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-38">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-81">extended attribute</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-7">supports named properties</a>,
+there must exist an object known as the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-named-properties-object">named properties object</dfn> for that interface on which named properties are exposed.</p>
    <div class="algorithm" data-algorithm="value of [[Prototype]] property of named properties objects">
     <p>The <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-5">named properties object</a> for a given interface <var>A</var> must have an internal
     [[Prototype]] property whose value is returned from
@@ -9558,16 +9567,16 @@ extended attribute, then return <a data-link-type="dfn" href="https://tc39.githu
       <p>Otherwise, return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a>.</p>
     </ol>
    </div>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-2">class string</a> of a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-6">named properties object</a> is the concatenation of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-92">interface</a>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-65">identifier</a> and the string “Properties”.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-2">class string</a> of a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-6">named properties object</a> is the concatenation of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-93">interface</a>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-65">identifier</a> and the string “Properties”.</p>
    <h5 class="heading settled" data-level="3.6.4.1" id="named-properties-object-getownproperty"><span class="secno">3.6.4.1. </span><span class="content">Named properties object [[GetOwnProperty]] method</span><a class="self-link" href="#named-properties-object-getownproperty"></a></h5>
    <div class="algorithm" data-algorithm="to invoke the internal [[GetOwnProperty]] method of named properties object">
     <p>When the [[GetOwnProperty]] internal method of a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-7">named properties object</a> <var>O</var> is called with property key <var>P</var>, the following steps are taken:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>A</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-93">interface</a> for the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-8">named properties object</a> <var>O</var>.</p>
+      <p>Let <var>A</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-94">interface</a> for the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-8">named properties object</a> <var>O</var>.</p>
      <li data-md="">
       <p>Let <var>object</var> be the sole object from <var>O</var>’s ECMAScript global environment that implements <var>A</var>.</p>
-      <p class="note" role="note">Note: For example, if the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-94">interface</a> is the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> interface,
+      <p class="note" role="note">Note: For example, if the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-95">interface</a> is the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> interface,
 then the sole object will be this global environment’s window object.</p>
      <li data-md="">
       <p>If the result of running the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-1">named property visibility algorithm</a> with
@@ -9589,7 +9598,7 @@ of performing the steps listed in the description of <var>operation</var> with <
         <p>Set <var>desc</var>.[[Value]] to the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-40">converting</a> <var>value</var> to an ECMAScript value.</p>
        <li data-md="">
         <p>If <var>A</var> implements an interface with the
-[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-5">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-80">extended attribute</a>,
+[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-5">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-82">extended attribute</a>,
 then set <var>desc</var>.[[Enumerable]] to <emu-val>false</emu-val>,
 otherwise set it to <emu-val>true</emu-val>.</p>
        <li data-md="">
@@ -9634,7 +9643,7 @@ called, the same algorithm must be executed as is defined for the [[SetPrototype
     making [[PreventExtensions]] fail.</p>
    </div>
    <h4 class="heading settled" data-level="3.6.5" id="es-constants"><span class="secno">3.6.5. </span><span class="content">Constants</span><a class="self-link" href="#es-constants"></a></h4>
-   <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-4">exposed</a> <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-25">constant</a> defined on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-95">interface</a> <var>A</var>,
+   <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-4">exposed</a> <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-25">constant</a> defined on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-96">interface</a> <var>A</var>,
 there must be a corresponding property.
 The property has the following characteristics:</p>
    <ul>
@@ -9644,12 +9653,12 @@ The property has the following characteristics:</p>
      <p>The location of the property is determined as follows:</p>
      <ul>
       <li data-md="">
-       <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-37">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-38">PrimaryGlobal</a></code>] extended attribute,
+       <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-39">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-40">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on the single object that implements the interface.</p>
       <li data-md="">
-       <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-19">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-39">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-40">PrimaryGlobal</a></code>] annotated interface, then
-the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-41">Global</a></code>]- or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-42">PrimaryGlobal</a></code>]-annotated interface as well as on
+       <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-19">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-41">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-42">PrimaryGlobal</a></code>] annotated interface, then
+the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-43">Global</a></code>]- or
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-44">PrimaryGlobal</a></code>]-annotated interface as well as on
 the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-17">interface prototype object</a>.</p>
       <li data-md="">
        <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-18">interface prototype object</a>.</p>
@@ -9662,7 +9671,7 @@ the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-pro
    <p>In addition, a property with the same characteristics must
 exist on the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-11">interface object</a>, if that object exists.</p>
    <h4 class="heading settled" data-level="3.6.6" id="es-attributes"><span class="secno">3.6.6. </span><span class="content">Attributes</span><a class="self-link" href="#es-attributes"></a></h4>
-   <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-5">exposed</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-49">attribute</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-96">interface</a>, whether it
+   <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-5">exposed</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-49">attribute</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-97">interface</a>, whether it
 was declared on the interface itself or one of its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-20">consequential interfaces</a>,
 there must exist a corresponding property.
 The characteristics of this property are as follows:</p>
@@ -9677,12 +9686,12 @@ The characteristics of this property are as follows:</p>
 then there is a single corresponding property and it exists on the interface’s <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-12">interface object</a>.</p>
       <li data-md="">
        <p>Otherwise, if the attribute is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-2">unforgeable</a> on
-the interface or if the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-43">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-44">PrimaryGlobal</a></code>] extended attribute,
+the interface or if the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-45">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-46">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on every object that implements the interface.</p>
       <li data-md="">
-       <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-21">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-45">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-46">PrimaryGlobal</a></code>]-annotated interface, then
-the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-47">Global</a></code>]- or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-48">PrimaryGlobal</a></code>]-annotated interface as well as on
+       <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-21">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-47">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-48">PrimaryGlobal</a></code>]-annotated interface, then
+the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-49">Global</a></code>]- or
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-50">PrimaryGlobal</a></code>]-annotated interface as well as on
 the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-19">interface prototype object</a>.</p>
       <li data-md="">
        <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-20">interface prototype object</a>.</p>
@@ -9709,7 +9718,7 @@ declared with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable"
         <p>If the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-51">attribute</a> is a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-14">regular attribute</a>, then:</p>
         <ol>
          <li data-md="">
-          <p>Let <var>I</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-97">interface</a> whose <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-21">interface prototype object</a> this property corresponding to the attribute appears on.</p>
+          <p>Let <var>I</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-98">interface</a> whose <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-21">interface prototype object</a> this property corresponding to the attribute appears on.</p>
           <p class="note" role="note">Note: This means that even if an implements statement was used to make
 an attribute available on the interface, <var>I</var> is the interface
 on the left hand side of the implements statement, and not the one
@@ -9732,7 +9741,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <ol>
            <li data-md="">
             <p>If the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-53">attribute</a> was specified with the
-[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-8">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-81">extended attribute</a>,
+[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-8">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-83">extended attribute</a>,
 then return <emu-val>undefined</emu-val>.</p>
            <li data-md="">
             <p>Otherwise, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-30">throw a <emu-val>TypeError</emu-val></a>.</p>
@@ -9759,7 +9768,7 @@ concatenation of “get ” and the identifier of the attribute.</p>
     <li data-md="">
      <div class="algorithm" data-algorithm="attribute setter">
       <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-attribute-setter">attribute setter</dfn> is <emu-val>undefined</emu-val> if the attribute is declared <code>readonly</code> and does not have a
-    [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-9">LenientThis</a></code>], [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-15">PutForwards</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-11">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-82">extended attribute</a> declared on it.
+    [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-9">LenientThis</a></code>], [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-15">PutForwards</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-11">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-84">extended attribute</a> declared on it.
     Otherwise, it is a <emu-val>Function</emu-val> object whose behavior when invoked is as follows:</p>
       <ol>
        <li data-md="">
@@ -9770,7 +9779,7 @@ concatenation of “get ” and the identifier of the attribute.</p>
         <p>If the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-54">attribute</a> is a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-15">regular attribute</a>, then:</p>
         <ol>
          <li data-md="">
-          <p>Let <var>I</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-98">interface</a> whose <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-22">interface prototype object</a> this property corresponding to the attribute appears on.</p>
+          <p>Let <var>I</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-99">interface</a> whose <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-22">interface prototype object</a> this property corresponding to the attribute appears on.</p>
          <li data-md="">
           <p>Let <var>O</var> be the <emu-val>this</emu-val> value.</p>
          <li data-md="">
@@ -9788,7 +9797,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>Let <var>validThis</var> be <emu-val>true</emu-val> if <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-23">platform object</a> that implements <var>I</var>, or <emu-val>false</emu-val> otherwise.</p>
          <li data-md="">
           <p>If <var>validThis</var> is <emu-val>false</emu-val> and the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-56">attribute</a> was not specified with the
-[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-10">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-83">extended attribute</a>,
+[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-10">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-85">extended attribute</a>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-32">throw a <emu-val>TypeError</emu-val></a>.</p>
          <li data-md="">
           <p>If the attribute is declared with a [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-12">Replaceable</a></code>]
@@ -9862,7 +9871,7 @@ accessed, they are able to expose instance-specific data.</p>
    <p class="note" role="note">Note: Note that attempting to assign to a property corresponding to a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-14">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-57">attribute</a> results in different behavior depending on whether the script doing so is in strict mode.
 When in strict mode, such an assignment will result in a <emu-val>TypeError</emu-val> being thrown.  When not in strict mode, the assignment attempt will be ignored.</p>
    <h4 class="heading settled" data-level="3.6.7" id="es-operations"><span class="secno">3.6.7. </span><span class="content">Operations</span><a class="self-link" href="#es-operations"></a></h4>
-   <p>For each unique <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-71">identifier</a> of an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-6">exposed</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-52">operation</a> defined on the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-99">interface</a>, there
+   <p>For each unique <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-71">identifier</a> of an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-6">exposed</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-52">operation</a> defined on the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-100">interface</a>, there
 must exist a corresponding property,
 unless the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-9">effective overload set</a> for that <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-72">identifier</a> and <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-53">operation</a> and with an argument count of 0 has no entries.</p>
    <p>The characteristics of this property are as follows:</p>
@@ -9877,12 +9886,12 @@ unless the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-fo
 the property exists on the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-13">interface object</a>.</p>
       <li data-md="">
        <p>Otherwise, if the operation is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-3">unforgeable</a> on
-the interface or if the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-49">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-50">PrimaryGlobal</a></code>] extended attribute,
+the interface or if the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-51">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-52">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on every object that implements the interface.</p>
       <li data-md="">
-       <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-22">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-51">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-52">PrimaryGlobal</a></code>]-annotated interface, then
-the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-53">Global</a></code>]- or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-54">PrimaryGlobal</a></code>]-annotated interface as well as on
+       <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-22">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-53">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-54">PrimaryGlobal</a></code>]-annotated interface, then
+the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-55">Global</a></code>]- or
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-56">PrimaryGlobal</a></code>]-annotated interface as well as on
 the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-23">interface prototype object</a>.</p>
       <li data-md="">
        <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-24">interface prototype object</a>.</p>
@@ -9900,11 +9909,11 @@ available on the interface, we pass in the interface on the left-hand side of th
 where the operation was originally declared.</p>
    </ul>
    <p class="advisement"> The above description has some bugs, especially around partial interfaces. See <a href="https://github.com/heycam/webidl/issues/164">issue #164</a>. </p>
-   <p>For <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-10">namespaces</a>, the properties corresponding to each declared operation are described in <a href="#namespace-object">§3.11.1 Namespace object</a>. (We hope to eventually move interfaces to the same explicit
+   <p>For <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-10">namespaces</a>, the properties corresponding to each declared operation are described in <a href="#namespace-object">§3.12.1 Namespace object</a>. (We hope to eventually move interfaces to the same explicit
 property-installation style as namespaces.)</p>
    <div class="algorithm" data-algorithm="create an operation function">
      To <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="creating an operation function" data-noexport="" id="dfn-create-operation-function">create an operation function</dfn>,
-    given an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-54">operation</a> <var>op</var>, a <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-11">namespace</a> or <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-100">interface</a> <var>target</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>: 
+    given an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-54">operation</a> <var>op</var>, a <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-11">namespace</a> or <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-101">interface</a> <var>target</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>: 
     <ol>
      <li data-md="">
       <p>Let <var>id</var> be <var>op</var>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-74">identifier</a>.</p>
@@ -9918,7 +9927,7 @@ values <var>arg</var><sub>0..<var>n</var>−1</sub>:</p>
          <li data-md="">
           <p>Let <var>O</var> be <emu-val>null</emu-val>.</p>
          <li data-md="">
-          <p>If <var>target</var> is an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-101">interface</a>, and <var>op</var> is not a <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-14">static operation</a>:</p>
+          <p>If <var>target</var> is an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-102">interface</a>, and <var>op</var> is not a <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-14">static operation</a>:</p>
           <ol>
            <li data-md="">
             <p>If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, set <var>O</var> to <var>realm</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global">global object</a>. (This
@@ -9975,14 +9984,14 @@ PropertyDescriptor<span class="prop-desc">{[[Value]]: <var>length</var>, [[Writa
     </ol>
    </div>
    <h5 class="heading settled" data-level="3.6.7.1" id="es-stringifier"><span class="secno">3.6.7.1. </span><span class="content">Stringifiers</span><a class="self-link" href="#es-stringifier"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-102">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-7">exposed</a> <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-3">stringifier</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-103">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-7">exposed</a> <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-3">stringifier</a>,
 then there must exist a property with the following characteristics:</p>
    <ul>
     <li data-md="">
      <p>The name of the property is “toString”.</p>
     <li data-md="">
      <p>If the <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-4">stringifier</a> is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-5">unforgeable</a> on the interface
-or if the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-55">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-56">PrimaryGlobal</a></code>] extended attribute,
+or if the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-57">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-58">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on every object that implements the interface.
 Otherwise, the property exists on the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-25">interface prototype object</a>.</p>
     <li data-md="">
@@ -10007,7 +10016,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-103">interface</a> on which the stringifier was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-35">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-104">interface</a> on which the stringifier was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-35">throw a <emu-val>TypeError</emu-val></a>.</p>
        <li data-md="">
         <p>Let <var>V</var> be an uninitialized variable.</p>
        <li data-md="">
@@ -10042,17 +10051,17 @@ property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
 property is the <emu-val>String</emu-val> value “toString”.</p>
    </ul>
    <h5 class="heading settled" data-level="3.6.7.2" id="es-serializer"><span class="secno">3.6.7.2. </span><span class="content">Serializers</span><a class="self-link" href="#es-serializer"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-104">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-8">exposed</a> <a data-link-type="dfn" href="#dfn-serializer" id="ref-for-dfn-serializer-5">serializer</a>, then
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-105">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-8">exposed</a> <a data-link-type="dfn" href="#dfn-serializer" id="ref-for-dfn-serializer-5">serializer</a>, then
 a property must exist whose name is “toJSON”, with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <emu-val>Function</emu-val> object.</p>
    <p>The location of the property is determined as follows:</p>
    <ul>
     <li data-md="">
-     <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-57">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-58">PrimaryGlobal</a></code>] extended attribute,
+     <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-59">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-60">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on the single object that implements the interface.</p>
     <li data-md="">
-     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-23">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-59">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-60">PrimaryGlobal</a></code>]-annotated interface, then
-the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-61">Global</a></code>]- or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-62">PrimaryGlobal</a></code>]-annotated interface as well as on
+     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-23">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-61">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-62">PrimaryGlobal</a></code>]-annotated interface, then
+the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-63">Global</a></code>]- or
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-64">PrimaryGlobal</a></code>]-annotated interface as well as on
 the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-26">interface prototype object</a>.</p>
     <li data-md="">
      <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-27">interface prototype object</a>.</p>
@@ -10075,7 +10084,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-105">interface</a> on which the serializer was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-36">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-106">interface</a> on which the serializer was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-36">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>Depending on how <code>serializer</code> was specified:</p>
       <dl class="switch">
@@ -10092,7 +10101,7 @@ using <var>O</var> as the <emu-val>this</emu-val> value and passing no arguments
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-serialized-value" id="ref-for-dfn-serialized-value-8">serialized value</a> that is the result of invoking the <a data-link-type="dfn" href="#dfn-serialization-behavior" id="ref-for-dfn-serialization-behavior-15">serialization behavior</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-106">interface</a> for object <var>O</var>.</p>
+          <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-serialized-value" id="ref-for-dfn-serialized-value-8">serialized value</a> that is the result of invoking the <a data-link-type="dfn" href="#dfn-serialization-behavior" id="ref-for-dfn-serialization-behavior-15">serialization behavior</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-107">interface</a> for object <var>O</var>.</p>
          <li data-md="">
           <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-serialized-value-to-ecmascript-value" id="ref-for-dfn-convert-serialized-value-to-ecmascript-value-1">converting</a> <var>S</var> to an ECMAScript value.</p>
         </ol>
@@ -10165,12 +10174,12 @@ property is the <emu-val>String</emu-val> value “toJSON”.</p>
    </div>
    <h4 class="heading settled" data-level="3.6.8" id="es-iterators"><span class="secno">3.6.8. </span><span class="content">Common iterator behavior</span><a class="self-link" href="#es-iterators"></a></h4>
    <h5 class="heading settled" data-level="3.6.8.1" id="es-iterator"><span class="secno">3.6.8.1. </span><span class="content">@@iterator</span><a class="self-link" href="#es-iterator"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-107">interface</a> has any of the following:</p>
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-108">interface</a> has any of the following:</p>
    <ul>
     <li data-md="">
      <p>an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-9">iterable declaration</a></p>
     <li data-md="">
-     <p>an <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-5">indexed property getter</a> and
+     <p>an <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-6">indexed property getter</a> and
 an <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-6">integer-typed</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-59">attribute</a> named “length”</p>
     <li data-md="">
      <p>a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-7">maplike declaration</a></p>
@@ -10182,17 +10191,17 @@ whose name is the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#
    <p>The location of the property is determined as follows:</p>
    <ul>
     <li data-md="">
-     <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-63">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-64">PrimaryGlobal</a></code>] extended attribute,
+     <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-65">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-66">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on the single object that implements the interface.</p>
     <li data-md="">
-     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-24">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-65">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-66">PrimaryGlobal</a></code>]-annotated interface, then
-the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-67">Global</a></code>]- or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-68">PrimaryGlobal</a></code>]-annotated interface as well as on
+     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-24">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-67">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-68">PrimaryGlobal</a></code>]-annotated interface, then
+the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-69">Global</a></code>]- or
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-70">PrimaryGlobal</a></code>]-annotated interface as well as on
 the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-28">interface prototype object</a>.</p>
     <li data-md="">
      <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-29">interface prototype object</a>.</p>
    </ul>
-   <p>If the interface defines an <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-6">indexed property getter</a>,
+   <p>If the interface defines an <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-7">indexed property getter</a>,
 then the <emu-val>Function</emu-val> object is <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ArrayProto_values%</a>.</p>
    <div class="algorithm" data-algorithm="to invoke the @@iterator property of interfaces with a pair iterator">
     <p>If the interface has a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-4">pair iterator</a>,
@@ -10212,7 +10221,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-108">interface</a> the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-10">iterable declaration</a> is on.</p>
+      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-109">interface</a> the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-10">iterable declaration</a> is on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-29">platform object</a> that implements <var>interface</var>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-37">throw a <emu-val>TypeError</emu-val></a>.</p>
@@ -10241,7 +10250,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-31">platform object</a> that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-109">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-9">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-9">setlike declaration</a> is defined,
+      <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-31">platform object</a> that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-110">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-9">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-9">setlike declaration</a> is defined,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-38">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>If the interface has a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-10">maplike declaration</a>, then:</p>
@@ -10268,7 +10277,7 @@ is the <emu-val>String</emu-val> value “entries”
 if the interface has a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-5">pair iterator</a> or a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-11">maplike declaration</a> and the <emu-val>String</emu-val> “values”
 if the interface has a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-10">setlike declaration</a>.</p>
    <h5 class="heading settled" data-level="3.6.8.2" id="es-forEach"><span class="secno">3.6.8.2. </span><span class="content">forEach</span><a class="self-link" href="#es-forEach"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-110">interface</a> has any of the following:</p>
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-111">interface</a> has any of the following:</p>
    <ul>
     <li data-md="">
      <p>an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-11">iterable declaration</a></p>
@@ -10281,17 +10290,17 @@ if the interface has a <a data-link-type="dfn" href="#dfn-setlike-declaration" i
    <p>The location of the property is determined as follows:</p>
    <ul>
     <li data-md="">
-     <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-69">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-70">PrimaryGlobal</a></code>] extended attribute,
+     <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-71">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-72">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on the single object that implements the interface.</p>
     <li data-md="">
-     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-25">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-71">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-72">PrimaryGlobal</a></code>]-annotated interface, then
-the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-73">Global</a></code>]- or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-74">PrimaryGlobal</a></code>]-annotated interface as well as on
+     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-25">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-73">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-74">PrimaryGlobal</a></code>]-annotated interface, then
+the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-75">Global</a></code>]- or
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-76">PrimaryGlobal</a></code>]-annotated interface as well as on
 the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-30">interface prototype object</a>.</p>
     <li data-md="">
      <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-31">interface prototype object</a>.</p>
    </ul>
-   <p>If the interface defines an <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-7">indexed property getter</a>,
+   <p>If the interface defines an <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-8">indexed property getter</a>,
 then the <emu-val>Function</emu-val> object is
 the initial value of the “forEach” data property of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ArrayPrototype%</a>.</p>
    <div class="algorithm" data-algorithm="to invoke the forEach method of interfaces with indexed properties">
@@ -10348,7 +10357,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-111">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-14">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-13">setlike declaration</a> is declared.</p>
+      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-112">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-14">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-13">setlike declaration</a> is declared.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-33">platform object</a> that implements <var>interface</var>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-39">throw a <emu-val>TypeError</emu-val></a>.</p>
@@ -10392,17 +10401,17 @@ property is the <emu-val>Number</emu-val> value <emu-val>1</emu-val>.</p>
 property is the <emu-val>String</emu-val> value “forEach”.</p>
    <h4 class="heading settled" data-level="3.6.9" id="es-iterable"><span class="secno">3.6.9. </span><span class="content">Iterable declarations</span><a class="self-link" href="#es-iterable"></a></h4>
    <h5 class="heading settled" data-level="3.6.9.1" id="es-iterable-entries"><span class="secno">3.6.9.1. </span><span class="content">entries</span><a class="self-link" href="#es-iterable-entries"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-112">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-13">iterable declaration</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-113">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-13">iterable declaration</a>,
 then a property named “entries” must exist with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-10">function object</a>.</p>
    <p>The location of the property is determined as follows:</p>
    <ul>
     <li data-md="">
-     <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-75">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-76">PrimaryGlobal</a></code>] extended attribute,
+     <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-77">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-78">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on the single object that implements the interface.</p>
     <li data-md="">
-     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-26">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-77">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-78">PrimaryGlobal</a></code>]-annotated interface, then
-the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-79">Global</a></code>]- or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-80">PrimaryGlobal</a></code>]-annotated interface as well as on
+     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-26">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-79">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-80">PrimaryGlobal</a></code>]-annotated interface, then
+the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-81">Global</a></code>]- or
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-82">PrimaryGlobal</a></code>]-annotated interface as well as on
 the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-32">interface prototype object</a>.</p>
     <li data-md="">
      <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-33">interface prototype object</a>.</p>
@@ -10414,17 +10423,17 @@ the initial value of the “entries” data property of <a data-link-type="dfn" 
 then the <emu-val>Function</emu-val> object is
 the value of the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> property.</p>
    <h5 class="heading settled" data-level="3.6.9.2" id="es-iterable-keys"><span class="secno">3.6.9.2. </span><span class="content">keys</span><a class="self-link" href="#es-iterable-keys"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-113">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-14">iterable declaration</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-114">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-14">iterable declaration</a>,
 then a property named “keys” must exist with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-11">function object</a>.</p>
    <p>The location of the property is determined as follows:</p>
    <ul>
     <li data-md="">
-     <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-81">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-82">PrimaryGlobal</a></code>] extended attribute,
+     <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-83">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-84">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on the single object that implements the interface.</p>
     <li data-md="">
-     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-27">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-83">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-84">PrimaryGlobal</a></code>]-annotated interface, then
-the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-85">Global</a></code>]- or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-86">PrimaryGlobal</a></code>]-annotated interface as well as on
+     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-27">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-85">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-86">PrimaryGlobal</a></code>]-annotated interface, then
+the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-87">Global</a></code>]- or
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-88">PrimaryGlobal</a></code>]-annotated interface as well as on
 the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-34">interface prototype object</a>.</p>
     <li data-md="">
      <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-35">interface prototype object</a>.</p>
@@ -10450,7 +10459,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-114">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-15">iterable declaration</a> is declared on.</p>
+      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-115">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-15">iterable declaration</a> is declared on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-35">platform object</a> that implements <var>interface</var>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-42">throw a <emu-val>TypeError</emu-val></a>.</p>
@@ -10463,18 +10472,18 @@ then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-thr
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “keys”.</p>
    <h5 class="heading settled" data-level="3.6.9.3" id="es-iterable-values"><span class="secno">3.6.9.3. </span><span class="content">values</span><a class="self-link" href="#es-iterable-values"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-115">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-16">iterable declaration</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-116">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-16">iterable declaration</a>,
 then a property named “values” must exist
 with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-12">function object</a>.</p>
    <p>The location of the property is determined as follows:</p>
    <ul>
     <li data-md="">
-     <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-87">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-88">PrimaryGlobal</a></code>] extended attribute,
+     <p>If the interface was declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-89">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-90">PrimaryGlobal</a></code>] extended attribute,
 then the property exists on the single object that implements the interface.</p>
     <li data-md="">
-     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-28">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-89">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-90">PrimaryGlobal</a></code>]-annotated interface, then
-the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-91">Global</a></code>]- or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-92">PrimaryGlobal</a></code>]-annotated interface as well as on
+     <p>Otherwise, if the interface is a <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-28">consequential interface</a> of a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-91">Global</a></code>]- or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-92">PrimaryGlobal</a></code>]-annotated interface, then
+the property exists on the single object that implements the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-93">Global</a></code>]- or
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-94">PrimaryGlobal</a></code>]-annotated interface as well as on
 the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-36">interface prototype object</a>.</p>
     <li data-md="">
      <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-37">interface prototype object</a>.</p>
@@ -10500,7 +10509,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-116">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-17">iterable declaration</a> is declared on.</p>
+      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-117">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-17">iterable declaration</a> is declared on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-37">platform object</a> that implements <var>interface</var>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-43">throw a <emu-val>TypeError</emu-val></a>.</p>
@@ -10513,8 +10522,8 @@ then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-thr
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “values”.</p>
    <h5 class="heading settled" data-level="3.6.9.4" id="es-default-iterator-object"><span class="secno">3.6.9.4. </span><span class="content">Default iterator objects</span><a class="self-link" href="#es-default-iterator-object"></a></h5>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-default-iterator-object">default iterator object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-117">interface</a>, target and iteration kind
-is an object whose internal [[Prototype]] property is the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-2">iterator prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-118">interface</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-default-iterator-object">default iterator object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-118">interface</a>, target and iteration kind
+is an object whose internal [[Prototype]] property is the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-2">iterator prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-119">interface</a>.</p>
    <p>A <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-4">default iterator object</a> has three internal values:</p>
    <ol>
     <li data-md="">
@@ -10525,20 +10534,20 @@ is an object whose internal [[Prototype]] property is the <a data-link-type="dfn
      <p>its <em>index</em>, which is the current index into the values value to be iterated.</p>
    </ol>
    <p class="note" role="note">Note: Default iterator objects are only used for <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-10">pair iterators</a>; <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-10">value iterators</a>, as they are currently
-restricted to iterating over an object’s <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-8">supported indexed properties</a>,
+restricted to iterating over an object’s <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-11">supported indexed properties</a>,
 use standard ECMAScript Array iterator objects.</p>
    <p>When a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-5">default iterator object</a> is first created,
 its index is set to 0.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-3">class string</a> of a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-6">default iterator object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-119">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-79">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-120">interface</a> and the string “Iterator”.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-3">class string</a> of a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-6">default iterator object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-120">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-79">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-121">interface</a> and the string “Iterator”.</p>
    <h5 class="heading settled" data-level="3.6.9.5" id="es-iterator-prototype-object"><span class="secno">3.6.9.5. </span><span class="content">Iterator prototype object</span><a class="self-link" href="#es-iterator-prototype-object"></a></h5>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-iterator-prototype-object">iterator prototype object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-121">interface</a> is an object that exists for every interface that has a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-11">pair iterator</a>.  It serves as the
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-iterator-prototype-object">iterator prototype object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-122">interface</a> is an object that exists for every interface that has a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-11">pair iterator</a>.  It serves as the
 prototype for <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-7">default iterator objects</a> for the interface.</p>
    <p>The internal [[Prototype]] property of an <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-3">iterator prototype object</a> must be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%IteratorPrototype%</a>.</p>
    <div class="algorithm" data-algorithm="to invoke the next property of iterators">
     <p>An <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-4">iterator prototype object</a> must have a property named “next” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-13">function object</a> that behaves as follows:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-122">interface</a> for which the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-5">iterator prototype object</a> exists.</p>
+      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-123">interface</a> for which the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-5">iterator prototype object</a> exists.</p>
      <li data-md="">
       <p>Let <var>object</var> be the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-toobject">ToObject</a> on the <emu-val>this</emu-val> value.</p>
      <li data-md="">
@@ -10623,13 +10632,13 @@ return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createi
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createiterresultobject">CreateIterResultObject</a>(<var>result</var>, <emu-val>false</emu-val>).</p>
     </ol>
    </div>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-4">class string</a> of an <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-6">iterator prototype object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-123">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-80">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-124">interface</a> and the string “Iterator”.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-4">class string</a> of an <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-6">iterator prototype object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-124">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-80">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-125">interface</a> and the string “Iterator”.</p>
    <h4 class="heading settled" data-level="3.6.10" id="es-maplike"><span class="secno">3.6.10. </span><span class="content">Maplike declarations</span><a class="self-link" href="#es-maplike"></a></h4>
-   <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-125">interface</a> that has a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-16">maplike declaration</a> must have a [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
+   <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-126">interface</a> that has a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-16">maplike declaration</a> must have a [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
 initially set to a newly created <emu-val>Map</emu-val> object.
 This <emu-val>Map</emu-val> object’s [[MapData]] internal slot is
 the object’s <a data-link-type="dfn" href="#dfn-map-entries" id="ref-for-dfn-map-entries-3">map entries</a>.</p>
-   <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-126">interface</a> <var>A</var> is declared with
+   <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-127">interface</a> <var>A</var> is declared with
 a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-17">maplike declaration</a>, then
 there exists a number of additional properties on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-38">interface prototype object</a>.
 These additional properties are described in the sub-sections below.</p>
@@ -10872,11 +10881,11 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>2</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “set”.</p>
    <h4 class="heading settled" data-level="3.6.11" id="es-setlike"><span class="secno">3.6.11. </span><span class="content">Setlike declarations</span><a class="self-link" href="#es-setlike"></a></h4>
-   <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-127">interface</a> that has a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-14">setlike declaration</a> must have a [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
+   <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-128">interface</a> that has a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-14">setlike declaration</a> must have a [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
 initially set to a newly created <emu-val>Set</emu-val> object.
 This <emu-val>Set</emu-val> object’s [[SetData]] internal slot is
 the object’s <a data-link-type="dfn" href="#dfn-set-entries" id="ref-for-dfn-set-entries-3">set entries</a>.</p>
-   <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-128">interface</a> <var>A</var> is declared with a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-15">setlike declaration</a>, then
+   <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-129">interface</a> <var>A</var> is declared with a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-15">setlike declaration</a>, then
 there exists a number of additional properties
 on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-46">interface prototype object</a>.
 These additional properties are described in the sub-sections below.</p>
@@ -11090,7 +11099,7 @@ and similarly with their setters.</p>
     <p>When invoking an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-60">operation</a> by calling
     a <emu-val>Function</emu-val> object that is the value of one of the copies that exists
     due to an implements statement, the <emu-val>this</emu-val> value is
-    checked to ensure that it is an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-129">interface</a> corresponding to the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-54">interface prototype object</a> that the property is on.</p>
+    checked to ensure that it is an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-130">interface</a> corresponding to the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-54">interface prototype object</a> that the property is on.</p>
     <p>For example, consider the following IDL:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">A</span> {
   <span class="kt">void</span> <span class="nv">f</span>();
@@ -11125,24 +11134,18 @@ updated to be the <a data-link-type="dfn" href="#dfn-interface-prototype-object"
 a platform object that implements one or more interfaces
 must be the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-81">identifier</a> of
 the <a data-link-type="dfn" href="#dfn-primary-interface" id="ref-for-dfn-primary-interface-3">primary interface</a> of the platform object.</p>
-   <h4 class="heading settled" data-level="3.8.1" id="indexed-and-named-properties"><span class="secno">3.8.1. </span><span class="content">Indexed and named properties</span><a class="self-link" href="#indexed-and-named-properties"></a></h4>
-   <p>If a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-52">platform object</a> implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-130">interface</a> that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-9">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-5">named properties</a>,
-the object will appear to have additional properties that correspond to the
-object’s indexed and named properties.  These properties are not “real” own
+   <h3 class="heading settled" data-level="3.9" id="es-legacy-platform-objects"><span class="secno">3.9. </span><span class="content">Legacy platform objects</span><span id="indexed-and-named-properties"></span><a class="self-link" href="#es-legacy-platform-objects"></a></h3>
+   <p><a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-4">Legacy platform objects</a> will appear to have additional properties that correspond to the <a data-link-type="dfn" href="#idl-indexed-properties" id="ref-for-idl-indexed-properties-3">indexed</a> and <a data-link-type="dfn" href="#idl-named-properties" id="ref-for-idl-named-properties-3">named properties</a>.  These properties are not “real” own
 properties on the object, but are made to look like they are by being exposed
 by the [[GetOwnProperty]] internal method.</p>
-   <p>However, when the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-93">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-94">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-84">extended attribute</a> has been used,
-named properties are not exposed on the object but on another object
-in the prototype chain, the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-14">named properties object</a>.</p>
    <p>It is permissible for an object to implement multiple interfaces that support indexed properties.
 However, if so, and there are conflicting definitions as to the object’s <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-4">supported property indices</a>,
 or if one of the interfaces is a <a data-link-type="dfn" href="#dfn-supplemental-interface" id="ref-for-dfn-supplemental-interface-8">supplemental interface</a> for the
-platform object, then it is undefined what additional properties the object will appear to
+legacy platform object, then it is undefined what additional properties the object will appear to
 have, or what its exact behavior will be with regard to its indexed properties.
 The same applies for named properties.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-8">indexed property getter</a> that is defined on the derived-most interface that the
-platform object implements is the one that defines the behavior
+   <p>The <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-9">indexed property getter</a> that is defined on the derived-most interface that the
+legacy platform object implements is the one that defines the behavior
 when indexing the object with an array index.  Similarly for <a data-link-type="dfn" href="#dfn-indexed-property-setter" id="ref-for-dfn-indexed-property-setter-4">indexed property setters</a>.
 This way, the definitions of these special operations from
 ancestor interfaces can be overridden.</p>
@@ -11170,23 +11173,25 @@ the interfaces that <var>O</var> implements.</p>
    <div class="algorithm" data-algorithm="named property visibility algorithm">
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-named-property-visibility">named property visibility algorithm</dfn> is used to determine if a given named property is exposed on an object.
     Some named properties are not exposed on an object depending on whether
-    the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-8">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-85">extended attribute</a> was used.
+    the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-8">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-86">extended attribute</a> was used.
     The algorithm operates as follows, with property name <var>P</var> and object <var>O</var>:</p>
     <ol>
      <li data-md="">
       <p>If <var>P</var> is not a <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-4">supported property name</a> of <var>O</var>, then return false.</p>
      <li data-md="">
       <p>If <var>O</var> has an own property named <var>P</var>, then return false.</p>
-      <p class="note" role="note">Note: This will include cases in which <var>O</var> has unforgeable properties, because in practice those are always set up before objects have any supported property names, and once set up will make the corresponding named properties invisible.</p>
+      <p class="note" role="note">Note: This will include cases in which <var>O</var> has unforgeable properties,
+  because in practice those are always set up before objects have any supported property names,
+  and once set up will make the corresponding named properties invisible.</p>
      <li data-md="">
-      <p>If <var>O</var> implements an interface that has the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-9">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-86">extended attribute</a>, then return true.</p>
+      <p>If <var>O</var> implements an interface that has the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-9">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-87">extended attribute</a>, then return true.</p>
      <li data-md="">
       <p>Initialize <var>prototype</var> to be the value of the internal [[Prototype]] property of <var>O</var>.</p>
      <li data-md="">
       <p>While <var>prototype</var> is not null:</p>
       <ol>
        <li data-md="">
-        <p>If <var>prototype</var> is not a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-15">named properties object</a>,
+        <p>If <var>prototype</var> is not a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-14">named properties object</a>,
 and <var>prototype</var> has an own property named <var>P</var>, then return false.</p>
        <li data-md="">
         <p>Set <var>prototype</var> to be the value of the internal [[Prototype]] property of <var>prototype</var>.</p>
@@ -11194,42 +11199,42 @@ and <var>prototype</var> has an own property named <var>P</var>, then return fal
      <li data-md="">
       <p>Return true.</p>
     </ol>
+    <div class="note" role="note">
+     <p>This should ensure that for objects with named properties, property resolution is done in the following order:</p>
+     <ol>
+      <li data-md="">
+       <p>Indexed properties.</p>
+      <li data-md="">
+       <p>Own properties, including unforgeable attributes and operations.</p>
+      <li data-md="">
+       <p>Then, if [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-10">OverrideBuiltins</a></code>]:</p>
+       <ol>
+        <li data-md="">
+         <p>Named properties.</p>
+        <li data-md="">
+         <p>Properties from the prototype chain.</p>
+       </ol>
+      <li data-md="">
+       <p>Otherwise, if not [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-11">OverrideBuiltins</a></code>]:</p>
+       <ol>
+        <li data-md="">
+         <p>Properties from the prototype chain.</p>
+        <li data-md="">
+         <p>Named properties.</p>
+       </ol>
+     </ol>
+    </div>
    </div>
-   <div class="note" role="note">
-    <p>This should ensure that for objects with named properties, property resolution is done in the following order:</p>
-    <ol>
-     <li data-md="">
-      <p>Indexed properties.</p>
-     <li data-md="">
-      <p>Own properties, including unforgeable attributes and operations.</p>
-     <li data-md="">
-      <p>Then, if [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-10">OverrideBuiltins</a></code>]:</p>
-      <ol>
-       <li data-md="">
-        <p>Named properties.</p>
-       <li data-md="">
-        <p>Properties from the prototype chain.</p>
-      </ol>
-     <li data-md="">
-      <p>Otherwise, if not [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-11">OverrideBuiltins</a></code>]:</p>
-      <ol>
-       <li data-md="">
-        <p>Properties from the prototype chain.</p>
-       <li data-md="">
-        <p>Named properties.</p>
-      </ol>
-    </ol>
-   </div>
-   <p>Support for <a data-link-type="dfn" href="#dfn-getter" id="ref-for-dfn-getter-1">getters</a> is
-handled by the <a href="#getownproperty">platform object [[GetOwnProperty]] method</a> defined in section <a href="#getownproperty">§3.8.3 Platform object [[GetOwnProperty]] method</a>, and
-for <a data-link-type="dfn" href="#dfn-setter" id="ref-for-dfn-setter-1">setters</a> by the <a href="#defineownproperty">platform object [[DefineOwnProperty]] method</a> defined in section <a href="#defineownproperty">§3.8.8 Platform object [[DefineOwnProperty]] method</a> and the <a href="#platformobjectset">platform object [[Set]] method</a> defined in section <a href="#platformobjectset">§3.8.6 Platform object [[Set]] method</a>.</p>
-   <h4 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="3.8.2" data-lt="The PlatformObjectGetOwnProperty abstract operation" data-noexport="" id="getownproperty-guts"><span class="secno">3.8.2. </span><span class="content">The PlatformObjectGetOwnProperty abstract operation</span></h4>
-   <div class="algorithm" data-algorithm="PlatformObjectGetOwnProperty abstract operation">
-    <p>The PlatformObjectGetOwnProperty abstract operation performs the following steps when
+   <p>Support for <a data-link-type="dfn" href="#dfn-getter" id="ref-for-dfn-getter-1">getters</a> is handled by the <a href="#legacy-platform-object-getownproperty">legacy platform object [[GetOwnProperty]] method</a>,
+and for <a data-link-type="dfn" href="#dfn-setter" id="ref-for-dfn-setter-1">setters</a> by the <a href="#legacy-platform-object-defineownproperty">legacy platform object [[DefineOwnProperty]] method</a>,
+and the <a href="#legacy-platform-object-set">legacy platform object [[Set]] method</a>.</p>
+   <h4 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="3.9.1" data-lt="LegacyPlatformObjectGetOwnProperty|The PlatformObjectGetOwnProperty abstract operation" data-noexport="" id="getownproperty-guts"><span class="secno">3.9.1. </span><span class="content">The LegacyPlatformObjectGetOwnProperty abstract operation</span></h4>
+   <div class="algorithm" data-algorithm="LegacyPlatformObjectGetOwnProperty abstract operation">
+    <p>The LegacyPlatformObjectGetOwnProperty abstract operation performs the following steps when
     called with an object <var>O</var>, a property name <var>P</var>, and a boolean <var>ignoreNamedProps</var> value:</p>
     <ol>
      <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-10">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-1">array index property name</a>, then:</p>
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-12">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-1">array index property name</a>, then:</p>
       <ol>
        <li data-md="">
         <p>Let <var>index</var> be the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-touint32">ToUint32</a>(<var>P</var>).</p>
@@ -11261,8 +11266,8 @@ of performing the steps listed in the description of <var>operation</var> with <
         <p>Set <var>ignoreNamedProps</var> to true.</p>
       </ol>
      <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-6">supports named properties</a>, <var>O</var> does not
-implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-132">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-95">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-96">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-87">extended attribute</a>, the result of running the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-2">named property visibility algorithm</a> with
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-8">supports named properties</a>,
+the result of running the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-2">named property visibility algorithm</a> with
 property name <var>P</var> and object <var>O</var> is true, and <var>ignoreNamedProps</var> is false, then:</p>
       <ol>
        <li data-md="">
@@ -11295,15 +11300,15 @@ otherwise set it to <emu-val>true</emu-val>.</p>
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinarygetownproperty">OrdinaryGetOwnProperty</a>(<var>O</var>, <var>P</var>).</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.8.3" id="getownproperty"><span class="secno">3.8.3. </span><span class="content">Platform object [[GetOwnProperty]] method</span><a class="self-link" href="#getownproperty"></a></h4>
+   <h4 class="heading settled" data-level="3.9.2" id="legacy-platform-object-getownproperty" oldis="getownproperty"><span class="secno">3.9.2. </span><span class="content">Legacy platform object [[GetOwnProperty]] method</span><a class="self-link" href="#legacy-platform-object-getownproperty"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[GetOwnProperty]] method of platform objects">
-    <p>The internal [[GetOwnProperty]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-53">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-133">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-11">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-7">named properties</a> must behave as follows when called with property name <var>P</var>:</p>
+    <p>The internal [[GetOwnProperty]] method of every <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-5">legacy platform object</a> <var>O</var> must behave as follows when called with property name <var>P</var>:</p>
     <ol>
      <li data-md="">
-      <p>Return the result of invoking the <a data-link-type="dfn" href="#getownproperty-guts" id="ref-for-getownproperty-guts-1">PlatformObjectGetOwnProperty</a> abstract operation with <var>O</var>, <var>P</var>, and <emu-val>false</emu-val> as arguments.</p>
+      <p>Return <a data-link-type="dfn" href="#getownproperty-guts" id="ref-for-getownproperty-guts-1">LegacyPlatformObjectGetOwnProperty</a>(<var>O</var>, <var>P</var>, <emu-val>false</emu-val>).</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.8.4" id="invoking-indexed-setter"><span class="secno">3.8.4. </span><span class="content">Invoking a platform object indexed property setter</span><a class="self-link" href="#invoking-indexed-setter"></a></h4>
+   <h4 class="heading settled" data-level="3.9.3" id="invoking-indexed-setter"><span class="secno">3.9.3. </span><span class="content">Invoking a legacy platform object indexed property setter</span><a class="self-link" href="#invoking-indexed-setter"></a></h4>
    <div class="algorithm" data-algorithm="invoke an indexed property setter">
     <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="invoke the indexed property setter" id="invoke-indexed-setter">invoke an indexed property setter</dfn> with property name <var>P</var> and ECMAScript value <var>V</var>, the following steps must be performed:</p>
     <ol>
@@ -11330,7 +11335,7 @@ and false otherwise.</p>
       <p>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.8.5" id="invoking-named-setter"><span class="secno">3.8.5. </span><span class="content">Invoking a platform object named property setter</span><a class="self-link" href="#invoking-named-setter"></a></h4>
+   <h4 class="heading settled" data-level="3.9.4" id="invoking-named-setter"><span class="secno">3.9.4. </span><span class="content">Invoking a legacy platform object named property setter</span><a class="self-link" href="#invoking-named-setter"></a></h4>
    <div class="algorithm" data-algorithm="invoke a named property setter">
     <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="invoke the named property setter" id="invoke-named-setter">invoke a named property setter</dfn> with property name <var>P</var> and ECMAScript value <var>V</var>, the following steps must be performed:</p>
     <ol>
@@ -11354,9 +11359,9 @@ and false otherwise.</p>
       <p>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of <var>operation</var> with <var>P</var> and <var>value</var> as the two argument values.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.8.6" id="platformobjectset"><span class="secno">3.8.6. </span><span class="content">Platform object [[Set]] method</span><a class="self-link" href="#platformobjectset"></a></h4>
-   <div class="algorithm" data-algorithm="to invoke the internal [[Set]] method of platform objects">
-    <p>The internal [[Set]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-54">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-134">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-12">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-8">named properties</a> must behave as follows when called with
+   <h4 class="heading settled" data-level="3.9.5" id="legacy-platform-object-set" oldis="platformobjectset"><span class="secno">3.9.5. </span><span class="content">Legacy platform object [[Set]] method</span><a class="self-link" href="#legacy-platform-object-set"></a></h4>
+   <div class="algorithm" data-algorithm="to invoke the internal [[Set]] method of legacy platform objects">
+    <p>The internal [[Set]] method of every <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-6">legacy platform object</a> <var>O</var> must behave as follows when called with
     property name <var>P</var>, value <var>V</var>, and ECMAScript language value <var>Receiver</var>:</p>
     <ol>
      <li data-md="">
@@ -11381,27 +11386,26 @@ and <var>O</var> implements an interface with a <a data-link-type="dfn" href="#d
         </ol>
       </ol>
      <li data-md="">
-      <p>Let <var>ownDesc</var> be the result of invoking the <a data-link-type="dfn" href="#getownproperty-guts" id="ref-for-getownproperty-guts-2">PlatformObjectGetOwnProperty</a> abstract operation with <var>O</var>, <var>P</var>, and <emu-val>true</emu-val> as arguments.</p>
+      <p>Let <var>ownDesc</var> be <a data-link-type="dfn" href="#getownproperty-guts" id="ref-for-getownproperty-guts-2">LegacyPlatformObjectGetOwnProperty</a>(<var>O</var>, <var>P</var>, <emu-val>true</emu-val>).</p>
      <li data-md="">
       <p>Perform steps 3-11 of the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver">default [[Set]] internal method</a>.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.8.7" id="platformobjectsetprototypeof"><span class="secno">3.8.7. </span><span class="content">Platform object [[SetPrototypeOf]] method</span><a class="self-link" href="#platformobjectsetprototypeof"></a></h4>
-   <div class="algorithm" data-algorithm="to invoke the internal [[SetPrototypeOf]] method of platform objects">
-    <p>The internal [[SetPrototypeOf]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-55">platform object</a> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-135">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-97">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-98">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-89">extended attribute</a> must execute the same algorithm as is defined for the
+   <h4 class="heading settled" data-level="3.9.6" id="legacy-platform-object-setprototypeof" oldis="platformobjectsetprototypeof"><span class="secno">3.9.6. </span><span class="content">Legacy platform object [[SetPrototypeOf]] method</span><a class="self-link" href="#legacy-platform-object-setprototypeof"></a></h4>
+   <div class="algorithm" data-algorithm="to invoke the internal [[SetPrototypeOf]] method of legacy platform objects">
+    <p>The internal [[SetPrototypeOf]] method of every <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-7">legacy platform object</a> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-132">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-95">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-96">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-89">extended attribute</a> must execute the same algorithm as is defined for the
     [[SetPrototypeOf]] internal method of an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">immutable prototype exotic object</a>.</p>
    </div>
    <p class="note" role="note">Note: For <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> objects, it is unobservable whether this is implemented, since the presence of
 the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#windowproxy">WindowProxy</a></code> object ensures that [[SetPrototypeOf]] is never called on a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> object
 directly. For other global objects, however, this is necessary.</p>
-   <h4 class="heading settled" data-level="3.8.8" id="defineownproperty"><span class="secno">3.8.8. </span><span class="content">Platform object [[DefineOwnProperty]] method</span><a class="self-link" href="#defineownproperty"></a></h4>
-   <div class="algorithm" data-algorithm="to invoke the internal [[DefineOwnProperty]] method of platform objects">
-    <p>When the internal [[DefineOwnProperty]] method of a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-56">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-136">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-14">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-10">named properties</a> is called with
-    property key <var>P</var> and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">Property Descriptor</a> <var>Desc</var>,
+   <h4 class="heading settled" data-level="3.9.7" id="legacy-platform-object-defineownproperty" oldis="defineownproperty"><span class="secno">3.9.7. </span><span class="content">Legacy platform object [[DefineOwnProperty]] method</span><a class="self-link" href="#legacy-platform-object-defineownproperty"></a></h4>
+   <div class="algorithm" data-algorithm="to invoke the internal [[DefineOwnProperty]] method of legacy platform objects">
+    <p>When the internal [[DefineOwnProperty]] method of a <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-8">legacy platform object</a> <var>O</var> is called with property key <var>P</var> and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">Property Descriptor</a> <var>Desc</var>,
     the following steps must be taken:</p>
     <ol>
      <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-15">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-4">array index property name</a>, then:</p>
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-14">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-4">array index property name</a>, then:</p>
       <ol>
        <li data-md="">
         <p>If the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-isdatadescriptor">IsDataDescriptor</a>(<var>Desc</var>) is <emu-val>false</emu-val>, then return <emu-val>false</emu-val>.</p>
@@ -11413,8 +11417,8 @@ directly. For other global objects, however, this is necessary.</p>
         <p>Return <emu-val>true</emu-val>.</p>
       </ol>
      <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-11">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-137">interface</a> with the
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-99">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-100">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-90">extended attribute</a> and <var>P</var> is not an <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-dfn-unforgeable-property-name-1">unforgeable property name</a> of <var>O</var>, then:</p>
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-10">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-133">interface</a> with the
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-97">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-98">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-90">extended attribute</a> and <var>P</var> is not an <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-dfn-unforgeable-property-name-1">unforgeable property name</a> of <var>O</var>, then:</p>
       <ol>
        <li data-md="">
         <p>Let <var>creating</var> be true if <var>P</var> is not a <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-6">supported property name</a>, and false otherwise.</p>
@@ -11438,19 +11442,19 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
         </ol>
       </ol>
      <li data-md="">
-      <p>If <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-138">interface</a> with the
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-101">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-102">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-92">extended attribute</a>, then set <var>Desc</var>.[[Configurable]] to <emu-val>true</emu-val>.</p>
+      <p>If <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-134">interface</a> with the
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-99">Global</a></code>] or
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-100">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-92">extended attribute</a>, then set <var>Desc</var>.[[Configurable]] to <emu-val>true</emu-val>.</p>
      <li data-md="">
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinarydefineownproperty">OrdinaryDefineOwnProperty</a>(<var>O</var>, <var>P</var>, <var>Desc</var>).</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.8.9" id="delete"><span class="secno">3.8.9. </span><span class="content">Platform object [[Delete]] method</span><a class="self-link" href="#delete"></a></h4>
-   <div class="algorithm" data-algorithm="to invoke the internal [[Delete]] method of platform objects">
-    <p>The internal [[Delete]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-57">platform object</a> <var>O</var> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-139">interface</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-16">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-12">named properties</a> must behave as follows when called with property name <var>P</var>.</p>
+   <h4 class="heading settled" data-level="3.9.8" id="legacy-platform-object-delete" oldis="delete"><span class="secno">3.9.8. </span><span class="content">Legacy platform object [[Delete]] method</span><a class="self-link" href="#legacy-platform-object-delete"></a></h4>
+   <div class="algorithm" data-algorithm="to invoke the internal [[Delete]] method of legacy platform objects">
+    <p>The internal [[Delete]] method of every <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-9">legacy platform object</a> <var>O</var> must behave as follows when called with property name <var>P</var>.</p>
     <ol>
      <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-17">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-5">array index property name</a>, then:</p>
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-15">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-5">array index property name</a>, then:</p>
       <ol>
        <li data-md="">
         <p>Let <var>index</var> be the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-touint32">ToUint32</a>(<var>P</var>).</p>
@@ -11460,8 +11464,8 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
         <p>Return <emu-val>false</emu-val>.</p>
       </ol>
      <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-13">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-140">interface</a> with the
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-103">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-104">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-93">extended attribute</a> and the result of calling the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-3">named property visibility algorithm</a> with property name <var>P</var> and object <var>O</var> is true, then:</p>
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-11">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-135">interface</a> with the
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-101">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-102">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-93">extended attribute</a> and the result of calling the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-3">named property visibility algorithm</a> with property name <var>P</var> and object <var>O</var> is true, then:</p>
       <ol>
        <li data-md="">
         <p>If <var>O</var> does not implement an interface with a <a data-link-type="dfn" href="#dfn-named-property-deleter" id="ref-for-dfn-named-property-deleter-5">named property deleter</a>, then return <emu-val>false</emu-val>.</p>
@@ -11498,12 +11502,14 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
       <p>Return <emu-val>true</emu-val>.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.8.10" id="call"><span class="secno">3.8.10. </span><span class="content">Platform object [[Call]] method</span><a class="self-link" href="#call"></a></h4>
-   <div class="algorithm" data-algorithm="to invoke the internal [[Call]] method of platform objects">
-    <p>The internal [[Call]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-58">platform object</a> that implements
-    an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-141">interface</a> <var>I</var> with at least one <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-8">legacy caller</a> must behave as follows,
+   <h4 class="heading settled" data-level="3.9.9" id="legacy-platform-object-call" oldis="call"><span class="secno">3.9.9. </span><span class="content">Legacy platform object [[Call]] method</span><a class="self-link" href="#legacy-platform-object-call"></a></h4>
+   <div class="algorithm" data-algorithm="to invoke the internal [[Call]] method of legacy platform objects">
+    <p>The internal [[Call]] method of <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-10">legacy platform object</a> that implements
+    an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-136">interface</a> <var>I</var> must behave as follows,
     assuming <var>arg</var><sub>0..<var>n</var>−1</sub> is the list of argument values passed to [[Call]]:</p>
     <ol>
+     <li data-md="">
+      <p>If <var>I</var> has no <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-11">legacy callers</a>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-56">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-12">effective overload set</a> for legacy callers on <var>I</var> and with argument count <var>n</var>.</p>
      <li data-md="">
@@ -11514,33 +11520,30 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
       <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-58">converting</a> the return value from those actions to an ECMAScript value of the type <var>operation</var> is declared to return (or <emu-val>undefined</emu-val> if <var>operation</var> is declared to return <code class="idl"><a data-link-type="idl" href="#idl-void" id="ref-for-idl-void-6">void</a></code>).</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.8.11" id="preventextensions"><span class="secno">3.8.11. </span><span class="content">Platform object [[PreventExtensions]] method</span><a class="self-link" href="#preventextensions"></a></h4>
-   <div class="algorithm" data-algorithm="to invoke the internal [[PreventExtensions]] method of platform objects">
-    <p>When the [[PreventExtensions]] internal method of a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-59">platform object</a> <var>O</var> is called,
+   <h4 class="heading settled" data-level="3.9.10" id="legacy-platform-object-preventextensions" oldis="preventextensions"><span class="secno">3.9.10. </span><span class="content">Legacy platform object [[PreventExtensions]] method</span><a class="self-link" href="#legacy-platform-object-preventextensions"></a></h4>
+   <div class="algorithm" data-algorithm="to invoke the internal [[PreventExtensions]] method of legacy platform objects">
+    <p>When the [[PreventExtensions]] internal method of a <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-11">legacy platform object</a> is called,
     the following steps are taken:</p>
     <ol>
      <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-18">supports indexed properties</a> or <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-14">supports named properties</a>,
-return <emu-val>false</emu-val>.</p>
-     <li data-md="">
-      <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinarypreventextensions">OrdinaryPreventExtensions</a>(<var>O</var>).</p>
+      <p>return <emu-val>false</emu-val>.</p>
     </ol>
-    <p class="note" role="note">Note: this keeps <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-60">platform objects</a> which <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-19">support indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-15">named properties</a> extensible by
+    <p class="note" role="note">Note: this keeps <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-12">legacy platform objects</a> extensible by
     making [[PreventExtensions]] fail for them.</p>
    </div>
-   <h4 class="heading settled" data-level="3.8.12" id="property-enumeration"><span class="secno">3.8.12. </span><span class="content">Property enumeration</span><a class="self-link" href="#property-enumeration"></a></h4>
+   <h4 class="heading settled" data-level="3.9.11" id="property-enumeration"><span class="secno">3.9.11. </span><span class="content">Property enumeration</span><a class="self-link" href="#property-enumeration"></a></h4>
    <p>This document does not define a complete property enumeration order
-for all <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-61">platform objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-142">interfaces</a> (or for <a href="#es-exception-objects" id="ref-for-es-exception-objects-1">platform objects representing exceptions</a>).
-However, if a platform object implements an interface that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-20">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-16">named properties</a>, then
+for <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-52">platform objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-137">interfaces</a> (or for <a href="#es-exception-objects" id="ref-for-es-exception-objects-1">platform objects representing exceptions</a>).
+However, for <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-13">legacy platform objects</a>,
 properties on the object must be
 enumerated in the following order:</p>
    <ol>
     <li data-md="">
-     <p>If the object <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-21">supports indexed properties</a>, then
+     <p>If the object <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-16">supports indexed properties</a>, then
 the object’s <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-8">supported property indices</a> are
 enumerated first, in numerical order.</p>
     <li data-md="">
-     <p>If the object <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-17">supports named properties</a> and doesn’t implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-143">interface</a> with the
+     <p>If the object <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-12">supports named properties</a> and doesn’t implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-138">interface</a> with the
 [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-7">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-94">extended attribute</a>, then
 the object’s <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-7">supported property names</a> that
 are visible according to the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-4">named property visibility algorithm</a> are enumerated next, in the order given in the definition of the set of supported property names.</p>
@@ -11549,7 +11552,7 @@ are visible according to the <a data-link-type="dfn" href="#dfn-named-property-v
 in no defined order.</p>
    </ol>
    <p class="note" role="note">Note: Future versions of the ECMAScript specification may define a total order for property enumeration.</p>
-   <h3 class="heading settled" data-level="3.9" id="es-user-objects"><span class="secno">3.9. </span><span class="content">User objects implementing callback interfaces</span><a class="self-link" href="#es-user-objects"></a></h3>
+   <h3 class="heading settled" data-level="3.10" id="es-user-objects"><span class="secno">3.10. </span><span class="content">User objects implementing callback interfaces</span><a class="self-link" href="#es-user-objects"></a></h3>
    <p>As described in <a href="#idl-objects">§2.10 Objects implementing interfaces</a>, <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-26">callback interfaces</a> can be
 implemented in script by an ECMAScript object.
 The following cases determine whether and how a given object
@@ -11578,7 +11581,7 @@ is the result of invoking [[Get]] on the object with a
 property name that is that identifier.</p>
    </ul>
    <p>Note that ECMAScript objects need not have
-properties corresponding to <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-29">constants</a> on them to be considered as <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-9">user objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-144">interfaces</a> that happen
+properties corresponding to <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-29">constants</a> on them to be considered as <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-9">user objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-139">interfaces</a> that happen
 to have constants declared on them.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-single-operation-callback-interface">single operation callback interface</dfn> is
 a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-27">callback interface</a> that:</p>
@@ -11791,7 +11794,7 @@ either an abrupt completion or a normal completion for the value <emu-val>true</
       </ol>
     </ol>
    </div>
-   <h3 class="heading settled" data-level="3.10" id="es-invoking-callback-functions"><span class="secno">3.10. </span><span class="content">Invoking callback functions</span><a class="self-link" href="#es-invoking-callback-functions"></a></h3>
+   <h3 class="heading settled" data-level="3.11" id="es-invoking-callback-functions"><span class="secno">3.11. </span><span class="content">Invoking callback functions</span><a class="self-link" href="#es-invoking-callback-functions"></a></h3>
    <p>An ECMAScript <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">callable</a> object that is being
 used as a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-28">callback function</a> value is
 called in a manner similar to how <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-61">operations</a> on <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-10">user objects</a> are called (as
@@ -11887,15 +11890,15 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
       </ol>
     </ol>
    </div>
-   <h3 class="heading settled" data-level="3.11" id="es-namespaces"><span class="secno">3.11. </span><span class="content">Namespaces</span><a class="self-link" href="#es-namespaces"></a></h3>
+   <h3 class="heading settled" data-level="3.12" id="es-namespaces"><span class="secno">3.12. </span><span class="content">Namespaces</span><a class="self-link" href="#es-namespaces"></a></h3>
    <p>For every <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-12">namespace</a> that is <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-9">exposed</a> in a given ECMAScript global environment,
 a corresponding property must exist on the ECMAScript
 environment’s global object. The name of the property is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-90">identifier</a> of the namespace, and its value is an object
 called the <dfn data-dfn-type="dfn" data-export="" id="dfn-namespace-object">namespace object<a class="self-link" href="#dfn-namespace-object"></a></dfn>.</p>
    <p>The property has the attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>,
 [[Configurable]]: <emu-val>true</emu-val> }</span>. The characteristics of a
-namespace object are described in <a href="#namespace-object">§3.11.1 Namespace object</a>.</p>
-   <h4 class="heading settled" data-level="3.11.1" id="namespace-object"><span class="secno">3.11.1. </span><span class="content">Namespace object</span><a class="self-link" href="#namespace-object"></a></h4>
+namespace object are described in <a href="#namespace-object">§3.12.1 Namespace object</a>.</p>
+   <h4 class="heading settled" data-level="3.12.1" id="namespace-object"><span class="secno">3.12.1. </span><span class="content">Namespace object</span><a class="self-link" href="#namespace-object"></a></h4>
    <div class="algorithm" data-algorithm="to create a namespace object">
     <p>The namespace object for a given <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-13">namespace</a> <var>namespace</var> and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var> is created as follows:</p>
     <ol>
@@ -11911,13 +11914,13 @@ namespace object are described in <a href="#namespace-object">§3.11.1 Namespace
       </ol>
     </ol>
    </div>
-   <h3 class="heading settled" data-level="3.12" id="es-exceptions"><span class="secno">3.12. </span><span class="content">Exceptions</span><a class="self-link" href="#es-exceptions"></a></h3>
+   <h3 class="heading settled" data-level="3.13" id="es-exceptions"><span class="secno">3.13. </span><span class="content">Exceptions</span><a class="self-link" href="#es-exceptions"></a></h3>
    <p>There must exist a property on the ECMAScript global object
 whose name is “DOMException” and value is an object called the <dfn class="dfn-paneled" data-dfn-for="DOMException" data-dfn-type="dfn" data-export="" id="dfn-DOMException-constructor-object">DOMException constructor object</dfn>,
 which provides access to legacy DOMException code constants and allows construction of
 DOMException instances.
 The property has the attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
-   <h4 class="heading settled" data-level="3.12.1" id="es-DOMException-constructor-object"><span class="secno">3.12.1. </span><span class="content">DOMException constructor object</span><a class="self-link" href="#es-DOMException-constructor-object"></a></h4>
+   <h4 class="heading settled" data-level="3.13.1" id="es-DOMException-constructor-object"><span class="secno">3.13.1. </span><span class="content">DOMException constructor object</span><a class="self-link" href="#es-DOMException-constructor-object"></a></h4>
    <p>The DOMException constructor object must be a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-18">function object</a> but with a [[Prototype]] value of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Error%</a>.</p>
    <p>For every legacy code listed in the <a href="#dfn-error-names-table" id="ref-for-dfn-error-names-table-2">error names table</a>,
 there must be a property on the DOMException constructor object
@@ -11926,7 +11929,7 @@ attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[E
    <p>The DOMException constructor object must also have a property named
 “prototype” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span> whose value is an object called the <dfn class="dfn-paneled" data-dfn-for="DOMException" data-dfn-type="dfn" data-export="" id="dfn-DOMException-prototype-object">DOMException prototype object</dfn>.
 This object also provides access to the legacy code values.</p>
-   <h5 class="heading settled" data-level="3.12.1.1" id="es-DOMException-call"><span class="secno">3.12.1.1. </span><span class="content">DOMException(message, name)</span><a class="self-link" href="#es-DOMException-call"></a></h5>
+   <h5 class="heading settled" data-level="3.13.1.1" id="es-DOMException-call"><span class="secno">3.13.1.1. </span><span class="content">DOMException(message, name)</span><a class="self-link" href="#es-DOMException-call"></a></h5>
    <div class="algorithm" data-algorithm="to create a DOMException">
     <p>When the DOMException function is called with arguments <var>message</var> and <var>name</var>,
     the following steps are taken:</p>
@@ -11963,7 +11966,7 @@ This object also provides access to the legacy code values.</p>
       <p>Return <var>O</var>.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.12.2" id="es-DOMException-prototype-object"><span class="secno">3.12.2. </span><span class="content">DOMException prototype object</span><a class="self-link" href="#es-DOMException-prototype-object"></a></h4>
+   <h4 class="heading settled" data-level="3.13.2" id="es-DOMException-prototype-object"><span class="secno">3.13.2. </span><span class="content">DOMException prototype object</span><a class="self-link" href="#es-DOMException-prototype-object"></a></h4>
    <p>The DOMException prototype object must
 have an internal [[Prototype]] property whose value is <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ErrorPrototype%</a>.</p>
    <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-6">class string</a> of the <a data-link-type="dfn" href="#dfn-DOMException-prototype-object" id="ref-for-dfn-DOMException-prototype-object-2">DOMException prototype object</a> is “DOMExceptionPrototype”.</p>
@@ -11973,10 +11976,10 @@ on the DOMException prototype object with attributes <span class="prop-desc">{ [
 there must be a property on the DOMException prototype object
 whose name and value are as indicated in the table.  The property has
 attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span>.</p>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="3.13" data-lt="Exception objects" data-noexport="" id="es-exception-objects"><span class="secno">3.13. </span><span class="content">Exception objects</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="3.14" data-lt="Exception objects" data-noexport="" id="es-exception-objects"><span class="secno">3.14. </span><span class="content">Exception objects</span></h3>
    <p><a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-5">Simple exceptions</a> are represented
 by native ECMAScript objects of the corresponding type.</p>
-   <p><code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-28">DOMExceptions</a></code> are represented by <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-62">platform objects</a> that inherit from
+   <p><code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-28">DOMExceptions</a></code> are represented by <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-53">platform objects</a> that inherit from
 the <a data-link-type="dfn" href="#dfn-DOMException-prototype-object" id="ref-for-dfn-DOMException-prototype-object-3">DOMException prototype object</a>.</p>
    <p>Every platform object representing a DOMException in ECMAScript is associated with a global environment, just
 as the <a data-link-type="dfn" href="#dfn-initial-object" id="ref-for-dfn-initial-object-5">initial objects</a> are.
@@ -11994,17 +11997,17 @@ to being passed to Object.prototype.toString and it having a “code” property
 If an implementation places non-standard properties on native <emu-val>Error</emu-val> objects, exposing for example
 stack traces or error line numbers, then these ought to be exposed
 on exception objects too.</p>
-   <h3 class="heading settled" data-level="3.14" id="es-creating-throwing-exceptions"><span class="secno">3.14. </span><span class="content">Creating and throwing exceptions</span><a class="self-link" href="#es-creating-throwing-exceptions"></a></h3>
+   <h3 class="heading settled" data-level="3.15" id="es-creating-throwing-exceptions"><span class="secno">3.15. </span><span class="content">Creating and throwing exceptions</span><a class="self-link" href="#es-creating-throwing-exceptions"></a></h3>
    <div class="algorithm" data-algorithm="current global environment">
     <p>First, we define the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-current-global-environment">current global environment</dfn> as the result of running the following algorithm:</p>
     <ol>
      <li data-md="">
       <p>Let <var>F</var> be the <emu-val>Function</emu-val> object used
 as the <emu-val>this</emu-val> value in the top-most call
-on the ECMAScript call stack where <var>F</var> corresponds to an IDL <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-63">attribute</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-62">operation</a>, <a data-link-type="dfn" href="#idl-indexed-properties" id="ref-for-idl-indexed-properties-3">indexed property</a>, <a data-link-type="dfn" href="#idl-named-properties" id="ref-for-idl-named-properties-3">named property</a>, <a href="#Constructor" id="ref-for-Constructor-24">constructor</a>, <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-5">named constructor</a> or <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-6">stringifier</a>.</p>
+on the ECMAScript call stack where <var>F</var> corresponds to an IDL <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-63">attribute</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-62">operation</a>, <a data-link-type="dfn" href="#idl-indexed-properties" id="ref-for-idl-indexed-properties-4">indexed property</a>, <a data-link-type="dfn" href="#idl-named-properties" id="ref-for-idl-named-properties-4">named property</a>, <a href="#Constructor" id="ref-for-Constructor-24">constructor</a>, <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-5">named constructor</a> or <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-6">stringifier</a>.</p>
      <li data-md="">
       <p>If <var>F</var> corresponds to an attribute, operation or stringifier, then return
-the global environment associated with the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-145">interface</a> that definition appears on.</p>
+the global environment associated with the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-140">interface</a> that definition appears on.</p>
      <li data-md="">
       <p>Otherwise, if <var>F</var> corresponds to an indexed or named property, then return
 the global environment associated with the interface that
@@ -12116,7 +12119,7 @@ a <span class="k">instanceof</span> Object<span class="p">;</span>              
    </div>
    <p>Any requirements in this document to throw an instance of an ECMAScript built-in <emu-val>Error</emu-val> must use
 the built-in from the <a data-link-type="dfn" href="#dfn-current-global-environment" id="ref-for-dfn-current-global-environment-2">current global environment</a>.</p>
-   <h3 class="heading settled" data-level="3.15" id="es-handling-exceptions"><span class="secno">3.15. </span><span class="content">Handling exceptions</span><a class="self-link" href="#es-handling-exceptions"></a></h3>
+   <h3 class="heading settled" data-level="3.16" id="es-handling-exceptions"><span class="secno">3.16. </span><span class="content">Handling exceptions</span><a class="self-link" href="#es-handling-exceptions"></a></h3>
    <p>None of the algorithms or processing requirements in the
 ECMAScript language binding catch ECMAScript exceptions.  Whenever
 an ECMAScript <emu-val>Function</emu-val> is invoked due
@@ -12125,7 +12128,7 @@ must propagate to the caller, and if
 not caught there, to its caller, and so on.</p>
    <div class="example" id="example-1432e05c">
     <a class="self-link" href="#example-1432e05c"></a> 
-    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-45">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-146">interfaces</a> and an <a data-link-type="dfn" href="#dfn-exception" id="ref-for-dfn-exception-1">exception</a>.
+    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-45">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-141">interfaces</a> and an <a data-link-type="dfn" href="#dfn-exception" id="ref-for-dfn-exception-1">exception</a>.
     The <code>valueOf</code> attribute on <code class="idl">ExceptionThrower</code> is defined to throw an exception whenever an attempt is made
     to get its value.</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Dahut</span> {
@@ -12356,7 +12359,7 @@ and “<span class="input">.</span>” is tokenized as the quoted terminal symbo
 used in the grammar and the values used for <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> terminals.  Thus, for
 example, the input text “<span class="input">Const</span>” is tokenized as
 an <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> rather than the
-terminal symbol <emu-t>const</emu-t>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-147">interface</a> with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-92">identifier</a> “A” is distinct from one named “a”, and an <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-96">extended attribute</a> [<code class="idl">constructor</code>] will not be recognized as
+terminal symbol <emu-t>const</emu-t>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-142">interface</a> with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-92">identifier</a> “A” is distinct from one named “a”, and an <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-96">extended attribute</a> [<code class="idl">constructor</code>] will not be recognized as
 the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-25">Constructor</a></code>]
 extended attribute.</p>
    <p>Implicitly, any number of <emu-t class="regex"><a href="#prod-whitespace">whitespace</a></emu-t> and <emu-t class="regex"><a href="#prod-comment">comment</a></emu-t> terminals are allowed between every other terminal
@@ -12644,7 +12647,7 @@ language binding.</p>
    <li><a href="#idl-any">any</a><span>, in §2.11</span>
    <li><a href="#idl-ArrayBuffer">ArrayBuffer</a><span>, in §2.11.30</span>
    <li><a href="#ArrayBufferView">ArrayBufferView</a><span>, in §4</span>
-   <li><a href="#dfn-array-index-property-name">array index property name</a><span>, in §3.8.1</span>
+   <li><a href="#dfn-array-index-property-name">array index property name</a><span>, in §3.9</span>
    <li><a href="#dfn-associated-realm">associated Realm</a><span>, in §3.1</span>
    <li><a href="#dfn-attribute">attribute</a><span>, in §2.2.2</span>
    <li><a href="#dfn-attribute-getter">attribute getter</a><span>, in §3.6.6</span>
@@ -12655,12 +12658,12 @@ language binding.</p>
    <li><a href="#dfn-buffer-source-type">buffer source types</a><span>, in §2.11</span>
    <li><a href="#idl-byte">byte</a><span>, in §2.11.2</span>
    <li><a href="#idl-ByteString">ByteString</a><span>, in §2.11.15</span>
-   <li><a href="#call-a-user-objects-operation">call a user object’s operation</a><span>, in §3.9</span>
+   <li><a href="#call-a-user-objects-operation">call a user object’s operation</a><span>, in §3.10</span>
    <li><a href="#dfn-callback-context">callback context</a><span>, in §2.11.19</span>
    <li><a href="#dfn-callback-function">callback function</a><span>, in §2.7</span>
    <li><a href="#idl-callback-function">Callback function types</a><span>, in §2.11.21</span>
    <li><a href="#dfn-callback-interface">callback interface</a><span>, in §2.2</span>
-   <li><a href="#dfn-callback-this-value">callback this value</a><span>, in §3.9</span>
+   <li><a href="#dfn-callback-this-value">callback this value</a><span>, in §3.10</span>
    <li><a href="#dfn-change-global-environment">change</a><span>, in §3.8</span>
    <li><a href="#Clamp">Clamp</a><span>, in §3.3</span>
    <li><a href="#dfn-class-string">class string</a><span>, in §3</span>
@@ -12686,7 +12689,7 @@ language binding.</p>
    <li><a href="#create-frozen-array-from-iterable">Creating a frozen array from an iterable</a><span>, in §3.2.25</span>
    <li><a href="#dfn-create-operation-function">creating an operation function</a><span>, in §3.6.7</span>
    <li><a href="#create-sequence-from-iterable">Creating a sequence from an iterable</a><span>, in §3.2.18</span>
-   <li><a href="#dfn-current-global-environment">current global environment</a><span>, in §3.14</span>
+   <li><a href="#dfn-current-global-environment">current global environment</a><span>, in §3.15</span>
    <li><a href="#dom-domexception-data_clone_err">DATA_CLONE_ERR</a><span>, in §2.5.1</span>
    <li><a href="#datacloneerror">DataCloneError</a><span>, in §2.5.1</span>
    <li><a href="#dataerror">DataError</a><span>, in §2.5.1</span>
@@ -12710,8 +12713,8 @@ language binding.</p>
    <li><a href="#dfn-distinguishable">distinguishable</a><span>, in §2.2.6</span>
    <li><a href="#dfn-distinguishing-argument-index">distinguishing argument index</a><span>, in §2.2.6</span>
    <li><a href="#dfn-DOMException">DOMException</a><span>, in §2.5</span>
-   <li><a href="#dfn-DOMException-constructor-object">DOMException constructor object</a><span>, in §3.12</span>
-   <li><a href="#dfn-DOMException-prototype-object">DOMException prototype object</a><span>, in §3.12.1</span>
+   <li><a href="#dfn-DOMException-constructor-object">DOMException constructor object</a><span>, in §3.13</span>
+   <li><a href="#dfn-DOMException-prototype-object">DOMException prototype object</a><span>, in §3.13.1</span>
    <li><a href="#idl-DOMString">DOMString</a><span>, in §2.11.14</span>
    <li><a href="#DOMTimeStamp">DOMTimeStamp</a><span>, in §4.2</span>
    <li><a href="#idl-double">double</a><span>, in §2.11.12</span>
@@ -12733,7 +12736,7 @@ language binding.</p>
    <li><a href="#exceptiondef-evalerror">EvalError</a><span>, in §2.5</span>
    <li><a href="#dfn-example-term">example term</a><span>, in §Unnumbered section</span>
    <li><a href="#dfn-exception">exception</a><span>, in §2.5</span>
-   <li><a href="#es-exception-objects">Exception objects</a><span>, in §3.12.2</span>
+   <li><a href="#es-exception-objects">Exception objects</a><span>, in §3.13.2</span>
    <li><a href="#dfn-exception-type">exception types</a><span>, in §2.11</span>
    <li><a href="#Exposed">Exposed</a><span>, in §3.3.3</span>
    <li><a href="#dfn-exposed">exposed</a><span>, in §3.3.4</span>
@@ -12753,7 +12756,7 @@ language binding.</p>
    <li><a href="#dfn-function-object">function object</a><span>, in §3</span>
    <li><a href="#dfn-get-buffer-source-copy">get a copy of the buffer source</a><span>, in §2.11.30</span>
    <li><a href="#dfn-get-buffer-source-reference">get a reference to the buffer source</a><span>, in §2.11.30</span>
-   <li><a href="#get-a-user-objects-attribute-value">get a user object’s attribute value</a><span>, in §3.9</span>
+   <li><a href="#get-a-user-objects-attribute-value">get a user object’s attribute value</a><span>, in §3.10</span>
    <li><a href="#dfn-getter">getter</a><span>, in §2.2.4</span>
    <li><a href="#Global">Global</a><span>, in §3.3.4</span>
    <li><a href="#dfn-global-name">global names</a><span>, in §3.3.5</span>
@@ -12801,15 +12804,17 @@ language binding.</p>
    <li><a href="#invalidnodetypeerror">InvalidNodeTypeError</a><span>, in §2.5.1</span>
    <li><a href="#dom-domexception-invalid_state_err">INVALID_STATE_ERR</a><span>, in §2.5.1</span>
    <li><a href="#invalidstateerror">InvalidStateError</a><span>, in §2.5.1</span>
-   <li><a href="#invoke-a-callback-function">invoke</a><span>, in §3.10</span>
-   <li><a href="#invoke-indexed-setter">invoke the indexed property setter</a><span>, in §3.8.4</span>
-   <li><a href="#invoke-named-setter">invoke the named property setter</a><span>, in §3.8.5</span>
+   <li><a href="#invoke-a-callback-function">invoke</a><span>, in §3.11</span>
+   <li><a href="#invoke-indexed-setter">invoke the indexed property setter</a><span>, in §3.9.3</span>
+   <li><a href="#invoke-named-setter">invoke the named property setter</a><span>, in §3.9.4</span>
    <li><a href="#dfn-iterable">iterable</a><span>, in §2.2.7</span>
    <li><a href="#dfn-iterable-declaration">iterable declaration</a><span>, in §2.2.7</span>
    <li><a href="#dfn-iterator-prototype-object">iterator prototype object</a><span>, in §3.6.9.5</span>
    <li><a href="#dfn-legacy-caller">legacy</a><span>, in §2.2.4</span>
    <li><a href="#LegacyArrayClass">LegacyArrayClass</a><span>, in §3.3.5</span>
    <li><a href="#idl-legacy-callers">Legacy callers</a><span>, in §2.2.4</span>
+   <li><a href="#getownproperty-guts">LegacyPlatformObjectGetOwnProperty</a><span>, in §3.9</span>
+   <li><a href="#dfn-legacy-platform-object">Legacy platform objects</a><span>, in §2.10</span>
    <li><a href="#LegacyUnenumerableNamedProperties">LegacyUnenumerableNamedProperties</a><span>, in §3.3.6</span>
    <li><a href="#LenientSetter">LenientSetter</a><span>, in §3.3.7</span>
    <li><a href="#LenientThis">LenientThis</a><span>, in §3.3.8</span>
@@ -12830,12 +12835,12 @@ language binding.</p>
    <li><a href="#dfn-named-property-deleter">named property deleter</a><span>, in §2.2.4</span>
    <li><a href="#dfn-named-property-getter">named property getter</a><span>, in §2.2.4</span>
    <li><a href="#dfn-named-property-setter">named property setter</a><span>, in §2.2.4</span>
-   <li><a href="#dfn-named-property-visibility">named property visibility algorithm</a><span>, in §3.8.1</span>
+   <li><a href="#dfn-named-property-visibility">named property visibility algorithm</a><span>, in §3.9</span>
    <li><a href="#dfn-namespace">namespace</a><span>, in §2.3</span>
    <li><a href="#dom-domexception-namespace_err">NAMESPACE_ERR</a><span>, in §2.5.1</span>
    <li><a href="#namespaceerror">NamespaceError</a><span>, in §2.5.1</span>
    <li><a href="#dfn-namespace-member">namespace member</a><span>, in §2.3</span>
-   <li><a href="#dfn-namespace-object">namespace object</a><span>, in §3.11</span>
+   <li><a href="#dfn-namespace-object">namespace object</a><span>, in §3.12</span>
    <li><a href="#dom-domexception-network_err">NETWORK_ERR</a><span>, in §2.5.1</span>
    <li><a href="#networkerror">NetworkError</a><span>, in §2.5.1</span>
    <li><a href="#NewObject">NewObject</a><span>, in §3.3.10</span>
@@ -12904,7 +12909,7 @@ language binding.</p>
    <li><a href="#dfn-serialization-pattern">serialization pattern</a><span>, in §2.2.4.3</span>
    <li><a href="#dfn-serialized-value">serialized value</a><span>, in §2.2.4.3</span>
    <li><a href="#dfn-serializer">serializer</a><span>, in §2.2.4</span>
-   <li><a href="#set-a-user-objects-attribute-value">set a user object’s attribute value</a><span>, in §3.9</span>
+   <li><a href="#set-a-user-objects-attribute-value">set a user object’s attribute value</a><span>, in §3.10</span>
    <li><a href="#dfn-set-entries">set entries</a><span>, in §2.2.9</span>
    <li><a href="#dfn-setlike">setlike</a><span>, in §2.2.9</span>
    <li><a href="#dfn-setlike-declaration">setlike declaration</a><span>, in §2.2.9</span>
@@ -12916,7 +12921,7 @@ language binding.</p>
    <li><a href="#dfn-set-the-value-of-an-existing-named-property">set the value of an existing named property</a><span>, in §2.2.4.5</span>
    <li><a href="#idl-short">short</a><span>, in §2.11.4</span>
    <li><a href="#dfn-simple-exception">simple exception</a><span>, in §2.5</span>
-   <li><a href="#dfn-single-operation-callback-interface">single operation callback interface</a><span>, in §3.9</span>
+   <li><a href="#dfn-single-operation-callback-interface">single operation callback interface</a><span>, in §3.10</span>
    <li><a href="#dfn-special-keyword">special keywords</a><span>, in §2.2.4</span>
    <li><a href="#dfn-special-operation">special operation</a><span>, in §2.2.4</span>
    <li><a href="#dfn-specific-type">specific type</a><span>, in §2.11.1</span>
@@ -12937,7 +12942,7 @@ language binding.</p>
    <li><a href="#dfn-xattr-identifier">takes an identifier</a><span>, in §2.12</span>
    <li><a href="#dfn-xattr-identifier-list">takes an identifier list</a><span>, in §2.12</span>
    <li><a href="#dfn-xattr-no-arguments">takes no arguments</a><span>, in §2.12</span>
-   <li><a href="#getownproperty-guts">The PlatformObjectGetOwnProperty abstract operation</a><span>, in §3.8.1</span>
+   <li><a href="#getownproperty-guts">The PlatformObjectGetOwnProperty abstract operation</a><span>, in §3.9</span>
    <li><a href="#dfn-throw">throw</a><span>, in §2.5</span>
    <li><a href="#dfn-throw">thrown</a><span>, in §2.5</span>
    <li><a href="#dom-domexception-timeout_err">TIMEOUT_ERR</a><span>, in §2.5.1</span>
@@ -12955,7 +12960,7 @@ language binding.</p>
    <li><a href="#idl-Uint8ClampedArray">Uint8ClampedArray</a><span>, in §2.11.30</span>
    <li><a href="#dfn-unforgeable-on-an-interface">unforgeable</a><span>, in §3.3.20</span>
    <li><a href="#Unforgeable">Unforgeable</a><span>, in §3.3.19</span>
-   <li><a href="#dfn-unforgeable-property-name">unforgeable property name</a><span>, in §3.8.1</span>
+   <li><a href="#dfn-unforgeable-property-name">unforgeable property name</a><span>, in §3.9</span>
    <li><a href="#dfn-union-type">union type</a><span>, in §2.11.27</span>
    <li><a href="#unknownerror">UnknownError</a><span>, in §2.5.1</span>
    <li><a href="#idl-unrestricted-double">unrestricted double</a><span>, in §2.11.13</span>
@@ -13047,7 +13052,6 @@ language binding.</p>
      <li><a href="https://tc39.github.io/ecma262/#sec-objectcreate">objectcreate</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-ordinarydefineownproperty">ordinarydefineownproperty</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-ordinarygetownproperty">ordinarygetownproperty</a>
-     <li><a href="https://tc39.github.io/ecma262/#sec-ordinarypreventextensions">ordinarypreventextensions</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-own-property">own property</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">property descriptor</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-code-realms">realm</a>
@@ -13168,7 +13172,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-idl-fragment-42">3.3.18. [TreatNonObjectAsNull]</a>
     <li><a href="#ref-for-dfn-idl-fragment-43">3.3.19. [TreatNullAs]</a>
     <li><a href="#ref-for-dfn-idl-fragment-44">3.3.20. [Unforgeable]</a>
-    <li><a href="#ref-for-dfn-idl-fragment-45">3.15. Handling exceptions</a>
+    <li><a href="#ref-for-dfn-idl-fragment-45">3.16. Handling exceptions</a>
     <li><a href="#ref-for-dfn-idl-fragment-46">5. Extensibility</a>
     <li><a href="#ref-for-dfn-idl-fragment-47">6. Referencing this specification</a>
     <li><a href="#ref-for-dfn-idl-fragment-48">IDL grammar</a> <a href="#ref-for-dfn-idl-fragment-49">(2)</a>
@@ -13230,13 +13234,13 @@ language binding.</p>
     <li><a href="#ref-for-dfn-identifier-79">3.6.9.4. Default iterator objects</a>
     <li><a href="#ref-for-dfn-identifier-80">3.6.9.5. Iterator prototype object</a>
     <li><a href="#ref-for-dfn-identifier-81">3.8. Platform objects implementing interfaces</a>
-    <li><a href="#ref-for-dfn-identifier-82">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a> <a href="#ref-for-dfn-identifier-83">(2)</a>
-    <li><a href="#ref-for-dfn-identifier-84">3.8.4. Invoking a platform object indexed property setter</a>
-    <li><a href="#ref-for-dfn-identifier-85">3.8.5. Invoking a platform object named property setter</a>
-    <li><a href="#ref-for-dfn-identifier-86">3.8.9. Platform object [[Delete]] method</a>
-    <li><a href="#ref-for-dfn-identifier-87">3.9. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-identifier-88">(2)</a> <a href="#ref-for-dfn-identifier-89">(3)</a>
-    <li><a href="#ref-for-dfn-identifier-90">3.11. Namespaces</a>
-    <li><a href="#ref-for-dfn-identifier-91">3.11.1. Namespace object</a>
+    <li><a href="#ref-for-dfn-identifier-82">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a> <a href="#ref-for-dfn-identifier-83">(2)</a>
+    <li><a href="#ref-for-dfn-identifier-84">3.9.3. Invoking a legacy platform object indexed property setter</a>
+    <li><a href="#ref-for-dfn-identifier-85">3.9.4. Invoking a legacy platform object named property setter</a>
+    <li><a href="#ref-for-dfn-identifier-86">3.9.8. Legacy platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-identifier-87">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-identifier-88">(2)</a> <a href="#ref-for-dfn-identifier-89">(3)</a>
+    <li><a href="#ref-for-dfn-identifier-90">3.12. Namespaces</a>
+    <li><a href="#ref-for-dfn-identifier-91">3.12.1. Namespace object</a>
     <li><a href="#ref-for-dfn-identifier-92">IDL grammar</a>
    </ul>
   </aside>
@@ -13267,60 +13271,57 @@ language binding.</p>
     <li><a href="#ref-for-dfn-interface-45">2.2.8. Maplike declarations</a>
     <li><a href="#ref-for-dfn-interface-46">2.2.9. Setlike declarations</a>
     <li><a href="#ref-for-dfn-interface-47">2.9. Implements statements</a> <a href="#ref-for-dfn-interface-48">(2)</a>
-    <li><a href="#ref-for-dfn-interface-49">2.10. Objects implementing interfaces</a>
-    <li><a href="#ref-for-dfn-interface-50">2.11.19. Interface types</a>
-    <li><a href="#ref-for-dfn-interface-51">2.11.23. Nullable types — T?</a>
-    <li><a href="#ref-for-dfn-interface-52">3. ECMAScript binding</a>
-    <li><a href="#ref-for-dfn-interface-53">3.1. ECMAScript environment</a>
-    <li><a href="#ref-for-dfn-interface-54">3.2.13. Interface types</a>
-    <li><a href="#ref-for-dfn-interface-55">3.2.18.1. Creating a sequence from an iterable</a>
-    <li><a href="#ref-for-dfn-interface-56">3.3.2. [Constructor]</a>
-    <li><a href="#ref-for-dfn-interface-57">3.3.4. [Exposed]</a> <a href="#ref-for-dfn-interface-58">(2)</a> <a href="#ref-for-dfn-interface-59">(3)</a>
-    <li><a href="#ref-for-dfn-interface-60">3.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-interface-61">(2)</a> <a href="#ref-for-dfn-interface-62">(3)</a> <a href="#ref-for-dfn-interface-63">(4)</a>
-    <li><a href="#ref-for-dfn-interface-64">3.3.6. [LegacyArrayClass]</a> <a href="#ref-for-dfn-interface-65">(2)</a>
-    <li><a href="#ref-for-dfn-interface-66">3.3.7. [LegacyUnenumerableNamedProperties]</a>
-    <li><a href="#ref-for-dfn-interface-67">3.3.9. [LenientThis]</a>
-    <li><a href="#ref-for-dfn-interface-68">3.3.10. [NamedConstructor]</a>
-    <li><a href="#ref-for-dfn-interface-69">3.3.12. [NoInterfaceObject]</a>
-    <li><a href="#ref-for-dfn-interface-70">3.3.13. [OverrideBuiltins]</a> <a href="#ref-for-dfn-interface-71">(2)</a>
-    <li><a href="#ref-for-dfn-interface-72">3.3.14. [PutForwards]</a> <a href="#ref-for-dfn-interface-73">(2)</a>
-    <li><a href="#ref-for-dfn-interface-74">3.3.15. [Replaceable]</a>
-    <li><a href="#ref-for-dfn-interface-75">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-interface-76">(2)</a>
-    <li><a href="#ref-for-dfn-interface-77">3.6. Interfaces</a> <a href="#ref-for-dfn-interface-78">(2)</a>
-    <li><a href="#ref-for-dfn-interface-79">3.6.1. Interface object</a>
-    <li><a href="#ref-for-dfn-interface-80">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-dfn-interface-81">(2)</a> <a href="#ref-for-dfn-interface-82">(3)</a> <a href="#ref-for-dfn-interface-83">(4)</a>
-    <li><a href="#ref-for-dfn-interface-84">3.6.2. Named constructors</a> <a href="#ref-for-dfn-interface-85">(2)</a> <a href="#ref-for-dfn-interface-86">(3)</a> <a href="#ref-for-dfn-interface-87">(4)</a>
-    <li><a href="#ref-for-dfn-interface-88">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-interface-89">(2)</a> <a href="#ref-for-dfn-interface-90">(3)</a>
-    <li><a href="#ref-for-dfn-interface-91">3.6.4. Named properties object</a> <a href="#ref-for-dfn-interface-92">(2)</a>
-    <li><a href="#ref-for-dfn-interface-93">3.6.4.1. Named properties object [[GetOwnProperty]] method</a> <a href="#ref-for-dfn-interface-94">(2)</a>
-    <li><a href="#ref-for-dfn-interface-95">3.6.5. Constants</a>
-    <li><a href="#ref-for-dfn-interface-96">3.6.6. Attributes</a> <a href="#ref-for-dfn-interface-97">(2)</a> <a href="#ref-for-dfn-interface-98">(3)</a>
-    <li><a href="#ref-for-dfn-interface-99">3.6.7. Operations</a> <a href="#ref-for-dfn-interface-100">(2)</a> <a href="#ref-for-dfn-interface-101">(3)</a>
-    <li><a href="#ref-for-dfn-interface-102">3.6.7.1. Stringifiers</a> <a href="#ref-for-dfn-interface-103">(2)</a>
-    <li><a href="#ref-for-dfn-interface-104">3.6.7.2. Serializers</a> <a href="#ref-for-dfn-interface-105">(2)</a> <a href="#ref-for-dfn-interface-106">(3)</a>
-    <li><a href="#ref-for-dfn-interface-107">3.6.8.1. @@iterator</a> <a href="#ref-for-dfn-interface-108">(2)</a> <a href="#ref-for-dfn-interface-109">(3)</a>
-    <li><a href="#ref-for-dfn-interface-110">3.6.8.2. forEach</a> <a href="#ref-for-dfn-interface-111">(2)</a>
-    <li><a href="#ref-for-dfn-interface-112">3.6.9.1. entries</a>
-    <li><a href="#ref-for-dfn-interface-113">3.6.9.2. keys</a> <a href="#ref-for-dfn-interface-114">(2)</a>
-    <li><a href="#ref-for-dfn-interface-115">3.6.9.3. values</a> <a href="#ref-for-dfn-interface-116">(2)</a>
-    <li><a href="#ref-for-dfn-interface-117">3.6.9.4. Default iterator objects</a> <a href="#ref-for-dfn-interface-118">(2)</a> <a href="#ref-for-dfn-interface-119">(3)</a> <a href="#ref-for-dfn-interface-120">(4)</a>
-    <li><a href="#ref-for-dfn-interface-121">3.6.9.5. Iterator prototype object</a> <a href="#ref-for-dfn-interface-122">(2)</a> <a href="#ref-for-dfn-interface-123">(3)</a> <a href="#ref-for-dfn-interface-124">(4)</a>
-    <li><a href="#ref-for-dfn-interface-125">3.6.10. Maplike declarations</a> <a href="#ref-for-dfn-interface-126">(2)</a>
-    <li><a href="#ref-for-dfn-interface-127">3.6.11. Setlike declarations</a> <a href="#ref-for-dfn-interface-128">(2)</a>
-    <li><a href="#ref-for-dfn-interface-129">3.7. Implements statements</a>
-    <li><a href="#ref-for-dfn-interface-130">3.8.1. Indexed and named properties</a> <a href="#ref-for-dfn-interface-131">(2)</a>
-    <li><a href="#ref-for-dfn-interface-132">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-dfn-interface-133">3.8.3. Platform object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-interface-134">3.8.6. Platform object [[Set]] method</a>
-    <li><a href="#ref-for-dfn-interface-135">3.8.7. Platform object [[SetPrototypeOf]] method</a>
-    <li><a href="#ref-for-dfn-interface-136">3.8.8. Platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-interface-137">(2)</a> <a href="#ref-for-dfn-interface-138">(3)</a>
-    <li><a href="#ref-for-dfn-interface-139">3.8.9. Platform object [[Delete]] method</a> <a href="#ref-for-dfn-interface-140">(2)</a>
-    <li><a href="#ref-for-dfn-interface-141">3.8.10. Platform object [[Call]] method</a>
-    <li><a href="#ref-for-dfn-interface-142">3.8.12. Property enumeration</a> <a href="#ref-for-dfn-interface-143">(2)</a>
-    <li><a href="#ref-for-dfn-interface-144">3.9. User objects implementing callback interfaces</a>
-    <li><a href="#ref-for-dfn-interface-145">3.14. Creating and throwing exceptions</a>
-    <li><a href="#ref-for-dfn-interface-146">3.15. Handling exceptions</a>
-    <li><a href="#ref-for-dfn-interface-147">IDL grammar</a>
+    <li><a href="#ref-for-dfn-interface-49">2.10. Objects implementing interfaces</a> <a href="#ref-for-dfn-interface-50">(2)</a>
+    <li><a href="#ref-for-dfn-interface-51">2.11.19. Interface types</a>
+    <li><a href="#ref-for-dfn-interface-52">2.11.23. Nullable types — T?</a>
+    <li><a href="#ref-for-dfn-interface-53">3. ECMAScript binding</a>
+    <li><a href="#ref-for-dfn-interface-54">3.1. ECMAScript environment</a>
+    <li><a href="#ref-for-dfn-interface-55">3.2.13. Interface types</a>
+    <li><a href="#ref-for-dfn-interface-56">3.2.18.1. Creating a sequence from an iterable</a>
+    <li><a href="#ref-for-dfn-interface-57">3.3.2. [Constructor]</a>
+    <li><a href="#ref-for-dfn-interface-58">3.3.4. [Exposed]</a> <a href="#ref-for-dfn-interface-59">(2)</a> <a href="#ref-for-dfn-interface-60">(3)</a>
+    <li><a href="#ref-for-dfn-interface-61">3.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-interface-62">(2)</a> <a href="#ref-for-dfn-interface-63">(3)</a> <a href="#ref-for-dfn-interface-64">(4)</a>
+    <li><a href="#ref-for-dfn-interface-65">3.3.6. [LegacyArrayClass]</a> <a href="#ref-for-dfn-interface-66">(2)</a>
+    <li><a href="#ref-for-dfn-interface-67">3.3.7. [LegacyUnenumerableNamedProperties]</a>
+    <li><a href="#ref-for-dfn-interface-68">3.3.9. [LenientThis]</a>
+    <li><a href="#ref-for-dfn-interface-69">3.3.10. [NamedConstructor]</a>
+    <li><a href="#ref-for-dfn-interface-70">3.3.12. [NoInterfaceObject]</a>
+    <li><a href="#ref-for-dfn-interface-71">3.3.13. [OverrideBuiltins]</a> <a href="#ref-for-dfn-interface-72">(2)</a>
+    <li><a href="#ref-for-dfn-interface-73">3.3.14. [PutForwards]</a> <a href="#ref-for-dfn-interface-74">(2)</a>
+    <li><a href="#ref-for-dfn-interface-75">3.3.15. [Replaceable]</a>
+    <li><a href="#ref-for-dfn-interface-76">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-interface-77">(2)</a>
+    <li><a href="#ref-for-dfn-interface-78">3.6. Interfaces</a> <a href="#ref-for-dfn-interface-79">(2)</a>
+    <li><a href="#ref-for-dfn-interface-80">3.6.1. Interface object</a>
+    <li><a href="#ref-for-dfn-interface-81">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-dfn-interface-82">(2)</a> <a href="#ref-for-dfn-interface-83">(3)</a> <a href="#ref-for-dfn-interface-84">(4)</a>
+    <li><a href="#ref-for-dfn-interface-85">3.6.2. Named constructors</a> <a href="#ref-for-dfn-interface-86">(2)</a> <a href="#ref-for-dfn-interface-87">(3)</a> <a href="#ref-for-dfn-interface-88">(4)</a>
+    <li><a href="#ref-for-dfn-interface-89">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-interface-90">(2)</a> <a href="#ref-for-dfn-interface-91">(3)</a>
+    <li><a href="#ref-for-dfn-interface-92">3.6.4. Named properties object</a> <a href="#ref-for-dfn-interface-93">(2)</a>
+    <li><a href="#ref-for-dfn-interface-94">3.6.4.1. Named properties object [[GetOwnProperty]] method</a> <a href="#ref-for-dfn-interface-95">(2)</a>
+    <li><a href="#ref-for-dfn-interface-96">3.6.5. Constants</a>
+    <li><a href="#ref-for-dfn-interface-97">3.6.6. Attributes</a> <a href="#ref-for-dfn-interface-98">(2)</a> <a href="#ref-for-dfn-interface-99">(3)</a>
+    <li><a href="#ref-for-dfn-interface-100">3.6.7. Operations</a> <a href="#ref-for-dfn-interface-101">(2)</a> <a href="#ref-for-dfn-interface-102">(3)</a>
+    <li><a href="#ref-for-dfn-interface-103">3.6.7.1. Stringifiers</a> <a href="#ref-for-dfn-interface-104">(2)</a>
+    <li><a href="#ref-for-dfn-interface-105">3.6.7.2. Serializers</a> <a href="#ref-for-dfn-interface-106">(2)</a> <a href="#ref-for-dfn-interface-107">(3)</a>
+    <li><a href="#ref-for-dfn-interface-108">3.6.8.1. @@iterator</a> <a href="#ref-for-dfn-interface-109">(2)</a> <a href="#ref-for-dfn-interface-110">(3)</a>
+    <li><a href="#ref-for-dfn-interface-111">3.6.8.2. forEach</a> <a href="#ref-for-dfn-interface-112">(2)</a>
+    <li><a href="#ref-for-dfn-interface-113">3.6.9.1. entries</a>
+    <li><a href="#ref-for-dfn-interface-114">3.6.9.2. keys</a> <a href="#ref-for-dfn-interface-115">(2)</a>
+    <li><a href="#ref-for-dfn-interface-116">3.6.9.3. values</a> <a href="#ref-for-dfn-interface-117">(2)</a>
+    <li><a href="#ref-for-dfn-interface-118">3.6.9.4. Default iterator objects</a> <a href="#ref-for-dfn-interface-119">(2)</a> <a href="#ref-for-dfn-interface-120">(3)</a> <a href="#ref-for-dfn-interface-121">(4)</a>
+    <li><a href="#ref-for-dfn-interface-122">3.6.9.5. Iterator prototype object</a> <a href="#ref-for-dfn-interface-123">(2)</a> <a href="#ref-for-dfn-interface-124">(3)</a> <a href="#ref-for-dfn-interface-125">(4)</a>
+    <li><a href="#ref-for-dfn-interface-126">3.6.10. Maplike declarations</a> <a href="#ref-for-dfn-interface-127">(2)</a>
+    <li><a href="#ref-for-dfn-interface-128">3.6.11. Setlike declarations</a> <a href="#ref-for-dfn-interface-129">(2)</a>
+    <li><a href="#ref-for-dfn-interface-130">3.7. Implements statements</a>
+    <li><a href="#ref-for-dfn-interface-131">3.9. Legacy platform objects</a>
+    <li><a href="#ref-for-dfn-interface-132">3.9.6. Legacy platform object [[SetPrototypeOf]] method</a>
+    <li><a href="#ref-for-dfn-interface-133">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-interface-134">(2)</a>
+    <li><a href="#ref-for-dfn-interface-135">3.9.8. Legacy platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-interface-136">3.9.9. Legacy platform object [[Call]] method</a>
+    <li><a href="#ref-for-dfn-interface-137">3.9.11. Property enumeration</a> <a href="#ref-for-dfn-interface-138">(2)</a>
+    <li><a href="#ref-for-dfn-interface-139">3.10. User objects implementing callback interfaces</a>
+    <li><a href="#ref-for-dfn-interface-140">3.15. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-interface-141">3.16. Handling exceptions</a>
+    <li><a href="#ref-for-dfn-interface-142">IDL grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-interface-member">
@@ -13343,7 +13344,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-interface-member-23">3.6.10.7. set</a>
     <li><a href="#ref-for-dfn-interface-member-24">3.6.11.5. add and delete</a>
     <li><a href="#ref-for-dfn-interface-member-25">3.6.11.6. clear</a>
-    <li><a href="#ref-for-dfn-interface-member-26">3.8.1. Indexed and named properties</a>
+    <li><a href="#ref-for-dfn-interface-member-26">3.9. Legacy platform objects</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-inherit">
@@ -13356,7 +13357,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-inherit-10">3.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-inherit-11">(2)</a>
     <li><a href="#ref-for-dfn-inherit-12">3.3.6. [LegacyArrayClass]</a>
     <li><a href="#ref-for-dfn-inherit-13">3.3.17. [SecureContext]</a>
-    <li><a href="#ref-for-dfn-inherit-14">3.9. User objects implementing callback interfaces</a>
+    <li><a href="#ref-for-dfn-inherit-14">3.10. User objects implementing callback interfaces</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-inherited-interfaces">
@@ -13391,7 +13392,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-callback-interface-23">3.3.19. [TreatNullAs]</a>
     <li><a href="#ref-for-dfn-callback-interface-24">3.5. Overload resolution algorithm</a>
     <li><a href="#ref-for-dfn-callback-interface-25">3.6. Interfaces</a>
-    <li><a href="#ref-for-dfn-callback-interface-26">3.9. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-callback-interface-27">(2)</a>
+    <li><a href="#ref-for-dfn-callback-interface-26">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-callback-interface-27">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-partial-interface">
@@ -13427,7 +13428,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-constant-24">3.6.3. Interface prototype object</a>
     <li><a href="#ref-for-dfn-constant-25">3.6.5. Constants</a> <a href="#ref-for-dfn-constant-26">(2)</a> <a href="#ref-for-dfn-constant-27">(3)</a>
     <li><a href="#ref-for-dfn-constant-28">3.7. Implements statements</a>
-    <li><a href="#ref-for-dfn-constant-29">3.9. User objects implementing callback interfaces</a>
+    <li><a href="#ref-for-dfn-constant-29">3.10. User objects implementing callback interfaces</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-attribute">
@@ -13467,8 +13468,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-attribute-58">3.6.7.1. Stringifiers</a>
     <li><a href="#ref-for-dfn-attribute-59">3.6.8.1. @@iterator</a>
     <li><a href="#ref-for-dfn-attribute-60">3.7. Implements statements</a> <a href="#ref-for-dfn-attribute-61">(2)</a>
-    <li><a href="#ref-for-dfn-attribute-62">3.9. User objects implementing callback interfaces</a>
-    <li><a href="#ref-for-dfn-attribute-63">3.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-attribute-62">3.10. User objects implementing callback interfaces</a>
+    <li><a href="#ref-for-dfn-attribute-63">3.15. Creating and throwing exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-regular-attribute">
@@ -13546,8 +13547,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-operation-57">3.6.7.2. Serializers</a>
     <li><a href="#ref-for-dfn-operation-58">3.6.8.2. forEach</a>
     <li><a href="#ref-for-dfn-operation-59">3.7. Implements statements</a> <a href="#ref-for-dfn-operation-60">(2)</a>
-    <li><a href="#ref-for-dfn-operation-61">3.10. Invoking callback functions</a>
-    <li><a href="#ref-for-dfn-operation-62">3.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-operation-61">3.11. Invoking callback functions</a>
+    <li><a href="#ref-for-dfn-operation-62">3.15. Creating and throwing exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-regular-operation">
@@ -13562,8 +13563,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-regular-operation-14">3.6.1. Interface object</a>
     <li><a href="#ref-for-dfn-regular-operation-15">3.6.3. Interface prototype object</a>
     <li><a href="#ref-for-dfn-regular-operation-16">3.6.7. Operations</a> <a href="#ref-for-dfn-regular-operation-17">(2)</a>
-    <li><a href="#ref-for-dfn-regular-operation-18">3.9. User objects implementing callback interfaces</a>
-    <li><a href="#ref-for-dfn-regular-operation-19">3.11.1. Namespace object</a>
+    <li><a href="#ref-for-dfn-regular-operation-18">3.10. User objects implementing callback interfaces</a>
+    <li><a href="#ref-for-dfn-regular-operation-19">3.12.1. Namespace object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-return-type">
@@ -13574,9 +13575,9 @@ language binding.</p>
     <li><a href="#ref-for-dfn-return-type-3">3.2.2. void</a>
     <li><a href="#ref-for-dfn-return-type-4">3.3.11. [NewObject]</a>
     <li><a href="#ref-for-dfn-return-type-5">3.6.7. Operations</a>
-    <li><a href="#ref-for-dfn-return-type-6">3.8.9. Platform object [[Delete]] method</a>
-    <li><a href="#ref-for-dfn-return-type-7">3.9. User objects implementing callback interfaces</a>
-    <li><a href="#ref-for-dfn-return-type-8">3.10. Invoking callback functions</a>
+    <li><a href="#ref-for-dfn-return-type-6">3.9.8. Legacy platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-return-type-7">3.10. User objects implementing callback interfaces</a>
+    <li><a href="#ref-for-dfn-return-type-8">3.11. Invoking callback functions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="idl-void">
@@ -13584,9 +13585,9 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-idl-void-1">3.2.2. void</a> <a href="#ref-for-idl-void-2">(2)</a> <a href="#ref-for-idl-void-3">(3)</a>
     <li><a href="#ref-for-idl-void-4">3.2.20. Promise types — Promise&lt;T></a> <a href="#ref-for-idl-void-5">(2)</a>
-    <li><a href="#ref-for-idl-void-6">3.8.10. Platform object [[Call]] method</a>
-    <li><a href="#ref-for-idl-void-7">3.9. User objects implementing callback interfaces</a>
-    <li><a href="#ref-for-idl-void-8">3.10. Invoking callback functions</a>
+    <li><a href="#ref-for-idl-void-6">3.9.9. Legacy platform object [[Call]] method</a>
+    <li><a href="#ref-for-idl-void-7">3.10. User objects implementing callback interfaces</a>
+    <li><a href="#ref-for-idl-void-8">3.11. Invoking callback functions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-variadic">
@@ -13645,13 +13646,13 @@ language binding.</p>
   <aside class="dfn-panel" data-for="dfn-getter">
    <b><a href="#dfn-getter">#dfn-getter</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-getter-1">3.8.1. Indexed and named properties</a>
+    <li><a href="#ref-for-dfn-getter-1">3.9. Legacy platform objects</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-setter">
    <b><a href="#dfn-setter">#dfn-setter</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-setter-1">3.8.1. Indexed and named properties</a>
+    <li><a href="#ref-for-dfn-setter-1">3.9. Legacy platform objects</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-stringifier">
@@ -13660,7 +13661,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-stringifier-1">2.2.4.2. Stringifiers</a>
     <li><a href="#ref-for-dfn-stringifier-2">3.3.5. [Global] and [PrimaryGlobal]</a>
     <li><a href="#ref-for-dfn-stringifier-3">3.6.7.1. Stringifiers</a> <a href="#ref-for-dfn-stringifier-4">(2)</a> <a href="#ref-for-dfn-stringifier-5">(3)</a>
-    <li><a href="#ref-for-dfn-stringifier-6">3.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-stringifier-6">3.15. Creating and throwing exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-serializer">
@@ -13686,9 +13687,9 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-dfn-named-property-setter-1">2.2.4.5. Named properties</a> <a href="#ref-for-dfn-named-property-setter-2">(2)</a>
     <li><a href="#ref-for-dfn-named-property-setter-3">3.3.5. [Global] and [PrimaryGlobal]</a>
-    <li><a href="#ref-for-dfn-named-property-setter-4">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-dfn-named-property-setter-5">3.8.6. Platform object [[Set]] method</a>
-    <li><a href="#ref-for-dfn-named-property-setter-6">3.8.8. Platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-named-property-setter-7">(2)</a>
+    <li><a href="#ref-for-dfn-named-property-setter-4">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
+    <li><a href="#ref-for-dfn-named-property-setter-5">3.9.5. Legacy platform object [[Set]] method</a>
+    <li><a href="#ref-for-dfn-named-property-setter-6">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-named-property-setter-7">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-indexed-property-getter">
@@ -13696,9 +13697,10 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-dfn-indexed-property-getter-1">2.2.4.4. Indexed properties</a> <a href="#ref-for-dfn-indexed-property-getter-2">(2)</a> <a href="#ref-for-dfn-indexed-property-getter-3">(3)</a>
     <li><a href="#ref-for-dfn-indexed-property-getter-4">2.2.7. Iterable declarations</a>
-    <li><a href="#ref-for-dfn-indexed-property-getter-5">3.6.8.1. @@iterator</a> <a href="#ref-for-dfn-indexed-property-getter-6">(2)</a>
-    <li><a href="#ref-for-dfn-indexed-property-getter-7">3.6.8.2. forEach</a>
-    <li><a href="#ref-for-dfn-indexed-property-getter-8">3.8.1. Indexed and named properties</a>
+    <li><a href="#ref-for-dfn-indexed-property-getter-5">3.3.5. [Global] and [PrimaryGlobal]</a>
+    <li><a href="#ref-for-dfn-indexed-property-getter-6">3.6.8.1. @@iterator</a> <a href="#ref-for-dfn-indexed-property-getter-7">(2)</a>
+    <li><a href="#ref-for-dfn-indexed-property-getter-8">3.6.8.2. forEach</a>
+    <li><a href="#ref-for-dfn-indexed-property-getter-9">3.9. Legacy platform objects</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-indexed-property-setter">
@@ -13706,10 +13708,10 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-dfn-indexed-property-setter-1">2.2.4.4. Indexed properties</a> <a href="#ref-for-dfn-indexed-property-setter-2">(2)</a>
     <li><a href="#ref-for-dfn-indexed-property-setter-3">3.3.6. [LegacyArrayClass]</a>
-    <li><a href="#ref-for-dfn-indexed-property-setter-4">3.8.1. Indexed and named properties</a>
-    <li><a href="#ref-for-dfn-indexed-property-setter-5">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-dfn-indexed-property-setter-6">3.8.6. Platform object [[Set]] method</a>
-    <li><a href="#ref-for-dfn-indexed-property-setter-7">3.8.8. Platform object [[DefineOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-indexed-property-setter-4">3.9. Legacy platform objects</a>
+    <li><a href="#ref-for-dfn-indexed-property-setter-5">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
+    <li><a href="#ref-for-dfn-indexed-property-setter-6">3.9.5. Legacy platform object [[Set]] method</a>
+    <li><a href="#ref-for-dfn-indexed-property-setter-7">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-named-property-deleter">
@@ -13717,15 +13719,16 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-dfn-named-property-deleter-1">2.2.4. Special operations</a> <a href="#ref-for-dfn-named-property-deleter-2">(2)</a>
     <li><a href="#ref-for-dfn-named-property-deleter-3">2.2.4.5. Named properties</a> <a href="#ref-for-dfn-named-property-deleter-4">(2)</a>
-    <li><a href="#ref-for-dfn-named-property-deleter-5">3.8.9. Platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-named-property-deleter-5">3.9.8. Legacy platform object [[Delete]] method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="idl-legacy-callers">
    <b><a href="#idl-legacy-callers">#idl-legacy-callers</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-legacy-callers-1">2.2.4.1. Legacy callers</a> <a href="#ref-for-idl-legacy-callers-2">(2)</a>
-    <li><a href="#ref-for-idl-legacy-callers-3">2.2.6. Overloading</a> <a href="#ref-for-idl-legacy-callers-4">(2)</a> <a href="#ref-for-idl-legacy-callers-5">(3)</a> <a href="#ref-for-idl-legacy-callers-6">(4)</a> <a href="#ref-for-idl-legacy-callers-7">(5)</a>
-    <li><a href="#ref-for-idl-legacy-callers-8">3.8.10. Platform object [[Call]] method</a>
+    <li><a href="#ref-for-idl-legacy-callers-1">2.2.4.1. Legacy callers</a> <a href="#ref-for-idl-legacy-callers-2">(2)</a> <a href="#ref-for-idl-legacy-callers-3">(3)</a> <a href="#ref-for-idl-legacy-callers-4">(4)</a>
+    <li><a href="#ref-for-idl-legacy-callers-5">2.2.6. Overloading</a> <a href="#ref-for-idl-legacy-callers-6">(2)</a> <a href="#ref-for-idl-legacy-callers-7">(3)</a> <a href="#ref-for-idl-legacy-callers-8">(4)</a> <a href="#ref-for-idl-legacy-callers-9">(5)</a>
+    <li><a href="#ref-for-idl-legacy-callers-10">2.10. Objects implementing interfaces</a>
+    <li><a href="#ref-for-idl-legacy-callers-11">3.9.9. Legacy platform object [[Call]] method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-stringification-behavior">
@@ -13772,53 +13775,53 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-idl-indexed-properties-1">2.2.4. Special operations</a>
     <li><a href="#ref-for-idl-indexed-properties-2">2.2.4.5. Named properties</a>
-    <li><a href="#ref-for-idl-indexed-properties-3">3.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-idl-indexed-properties-3">3.9. Legacy platform objects</a>
+    <li><a href="#ref-for-idl-indexed-properties-4">3.15. Creating and throwing exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-support-indexed-properties">
    <b><a href="#dfn-support-indexed-properties">#dfn-support-indexed-properties</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-support-indexed-properties-1">2.2.4.4. Indexed properties</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-2">2.2.7. Iterable declarations</a> <a href="#ref-for-dfn-support-indexed-properties-3">(2)</a> <a href="#ref-for-dfn-support-indexed-properties-4">(3)</a> <a href="#ref-for-dfn-support-indexed-properties-5">(4)</a> <a href="#ref-for-dfn-support-indexed-properties-6">(5)</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-7">3.3.6. [LegacyArrayClass]</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-8">3.6.9.4. Default iterator objects</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-9">3.8.1. Indexed and named properties</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-10">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-11">3.8.3. Platform object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-12">3.8.6. Platform object [[Set]] method</a> <a href="#ref-for-dfn-support-indexed-properties-13">(2)</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-14">3.8.8. Platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-support-indexed-properties-15">(2)</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-16">3.8.9. Platform object [[Delete]] method</a> <a href="#ref-for-dfn-support-indexed-properties-17">(2)</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-18">3.8.11. Platform object [[PreventExtensions]] method</a> <a href="#ref-for-dfn-support-indexed-properties-19">(2)</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-20">3.8.12. Property enumeration</a> <a href="#ref-for-dfn-support-indexed-properties-21">(2)</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-1">2.2.4.1. Legacy callers</a> <a href="#ref-for-dfn-support-indexed-properties-2">(2)</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-3">2.2.4.4. Indexed properties</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-4">2.2.7. Iterable declarations</a> <a href="#ref-for-dfn-support-indexed-properties-5">(2)</a> <a href="#ref-for-dfn-support-indexed-properties-6">(3)</a> <a href="#ref-for-dfn-support-indexed-properties-7">(4)</a> <a href="#ref-for-dfn-support-indexed-properties-8">(5)</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-9">2.10. Objects implementing interfaces</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-10">3.3.6. [LegacyArrayClass]</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-11">3.6.9.4. Default iterator objects</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-12">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-13">3.9.5. Legacy platform object [[Set]] method</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-14">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-15">3.9.8. Legacy platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-16">3.9.11. Property enumeration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-supported-property-indices">
    <b><a href="#dfn-supported-property-indices">#dfn-supported-property-indices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-supported-property-indices-1">2.2.4.4. Indexed properties</a> <a href="#ref-for-dfn-supported-property-indices-2">(2)</a> <a href="#ref-for-dfn-supported-property-indices-3">(3)</a>
-    <li><a href="#ref-for-dfn-supported-property-indices-4">3.8.1. Indexed and named properties</a>
-    <li><a href="#ref-for-dfn-supported-property-indices-5">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-dfn-supported-property-indices-6">3.8.4. Invoking a platform object indexed property setter</a>
-    <li><a href="#ref-for-dfn-supported-property-indices-7">3.8.9. Platform object [[Delete]] method</a>
-    <li><a href="#ref-for-dfn-supported-property-indices-8">3.8.12. Property enumeration</a>
+    <li><a href="#ref-for-dfn-supported-property-indices-4">3.9. Legacy platform objects</a>
+    <li><a href="#ref-for-dfn-supported-property-indices-5">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
+    <li><a href="#ref-for-dfn-supported-property-indices-6">3.9.3. Invoking a legacy platform object indexed property setter</a>
+    <li><a href="#ref-for-dfn-supported-property-indices-7">3.9.8. Legacy platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-supported-property-indices-8">3.9.11. Property enumeration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-determine-the-value-of-an-indexed-property">
    <b><a href="#dfn-determine-the-value-of-an-indexed-property">#dfn-determine-the-value-of-an-indexed-property</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-determine-the-value-of-an-indexed-property-1">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
+    <li><a href="#ref-for-dfn-determine-the-value-of-an-indexed-property-1">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-set-the-value-of-an-existing-indexed-property">
    <b><a href="#dfn-set-the-value-of-an-existing-indexed-property">#dfn-set-the-value-of-an-existing-indexed-property</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-set-the-value-of-an-existing-indexed-property-1">3.8.4. Invoking a platform object indexed property setter</a>
+    <li><a href="#ref-for-dfn-set-the-value-of-an-existing-indexed-property-1">3.9.3. Invoking a legacy platform object indexed property setter</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-set-the-value-of-a-new-indexed-property">
    <b><a href="#dfn-set-the-value-of-a-new-indexed-property">#dfn-set-the-value-of-a-new-indexed-property</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-set-the-value-of-a-new-indexed-property-1">3.8.4. Invoking a platform object indexed property setter</a>
+    <li><a href="#ref-for-dfn-set-the-value-of-a-new-indexed-property-1">3.9.3. Invoking a legacy platform object indexed property setter</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="idl-named-properties">
@@ -13826,24 +13829,24 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-idl-named-properties-1">2.2.4. Special operations</a>
     <li><a href="#ref-for-idl-named-properties-2">3.3.5. [Global] and [PrimaryGlobal]</a>
-    <li><a href="#ref-for-idl-named-properties-3">3.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-idl-named-properties-3">3.9. Legacy platform objects</a>
+    <li><a href="#ref-for-idl-named-properties-4">3.15. Creating and throwing exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-support-named-properties">
    <b><a href="#dfn-support-named-properties">#dfn-support-named-properties</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-support-named-properties-1">2.2.4.5. Named properties</a>
-    <li><a href="#ref-for-dfn-support-named-properties-2">3.3.7. [LegacyUnenumerableNamedProperties]</a>
-    <li><a href="#ref-for-dfn-support-named-properties-3">3.6.3. Interface prototype object</a>
-    <li><a href="#ref-for-dfn-support-named-properties-4">3.6.4. Named properties object</a>
-    <li><a href="#ref-for-dfn-support-named-properties-5">3.8.1. Indexed and named properties</a>
-    <li><a href="#ref-for-dfn-support-named-properties-6">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-dfn-support-named-properties-7">3.8.3. Platform object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-support-named-properties-8">3.8.6. Platform object [[Set]] method</a> <a href="#ref-for-dfn-support-named-properties-9">(2)</a>
-    <li><a href="#ref-for-dfn-support-named-properties-10">3.8.8. Platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-support-named-properties-11">(2)</a>
-    <li><a href="#ref-for-dfn-support-named-properties-12">3.8.9. Platform object [[Delete]] method</a> <a href="#ref-for-dfn-support-named-properties-13">(2)</a>
-    <li><a href="#ref-for-dfn-support-named-properties-14">3.8.11. Platform object [[PreventExtensions]] method</a> <a href="#ref-for-dfn-support-named-properties-15">(2)</a>
-    <li><a href="#ref-for-dfn-support-named-properties-16">3.8.12. Property enumeration</a> <a href="#ref-for-dfn-support-named-properties-17">(2)</a>
+    <li><a href="#ref-for-dfn-support-named-properties-1">2.2.4.1. Legacy callers</a> <a href="#ref-for-dfn-support-named-properties-2">(2)</a>
+    <li><a href="#ref-for-dfn-support-named-properties-3">2.2.4.5. Named properties</a>
+    <li><a href="#ref-for-dfn-support-named-properties-4">2.10. Objects implementing interfaces</a>
+    <li><a href="#ref-for-dfn-support-named-properties-5">3.3.7. [LegacyUnenumerableNamedProperties]</a>
+    <li><a href="#ref-for-dfn-support-named-properties-6">3.6.3. Interface prototype object</a>
+    <li><a href="#ref-for-dfn-support-named-properties-7">3.6.4. Named properties object</a>
+    <li><a href="#ref-for-dfn-support-named-properties-8">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
+    <li><a href="#ref-for-dfn-support-named-properties-9">3.9.5. Legacy platform object [[Set]] method</a>
+    <li><a href="#ref-for-dfn-support-named-properties-10">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-support-named-properties-11">3.9.8. Legacy platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-support-named-properties-12">3.9.11. Property enumeration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-supported-property-names">
@@ -13851,35 +13854,35 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-dfn-supported-property-names-1">2.2.4.5. Named properties</a> <a href="#ref-for-dfn-supported-property-names-2">(2)</a>
     <li><a href="#ref-for-dfn-supported-property-names-3">3.3.13. [OverrideBuiltins]</a>
-    <li><a href="#ref-for-dfn-supported-property-names-4">3.8.1. Indexed and named properties</a>
-    <li><a href="#ref-for-dfn-supported-property-names-5">3.8.5. Invoking a platform object named property setter</a>
-    <li><a href="#ref-for-dfn-supported-property-names-6">3.8.8. Platform object [[DefineOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-supported-property-names-7">3.8.12. Property enumeration</a>
+    <li><a href="#ref-for-dfn-supported-property-names-4">3.9. Legacy platform objects</a>
+    <li><a href="#ref-for-dfn-supported-property-names-5">3.9.4. Invoking a legacy platform object named property setter</a>
+    <li><a href="#ref-for-dfn-supported-property-names-6">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-supported-property-names-7">3.9.11. Property enumeration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-determine-the-value-of-a-named-property">
    <b><a href="#dfn-determine-the-value-of-a-named-property">#dfn-determine-the-value-of-a-named-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-determine-the-value-of-a-named-property-1">3.6.4.1. Named properties object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-determine-the-value-of-a-named-property-2">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
+    <li><a href="#ref-for-dfn-determine-the-value-of-a-named-property-2">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-set-the-value-of-an-existing-named-property">
    <b><a href="#dfn-set-the-value-of-an-existing-named-property">#dfn-set-the-value-of-an-existing-named-property</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-set-the-value-of-an-existing-named-property-1">3.8.5. Invoking a platform object named property setter</a>
+    <li><a href="#ref-for-dfn-set-the-value-of-an-existing-named-property-1">3.9.4. Invoking a legacy platform object named property setter</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-set-the-value-of-a-new-named-property">
    <b><a href="#dfn-set-the-value-of-a-new-named-property">#dfn-set-the-value-of-a-new-named-property</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-set-the-value-of-a-new-named-property-1">3.8.5. Invoking a platform object named property setter</a>
+    <li><a href="#ref-for-dfn-set-the-value-of-a-new-named-property-1">3.9.4. Invoking a legacy platform object named property setter</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-delete-an-existing-named-property">
    <b><a href="#dfn-delete-an-existing-named-property">#dfn-delete-an-existing-named-property</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-delete-an-existing-named-property-1">3.8.9. Platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-delete-an-existing-named-property-1">3.9.8. Legacy platform object [[Delete]] method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-static-attribute">
@@ -13925,7 +13928,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-effective-overload-set-5">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-dfn-effective-overload-set-6">(2)</a>
     <li><a href="#ref-for-dfn-effective-overload-set-7">3.6.2. Named constructors</a> <a href="#ref-for-dfn-effective-overload-set-8">(2)</a>
     <li><a href="#ref-for-dfn-effective-overload-set-9">3.6.7. Operations</a> <a href="#ref-for-dfn-effective-overload-set-10">(2)</a> <a href="#ref-for-dfn-effective-overload-set-11">(3)</a>
-    <li><a href="#ref-for-dfn-effective-overload-set-12">3.8.10. Platform object [[Call]] method</a>
+    <li><a href="#ref-for-dfn-effective-overload-set-12">3.9.9. Legacy platform object [[Call]] method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-optionality-value">
@@ -14060,8 +14063,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-namespace-6">3.3.4. [Exposed]</a> <a href="#ref-for-dfn-namespace-7">(2)</a>
     <li><a href="#ref-for-dfn-namespace-8">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-namespace-9">(2)</a>
     <li><a href="#ref-for-dfn-namespace-10">3.6.7. Operations</a> <a href="#ref-for-dfn-namespace-11">(2)</a>
-    <li><a href="#ref-for-dfn-namespace-12">3.11. Namespaces</a>
-    <li><a href="#ref-for-dfn-namespace-13">3.11.1. Namespace object</a>
+    <li><a href="#ref-for-dfn-namespace-12">3.12. Namespaces</a>
+    <li><a href="#ref-for-dfn-namespace-13">3.12.1. Namespace object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-namespace-member">
@@ -14071,7 +14074,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-namespace-member-2">2.12. Extended attributes</a>
     <li><a href="#ref-for-dfn-namespace-member-3">3.3.4. [Exposed]</a> <a href="#ref-for-dfn-namespace-member-4">(2)</a>
     <li><a href="#ref-for-dfn-namespace-member-5">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-namespace-member-6">(2)</a>
-    <li><a href="#ref-for-dfn-namespace-member-7">3.11.1. Namespace object</a>
+    <li><a href="#ref-for-dfn-namespace-member-7">3.12.1. Namespace object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-partial-namespace">
@@ -14161,14 +14164,14 @@ language binding.</p>
   <aside class="dfn-panel" data-for="dfn-exception">
    <b><a href="#dfn-exception">#dfn-exception</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-exception-1">3.15. Handling exceptions</a>
+    <li><a href="#ref-for-dfn-exception-1">3.16. Handling exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-exception-error-name">
    <b><a href="#dfn-exception-error-name">#dfn-exception-error-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-exception-error-name-1">2.5. Exceptions</a> <a href="#ref-for-dfn-exception-error-name-2">(2)</a> <a href="#ref-for-dfn-exception-error-name-3">(3)</a> <a href="#ref-for-dfn-exception-error-name-4">(4)</a> <a href="#ref-for-dfn-exception-error-name-5">(5)</a>
-    <li><a href="#ref-for-dfn-exception-error-name-6">3.14. Creating and throwing exceptions</a> <a href="#ref-for-dfn-exception-error-name-7">(2)</a> <a href="#ref-for-dfn-exception-error-name-8">(3)</a>
+    <li><a href="#ref-for-dfn-exception-error-name-6">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-exception-error-name-7">(2)</a> <a href="#ref-for-dfn-exception-error-name-8">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-simple-exception">
@@ -14176,8 +14179,8 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-dfn-simple-exception-1">2.5. Exceptions</a> <a href="#ref-for-dfn-simple-exception-2">(2)</a> <a href="#ref-for-dfn-simple-exception-3">(3)</a>
     <li><a href="#ref-for-dfn-simple-exception-4">2.11.28. Error</a>
-    <li><a href="#ref-for-dfn-simple-exception-5">3.13. Exception objects</a>
-    <li><a href="#ref-for-dfn-simple-exception-6">3.14. Creating and throwing exceptions</a> <a href="#ref-for-dfn-simple-exception-7">(2)</a> <a href="#ref-for-dfn-simple-exception-8">(3)</a> <a href="#ref-for-dfn-simple-exception-9">(4)</a>
+    <li><a href="#ref-for-dfn-simple-exception-5">3.14. Exception objects</a>
+    <li><a href="#ref-for-dfn-simple-exception-6">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-simple-exception-7">(2)</a> <a href="#ref-for-dfn-simple-exception-8">(3)</a> <a href="#ref-for-dfn-simple-exception-9">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="exceptiondef-typeerror">
@@ -14200,31 +14203,31 @@ language binding.</p>
     <li><a href="#ref-for-dfn-DOMException-18">3.2.22. Error</a>
     <li><a href="#ref-for-dfn-DOMException-19">3.2.23. DOMException</a> <a href="#ref-for-dfn-DOMException-20">(2)</a> <a href="#ref-for-dfn-DOMException-21">(3)</a> <a href="#ref-for-dfn-DOMException-22">(4)</a> <a href="#ref-for-dfn-DOMException-23">(5)</a> <a href="#ref-for-dfn-DOMException-24">(6)</a> <a href="#ref-for-dfn-DOMException-25">(7)</a>
     <li><a href="#ref-for-dfn-DOMException-26">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-DOMException-27">(2)</a>
-    <li><a href="#ref-for-dfn-DOMException-28">3.13. Exception objects</a> <a href="#ref-for-dfn-DOMException-29">(2)</a> <a href="#ref-for-dfn-DOMException-30">(3)</a>
-    <li><a href="#ref-for-dfn-DOMException-31">3.14. Creating and throwing exceptions</a> <a href="#ref-for-dfn-DOMException-32">(2)</a> <a href="#ref-for-dfn-DOMException-33">(3)</a> <a href="#ref-for-dfn-DOMException-34">(4)</a>
+    <li><a href="#ref-for-dfn-DOMException-28">3.14. Exception objects</a> <a href="#ref-for-dfn-DOMException-29">(2)</a> <a href="#ref-for-dfn-DOMException-30">(3)</a>
+    <li><a href="#ref-for-dfn-DOMException-31">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-DOMException-32">(2)</a> <a href="#ref-for-dfn-DOMException-33">(3)</a> <a href="#ref-for-dfn-DOMException-34">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-create-exception">
    <b><a href="#dfn-create-exception">#dfn-create-exception</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-create-exception-1">2.5. Exceptions</a> <a href="#ref-for-dfn-create-exception-2">(2)</a>
-    <li><a href="#ref-for-dfn-create-exception-3">3.14. Creating and throwing exceptions</a> <a href="#ref-for-dfn-create-exception-4">(2)</a>
+    <li><a href="#ref-for-dfn-create-exception-3">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-create-exception-4">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-throw">
    <b><a href="#dfn-throw">#dfn-throw</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw-1">2.5. Exceptions</a> <a href="#ref-for-dfn-throw-2">(2)</a>
-    <li><a href="#ref-for-dfn-throw-3">3.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-throw-3">3.15. Creating and throwing exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-error-names-table">
    <b><a href="#dfn-error-names-table">#dfn-error-names-table</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-error-names-table-1">2.5. Exceptions</a>
-    <li><a href="#ref-for-dfn-error-names-table-2">3.12.1. DOMException constructor object</a>
-    <li><a href="#ref-for-dfn-error-names-table-3">3.12.1.1. DOMException(message, name)</a>
-    <li><a href="#ref-for-dfn-error-names-table-4">3.12.2. DOMException prototype object</a>
+    <li><a href="#ref-for-dfn-error-names-table-2">3.13.1. DOMException constructor object</a>
+    <li><a href="#ref-for-dfn-error-names-table-3">3.13.1.1. DOMException(message, name)</a>
+    <li><a href="#ref-for-dfn-error-names-table-4">3.13.2. DOMException prototype object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="indexsizeerror">
@@ -14236,7 +14239,7 @@ language binding.</p>
   <aside class="dfn-panel" data-for="notsupportederror">
    <b><a href="#notsupportederror">#notsupportederror</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-notsupportederror-1">3.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-notsupportederror-1">3.15. Creating and throwing exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="syntaxerror">
@@ -14286,7 +14289,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-callback-function-21">3.2.21. Union types</a>
     <li><a href="#ref-for-dfn-callback-function-22">3.3.18. [TreatNonObjectAsNull]</a> <a href="#ref-for-dfn-callback-function-23">(2)</a> <a href="#ref-for-dfn-callback-function-24">(3)</a> <a href="#ref-for-dfn-callback-function-25">(4)</a> <a href="#ref-for-dfn-callback-function-26">(5)</a>
     <li><a href="#ref-for-dfn-callback-function-27">3.5. Overload resolution algorithm</a>
-    <li><a href="#ref-for-dfn-callback-function-28">3.10. Invoking callback functions</a>
+    <li><a href="#ref-for-dfn-callback-function-28">3.11. Invoking callback functions</a>
     <li><a href="#ref-for-dfn-callback-function-29">4.4. Function</a>
     <li><a href="#ref-for-dfn-callback-function-30">4.5. VoidFunction</a>
    </ul>
@@ -14319,7 +14322,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-supplemental-interface-4">3.3.12. [NoInterfaceObject]</a>
     <li><a href="#ref-for-dfn-supplemental-interface-5">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-supplemental-interface-6">(2)</a>
     <li><a href="#ref-for-dfn-supplemental-interface-7">3.8. Platform objects implementing interfaces</a>
-    <li><a href="#ref-for-dfn-supplemental-interface-8">3.8.1. Indexed and named properties</a>
+    <li><a href="#ref-for-dfn-supplemental-interface-8">3.9. Legacy platform objects</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-consequential-interfaces">
@@ -14354,19 +14357,18 @@ language binding.</p>
    <b><a href="#dfn-platform-object">#dfn-platform-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-platform-object-1">2.2. Interfaces</a>
-    <li><a href="#ref-for-dfn-platform-object-2">2.2.4.1. Legacy callers</a>
-    <li><a href="#ref-for-dfn-platform-object-3">2.2.4.4. Indexed properties</a>
+    <li><a href="#ref-for-dfn-platform-object-2">2.2.4.1. Legacy callers</a> <a href="#ref-for-dfn-platform-object-3">(2)</a>
     <li><a href="#ref-for-dfn-platform-object-4">2.2.6. Overloading</a>
     <li><a href="#ref-for-dfn-platform-object-5">2.4. Dictionaries</a> <a href="#ref-for-dfn-platform-object-6">(2)</a>
-    <li><a href="#ref-for-dfn-platform-object-7">2.11.24. Sequence types — sequence&lt;T></a>
-    <li><a href="#ref-for-dfn-platform-object-8">2.11.25. Record types — record&lt;K, V></a>
-    <li><a href="#ref-for-dfn-platform-object-9">3. ECMAScript binding</a>
-    <li><a href="#ref-for-dfn-platform-object-10">3.1. ECMAScript environment</a>
-    <li><a href="#ref-for-dfn-platform-object-11">3.2. ECMAScript type mapping</a>
-    <li><a href="#ref-for-dfn-platform-object-12">3.2.2. void</a>
-    <li><a href="#ref-for-dfn-platform-object-13">3.2.13. Interface types</a>
-    <li><a href="#ref-for-dfn-platform-object-14">3.2.21. Union types</a>
-    <li><a href="#ref-for-dfn-platform-object-15">3.3.13. [OverrideBuiltins]</a>
+    <li><a href="#ref-for-dfn-platform-object-7">2.10. Objects implementing interfaces</a>
+    <li><a href="#ref-for-dfn-platform-object-8">2.11.24. Sequence types — sequence&lt;T></a>
+    <li><a href="#ref-for-dfn-platform-object-9">2.11.25. Record types — record&lt;K, V></a>
+    <li><a href="#ref-for-dfn-platform-object-10">3. ECMAScript binding</a>
+    <li><a href="#ref-for-dfn-platform-object-11">3.1. ECMAScript environment</a>
+    <li><a href="#ref-for-dfn-platform-object-12">3.2. ECMAScript type mapping</a>
+    <li><a href="#ref-for-dfn-platform-object-13">3.2.2. void</a>
+    <li><a href="#ref-for-dfn-platform-object-14">3.2.13. Interface types</a>
+    <li><a href="#ref-for-dfn-platform-object-15">3.2.21. Union types</a>
     <li><a href="#ref-for-dfn-platform-object-16">3.3.15. [Replaceable]</a> <a href="#ref-for-dfn-platform-object-17">(2)</a>
     <li><a href="#ref-for-dfn-platform-object-18">3.4. Security</a>
     <li><a href="#ref-for-dfn-platform-object-19">3.5. Overload resolution algorithm</a>
@@ -14389,16 +14391,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-platform-object-46">3.6.11.4. has</a>
     <li><a href="#ref-for-dfn-platform-object-47">3.6.11.5. add and delete</a>
     <li><a href="#ref-for-dfn-platform-object-48">3.8. Platform objects implementing interfaces</a> <a href="#ref-for-dfn-platform-object-49">(2)</a> <a href="#ref-for-dfn-platform-object-50">(3)</a> <a href="#ref-for-dfn-platform-object-51">(4)</a>
-    <li><a href="#ref-for-dfn-platform-object-52">3.8.1. Indexed and named properties</a>
-    <li><a href="#ref-for-dfn-platform-object-53">3.8.3. Platform object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-platform-object-54">3.8.6. Platform object [[Set]] method</a>
-    <li><a href="#ref-for-dfn-platform-object-55">3.8.7. Platform object [[SetPrototypeOf]] method</a>
-    <li><a href="#ref-for-dfn-platform-object-56">3.8.8. Platform object [[DefineOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-platform-object-57">3.8.9. Platform object [[Delete]] method</a>
-    <li><a href="#ref-for-dfn-platform-object-58">3.8.10. Platform object [[Call]] method</a>
-    <li><a href="#ref-for-dfn-platform-object-59">3.8.11. Platform object [[PreventExtensions]] method</a> <a href="#ref-for-dfn-platform-object-60">(2)</a>
-    <li><a href="#ref-for-dfn-platform-object-61">3.8.12. Property enumeration</a>
-    <li><a href="#ref-for-dfn-platform-object-62">3.13. Exception objects</a>
+    <li><a href="#ref-for-dfn-platform-object-52">3.9.11. Property enumeration</a>
+    <li><a href="#ref-for-dfn-platform-object-53">3.14. Exception objects</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-user-object">
@@ -14409,8 +14403,25 @@ language binding.</p>
     <li><a href="#ref-for-dfn-user-object-5">2.2.3. Operations</a>
     <li><a href="#ref-for-dfn-user-object-6">3.2.9. DOMString</a> <a href="#ref-for-dfn-user-object-7">(2)</a>
     <li><a href="#ref-for-dfn-user-object-8">3.2.13. Interface types</a>
-    <li><a href="#ref-for-dfn-user-object-9">3.9. User objects implementing callback interfaces</a>
-    <li><a href="#ref-for-dfn-user-object-10">3.10. Invoking callback functions</a>
+    <li><a href="#ref-for-dfn-user-object-9">3.10. User objects implementing callback interfaces</a>
+    <li><a href="#ref-for-dfn-user-object-10">3.11. Invoking callback functions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-legacy-platform-object">
+   <b><a href="#dfn-legacy-platform-object">#dfn-legacy-platform-object</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-legacy-platform-object-1">2.2.4.1. Legacy callers</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-2">2.2.4.4. Indexed properties</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-3">3.3.13. [OverrideBuiltins]</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-4">3.9. Legacy platform objects</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-5">3.9.2. Legacy platform object [[GetOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-6">3.9.5. Legacy platform object [[Set]] method</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-7">3.9.6. Legacy platform object [[SetPrototypeOf]] method</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-8">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-9">3.9.8. Legacy platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-10">3.9.9. Legacy platform object [[Call]] method</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-11">3.9.10. Legacy platform object [[PreventExtensions]] method</a> <a href="#ref-for-dfn-legacy-platform-object-12">(2)</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-13">3.9.11. Property enumeration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-integer-type">
@@ -14539,7 +14550,7 @@ language binding.</p>
     <li><a href="#ref-for-idl-boolean-11">3.2.3. boolean</a> <a href="#ref-for-idl-boolean-12">(2)</a> <a href="#ref-for-idl-boolean-13">(3)</a> <a href="#ref-for-idl-boolean-14">(4)</a>
     <li><a href="#ref-for-idl-boolean-15">3.2.21. Union types</a> <a href="#ref-for-idl-boolean-16">(2)</a> <a href="#ref-for-idl-boolean-17">(3)</a> <a href="#ref-for-idl-boolean-18">(4)</a>
     <li><a href="#ref-for-idl-boolean-19">3.5. Overload resolution algorithm</a> <a href="#ref-for-idl-boolean-20">(2)</a> <a href="#ref-for-idl-boolean-21">(3)</a> <a href="#ref-for-idl-boolean-22">(4)</a>
-    <li><a href="#ref-for-idl-boolean-23">3.8.9. Platform object [[Delete]] method</a>
+    <li><a href="#ref-for-idl-boolean-23">3.9.8. Legacy platform object [[Delete]] method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="idl-byte">
@@ -14746,7 +14757,7 @@ language binding.</p>
     <li><a href="#ref-for-idl-interface-15">3.5. Overload resolution algorithm</a>
     <li><a href="#ref-for-idl-interface-16">3.6.1.1. Constructible Interfaces</a>
     <li><a href="#ref-for-idl-interface-17">3.6.2. Named constructors</a>
-    <li><a href="#ref-for-idl-interface-18">3.9. User objects implementing callback interfaces</a> <a href="#ref-for-idl-interface-19">(2)</a> <a href="#ref-for-idl-interface-20">(3)</a>
+    <li><a href="#ref-for-idl-interface-18">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-idl-interface-19">(2)</a> <a href="#ref-for-idl-interface-20">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-callback-context">
@@ -14756,8 +14767,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-callback-context-3">2.11.22. Callback function types</a> <a href="#ref-for-dfn-callback-context-4">(2)</a>
     <li><a href="#ref-for-dfn-callback-context-5">3.2.13. Interface types</a>
     <li><a href="#ref-for-dfn-callback-context-6">3.2.16. Callback function types</a>
-    <li><a href="#ref-for-dfn-callback-context-7">3.9. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-callback-context-8">(2)</a> <a href="#ref-for-dfn-callback-context-9">(3)</a>
-    <li><a href="#ref-for-dfn-callback-context-10">3.10. Invoking callback functions</a>
+    <li><a href="#ref-for-dfn-callback-context-7">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-callback-context-8">(2)</a> <a href="#ref-for-dfn-callback-context-9">(3)</a>
+    <li><a href="#ref-for-dfn-callback-context-10">3.11. Invoking callback functions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="idl-dictionary">
@@ -14783,7 +14794,7 @@ language binding.</p>
    <b><a href="#idl-callback-function">#idl-callback-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-callback-function-1">3.2.16. Callback function types</a> <a href="#ref-for-idl-callback-function-2">(2)</a> <a href="#ref-for-idl-callback-function-3">(3)</a> <a href="#ref-for-idl-callback-function-4">(4)</a> <a href="#ref-for-idl-callback-function-5">(5)</a>
-    <li><a href="#ref-for-idl-callback-function-6">3.10. Invoking callback functions</a>
+    <li><a href="#ref-for-idl-callback-function-6">3.11. Invoking callback functions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-nullable-type">
@@ -14876,8 +14887,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-promise-type-3">3.2.20. Promise types — Promise&lt;T></a> <a href="#ref-for-dfn-promise-type-4">(2)</a> <a href="#ref-for-dfn-promise-type-5">(3)</a> <a href="#ref-for-dfn-promise-type-6">(4)</a>
     <li><a href="#ref-for-dfn-promise-type-7">3.3.11. [NewObject]</a>
     <li><a href="#ref-for-dfn-promise-type-8">3.6.7. Operations</a>
-    <li><a href="#ref-for-dfn-promise-type-9">3.9. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-promise-type-10">(2)</a>
-    <li><a href="#ref-for-dfn-promise-type-11">3.10. Invoking callback functions</a>
+    <li><a href="#ref-for-dfn-promise-type-9">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-promise-type-10">(2)</a>
+    <li><a href="#ref-for-dfn-promise-type-11">3.11. Invoking callback functions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-union-type">
@@ -15066,50 +15077,52 @@ language binding.</p>
     <li><a href="#ref-for-dfn-extended-attribute-3">2.2. Interfaces</a> <a href="#ref-for-dfn-extended-attribute-4">(2)</a> <a href="#ref-for-dfn-extended-attribute-5">(3)</a> <a href="#ref-for-dfn-extended-attribute-6">(4)</a>
     <li><a href="#ref-for-dfn-extended-attribute-7">2.2.2. Attributes</a> <a href="#ref-for-dfn-extended-attribute-8">(2)</a>
     <li><a href="#ref-for-dfn-extended-attribute-9">2.2.3. Operations</a> <a href="#ref-for-dfn-extended-attribute-10">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-11">2.2.6. Overloading</a> <a href="#ref-for-dfn-extended-attribute-12">(2)</a> <a href="#ref-for-dfn-extended-attribute-13">(3)</a> <a href="#ref-for-dfn-extended-attribute-14">(4)</a> <a href="#ref-for-dfn-extended-attribute-15">(5)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-16">2.2.8. Maplike declarations</a>
-    <li><a href="#ref-for-dfn-extended-attribute-17">2.2.9. Setlike declarations</a>
-    <li><a href="#ref-for-dfn-extended-attribute-18">2.6. Enumerations</a>
-    <li><a href="#ref-for-dfn-extended-attribute-19">2.8. Typedefs</a>
-    <li><a href="#ref-for-dfn-extended-attribute-20">2.9. Implements statements</a>
-    <li><a href="#ref-for-dfn-extended-attribute-21">2.12. Extended attributes</a>
-    <li><a href="#ref-for-dfn-extended-attribute-22">3.2.4.9. Abstract operations</a> <a href="#ref-for-dfn-extended-attribute-23">(2)</a> <a href="#ref-for-dfn-extended-attribute-24">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-25">3.3. ECMAScript-specific extended attributes</a>
-    <li><a href="#ref-for-dfn-extended-attribute-26">3.3.1. [Clamp]</a> <a href="#ref-for-dfn-extended-attribute-27">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-28">3.3.2. [Constructor]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-29">3.3.3. [EnforceRange]</a> <a href="#ref-for-dfn-extended-attribute-30">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-31">3.3.4. [Exposed]</a> <a href="#ref-for-dfn-extended-attribute-32">(2)</a> <a href="#ref-for-dfn-extended-attribute-33">(3)</a> <a href="#ref-for-dfn-extended-attribute-34">(4)</a> <a href="#ref-for-dfn-extended-attribute-35">(5)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-36">3.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-extended-attribute-37">(2)</a> <a href="#ref-for-dfn-extended-attribute-38">(3)</a> <a href="#ref-for-dfn-extended-attribute-39">(4)</a> <a href="#ref-for-dfn-extended-attribute-40">(5)</a> <a href="#ref-for-dfn-extended-attribute-41">(6)</a> <a href="#ref-for-dfn-extended-attribute-42">(7)</a> <a href="#ref-for-dfn-extended-attribute-43">(8)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-44">3.3.6. [LegacyArrayClass]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-45">3.3.7. [LegacyUnenumerableNamedProperties]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-46">3.3.8. [LenientSetter]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-47">3.3.9. [LenientThis]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-48">3.3.10. [NamedConstructor]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-49">3.3.11. [NewObject]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-50">3.3.12. [NoInterfaceObject]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-51">3.3.13. [OverrideBuiltins]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-52">3.3.14. [PutForwards]</a> <a href="#ref-for-dfn-extended-attribute-53">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-54">3.3.15. [Replaceable]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-55">3.3.16. [SameObject]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-56">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-extended-attribute-57">(2)</a> <a href="#ref-for-dfn-extended-attribute-58">(3)</a> <a href="#ref-for-dfn-extended-attribute-59">(4)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-60">3.3.18. [TreatNonObjectAsNull]</a> <a href="#ref-for-dfn-extended-attribute-61">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-62">3.3.19. [TreatNullAs]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-63">3.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-extended-attribute-64">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-65">3.3.21. [Unscopable]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-66">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-extended-attribute-67">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-68">3.6. Interfaces</a>
-    <li><a href="#ref-for-dfn-extended-attribute-69">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-dfn-extended-attribute-70">(2)</a> <a href="#ref-for-dfn-extended-attribute-71">(3)</a> <a href="#ref-for-dfn-extended-attribute-72">(4)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-73">3.6.2. Named constructors</a> <a href="#ref-for-dfn-extended-attribute-74">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-75">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-extended-attribute-76">(2)</a> <a href="#ref-for-dfn-extended-attribute-77">(3)</a> <a href="#ref-for-dfn-extended-attribute-78">(4)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-79">3.6.4. Named properties object</a>
-    <li><a href="#ref-for-dfn-extended-attribute-80">3.6.4.1. Named properties object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-extended-attribute-81">3.6.6. Attributes</a> <a href="#ref-for-dfn-extended-attribute-82">(2)</a> <a href="#ref-for-dfn-extended-attribute-83">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-84">3.8.1. Indexed and named properties</a> <a href="#ref-for-dfn-extended-attribute-85">(2)</a> <a href="#ref-for-dfn-extended-attribute-86">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-87">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a> <a href="#ref-for-dfn-extended-attribute-88">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-89">3.8.7. Platform object [[SetPrototypeOf]] method</a>
-    <li><a href="#ref-for-dfn-extended-attribute-90">3.8.8. Platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-extended-attribute-91">(2)</a> <a href="#ref-for-dfn-extended-attribute-92">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-93">3.8.9. Platform object [[Delete]] method</a>
-    <li><a href="#ref-for-dfn-extended-attribute-94">3.8.12. Property enumeration</a>
+    <li><a href="#ref-for-dfn-extended-attribute-11">2.2.4.1. Legacy callers</a>
+    <li><a href="#ref-for-dfn-extended-attribute-12">2.2.6. Overloading</a> <a href="#ref-for-dfn-extended-attribute-13">(2)</a> <a href="#ref-for-dfn-extended-attribute-14">(3)</a> <a href="#ref-for-dfn-extended-attribute-15">(4)</a> <a href="#ref-for-dfn-extended-attribute-16">(5)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-17">2.2.8. Maplike declarations</a>
+    <li><a href="#ref-for-dfn-extended-attribute-18">2.2.9. Setlike declarations</a>
+    <li><a href="#ref-for-dfn-extended-attribute-19">2.6. Enumerations</a>
+    <li><a href="#ref-for-dfn-extended-attribute-20">2.8. Typedefs</a>
+    <li><a href="#ref-for-dfn-extended-attribute-21">2.9. Implements statements</a>
+    <li><a href="#ref-for-dfn-extended-attribute-22">2.10. Objects implementing interfaces</a>
+    <li><a href="#ref-for-dfn-extended-attribute-23">2.12. Extended attributes</a>
+    <li><a href="#ref-for-dfn-extended-attribute-24">3.2.4.9. Abstract operations</a> <a href="#ref-for-dfn-extended-attribute-25">(2)</a> <a href="#ref-for-dfn-extended-attribute-26">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-27">3.3. ECMAScript-specific extended attributes</a>
+    <li><a href="#ref-for-dfn-extended-attribute-28">3.3.1. [Clamp]</a> <a href="#ref-for-dfn-extended-attribute-29">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-30">3.3.2. [Constructor]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-31">3.3.3. [EnforceRange]</a> <a href="#ref-for-dfn-extended-attribute-32">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-33">3.3.4. [Exposed]</a> <a href="#ref-for-dfn-extended-attribute-34">(2)</a> <a href="#ref-for-dfn-extended-attribute-35">(3)</a> <a href="#ref-for-dfn-extended-attribute-36">(4)</a> <a href="#ref-for-dfn-extended-attribute-37">(5)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-38">3.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-extended-attribute-39">(2)</a> <a href="#ref-for-dfn-extended-attribute-40">(3)</a> <a href="#ref-for-dfn-extended-attribute-41">(4)</a> <a href="#ref-for-dfn-extended-attribute-42">(5)</a> <a href="#ref-for-dfn-extended-attribute-43">(6)</a> <a href="#ref-for-dfn-extended-attribute-44">(7)</a> <a href="#ref-for-dfn-extended-attribute-45">(8)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-46">3.3.6. [LegacyArrayClass]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-47">3.3.7. [LegacyUnenumerableNamedProperties]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-48">3.3.8. [LenientSetter]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-49">3.3.9. [LenientThis]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-50">3.3.10. [NamedConstructor]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-51">3.3.11. [NewObject]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-52">3.3.12. [NoInterfaceObject]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-53">3.3.13. [OverrideBuiltins]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-54">3.3.14. [PutForwards]</a> <a href="#ref-for-dfn-extended-attribute-55">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-56">3.3.15. [Replaceable]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-57">3.3.16. [SameObject]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-58">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-extended-attribute-59">(2)</a> <a href="#ref-for-dfn-extended-attribute-60">(3)</a> <a href="#ref-for-dfn-extended-attribute-61">(4)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-62">3.3.18. [TreatNonObjectAsNull]</a> <a href="#ref-for-dfn-extended-attribute-63">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-64">3.3.19. [TreatNullAs]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-65">3.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-extended-attribute-66">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-67">3.3.21. [Unscopable]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-68">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-extended-attribute-69">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-70">3.6. Interfaces</a>
+    <li><a href="#ref-for-dfn-extended-attribute-71">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-dfn-extended-attribute-72">(2)</a> <a href="#ref-for-dfn-extended-attribute-73">(3)</a> <a href="#ref-for-dfn-extended-attribute-74">(4)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-75">3.6.2. Named constructors</a> <a href="#ref-for-dfn-extended-attribute-76">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-77">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-extended-attribute-78">(2)</a> <a href="#ref-for-dfn-extended-attribute-79">(3)</a> <a href="#ref-for-dfn-extended-attribute-80">(4)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-81">3.6.4. Named properties object</a>
+    <li><a href="#ref-for-dfn-extended-attribute-82">3.6.4.1. Named properties object [[GetOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-extended-attribute-83">3.6.6. Attributes</a> <a href="#ref-for-dfn-extended-attribute-84">(2)</a> <a href="#ref-for-dfn-extended-attribute-85">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-86">3.9. Legacy platform objects</a> <a href="#ref-for-dfn-extended-attribute-87">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-88">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
+    <li><a href="#ref-for-dfn-extended-attribute-89">3.9.6. Legacy platform object [[SetPrototypeOf]] method</a>
+    <li><a href="#ref-for-dfn-extended-attribute-90">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-extended-attribute-91">(2)</a> <a href="#ref-for-dfn-extended-attribute-92">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-93">3.9.8. Legacy platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-extended-attribute-94">3.9.11. Property enumeration</a>
     <li><a href="#ref-for-dfn-extended-attribute-95">5. Extensibility</a>
     <li><a href="#ref-for-dfn-extended-attribute-96">IDL grammar</a> <a href="#ref-for-dfn-extended-attribute-97">(2)</a>
    </ul>
@@ -15174,8 +15187,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-class-string-3">3.6.9.4. Default iterator objects</a>
     <li><a href="#ref-for-dfn-class-string-4">3.6.9.5. Iterator prototype object</a>
     <li><a href="#ref-for-dfn-class-string-5">3.8. Platform objects implementing interfaces</a>
-    <li><a href="#ref-for-dfn-class-string-6">3.12.2. DOMException prototype object</a>
-    <li><a href="#ref-for-dfn-class-string-7">3.13. Exception objects</a>
+    <li><a href="#ref-for-dfn-class-string-6">3.13.2. DOMException prototype object</a>
+    <li><a href="#ref-for-dfn-class-string-7">3.14. Exception objects</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-function-object">
@@ -15195,7 +15208,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-function-object-15">3.6.10.2. entries</a>
     <li><a href="#ref-for-dfn-function-object-16">3.6.11. Setlike declarations</a>
     <li><a href="#ref-for-dfn-function-object-17">3.6.11.2. values</a>
-    <li><a href="#ref-for-dfn-function-object-18">3.12.1. DOMException constructor object</a>
+    <li><a href="#ref-for-dfn-function-object-18">3.13.1. DOMException constructor object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="ecmascript-throw">
@@ -15238,6 +15251,7 @@ language binding.</p>
     <li><a href="#ref-for-ecmascript-throw-53">3.6.11.1. size</a>
     <li><a href="#ref-for-ecmascript-throw-54">3.6.11.4. has</a>
     <li><a href="#ref-for-ecmascript-throw-55">3.6.11.5. add and delete</a>
+    <li><a href="#ref-for-ecmascript-throw-56">3.9.9. Legacy platform object [[Call]] method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-initial-object">
@@ -15246,7 +15260,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-initial-object-1">3.1. ECMAScript environment</a> <a href="#ref-for-dfn-initial-object-2">(2)</a>
     <li><a href="#ref-for-dfn-initial-object-3">3.3.4. [Exposed]</a>
     <li><a href="#ref-for-dfn-initial-object-4">3.8. Platform objects implementing interfaces</a>
-    <li><a href="#ref-for-dfn-initial-object-5">3.13. Exception objects</a>
+    <li><a href="#ref-for-dfn-initial-object-5">3.14. Exception objects</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-expose">
@@ -15258,8 +15272,8 @@ language binding.</p>
   <aside class="dfn-panel" data-for="dfn-associated-realm">
    <b><a href="#dfn-associated-realm">#dfn-associated-realm</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-associated-realm-1">3.9. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-associated-realm-2">(2)</a> <a href="#ref-for-dfn-associated-realm-3">(3)</a>
-    <li><a href="#ref-for-dfn-associated-realm-4">3.10. Invoking callback functions</a>
+    <li><a href="#ref-for-dfn-associated-realm-1">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-associated-realm-2">(2)</a> <a href="#ref-for-dfn-associated-realm-3">(3)</a>
+    <li><a href="#ref-for-dfn-associated-realm-4">3.11. Invoking callback functions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-convert-ecmascript-to-idl-value">
@@ -15304,10 +15318,10 @@ language binding.</p>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-64">3.6.10.7. set</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-65">(2)</a>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-66">3.6.11.4. has</a>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-67">3.6.11.5. add and delete</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-68">3.8.4. Invoking a platform object indexed property setter</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-69">3.8.5. Invoking a platform object named property setter</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-70">3.9. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-71">(2)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-72">(3)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-73">(4)</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-74">3.10. Invoking callback functions</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-75">(2)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-76">(3)</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-68">3.9.3. Invoking a legacy platform object indexed property setter</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-69">3.9.4. Invoking a legacy platform object named property setter</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-70">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-71">(2)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-72">(3)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-73">(4)</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-74">3.11. Invoking callback functions</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-75">(2)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-76">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-convert-idl-to-ecmascript-value">
@@ -15358,11 +15372,11 @@ language binding.</p>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-52">3.6.10.7. set</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-53">(2)</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-54">3.6.11.4. has</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-55">3.6.11.5. add and delete</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-56">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-57">(2)</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-58">3.8.10. Platform object [[Call]] method</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-59">3.9. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-60">(2)</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-61">3.10. Invoking callback functions</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-62">3.14. Creating and throwing exceptions</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-63">(2)</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-56">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-57">(2)</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-58">3.9.9. Legacy platform object [[Call]] method</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-59">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-60">(2)</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-61">3.11. Invoking callback functions</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-62">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-63">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-integerpart">
@@ -15435,7 +15449,7 @@ language binding.</p>
     <li><a href="#ref-for-Constructor-11">3.3.2. [Constructor]</a> <a href="#ref-for-Constructor-12">(2)</a> <a href="#ref-for-Constructor-13">(3)</a> <a href="#ref-for-Constructor-14">(4)</a> <a href="#ref-for-Constructor-15">(5)</a> <a href="#ref-for-Constructor-16">(6)</a> <a href="#ref-for-Constructor-17">(7)</a> <a href="#ref-for-Constructor-18">(8)</a>
     <li><a href="#ref-for-Constructor-19">3.3.12. [NoInterfaceObject]</a>
     <li><a href="#ref-for-Constructor-20">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-Constructor-21">(2)</a> <a href="#ref-for-Constructor-22">(3)</a> <a href="#ref-for-Constructor-23">(4)</a>
-    <li><a href="#ref-for-Constructor-24">3.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-Constructor-24">3.15. Creating and throwing exceptions</a>
     <li><a href="#ref-for-Constructor-25">IDL grammar</a>
    </ul>
   </aside>
@@ -15480,33 +15494,32 @@ language binding.</p>
     <li><a href="#ref-for-dfn-exposed-6">3.6.7. Operations</a>
     <li><a href="#ref-for-dfn-exposed-7">3.6.7.1. Stringifiers</a>
     <li><a href="#ref-for-dfn-exposed-8">3.6.7.2. Serializers</a>
-    <li><a href="#ref-for-dfn-exposed-9">3.11. Namespaces</a>
-    <li><a href="#ref-for-dfn-exposed-10">3.11.1. Namespace object</a>
+    <li><a href="#ref-for-dfn-exposed-9">3.12. Namespaces</a>
+    <li><a href="#ref-for-dfn-exposed-10">3.12.1. Namespace object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="Global">
    <b><a href="#Global">#Global</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Global-1">2.2. Interfaces</a> <a href="#ref-for-Global-2">(2)</a> <a href="#ref-for-Global-3">(3)</a> <a href="#ref-for-Global-4">(4)</a>
-    <li><a href="#ref-for-Global-5">3.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-Global-6">(2)</a> <a href="#ref-for-Global-7">(3)</a> <a href="#ref-for-Global-8">(4)</a> <a href="#ref-for-Global-9">(5)</a> <a href="#ref-for-Global-10">(6)</a> <a href="#ref-for-Global-11">(7)</a> <a href="#ref-for-Global-12">(8)</a> <a href="#ref-for-Global-13">(9)</a> <a href="#ref-for-Global-14">(10)</a> <a href="#ref-for-Global-15">(11)</a> <a href="#ref-for-Global-16">(12)</a> <a href="#ref-for-Global-17">(13)</a> <a href="#ref-for-Global-18">(14)</a> <a href="#ref-for-Global-19">(15)</a> <a href="#ref-for-Global-20">(16)</a> <a href="#ref-for-Global-21">(17)</a> <a href="#ref-for-Global-22">(18)</a> <a href="#ref-for-Global-23">(19)</a> <a href="#ref-for-Global-24">(20)</a> <a href="#ref-for-Global-25">(21)</a> <a href="#ref-for-Global-26">(22)</a> <a href="#ref-for-Global-27">(23)</a> <a href="#ref-for-Global-28">(24)</a>
-    <li><a href="#ref-for-Global-29">3.3.13. [OverrideBuiltins]</a> <a href="#ref-for-Global-30">(2)</a>
-    <li><a href="#ref-for-Global-31">3.6.3. Interface prototype object</a> <a href="#ref-for-Global-32">(2)</a> <a href="#ref-for-Global-33">(3)</a> <a href="#ref-for-Global-34">(4)</a>
-    <li><a href="#ref-for-Global-35">3.6.4. Named properties object</a> <a href="#ref-for-Global-36">(2)</a>
-    <li><a href="#ref-for-Global-37">3.6.5. Constants</a> <a href="#ref-for-Global-38">(2)</a> <a href="#ref-for-Global-39">(3)</a> <a href="#ref-for-Global-40">(4)</a> <a href="#ref-for-Global-41">(5)</a> <a href="#ref-for-Global-42">(6)</a>
-    <li><a href="#ref-for-Global-43">3.6.6. Attributes</a> <a href="#ref-for-Global-44">(2)</a> <a href="#ref-for-Global-45">(3)</a> <a href="#ref-for-Global-46">(4)</a> <a href="#ref-for-Global-47">(5)</a> <a href="#ref-for-Global-48">(6)</a>
-    <li><a href="#ref-for-Global-49">3.6.7. Operations</a> <a href="#ref-for-Global-50">(2)</a> <a href="#ref-for-Global-51">(3)</a> <a href="#ref-for-Global-52">(4)</a> <a href="#ref-for-Global-53">(5)</a> <a href="#ref-for-Global-54">(6)</a>
-    <li><a href="#ref-for-Global-55">3.6.7.1. Stringifiers</a> <a href="#ref-for-Global-56">(2)</a>
-    <li><a href="#ref-for-Global-57">3.6.7.2. Serializers</a> <a href="#ref-for-Global-58">(2)</a> <a href="#ref-for-Global-59">(3)</a> <a href="#ref-for-Global-60">(4)</a> <a href="#ref-for-Global-61">(5)</a> <a href="#ref-for-Global-62">(6)</a>
-    <li><a href="#ref-for-Global-63">3.6.8.1. @@iterator</a> <a href="#ref-for-Global-64">(2)</a> <a href="#ref-for-Global-65">(3)</a> <a href="#ref-for-Global-66">(4)</a> <a href="#ref-for-Global-67">(5)</a> <a href="#ref-for-Global-68">(6)</a>
-    <li><a href="#ref-for-Global-69">3.6.8.2. forEach</a> <a href="#ref-for-Global-70">(2)</a> <a href="#ref-for-Global-71">(3)</a> <a href="#ref-for-Global-72">(4)</a> <a href="#ref-for-Global-73">(5)</a> <a href="#ref-for-Global-74">(6)</a>
-    <li><a href="#ref-for-Global-75">3.6.9.1. entries</a> <a href="#ref-for-Global-76">(2)</a> <a href="#ref-for-Global-77">(3)</a> <a href="#ref-for-Global-78">(4)</a> <a href="#ref-for-Global-79">(5)</a> <a href="#ref-for-Global-80">(6)</a>
-    <li><a href="#ref-for-Global-81">3.6.9.2. keys</a> <a href="#ref-for-Global-82">(2)</a> <a href="#ref-for-Global-83">(3)</a> <a href="#ref-for-Global-84">(4)</a> <a href="#ref-for-Global-85">(5)</a> <a href="#ref-for-Global-86">(6)</a>
-    <li><a href="#ref-for-Global-87">3.6.9.3. values</a> <a href="#ref-for-Global-88">(2)</a> <a href="#ref-for-Global-89">(3)</a> <a href="#ref-for-Global-90">(4)</a> <a href="#ref-for-Global-91">(5)</a> <a href="#ref-for-Global-92">(6)</a>
-    <li><a href="#ref-for-Global-93">3.8.1. Indexed and named properties</a> <a href="#ref-for-Global-94">(2)</a>
-    <li><a href="#ref-for-Global-95">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a> <a href="#ref-for-Global-96">(2)</a>
-    <li><a href="#ref-for-Global-97">3.8.7. Platform object [[SetPrototypeOf]] method</a> <a href="#ref-for-Global-98">(2)</a>
-    <li><a href="#ref-for-Global-99">3.8.8. Platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-Global-100">(2)</a> <a href="#ref-for-Global-101">(3)</a> <a href="#ref-for-Global-102">(4)</a>
-    <li><a href="#ref-for-Global-103">3.8.9. Platform object [[Delete]] method</a> <a href="#ref-for-Global-104">(2)</a>
+    <li><a href="#ref-for-Global-5">2.10. Objects implementing interfaces</a> <a href="#ref-for-Global-6">(2)</a>
+    <li><a href="#ref-for-Global-7">3.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-Global-8">(2)</a> <a href="#ref-for-Global-9">(3)</a> <a href="#ref-for-Global-10">(4)</a> <a href="#ref-for-Global-11">(5)</a> <a href="#ref-for-Global-12">(6)</a> <a href="#ref-for-Global-13">(7)</a> <a href="#ref-for-Global-14">(8)</a> <a href="#ref-for-Global-15">(9)</a> <a href="#ref-for-Global-16">(10)</a> <a href="#ref-for-Global-17">(11)</a> <a href="#ref-for-Global-18">(12)</a> <a href="#ref-for-Global-19">(13)</a> <a href="#ref-for-Global-20">(14)</a> <a href="#ref-for-Global-21">(15)</a> <a href="#ref-for-Global-22">(16)</a> <a href="#ref-for-Global-23">(17)</a> <a href="#ref-for-Global-24">(18)</a> <a href="#ref-for-Global-25">(19)</a> <a href="#ref-for-Global-26">(20)</a> <a href="#ref-for-Global-27">(21)</a> <a href="#ref-for-Global-28">(22)</a> <a href="#ref-for-Global-29">(23)</a> <a href="#ref-for-Global-30">(24)</a>
+    <li><a href="#ref-for-Global-31">3.3.13. [OverrideBuiltins]</a> <a href="#ref-for-Global-32">(2)</a>
+    <li><a href="#ref-for-Global-33">3.6.3. Interface prototype object</a> <a href="#ref-for-Global-34">(2)</a> <a href="#ref-for-Global-35">(3)</a> <a href="#ref-for-Global-36">(4)</a>
+    <li><a href="#ref-for-Global-37">3.6.4. Named properties object</a> <a href="#ref-for-Global-38">(2)</a>
+    <li><a href="#ref-for-Global-39">3.6.5. Constants</a> <a href="#ref-for-Global-40">(2)</a> <a href="#ref-for-Global-41">(3)</a> <a href="#ref-for-Global-42">(4)</a> <a href="#ref-for-Global-43">(5)</a> <a href="#ref-for-Global-44">(6)</a>
+    <li><a href="#ref-for-Global-45">3.6.6. Attributes</a> <a href="#ref-for-Global-46">(2)</a> <a href="#ref-for-Global-47">(3)</a> <a href="#ref-for-Global-48">(4)</a> <a href="#ref-for-Global-49">(5)</a> <a href="#ref-for-Global-50">(6)</a>
+    <li><a href="#ref-for-Global-51">3.6.7. Operations</a> <a href="#ref-for-Global-52">(2)</a> <a href="#ref-for-Global-53">(3)</a> <a href="#ref-for-Global-54">(4)</a> <a href="#ref-for-Global-55">(5)</a> <a href="#ref-for-Global-56">(6)</a>
+    <li><a href="#ref-for-Global-57">3.6.7.1. Stringifiers</a> <a href="#ref-for-Global-58">(2)</a>
+    <li><a href="#ref-for-Global-59">3.6.7.2. Serializers</a> <a href="#ref-for-Global-60">(2)</a> <a href="#ref-for-Global-61">(3)</a> <a href="#ref-for-Global-62">(4)</a> <a href="#ref-for-Global-63">(5)</a> <a href="#ref-for-Global-64">(6)</a>
+    <li><a href="#ref-for-Global-65">3.6.8.1. @@iterator</a> <a href="#ref-for-Global-66">(2)</a> <a href="#ref-for-Global-67">(3)</a> <a href="#ref-for-Global-68">(4)</a> <a href="#ref-for-Global-69">(5)</a> <a href="#ref-for-Global-70">(6)</a>
+    <li><a href="#ref-for-Global-71">3.6.8.2. forEach</a> <a href="#ref-for-Global-72">(2)</a> <a href="#ref-for-Global-73">(3)</a> <a href="#ref-for-Global-74">(4)</a> <a href="#ref-for-Global-75">(5)</a> <a href="#ref-for-Global-76">(6)</a>
+    <li><a href="#ref-for-Global-77">3.6.9.1. entries</a> <a href="#ref-for-Global-78">(2)</a> <a href="#ref-for-Global-79">(3)</a> <a href="#ref-for-Global-80">(4)</a> <a href="#ref-for-Global-81">(5)</a> <a href="#ref-for-Global-82">(6)</a>
+    <li><a href="#ref-for-Global-83">3.6.9.2. keys</a> <a href="#ref-for-Global-84">(2)</a> <a href="#ref-for-Global-85">(3)</a> <a href="#ref-for-Global-86">(4)</a> <a href="#ref-for-Global-87">(5)</a> <a href="#ref-for-Global-88">(6)</a>
+    <li><a href="#ref-for-Global-89">3.6.9.3. values</a> <a href="#ref-for-Global-90">(2)</a> <a href="#ref-for-Global-91">(3)</a> <a href="#ref-for-Global-92">(4)</a> <a href="#ref-for-Global-93">(5)</a> <a href="#ref-for-Global-94">(6)</a>
+    <li><a href="#ref-for-Global-95">3.9.6. Legacy platform object [[SetPrototypeOf]] method</a> <a href="#ref-for-Global-96">(2)</a>
+    <li><a href="#ref-for-Global-97">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-Global-98">(2)</a> <a href="#ref-for-Global-99">(3)</a> <a href="#ref-for-Global-100">(4)</a>
+    <li><a href="#ref-for-Global-101">3.9.8. Legacy platform object [[Delete]] method</a> <a href="#ref-for-Global-102">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-global-name">
@@ -15535,8 +15548,8 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-LegacyUnenumerableNamedProperties-1">3.3.7. [LegacyUnenumerableNamedProperties]</a> <a href="#ref-for-LegacyUnenumerableNamedProperties-2">(2)</a> <a href="#ref-for-LegacyUnenumerableNamedProperties-3">(3)</a> <a href="#ref-for-LegacyUnenumerableNamedProperties-4">(4)</a>
     <li><a href="#ref-for-LegacyUnenumerableNamedProperties-5">3.6.4.1. Named properties object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-LegacyUnenumerableNamedProperties-6">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-LegacyUnenumerableNamedProperties-7">3.8.12. Property enumeration</a>
+    <li><a href="#ref-for-LegacyUnenumerableNamedProperties-6">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
+    <li><a href="#ref-for-LegacyUnenumerableNamedProperties-7">3.9.11. Property enumeration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="LenientSetter">
@@ -15593,8 +15606,8 @@ language binding.</p>
     <li><a href="#ref-for-OverrideBuiltins-1">2.2. Interfaces</a> <a href="#ref-for-OverrideBuiltins-2">(2)</a>
     <li><a href="#ref-for-OverrideBuiltins-3">3.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-OverrideBuiltins-4">(2)</a>
     <li><a href="#ref-for-OverrideBuiltins-5">3.3.13. [OverrideBuiltins]</a> <a href="#ref-for-OverrideBuiltins-6">(2)</a> <a href="#ref-for-OverrideBuiltins-7">(3)</a>
-    <li><a href="#ref-for-OverrideBuiltins-8">3.8.1. Indexed and named properties</a> <a href="#ref-for-OverrideBuiltins-9">(2)</a> <a href="#ref-for-OverrideBuiltins-10">(3)</a> <a href="#ref-for-OverrideBuiltins-11">(4)</a>
-    <li><a href="#ref-for-OverrideBuiltins-12">3.8.8. Platform object [[DefineOwnProperty]] method</a>
+    <li><a href="#ref-for-OverrideBuiltins-8">3.9. Legacy platform objects</a> <a href="#ref-for-OverrideBuiltins-9">(2)</a> <a href="#ref-for-OverrideBuiltins-10">(3)</a> <a href="#ref-for-OverrideBuiltins-11">(4)</a>
+    <li><a href="#ref-for-OverrideBuiltins-12">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="PutForwards">
@@ -15651,7 +15664,7 @@ language binding.</p>
     <li><a href="#ref-for-TreatNonObjectAsNull-2">3.2.16. Callback function types</a> <a href="#ref-for-TreatNonObjectAsNull-3">(2)</a>
     <li><a href="#ref-for-TreatNonObjectAsNull-4">3.2.17. Nullable types — T?</a>
     <li><a href="#ref-for-TreatNonObjectAsNull-5">3.3.18. [TreatNonObjectAsNull]</a> <a href="#ref-for-TreatNonObjectAsNull-6">(2)</a> <a href="#ref-for-TreatNonObjectAsNull-7">(3)</a> <a href="#ref-for-TreatNonObjectAsNull-8">(4)</a> <a href="#ref-for-TreatNonObjectAsNull-9">(5)</a>
-    <li><a href="#ref-for-TreatNonObjectAsNull-10">3.10. Invoking callback functions</a>
+    <li><a href="#ref-for-TreatNonObjectAsNull-10">3.11. Invoking callback functions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="TreatNullAs">
@@ -15679,7 +15692,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-unforgeable-on-an-interface-2">3.6.6. Attributes</a>
     <li><a href="#ref-for-dfn-unforgeable-on-an-interface-3">3.6.7. Operations</a> <a href="#ref-for-dfn-unforgeable-on-an-interface-4">(2)</a>
     <li><a href="#ref-for-dfn-unforgeable-on-an-interface-5">3.6.7.1. Stringifiers</a> <a href="#ref-for-dfn-unforgeable-on-an-interface-6">(2)</a>
-    <li><a href="#ref-for-dfn-unforgeable-on-an-interface-7">3.8.1. Indexed and named properties</a>
+    <li><a href="#ref-for-dfn-unforgeable-on-an-interface-7">3.9. Legacy platform objects</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="Unscopable">
@@ -15718,7 +15731,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-overload-resolution-algorithm-1">3.6.1.1. Constructible Interfaces</a>
     <li><a href="#ref-for-dfn-overload-resolution-algorithm-2">3.6.2. Named constructors</a>
     <li><a href="#ref-for-dfn-overload-resolution-algorithm-3">3.6.7. Operations</a>
-    <li><a href="#ref-for-dfn-overload-resolution-algorithm-4">3.8.10. Platform object [[Call]] method</a>
+    <li><a href="#ref-for-dfn-overload-resolution-algorithm-4">3.9.9. Legacy platform object [[Call]] method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-interface-object">
@@ -15735,7 +15748,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-interface-object-11">3.6.5. Constants</a>
     <li><a href="#ref-for-dfn-interface-object-12">3.6.6. Attributes</a>
     <li><a href="#ref-for-dfn-interface-object-13">3.6.7. Operations</a>
-    <li><a href="#ref-for-dfn-interface-object-14">3.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-interface-object-14">3.15. Creating and throwing exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-named-constructor">
@@ -15743,7 +15756,7 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-dfn-named-constructor-1">3.1. ECMAScript environment</a>
     <li><a href="#ref-for-dfn-named-constructor-2">3.6.2. Named constructors</a> <a href="#ref-for-dfn-named-constructor-3">(2)</a> <a href="#ref-for-dfn-named-constructor-4">(3)</a>
-    <li><a href="#ref-for-dfn-named-constructor-5">3.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-named-constructor-5">3.15. Creating and throwing exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-interface-prototype-object">
@@ -15800,7 +15813,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-named-properties-object-10">3.6.4.3. Named properties object [[Delete]] method</a>
     <li><a href="#ref-for-dfn-named-properties-object-11">3.6.4.4. Named properties object [[SetPrototypeOf]] method</a>
     <li><a href="#ref-for-dfn-named-properties-object-12">3.6.4.5. Named properties object [[PreventExtensions]] method</a> <a href="#ref-for-dfn-named-properties-object-13">(2)</a>
-    <li><a href="#ref-for-dfn-named-properties-object-14">3.8.1. Indexed and named properties</a> <a href="#ref-for-dfn-named-properties-object-15">(2)</a>
+    <li><a href="#ref-for-dfn-named-properties-object-14">3.9. Legacy platform objects</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-attribute-getter">
@@ -15821,7 +15834,7 @@ language binding.</p>
    <b><a href="#dfn-create-operation-function">#dfn-create-operation-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-create-operation-function-1">3.6.7. Operations</a>
-    <li><a href="#ref-for-dfn-create-operation-function-2">3.11.1. Namespace object</a>
+    <li><a href="#ref-for-dfn-create-operation-function-2">3.12.1. Namespace object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-convert-serialized-value-to-ecmascript-value">
@@ -15884,59 +15897,59 @@ language binding.</p>
   <aside class="dfn-panel" data-for="dfn-array-index-property-name">
    <b><a href="#dfn-array-index-property-name">#dfn-array-index-property-name</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-array-index-property-name-1">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-dfn-array-index-property-name-2">3.8.6. Platform object [[Set]] method</a> <a href="#ref-for-dfn-array-index-property-name-3">(2)</a>
-    <li><a href="#ref-for-dfn-array-index-property-name-4">3.8.8. Platform object [[DefineOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-array-index-property-name-5">3.8.9. Platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-array-index-property-name-1">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
+    <li><a href="#ref-for-dfn-array-index-property-name-2">3.9.5. Legacy platform object [[Set]] method</a> <a href="#ref-for-dfn-array-index-property-name-3">(2)</a>
+    <li><a href="#ref-for-dfn-array-index-property-name-4">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-array-index-property-name-5">3.9.8. Legacy platform object [[Delete]] method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-unforgeable-property-name">
    <b><a href="#dfn-unforgeable-property-name">#dfn-unforgeable-property-name</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-unforgeable-property-name-1">3.8.8. Platform object [[DefineOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-unforgeable-property-name-1">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-named-property-visibility">
    <b><a href="#dfn-named-property-visibility">#dfn-named-property-visibility</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-named-property-visibility-1">3.6.4.1. Named properties object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-named-property-visibility-2">3.8.2. The PlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-dfn-named-property-visibility-3">3.8.9. Platform object [[Delete]] method</a>
-    <li><a href="#ref-for-dfn-named-property-visibility-4">3.8.12. Property enumeration</a>
+    <li><a href="#ref-for-dfn-named-property-visibility-2">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
+    <li><a href="#ref-for-dfn-named-property-visibility-3">3.9.8. Legacy platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-named-property-visibility-4">3.9.11. Property enumeration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="getownproperty-guts">
    <b><a href="#getownproperty-guts">#getownproperty-guts</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-getownproperty-guts-1">3.8.3. Platform object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-getownproperty-guts-2">3.8.6. Platform object [[Set]] method</a>
+    <li><a href="#ref-for-getownproperty-guts-1">3.9.2. Legacy platform object [[GetOwnProperty]] method</a>
+    <li><a href="#ref-for-getownproperty-guts-2">3.9.5. Legacy platform object [[Set]] method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="invoke-indexed-setter">
    <b><a href="#invoke-indexed-setter">#invoke-indexed-setter</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-invoke-indexed-setter-1">3.8.6. Platform object [[Set]] method</a>
-    <li><a href="#ref-for-invoke-indexed-setter-2">3.8.8. Platform object [[DefineOwnProperty]] method</a>
+    <li><a href="#ref-for-invoke-indexed-setter-1">3.9.5. Legacy platform object [[Set]] method</a>
+    <li><a href="#ref-for-invoke-indexed-setter-2">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="invoke-named-setter">
    <b><a href="#invoke-named-setter">#invoke-named-setter</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-invoke-named-setter-1">3.8.6. Platform object [[Set]] method</a>
-    <li><a href="#ref-for-invoke-named-setter-2">3.8.8. Platform object [[DefineOwnProperty]] method</a>
+    <li><a href="#ref-for-invoke-named-setter-1">3.9.5. Legacy platform object [[Set]] method</a>
+    <li><a href="#ref-for-invoke-named-setter-2">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-single-operation-callback-interface">
    <b><a href="#dfn-single-operation-callback-interface">#dfn-single-operation-callback-interface</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-single-operation-callback-interface-1">3.9. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-single-operation-callback-interface-2">(2)</a> <a href="#ref-for-dfn-single-operation-callback-interface-3">(3)</a> <a href="#ref-for-dfn-single-operation-callback-interface-4">(4)</a>
+    <li><a href="#ref-for-dfn-single-operation-callback-interface-1">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-single-operation-callback-interface-2">(2)</a> <a href="#ref-for-dfn-single-operation-callback-interface-3">(3)</a> <a href="#ref-for-dfn-single-operation-callback-interface-4">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-callback-this-value">
    <b><a href="#dfn-callback-this-value">#dfn-callback-this-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-callback-this-value-1">3.6.8.2. forEach</a>
-    <li><a href="#ref-for-dfn-callback-this-value-2">3.10. Invoking callback functions</a>
+    <li><a href="#ref-for-dfn-callback-this-value-2">3.11. Invoking callback functions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="invoke-a-callback-function">
@@ -15949,30 +15962,30 @@ language binding.</p>
    <b><a href="#dfn-DOMException-constructor-object">#dfn-DOMException-constructor-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-DOMException-constructor-object-1">3.1. ECMAScript environment</a>
-    <li><a href="#ref-for-dfn-DOMException-constructor-object-2">3.12.2. DOMException prototype object</a>
-    <li><a href="#ref-for-dfn-DOMException-constructor-object-3">3.13. Exception objects</a> <a href="#ref-for-dfn-DOMException-constructor-object-4">(2)</a>
-    <li><a href="#ref-for-dfn-DOMException-constructor-object-5">3.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-DOMException-constructor-object-2">3.13.2. DOMException prototype object</a>
+    <li><a href="#ref-for-dfn-DOMException-constructor-object-3">3.14. Exception objects</a> <a href="#ref-for-dfn-DOMException-constructor-object-4">(2)</a>
+    <li><a href="#ref-for-dfn-DOMException-constructor-object-5">3.15. Creating and throwing exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-DOMException-prototype-object">
    <b><a href="#dfn-DOMException-prototype-object">#dfn-DOMException-prototype-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-DOMException-prototype-object-1">3.1. ECMAScript environment</a>
-    <li><a href="#ref-for-dfn-DOMException-prototype-object-2">3.12.2. DOMException prototype object</a>
-    <li><a href="#ref-for-dfn-DOMException-prototype-object-3">3.13. Exception objects</a> <a href="#ref-for-dfn-DOMException-prototype-object-4">(2)</a>
+    <li><a href="#ref-for-dfn-DOMException-prototype-object-2">3.13.2. DOMException prototype object</a>
+    <li><a href="#ref-for-dfn-DOMException-prototype-object-3">3.14. Exception objects</a> <a href="#ref-for-dfn-DOMException-prototype-object-4">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="es-exception-objects">
    <b><a href="#es-exception-objects">#es-exception-objects</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-es-exception-objects-1">3.8.12. Property enumeration</a>
-    <li><a href="#ref-for-es-exception-objects-2">3.14. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-es-exception-objects-1">3.9.11. Property enumeration</a>
+    <li><a href="#ref-for-es-exception-objects-2">3.15. Creating and throwing exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-current-global-environment">
    <b><a href="#dfn-current-global-environment">#dfn-current-global-environment</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-current-global-environment-1">3.14. Creating and throwing exceptions</a> <a href="#ref-for-dfn-current-global-environment-2">(2)</a>
+    <li><a href="#ref-for-dfn-current-global-environment-1">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-current-global-environment-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="ArrayBufferView">

--- a/index.html
+++ b/index.html
@@ -1781,11 +1781,11 @@ are interoperable.</p>
         <li>
          <a href="#named-properties-object"><span class="secno">3.6.4</span> <span class="content">Named properties object</span></a>
          <ol class="toc">
-          <li><a href="#named-properties-object-getownproperty"><span class="secno">3.6.4.1</span> <span class="content">Named properties object [[GetOwnProperty]] method</span></a>
-          <li><a href="#named-properties-object-defineownproperty"><span class="secno">3.6.4.2</span> <span class="content">Named properties object [[DefineOwnProperty]] method</span></a>
-          <li><a href="#named-properties-object-delete"><span class="secno">3.6.4.3</span> <span class="content">Named properties object [[Delete]] method</span></a>
-          <li><a href="#named-properties-object-setprototypeof"><span class="secno">3.6.4.4</span> <span class="content">Named properties object [[SetPrototypeOf]] method</span></a>
-          <li><a href="#named-properties-object-preventextensions"><span class="secno">3.6.4.5</span> <span class="content">Named properties object [[PreventExtensions]] method</span></a>
+          <li><a href="#named-properties-object-getownproperty"><span class="secno">3.6.4.1</span> <span class="content">[[GetOwnProperty]]</span></a>
+          <li><a href="#named-properties-object-defineownproperty"><span class="secno">3.6.4.2</span> <span class="content">[[DefineOwnProperty]]</span></a>
+          <li><a href="#named-properties-object-delete"><span class="secno">3.6.4.3</span> <span class="content">[[Delete]]</span></a>
+          <li><a href="#named-properties-object-setprototypeof"><span class="secno">3.6.4.4</span> <span class="content">[[SetPrototypeOf]]</span></a>
+          <li><a href="#named-properties-object-preventextensions"><span class="secno">3.6.4.5</span> <span class="content">[[PreventExtensions]]</span></a>
          </ol>
         <li><a href="#es-constants"><span class="secno">3.6.5</span> <span class="content">Constants</span></a>
         <li><a href="#es-attributes"><span class="secno">3.6.6</span> <span class="content">Attributes</span></a>
@@ -1837,17 +1837,15 @@ are interoperable.</p>
       <li>
        <a href="#es-legacy-platform-objects"><span class="secno">3.9</span> <span class="content">Legacy platform objects</span></a>
        <ol class="toc">
-        <li><a href="#getownproperty-guts"><span class="secno">3.9.1</span> <span class="content">The LegacyPlatformObjectGetOwnProperty abstract operation</span></a>
-        <li><a href="#legacy-platform-object-getownproperty"><span class="secno">3.9.2</span> <span class="content">Legacy platform object [[GetOwnProperty]] method</span></a>
-        <li><a href="#invoking-indexed-setter"><span class="secno">3.9.3</span> <span class="content">Invoking a legacy platform object indexed property setter</span></a>
-        <li><a href="#invoking-named-setter"><span class="secno">3.9.4</span> <span class="content">Invoking a legacy platform object named property setter</span></a>
-        <li><a href="#legacy-platform-object-set"><span class="secno">3.9.5</span> <span class="content">Legacy platform object [[Set]] method</span></a>
-        <li><a href="#legacy-platform-object-setprototypeof"><span class="secno">3.9.6</span> <span class="content">Legacy platform object [[SetPrototypeOf]] method</span></a>
-        <li><a href="#legacy-platform-object-defineownproperty"><span class="secno">3.9.7</span> <span class="content">Legacy platform object [[DefineOwnProperty]] method</span></a>
-        <li><a href="#legacy-platform-object-delete"><span class="secno">3.9.8</span> <span class="content">Legacy platform object [[Delete]] method</span></a>
-        <li><a href="#legacy-platform-object-call"><span class="secno">3.9.9</span> <span class="content">Legacy platform object [[Call]] method</span></a>
-        <li><a href="#legacy-platform-object-preventextensions"><span class="secno">3.9.10</span> <span class="content">Legacy platform object [[PreventExtensions]] method</span></a>
-        <li><a href="#property-enumeration"><span class="secno">3.9.11</span> <span class="content">Property enumeration</span></a>
+        <li><a href="#legacy-platform-object-getownproperty"><span class="secno">3.9.1</span> <span class="content">[[GetOwnProperty]]</span></a>
+        <li><a href="#legacy-platform-object-set"><span class="secno">3.9.2</span> <span class="content">[[Set]]</span></a>
+        <li><a href="#legacy-platform-object-setprototypeof"><span class="secno">3.9.3</span> <span class="content">[[SetPrototypeOf]]</span></a>
+        <li><a href="#legacy-platform-object-defineownproperty"><span class="secno">3.9.4</span> <span class="content">[[DefineOwnProperty]]</span></a>
+        <li><a href="#legacy-platform-object-delete"><span class="secno">3.9.5</span> <span class="content">[[Delete]]</span></a>
+        <li><a href="#legacy-platform-object-call"><span class="secno">3.9.6</span> <span class="content">[[Call]]</span></a>
+        <li><a href="#legacy-platform-object-preventextensions"><span class="secno">3.9.7</span> <span class="content">[[PreventExtensions]]</span></a>
+        <li><a href="#legacy-platform-object-property-enumeration"><span class="secno">3.9.8</span> <span class="content">Property enumeration</span></a>
+        <li><a href="#legacy-platform-object-abstract-ops"><span class="secno">3.9.9</span> <span class="content">Abstract operations</span></a>
        </ol>
       <li><a href="#es-user-objects"><span class="secno">3.10</span> <span class="content">User objects implementing callback interfaces</span></a>
       <li><a href="#es-invoking-callback-functions"><span class="secno">3.11</span> <span class="content">Invoking callback functions</span></a>
@@ -3228,8 +3226,8 @@ legacy callers can be specified using an <a data-link-type="dfn" href="#dfn-oper
 is used to determine which legacy caller is invoked when the object is called
 as if it were a function.</p>
    <p><a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-2">Legacy callers</a> can only be defined on interfaces that also <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-1">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-1">named properties</a>.</p>
-   <p class="note" role="note">Note: This artificial restriction allows bundling all the interfaces
-which support these various legacy <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-11">extended attributes</a> into a single <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-2">platform object</a> category: <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-1">legacy platform objects</a>.
+   <p class="note" role="note">Note: This artificial restriction allows bundling all interfaces with exotic object behavior
+into a single <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-2">platform object</a> category: <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-1">legacy platform objects</a>.
 This is possible because all existing interfaces which have a <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-3">legacy caller</a> also <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-2">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-2">named properties</a>.</p>
    <p>Legacy callers must not be defined to return a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-1">promise type</a>.</p>
    <p class="advisement"> Legacy callers are universally recognised as an undesirable feature.  They exist
@@ -4010,7 +4008,7 @@ the notion of an <em>effective overload set</em> is used.</p>
 };
 </pre>
     <p>Note that the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-6">Constructor</a></code>] and
-    [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-4">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-12">extended attributes</a> are disallowed from appearing
+    [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-4">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-11">extended attributes</a> are disallowed from appearing
     on <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-7">partial interface</a> definitions,
     so there is no need to also disallow overloading for constructors.</p>
    </div>
@@ -4047,7 +4045,7 @@ the inputs to the algorithm needed to compute the set.</p>
     <dd data-md="">
      <ul>
       <li data-md="">
-       <p>the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-39">interface</a> on which the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-8">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-13">extended attributes</a> are to be found</p>
+       <p>the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-39">interface</a> on which the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-8">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-12">extended attributes</a> are to be found</p>
       <li data-md="">
        <p>the number of arguments to be passed</p>
      </ul>
@@ -4056,7 +4054,7 @@ the inputs to the algorithm needed to compute the set.</p>
     <dd data-md="">
      <ul>
       <li data-md="">
-       <p>the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-40">interface</a> on which the [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-6">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-14">extended attributes</a> are to be found</p>
+       <p>the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-40">interface</a> on which the [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-6">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-13">extended attributes</a> are to be found</p>
       <li data-md="">
        <p>the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-31">identifier</a> of the named constructors</p>
       <li data-md="">
@@ -4123,12 +4121,12 @@ identifier <var>A</var> defined on interface <var>I</var>.</p>
         <p>For constructors</p>
        <dd data-md="">
         <p>The elements of <var>F</var> are the
-[<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-9">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-15">extended attributes</a> on interface <var>I</var>.</p>
+[<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-9">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-14">extended attributes</a> on interface <var>I</var>.</p>
        <dt data-md="">
         <p>For named constructors</p>
        <dd data-md="">
         <p>The elements of <var>F</var> are the
-[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-7">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-16">extended attributes</a> on interface <var>I</var> whose <a data-link-type="dfn" href="#dfn-xattr-named-argument-list" id="ref-for-dfn-xattr-named-argument-list-2">named argument lists’</a> identifiers are <var>A</var>.</p>
+[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-7">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-15">extended attributes</a> on interface <var>I</var> whose <a data-link-type="dfn" href="#dfn-xattr-named-argument-list" id="ref-for-dfn-xattr-named-argument-list-2">named argument lists’</a> identifiers are <var>A</var>.</p>
        <dt data-md="">
         <p>For legacy callers</p>
        <dd data-md="">
@@ -4644,7 +4642,7 @@ A maplike interface and its <a data-link-type="dfn" href="#dfn-inherited-interfa
 <pre class="grammar" id="prod-MaplikeRest">MaplikeRest :
     "maplike" "&lt;" Type "," Type ">" ";"
 </pre>
-   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-17">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-4">maplike declarations</a>.</p>
+   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-16">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-4">maplike declarations</a>.</p>
    <p class="issue" id="issue-dbe4d1af"><a class="self-link" href="#issue-dbe4d1af"></a> Add example. </p>
    <h4 class="heading settled" data-level="2.2.9" id="idl-setlike"><span class="secno">2.2.9. </span><span class="content">Setlike declarations</span><a class="self-link" href="#idl-setlike"></a></h4>
    <p>An <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-46">interface</a> can be declared to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-setlike">setlike</dfn> by using a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-setlike-declaration">setlike declaration</dfn> (matching <emu-nt><a href="#prod-ReadWriteSetlike">ReadWriteSetlike</a></emu-nt> or <emu-t>readonly</emu-t> <emu-nt><a href="#prod-SetlikeRest">SetlikeRest</a></emu-nt>) in the body of the interface.</p>
@@ -4690,7 +4688,7 @@ A setlike interface and its <a data-link-type="dfn" href="#dfn-inherited-interfa
 <pre class="grammar" id="prod-SetlikeRest">SetlikeRest :
     "setlike" "&lt;" Type ">" ";"
 </pre>
-   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-18">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-5">setlike declarations</a>.</p>
+   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-17">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-5">setlike declarations</a>.</p>
    <p class="issue" id="issue-dbe4d1af0"><a class="self-link" href="#issue-dbe4d1af0"></a> Add example. </p>
    <h3 class="heading settled" data-level="2.3" id="idl-namespaces"><span class="secno">2.3. </span><span class="content">Namespaces</span><a class="self-link" href="#idl-namespaces"></a></h3>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-namespace">namespace</dfn> is a definition (matching <emu-nt><a href="#prod-Namespace">Namespace</a></emu-nt>) that declares a global singleton with
@@ -5212,7 +5210,7 @@ whose type is the enumeration, is language binding specific.</p>
    <p class="note" role="note">Note: In the ECMAScript binding, assignment of an invalid string value to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-18">attribute</a> is ignored, while
 passing such a value as an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-25">operation</a> argument
 results in an exception being thrown.</p>
-   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-19">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-enumeration" id="ref-for-dfn-enumeration-12">enumerations</a>.</p>
+   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-18">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-enumeration" id="ref-for-dfn-enumeration-12">enumerations</a>.</p>
 <pre class="grammar" id="prod-Enum">Enum :
     "enum" identifier "{" EnumValueList "}" ";"
 </pre>
@@ -5305,7 +5303,7 @@ the type in the IDL.</p>
 type gives the name.</p>
    <p>The <emu-nt><a href="#prod-Type">Type</a></emu-nt> must not
 identify the same or another <a data-link-type="dfn" href="#dfn-typedef" id="ref-for-dfn-typedef-11">typedef</a>.</p>
-   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-20">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-typedef" id="ref-for-dfn-typedef-12">typedefs</a>.</p>
+   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-19">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-typedef" id="ref-for-dfn-typedef-12">typedefs</a>.</p>
 <pre class="grammar" id="prod-Typedef">Typedef :
     "typedef" Type identifier ";"
 </pre>
@@ -5405,7 +5403,7 @@ of those consequential interfaces or on the original interface itself.</p>
 <span class="n">F</span> <span class="kt">implements</span> <span class="n">I</span>;  // H::z and I::z would clash when mixed in to F
 </pre>
    </div>
-   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-21">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-implements-statement" id="ref-for-dfn-implements-statement-6">implements statements</a>.</p>
+   <p>No <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-20">extended attributes</a> defined in this specification are applicable to <a data-link-type="dfn" href="#dfn-implements-statement" id="ref-for-dfn-implements-statement-6">implements statements</a>.</p>
 <pre class="grammar" id="prod-ImplementsStatement">ImplementsStatement :
     identifier "implements" identifier ";"
 </pre>
@@ -5445,7 +5443,7 @@ object that are considered to be platform objects:</p>
      <p>objects representing IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-9">DOMExceptions</a></code>.</p>
    </ul>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-legacy-platform-object">Legacy platform objects</dfn> are <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-7">platform objects</a> that implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-50">interface</a> which
-does not have a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-5">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-6">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-22">extended attribute</a>, <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-9">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-4">named properties</a>,
+does not have a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-5">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-6">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-21">extended attribute</a>, <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-9">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-4">named properties</a>,
 and may have one or multiple <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-10">legacy callers</a>.</p>
    <p>In a browser, for example,
 the browser-implemented DOM objects (implementing interfaces such as <code class="idl">Node</code> and <code class="idl">Document</code>) that provide access to a web page’s contents
@@ -6102,7 +6100,7 @@ and <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-29">
 is used to control how language bindings will handle those constructs.
 Extended attributes are specified with an <emu-nt><a href="#prod-ExtendedAttributeList">ExtendedAttributeList</a></emu-nt>,
 which is a square bracket enclosed, comma separated list of <emu-nt><a href="#prod-ExtendedAttribute">ExtendedAttribute</a></emu-nt>s.</p>
-   <p>The <emu-nt><a href="#prod-ExtendedAttribute">ExtendedAttribute</a></emu-nt> grammar symbol matches nearly any sequence of tokens, however the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-23">extended attributes</a> defined in this document only accept a more restricted syntax.
+   <p>The <emu-nt><a href="#prod-ExtendedAttribute">ExtendedAttribute</a></emu-nt> grammar symbol matches nearly any sequence of tokens, however the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-22">extended attributes</a> defined in this document only accept a more restricted syntax.
 Any extended attribute encountered in an <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-31">IDL fragment</a> is
 matched against the following six grammar symbols to determine
 which form (or forms) it is in:</p>
@@ -6587,7 +6585,7 @@ ECMAScript <emu-val>Boolean</emu-val> value <var>x</var>.</p>
        <li data-md="">
         <p>Otherwise let <var>lowerBound</var> be −2<sup>53</sup> + 1.</p>
         <p class="note" role="note">Note: this ensures <code class="idl"><a data-link-type="idl" href="#idl-long-long" id="ref-for-idl-long-long-11">long long</a></code> types annotated with
-[<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-4">EnforceRange</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-4">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-24">extended attributes</a> are representable in ECMAScript’s <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">Number type</a> as unambiguous integers.</p>
+[<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-4">EnforceRange</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-4">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-23">extended attributes</a> are representable in ECMAScript’s <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">Number type</a> as unambiguous integers.</p>
       </ol>
      <li data-md="">
       <p>Otherwise, if <var>signedness</var> is "unsigned", then:</p>
@@ -6611,7 +6609,7 @@ ECMAScript <emu-val>Boolean</emu-val> value <var>x</var>.</p>
       <p>If the conversion to an IDL value is being performed due to any of the following:</p>
       <ul>
        <li data-md="">
-        <p><var>V</var> is being assigned to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-25">attribute</a> annotated with the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-5">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-25">extended attribute</a>,</p>
+        <p><var>V</var> is being assigned to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-25">attribute</a> annotated with the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-5">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-24">extended attribute</a>,</p>
        <li data-md="">
         <p><var>V</var> is being passed as an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-31">operation</a> argument annotated with the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-6">EnforceRange</a></code>] extended attribute, or</p>
        <li data-md="">
@@ -6634,7 +6632,7 @@ then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-thr
       <p>If <var>x</var> is not <emu-val>NaN</emu-val> and the conversion to an IDL value is being performed due to any of the following:</p>
       <ul>
        <li data-md="">
-        <p><var>V</var> is being assigned to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-26">attribute</a> annotated with the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-5">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-26">extended attribute</a>,</p>
+        <p><var>V</var> is being assigned to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-26">attribute</a> annotated with the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-5">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-25">extended attribute</a>,</p>
        <li data-md="">
         <p><var>V</var> is being passed as an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-32">operation</a> argument annotated with the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-6">Clamp</a></code>] extended attribute, or</p>
        <li data-md="">
@@ -7680,9 +7678,9 @@ to the same object that the IDL <a class="idl-code" data-link-type="interface" h
     </ol>
    </div>
    <h3 class="heading settled" data-level="3.3" id="es-extended-attributes"><span class="secno">3.3. </span><span class="content">ECMAScript-specific extended attributes</span><a class="self-link" href="#es-extended-attributes"></a></h3>
-   <p>This section defines a number of <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-27">extended attributes</a> whose presence affects only the ECMAScript binding.</p>
+   <p>This section defines a number of <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-26">extended attributes</a> whose presence affects only the ECMAScript binding.</p>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.1" data-lt="Clamp" id="Clamp"><span class="secno">3.3.1. </span><span class="content">[Clamp]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-8">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-28">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-35">operation</a> argument,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-8">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-27">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-35">operation</a> argument,
 writable <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-31">attribute</a> or <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-19">dictionary member</a> whose type is one of the <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-4">integer types</a>,
 it indicates that when an ECMAScript <emu-val>Number</emu-val> is
 converted to the IDL type, out of range values will be clamped to the range
@@ -7703,7 +7701,7 @@ types in <a href="#es-type-mapping">§3.2 ECMAScript type mapping</a> for the sp
     <p>In the following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-34">IDL fragment</a>,
     two <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-36">operations</a> are declared that
     take three <code class="idl"><a data-link-type="idl" href="#idl-octet" id="ref-for-idl-octet-10">octet</a></code> arguments; one uses
-    the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-12">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-29">extended attribute</a> on all three arguments, while the other does not:</p>
+    the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-12">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-28">extended attribute</a> on all three arguments, while the other does not:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">GraphicsContext</span> {
   <span class="kt">void</span> <span class="nv">setColor</span>(<span class="kt">octet</span> <span class="nv">red</span>, <span class="kt">octet</span> <span class="nv">green</span>, <span class="kt">octet</span> <span class="nv">blue</span>);
   <span class="kt">void</span> <span class="nv">setColorClamped</span>([<span class="nv">Clamp</span>] <span class="kt">octet</span> <span class="nv">red</span>, [<span class="nv">Clamp</span>] <span class="kt">octet</span> <span class="nv">green</span>, [<span class="nv">Clamp</span>] <span class="kt">octet</span> <span class="nv">blue</span>);
@@ -7723,7 +7721,7 @@ types in <a href="#es-type-mapping">§3.2 ECMAScript type mapping</a> for the sp
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.2" data-lt="Constructor" id="Constructor"><span class="secno">3.3.2. </span><span class="content">[Constructor]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-11">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-30">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-57">interface</a>, it indicates that
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-11">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-29">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-57">interface</a>, it indicates that
 the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-3">interface object</a> for this interface
 will have an [[Construct]] internal method,
 allowing objects implementing the interface to be constructed.</p>
@@ -7783,7 +7781,7 @@ for an interface is to be implemented.</p>
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.3" data-lt="EnforceRange" id="EnforceRange"><span class="secno">3.3.3. </span><span class="content">[EnforceRange]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-9">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-31">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-37">operation</a> argument,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-9">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-30">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-37">operation</a> argument,
 writable <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-4">regular attribute</a> or <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-20">dictionary member</a> whose type is one of the <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-5">integer types</a>,
 it indicates that when an ECMAScript <emu-val>Number</emu-val> is
 converted to the IDL type, out of range values will cause an exception to
@@ -7805,7 +7803,7 @@ types in <a href="#es-type-mapping">§3.2 ECMAScript type mapping</a> for the sp
     <p>In the following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-35">IDL fragment</a>,
     two <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-38">operations</a> are declared that
     take three <code class="idl"><a data-link-type="idl" href="#idl-octet" id="ref-for-idl-octet-12">octet</a></code> arguments; one uses
-    the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-13">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-32">extended attribute</a> on all three arguments, while the other does not:</p>
+    the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-13">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-31">extended attribute</a> on all three arguments, while the other does not:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">GraphicsContext</span> {
   <span class="kt">void</span> <span class="nv">setColor</span>(<span class="kt">octet</span> <span class="nv">red</span>, <span class="kt">octet</span> <span class="nv">green</span>, <span class="kt">octet</span> <span class="nv">blue</span>);
   <span class="kt">void</span> <span class="nv">setColorEnforcedRange</span>([<span class="nv">EnforceRange</span>] <span class="kt">octet</span> <span class="nv">red</span>, [<span class="nv">EnforceRange</span>] <span class="kt">octet</span> <span class="nv">green</span>, [<span class="nv">EnforceRange</span>] <span class="kt">octet</span> <span class="nv">blue</span>);
@@ -7830,22 +7828,22 @@ types in <a href="#es-type-mapping">§3.2 ECMAScript type mapping</a> for the sp
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.4" data-lt="Exposed" id="Exposed"><span class="secno">3.3.4. </span><span class="content">[Exposed]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-9">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-33">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-58">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-8">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-6">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-3">partial namespace</a>, or
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-9">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-32">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-58">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-8">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-6">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-3">partial namespace</a>, or
 an individual <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-11">interface member</a> or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-3">namespace member</a>,
 it indicates that the construct is exposed
 on a particular set of global interfaces, rather than the default of
 being exposed only on the <a data-link-type="dfn" href="#dfn-primary-global-interface" id="ref-for-dfn-primary-global-interface-1">primary global interface</a>.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-10">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-34">extended attribute</a> must either <a data-link-type="dfn" href="#dfn-xattr-identifier" id="ref-for-dfn-xattr-identifier-1">take an identifier</a> or <a data-link-type="dfn" href="#dfn-xattr-identifier-list" id="ref-for-dfn-xattr-identifier-list-1">take an identifier list</a>.
+   <p>The [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-10">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-33">extended attribute</a> must either <a data-link-type="dfn" href="#dfn-xattr-identifier" id="ref-for-dfn-xattr-identifier-1">take an identifier</a> or <a data-link-type="dfn" href="#dfn-xattr-identifier-list" id="ref-for-dfn-xattr-identifier-list-1">take an identifier list</a>.
 Each of the identifiers mentioned must be
 a <a data-link-type="dfn" href="#dfn-global-name" id="ref-for-dfn-global-name-1">global name</a>.</p>
-   <p>Every construct that the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-11">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-35">extended attribute</a> can be specified on has an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exposure-set">exposure set</dfn>,
+   <p>Every construct that the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-11">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-34">extended attribute</a> can be specified on has an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exposure-set">exposure set</dfn>,
 which is a set of <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-59">interfaces</a> defining which global environments the construct can be used in.
 The <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-1">exposure set</a> for a given construct is defined as follows:</p>
    <ul>
     <li data-md="">
-     <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-12">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-36">extended attribute</a> is specified on the construct, then the <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-2">exposure set</a> is the set of all interfaces that have a <a data-link-type="dfn" href="#dfn-global-name" id="ref-for-dfn-global-name-2">global name</a> that is listed in the extended attribute’s argument.</p>
+     <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-12">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-35">extended attribute</a> is specified on the construct, then the <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-2">exposure set</a> is the set of all interfaces that have a <a data-link-type="dfn" href="#dfn-global-name" id="ref-for-dfn-global-name-2">global name</a> that is listed in the extended attribute’s argument.</p>
     <li data-md="">
-     <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-13">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-37">extended attribute</a> does not appear on a construct, then its <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-3">exposure set</a> is defined
+     <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-13">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-36">extended attribute</a> does not appear on a construct, then its <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-3">exposure set</a> is defined
 implicitly, depending on the type of construct:</p>
      <dl class="switch">
       <dt data-md="">
@@ -7973,7 +7971,7 @@ can be made once, at the time the <a data-link-type="dfn" href="#dfn-initial-obj
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.5" data-lt="Global|PrimaryGlobal" dfn="" id="Global"><span class="secno">3.3.5. </span><span class="content">[Global] and [PrimaryGlobal]</span><span id="PrimaryGlobal"></span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-7">Global</a></code>]
-or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-8">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-38">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-61">interface</a>,
+or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-8">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-37">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-61">interface</a>,
 it indicates that objects implementing this interface can
 be used as the global object in an ECMAScript environment,
 and that the structure of the prototype chain and how
@@ -8007,13 +8005,13 @@ will correspond to properties on the object itself rather than on <a data-link-t
     property would already have been created before the
     assignment is evaluated.</p>
    </div>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-9">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-10">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-39">extended attributes</a> is
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-9">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-10">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-38">extended attributes</a> is
 used on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-63">interface</a>, then:</p>
    <ul>
     <li data-md="">
      <p>The interface must not define a <a data-link-type="dfn" href="#dfn-named-property-setter" id="ref-for-dfn-named-property-setter-3">named property setter</a>.</p>
     <li data-md="">
-     <p>The interface must not define an <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-5">indexed property getter</a>.</p>
+     <p>The interface must not define <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-5">indexed property getters</a> or <a data-link-type="dfn" href="#dfn-indexed-property-setter" id="ref-for-dfn-indexed-property-setter-3">setters</a>.</p>
     <li data-md="">
      <p>The interface must not also be declared with the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-3">OverrideBuiltins</a></code>]
 extended attribute.</p>
@@ -8027,7 +8025,7 @@ extended attribute.</p>
 a <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-9">partial interface</a> definition, then that partial interface definition must
 be the part of the interface definition that defines
 the <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-named-property-getter-5">named property getter</a>.</p>
-   <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-13">Global</a></code>] and [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-14">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-40">extended attribute</a> must not
+   <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-13">Global</a></code>] and [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-14">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-39">extended attribute</a> must not
 be used on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-64">interface</a> that can have more
 than one object implementing it in the same ECMAScript global environment.</p>
    <p class="note" role="note">Note: This is because the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-3">named properties object</a>,
@@ -8035,7 +8033,7 @@ which exposes the named properties, is in the prototype chain, and it would not 
 sense for more than one object’s named properties to be exposed on an object that
 all of those objects inherit from.</p>
    <p>If an interface is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-15">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-16">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-41">extended attribute</a>, then
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-16">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-40">extended attribute</a>, then
 there must not be more than one <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-15">interface member</a> across
 the interface and its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-15">consequential interfaces</a> with the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-51">identifier</a>.
 There also must not be more than
@@ -8053,24 +8051,24 @@ extended attribute.</p>
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-20">PrimaryGlobal</a></code>]
 extended attributes must either <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-4">take no arguments</a> or <a data-link-type="dfn" href="#dfn-xattr-identifier-list" id="ref-for-dfn-xattr-identifier-list-2">take an identifier list</a>.</p>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-21">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-22">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-42">extended attribute</a> is declared with an identifier list argument, then those identifiers are the interface’s <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-global-name">global names</dfn>; otherwise, the interface has
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-22">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-41">extended attribute</a> is declared with an identifier list argument, then those identifiers are the interface’s <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-global-name">global names</dfn>; otherwise, the interface has
 a single global name, which is the interface’s identifier.</p>
    <p class="note" role="note">Note: The identifier argument list exists so that more than one global interface can
-be addressed with a single name in an [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-22">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-43">extended attribute</a>.</p>
+be addressed with a single name in an [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-22">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-42">extended attribute</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-23">Global</a></code>] and
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-24">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-44">extended attributes</a> must not be declared on the same
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-24">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-43">extended attributes</a> must not be declared on the same
 interface.  The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-25">PrimaryGlobal</a></code>]
 extended attribute must be declared on
 at most one interface.  The interface [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-26">PrimaryGlobal</a></code>]
 is declared on, if any, is known as the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-primary-global-interface">primary global interface</dfn>.</p>
-   <p>See <a href="#named-properties-object">§3.6.4 Named properties object</a>, <a href="#legacy-platform-object-getownproperty">§3.9.2 Legacy platform object [[GetOwnProperty]] method</a> and <a href="#legacy-platform-object-defineownproperty">§3.9.7 Legacy platform object [[DefineOwnProperty]] method</a> for the specific requirements that the use of
+   <p>See <a href="#named-properties-object">§3.6.4 Named properties object</a>, <a href="#legacy-platform-object-getownproperty" id="ref-for-legacy-platform-object-getownproperty-1">§3.9.1 [[GetOwnProperty]]</a> and <a href="#legacy-platform-object-defineownproperty">§3.9.4 [[DefineOwnProperty]]</a> for the specific requirements that the use of
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-27">Global</a></code>] and [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-28">PrimaryGlobal</a></code>]
 entails for named properties,
 and <a href="#es-constants">§3.6.5 Constants</a>, <a href="#es-attributes">§3.6.6 Attributes</a> and <a href="#es-operations">§3.6.7 Operations</a> for the requirements relating to the location of properties
 corresponding to <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-16">interface members</a>.</p>
    <div class="example" id="example-2b45d97a">
     <a class="self-link" href="#example-2b45d97a"></a> 
-    <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-29">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-45">extended attribute</a> is intended
+    <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-29">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-44">extended attribute</a> is intended
     to be used by the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> interface.
     ([<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-30">Global</a></code>] is intended to be used by worker global interfaces.)
     The <code class="idl">Window</code> interface exposes frames as properties on the <code class="idl">Window</code> object.  Since the <code class="idl">Window</code> object also serves as the
@@ -8113,7 +8111,7 @@ corresponding to <a data-link-type="dfn" href="#dfn-interface-member" id="ref-fo
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.6" data-lt="LegacyArrayClass" id="LegacyArrayClass"><span class="secno">3.3.6. </span><span class="content">[LegacyArrayClass]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-3">LegacyArrayClass</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-46">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-65">interface</a> that is not defined to <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-12">inherit</a> from another, it indicates that the internal [[Prototype]]
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-3">LegacyArrayClass</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-45">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-65">interface</a> that is not defined to <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-12">inherit</a> from another, it indicates that the internal [[Prototype]]
 property of its <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-5">interface prototype object</a> will be the <emu-val>Array</emu-val> prototype object rather than
 the <emu-val>Object</emu-val> prototype object.  This allows <emu-val>Array</emu-val> methods to be used more easily
 with objects implementing the interface.</p>
@@ -8154,13 +8152,13 @@ list<span class="p">.</span>concat<span class="p">(</span><span class="p">)</spa
 </span>list<span class="p">.</span>unshift<span class="p">(</span><span class="p">{</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>         <span class="c1">// Insert an item at index 0.
 </span></pre>
     <p><code class="idl">ImmutableItemList</code> has a read only
-    length <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-33">attribute</a> and no indexed property <a data-link-type="dfn" href="#dfn-indexed-property-setter" id="ref-for-dfn-indexed-property-setter-3">setter</a>.  The
+    length <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-33">attribute</a> and no indexed property <a data-link-type="dfn" href="#dfn-indexed-property-setter" id="ref-for-dfn-indexed-property-setter-4">setter</a>.  The
     mutating <emu-val>Array</emu-val> methods will generally not
     succeed on objects implementing <code class="idl">ImmutableItemList</code>.
     The exact behavior depends on the definition of the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-array-prototype-object">Array methods</a> themselves.</p>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.7" data-lt="LegacyUnenumerableNamedProperties" id="LegacyUnenumerableNamedProperties"><span class="secno">3.3.7. </span><span class="content">[LegacyUnenumerableNamedProperties]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-1">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-47">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-67">interface</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-5">supports named properties</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-1">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-46">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-67">interface</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-5">supports named properties</a>,
 it indicates that all the interface’s named properties are unenumerable.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-2">LegacyUnenumerableNamedProperties</a></code>]
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-6">take no arguments</a> and must not appear on an interface
@@ -8168,11 +8166,11 @@ that does not define a <a data-link-type="dfn" href="#dfn-named-property-getter"
    <p>If the [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-3">LegacyUnenumerableNamedProperties</a></code>]
 extended attribute is specified on an interface, then it applies to all its derived interfaces and
 must not be specified on any of them.</p>
-   <p>See <a href="#property-enumeration">§3.9.11 Property enumeration</a> for the specific requirements that the use of
+   <p>See <a href="#legacy-platform-object-property-enumeration">§3.9.8 Property enumeration</a> for the specific requirements that the use of
 [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-4">LegacyUnenumerableNamedProperties</a></code>]
 entails.</p>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.8" data-lt="LenientSetter" id="LenientSetter"><span class="secno">3.3.8. </span><span class="content">[LenientSetter]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-2">LenientSetter</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-48">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-6">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-5">regular attribute</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-2">LenientSetter</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-47">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-6">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-5">regular attribute</a>,
 it indicates that a no-op setter will be generated for the attribute’s
 accessor property.  This results in erroneous assignments to the property
 in strict mode to be ignored rather than causing an exception to be thrown.</p>
@@ -8222,7 +8220,7 @@ or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Re
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.9" data-lt="LenientThis" id="LenientThis"><span class="secno">3.3.9. </span><span class="content">[LenientThis]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-3">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-49">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-7">regular attribute</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-3">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-48">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-7">regular attribute</a>,
 it indicates that invocations of the attribute’s getter or setter
 with a <emu-val>this</emu-val> value that is not an
 object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-68">interface</a> on which the attribute appears will be ignored.</p>
@@ -8265,7 +8263,7 @@ is to be implemented.</p>
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.10" data-lt="NamedConstructor" id="NamedConstructor"><span class="secno">3.3.10. </span><span class="content">[NamedConstructor]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-8">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-50">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-69">interface</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-8">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-49">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-69">interface</a>,
 it indicates that the ECMAScript global object will have a property with the
 specified name whose value is a constructor function that can
 create objects that implement the interface.
@@ -8313,7 +8311,7 @@ are to be implemented.</p>
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.11" data-lt="NewObject" id="NewObject"><span class="secno">3.3.11. </span><span class="content">[NewObject]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#NewObject" id="ref-for-NewObject-2">NewObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-51">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-9">regular</a> or <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-7">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-40">operation</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#NewObject" id="ref-for-NewObject-2">NewObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-50">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-9">regular</a> or <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-7">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-40">operation</a>,
 then it indicates that when calling the operation,
 a reference to a newly created object
 must always be returned.</p>
@@ -8336,7 +8334,7 @@ a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.12" data-lt="NoInterfaceObject" id="NoInterfaceObject"><span class="secno">3.3.12. </span><span class="content">[NoInterfaceObject]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-4">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-52">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-70">interface</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-4">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-51">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-70">interface</a>,
 it indicates that an <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-5">interface object</a> will not exist for the interface in the ECMAScript binding.</p>
    <p class="advisement"> The [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-5">NoInterfaceObject</a></code>] extended attribute
     should not be used on interfaces that are not
@@ -8391,7 +8389,7 @@ Storage<span class="p">.</span>prototype<span class="p">.</span>addEntry <span c
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.13" data-lt="OverrideBuiltins" id="OverrideBuiltins"><span class="secno">3.3.13. </span><span class="content">[OverrideBuiltins]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-5">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-53">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-71">interface</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-5">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-52">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-71">interface</a>,
 it indicates that for a <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-3">legacy platform object</a> implementing the interface,
 properties corresponding to all of
 the object’s <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-3">supported property names</a> will appear to be on the object,
@@ -8409,7 +8407,7 @@ extended attribute.  If the extended attribute is specified on
 a <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-10">partial interface</a> definition, then that partial interface definition must
 be the part of the interface definition that defines
 the <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-named-property-getter-8">named property getter</a>.</p>
-   <p>See <a href="#es-legacy-platform-objects">§3.9 Legacy platform objects</a> and <a href="#legacy-platform-object-defineownproperty">§3.9.7 Legacy platform object [[DefineOwnProperty]] method</a> for the specific requirements that the use of
+   <p>See <a href="#es-legacy-platform-objects">§3.9 Legacy platform objects</a> and <a href="#legacy-platform-object-defineownproperty">§3.9.4 [[DefineOwnProperty]]</a> for the specific requirements that the use of
 [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-7">OverrideBuiltins</a></code>] entails.</p>
    <div class="example" id="example-1f93745b">
     <a class="self-link" href="#example-1f93745b"></a> 
@@ -8460,7 +8458,7 @@ the <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-na
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.14" data-lt="PutForwards" id="PutForwards"><span class="secno">3.3.14. </span><span class="content">[PutForwards]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-3">PutForwards</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-54">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-8">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-8">regular attribute</a> declaration whose type is
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-3">PutForwards</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-53">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-8">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-8">regular attribute</a> declaration whose type is
 an <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-12">interface type</a>,
 it indicates that assigning to the attribute will have specific behavior.
 Namely, the assignment is “forwarded” to the attribute (specified by
@@ -8483,7 +8481,7 @@ extended attribute appears,</p>
    <p>then there must be another <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-35">attribute</a> <var>B</var> declared on <var>J</var> whose <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-53">identifier</a> is <var>N</var>.  Assignment of a value to the attribute <var>A</var> on an object implementing <var>I</var> will result in that value
 being assigned to attribute <var>B</var> of the object that <var>A</var> references, instead.</p>
    <p>Note that [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-6">PutForwards</a></code>]-annotated <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-36">attributes</a> can be
-chained.  That is, an attribute with the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-7">PutForwards</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-55">extended attribute</a> can refer to an attribute that itself has that extended attribute.
+chained.  That is, an attribute with the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-7">PutForwards</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-54">extended attribute</a> can refer to an attribute that itself has that extended attribute.
 There must not exist a cycle in a
 chain of forwarded assignments.  A cycle exists if, when following
 the chain of forwarded assignments, a particular attribute on
@@ -8532,7 +8530,7 @@ p<span class="p">.</span>name <span class="o">=</span> <span class="s1">'John Ci
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.15" data-lt="Replaceable" id="Replaceable"><span class="secno">3.3.15. </span><span class="content">[Replaceable]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-4">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-56">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-10">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-9">regular attribute</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-4">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-55">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-10">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-9">regular attribute</a>,
 it indicates that setting the corresponding property on the <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-16">platform object</a> will result in
 an own property with the same name being created on the object
 which has the value being assigned.  This property will shadow
@@ -8588,7 +8586,7 @@ counter<span class="p">.</span>value<span class="p">;</span>                    
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.16" data-lt="SameObject" id="SameObject"><span class="secno">3.3.16. </span><span class="content">[SameObject]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-2">SameObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-57">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-12">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-41">attribute</a>, then it
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-2">SameObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-56">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-12">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-41">attribute</a>, then it
 indicates that when getting the value of the attribute on a given
 object, the same value must always
 be returned.</p>
@@ -8609,7 +8607,7 @@ be used on anything other than a <a data-link-type="dfn" href="#dfn-read-only" i
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.17" data-lt="SecureContext" id="SecureContext"><span class="secno">3.3.17. </span><span class="content">[SecureContext]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-9">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-58">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-76">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-11">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-8">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-4">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-17">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-5">namespace member</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-9">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-57">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-76">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-11">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-8">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-4">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-17">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-5">namespace member</a>,
 it indicates that the construct is exposed
 only within a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-10">SecureContext</a></code>]
@@ -8617,12 +8615,12 @@ extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" i
    <p>The [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-11">SecureContext</a></code>]
 extended attribute must not
 be used on anything other than an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-77">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-12">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-9">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-5">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-18">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-6">namespace member</a>.</p>
-   <p>Whether a construct that the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-12">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-59">extended attribute</a> can be specified on is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-available-only-in-secure-contexts">available only in secure contexts</dfn> is defined as follows:</p>
+   <p>Whether a construct that the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-12">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-58">extended attribute</a> can be specified on is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-available-only-in-secure-contexts">available only in secure contexts</dfn> is defined as follows:</p>
    <ul>
     <li data-md="">
-     <p>If the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-13">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-60">extended attribute</a> is specified on the construct, then it is <a data-link-type="dfn" href="#dfn-available-only-in-secure-contexts" id="ref-for-dfn-available-only-in-secure-contexts-2">available only in secure contexts</a>.</p>
+     <p>If the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-13">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-59">extended attribute</a> is specified on the construct, then it is <a data-link-type="dfn" href="#dfn-available-only-in-secure-contexts" id="ref-for-dfn-available-only-in-secure-contexts-2">available only in secure contexts</a>.</p>
     <li data-md="">
-     <p>Otherwise, if the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-14">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-61">extended attribute</a> does not appear on a construct, then whether it is <a data-link-type="dfn" href="#dfn-available-only-in-secure-contexts" id="ref-for-dfn-available-only-in-secure-contexts-3">available only in secure contexts</a> depends on the type of construct:</p>
+     <p>Otherwise, if the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-14">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-60">extended attribute</a> does not appear on a construct, then whether it is <a data-link-type="dfn" href="#dfn-available-only-in-secure-contexts" id="ref-for-dfn-available-only-in-secure-contexts-3">available only in secure contexts</a> depends on the type of construct:</p>
      <dl class="switch">
       <dt data-md="">
        <p>interface</p>
@@ -8680,7 +8678,7 @@ that does specify [<code class="idl"><a data-link-type="idl" href="#SecureContex
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.18" data-lt="TreatNonObjectAsNull" id="TreatNonObjectAsNull"><span class="secno">3.3.18. </span><span class="content">[TreatNonObjectAsNull]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-5">TreatNonObjectAsNull</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-62">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-22">callback function</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-5">TreatNonObjectAsNull</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-61">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-22">callback function</a>,
 then it indicates that any value assigned to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-43">attribute</a> whose type is a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-25">nullable</a> <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-23">callback function</a> that is not an object will be converted to
 the <emu-val>null</emu-val> value.</p>
    <p class="advisement"> Specifications should not use [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-6">TreatNonObjectAsNull</a></code>]
@@ -8695,7 +8693,7 @@ the <emu-val>null</emu-val> value.</p>
    <div class="example" id="example-28226fc6">
     <a class="self-link" href="#example-28226fc6"></a> 
     <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-42">IDL fragment</a> defines an interface that has one
-    attribute whose type is a [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-9">TreatNonObjectAsNull</a></code>]-annotated <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-25">callback function</a> and another whose type is a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-26">callback function</a> without the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-63">extended attribute</a>:</p>
+    attribute whose type is a [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-9">TreatNonObjectAsNull</a></code>]-annotated <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-25">callback function</a> and another whose type is a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-26">callback function</a> without the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-62">extended attribute</a>:</p>
 <pre class="highlight"><span class="kt">callback</span> <span class="nv">OccurrenceHandler</span> = <span class="kt">void</span> (<span class="kt">DOMString</span> <span class="nv">details</span>);
 
 [<span class="nv">TreatNonObjectAsNull</span>]
@@ -8728,7 +8726,7 @@ manager<span class="p">.</span>handler2<span class="p">;</span>            <span
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.19" data-lt="TreatNullAs" id="TreatNullAs"><span class="secno">3.3.19. </span><span class="content">[TreatNullAs]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#TreatNullAs" id="ref-for-TreatNullAs-8">TreatNullAs</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-64">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-44">attribute</a> or <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-45">operation</a> argument whose type is <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-52">DOMString</a></code>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#TreatNullAs" id="ref-for-TreatNullAs-8">TreatNullAs</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-63">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-44">attribute</a> or <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-45">operation</a> argument whose type is <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-52">DOMString</a></code>,
 it indicates that a <emu-val>null</emu-val> value
 assigned to the attribute or passed as the operation argument will be
 handled differently from its default handling.  Instead of being stringified
@@ -8781,7 +8779,7 @@ d<span class="p">.</span>isMemberOfBreed<span class="p">(</span><span class="kc"
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.20" data-lt="Unforgeable" id="Unforgeable"><span class="secno">3.3.20. </span><span class="content">[Unforgeable]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-3">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-65">extended attribute</a> appears on a non-<a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-10">static</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-45">attribute</a> or non-<a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-10">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-46">operations</a>, it indicates
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-3">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-64">extended attribute</a> appears on a non-<a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-10">static</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-45">attribute</a> or non-<a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-10">static</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-46">operations</a>, it indicates
 that the attribute or operation will be reflected as an ECMAScript property in
 a way that means its behavior cannot be modified and that performing
 a property lookup on the object will always result in the attribute’s
@@ -8790,7 +8788,7 @@ non-configurable and will exist as an own property on the object
 itself rather than on its prototype.</p>
    <p>An attribute or operation is said to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-unforgeable-on-an-interface">unforgeable</dfn> on a given interface <var>A</var> if the
 attribute or operation is declared on <var>A</var> or one of <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-16">consequential interfaces</a>, and is
-annotated with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-4">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-66">extended attribute</a>.</p>
+annotated with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-4">Unforgeable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-65">extended attribute</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-5">Unforgeable</a></code>]
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-15">take no arguments</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-6">Unforgeable</a></code>]
@@ -8817,7 +8815,7 @@ the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifi
 };
 </pre>
    </div>
-   <p>See <a href="#es-attributes">§3.6.6 Attributes</a>, <a href="#es-operations">§3.6.7 Operations</a>, <a href="#es-platform-objects">§3.8 Platform objects implementing interfaces</a>, <a href="#es-legacy-platform-objects">§3.9 Legacy platform objects</a> and <a href="#legacy-platform-object-defineownproperty">§3.9.7 Legacy platform object [[DefineOwnProperty]] method</a> for the specific requirements that the use of
+   <p>See <a href="#es-attributes">§3.6.6 Attributes</a>, <a href="#es-operations">§3.6.7 Operations</a>, <a href="#es-platform-objects">§3.8 Platform objects implementing interfaces</a>, <a href="#es-legacy-platform-objects">§3.9 Legacy platform objects</a> and <a href="#legacy-platform-object-defineownproperty">§3.9.4 [[DefineOwnProperty]]</a> for the specific requirements that the use of
 [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-7">Unforgeable</a></code>] entails.</p>
    <div class="example" id="example-8fe6c799">
     <a class="self-link" href="#example-8fe6c799"></a> 
@@ -8852,7 +8850,7 @@ system<span class="p">.</span>loginTime<span class="p">;</span>  <span class="c1
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.21" data-lt="Unscopable" id="Unscopable"><span class="secno">3.3.21. </span><span class="content">[Unscopable]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-1">Unscopable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-67">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-10">regular attribute</a> or <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-12">regular operation</a>, it
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-1">Unscopable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-66">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-10">regular attribute</a> or <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-12">regular operation</a>, it
 indicates that an object that implements an interface with the given
 interface member will not include its property name in any object
 environment record with it as its base object.  The result of this is
@@ -8902,7 +8900,7 @@ getter or setter function of an IDL attribute).</p>
    <h3 class="heading settled" data-level="3.5" id="es-overloads"><span class="secno">3.5. </span><span class="content">Overload resolution algorithm</span><a class="self-link" href="#es-overloads"></a></h3>
    <div class="algorithm" data-algorithm="overload resolution algorithm">
     <p>In order to define how overloaded function invocations are resolved, the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-overload-resolution-algorithm">overload resolution algorithm</dfn> is defined.  Its input is an <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-4">effective overload set</a>, <var>S</var>, and a list of ECMAScript values, <var>arg</var><sub>0..<var>n</var>−1</sub>.
-    Its output is a pair consisting of the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-50">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-68">extended attribute</a> of one of <var>S</var>’s entries
+    Its output is a pair consisting of the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-50">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-67">extended attribute</a> of one of <var>S</var>’s entries
     and a list of IDL values or the special value “missing”.  The algorithm behaves as follows:</p>
     <ol>
      <li data-md="">
@@ -9190,7 +9188,7 @@ that has one of the above types in its <a data-link-type="dfn" href="#dfn-flatte
         <p>Otherwise: <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-26">throw a <emu-val>TypeError</emu-val></a>.</p>
       </ol>
      <li data-md="">
-      <p>Let <var>callable</var> be the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-51">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-69">extended attribute</a> of the single entry in <var>S</var>.</p>
+      <p>Let <var>callable</var> be the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-51">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-68">extended attribute</a> of the single entry in <var>S</var>.</p>
      <li data-md="">
       <p>If <var>i</var> = <var>d</var> and <var>method</var> is not <emu-val>undefined</emu-val>, then</p>
       <ol>
@@ -9302,7 +9300,7 @@ ECMAScript global environment and:</p>
     <li data-md="">
      <p>is a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-25">callback interface</a> that has <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-21">constants</a> declared on it, or</p>
     <li data-md="">
-     <p>is a non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-79">interface</a> that is not declared with the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-13">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-70">extended attribute</a>,</p>
+     <p>is a non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-79">interface</a> that is not declared with the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-13">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-69">extended attribute</a>,</p>
    </ul>
    <p>a corresponding property must exist on the
 ECMAScript environment’s global object.
@@ -9346,11 +9344,11 @@ the Function.prototype object.</p>
    <p class="note" role="note">Note: Remember that interface objects for callback interfaces only exist if they have <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-23">constants</a> declared on them;
 when they do exist, they are not <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-5">function objects</a>.</p>
    <h5 class="heading settled" data-level="3.6.1.1" id="es-constructible-interfaces"><span class="secno">3.6.1.1. </span><span class="content">Constructible Interfaces</span><span id="es-interface-call"></span><a class="self-link" href="#es-constructible-interfaces"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-81">interface</a> is declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-20">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-71">extended attribute</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-81">interface</a> is declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-20">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-70">extended attribute</a>,
 then the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-7">interface object</a> can be called as a constructor
 to create an object that implements that interface.
 Calling that interface as a function will throw an exception.</p>
-   <p>Interfaces that are not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-21">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-72">extended attribute</a> will throw when called,
+   <p>Interfaces that are not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-21">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-71">extended attribute</a> will throw when called,
 both as a function and as a constructor.</p>
    <div class="algorithm" data-algorithm="to construct an object implementing an interface">
     <p>When evaluating the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-6">function object</a> <var>F</var>,
@@ -9359,7 +9357,7 @@ both as a function and as a constructor.</p>
     the following steps must be taken:</p>
     <ol>
      <li data-md="">
-      <p>If <var>I</var> was not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-22">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-73">extended attribute</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-27">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <var>I</var> was not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-22">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-72">extended attribute</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-27">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-built-in-function-objects">NewTarget</a> is <emu-val>undefined</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-28">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
@@ -9382,7 +9380,7 @@ both as a function and as a constructor.</p>
    </div>
    <div class="algorithm" data-algorithm="determine value of length property of non-callback interfaces">
     <p>Interface objects for non-callback interfaces must have a property named “length” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> whose value is a <emu-val>Number</emu-val>.
-    If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-23">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-74">extended attribute</a> does not appear on the interface definition, then the value is 0.
+    If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-23">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-73">extended attribute</a> does not appear on the interface definition, then the value is 0.
     Otherwise, the value is determined as follows:</p>
     <ol>
      <li data-md="">
@@ -9426,7 +9424,7 @@ return <emu-val>true</emu-val>.</p>
    </div>
    <h4 class="heading settled" data-level="3.6.2" id="named-constructors"><span class="secno">3.6.2. </span><span class="content">Named constructors</span><a class="self-link" href="#named-constructors"></a></h4>
    <p>A <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-2">named constructor</a> that exists due to one or more
-[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-17">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-75">extended attributes</a> with a given <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-60">identifier</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-7">function object</a>.
+[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-17">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-74">extended attributes</a> with a given <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-60">identifier</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-7">function object</a>.
 It must have a [[Call]] internal property,
 which allows construction of objects that
 implement the interface on which the
@@ -9467,10 +9465,10 @@ with the <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-n
 with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> whose value is the identifier used for the named constructor.</p>
    <p>A named constructor must also have a property named
 “prototype” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span> whose value is the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-9">interface prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-88">interface</a> on which the
-[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-20">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-76">extended attribute</a> appears.</p>
+[<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-20">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-75">extended attribute</a> appears.</p>
    <h4 class="heading settled" data-level="3.6.3" id="interface-prototype-object"><span class="secno">3.6.3. </span><span class="content">Interface prototype object</span><a class="self-link" href="#interface-prototype-object"></a></h4>
    <p>There must exist an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-10">interface prototype object</a> for every non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-89">interface</a> defined, regardless of whether the interface was declared with the
-[<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-14">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-77">extended attribute</a>.
+[<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-14">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-76">extended attribute</a>.
 The interface prototype object for a particular interface has
 properties that correspond to the <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-13">regular attributes</a> and <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-15">regular operations</a> defined on that interface.  These properties are described in more detail in
 sections <a href="#es-attributes">§3.6.6 Attributes</a> and <a href="#es-operations">§3.6.7 Operations</a>.</p>
@@ -9489,7 +9487,7 @@ is a reference to the interface object for the interface.</p>
     <ol>
      <li data-md="">
       <p>If <var>A</var> is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-33">Global</a></code>]
-or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-34">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-78">extended attribute</a>, and <var>A</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-6">supports named properties</a>, then
+or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-34">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-77">extended attribute</a>, and <var>A</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-6">supports named properties</a>, then
 return the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-4">named properties object</a> for <var>A</var>, as defined in <a href="#named-properties-object">§3.6.4 Named properties object</a>.</p>
      <li data-md="">
       <p>Otherwise, if <var>A</var> is declared to inherit from another
@@ -9503,7 +9501,7 @@ extended attribute, then return <a data-link-type="dfn" href="https://tc39.githu
    </div>
    <div class="note" role="note">
     <p>The <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-13">interface prototype object</a> of an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-90">interface</a> that is defined with
-    the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-16">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-79">extended attribute</a> will be accessible if the interface is used as a <a data-link-type="dfn" href="#dfn-supplemental-interface" id="ref-for-dfn-supplemental-interface-5">non-supplemental interface</a>.
+    the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-16">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-78">extended attribute</a> will be accessible if the interface is used as a <a data-link-type="dfn" href="#dfn-supplemental-interface" id="ref-for-dfn-supplemental-interface-5">non-supplemental interface</a>.
     For example, with the following IDL:</p>
 <pre class="highlight">[<span class="nv">NoInterfaceObject</span>]
 <span class="kt">interface</span> <span class="nv">Foo</span> {
@@ -9544,14 +9542,14 @@ interface member, <emu-val>true</emu-val>).</p>
     </ol>
    </div>
    <p>If the interface is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-35">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-36">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-80">extended attribute</a>, or the interface is in the set
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-36">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-79">extended attribute</a>, or the interface is in the set
 of <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces-16">inherited interfaces</a> for any
 other interface that is declared with one of these attributes, then the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-14">interface prototype object</a> must be an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">immutable prototype exotic object</a>.</p>
    <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-1">class string</a> of an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-15">interface prototype object</a> is the concatenation of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-91">interface</a>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-64">identifier</a> and the string
 “Prototype”.</p>
    <h4 class="heading settled" data-level="3.6.4" id="named-properties-object"><span class="secno">3.6.4. </span><span class="content">Named properties object</span><a class="self-link" href="#named-properties-object"></a></h4>
    <p>For every <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-92">interface</a> declared with the
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-37">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-38">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-81">extended attribute</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-7">supports named properties</a>,
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-37">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-38">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-80">extended attribute</a> that <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-7">supports named properties</a>,
 there must exist an object known as the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-named-properties-object">named properties object</dfn> for that interface on which named properties are exposed.</p>
    <div class="algorithm" data-algorithm="value of [[Prototype]] property of named properties objects">
     <p>The <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-5">named properties object</a> for a given interface <var>A</var> must have an internal
@@ -9568,7 +9566,7 @@ extended attribute, then return <a data-link-type="dfn" href="https://tc39.githu
     </ol>
    </div>
    <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-2">class string</a> of a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-6">named properties object</a> is the concatenation of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-93">interface</a>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-65">identifier</a> and the string “Properties”.</p>
-   <h5 class="heading settled" data-level="3.6.4.1" id="named-properties-object-getownproperty"><span class="secno">3.6.4.1. </span><span class="content">Named properties object [[GetOwnProperty]] method</span><a class="self-link" href="#named-properties-object-getownproperty"></a></h5>
+   <h5 class="heading settled" data-level="3.6.4.1" id="named-properties-object-getownproperty"><span class="secno">3.6.4.1. </span><span class="content">[[GetOwnProperty]]</span><a class="self-link" href="#named-properties-object-getownproperty"></a></h5>
    <div class="algorithm" data-algorithm="to invoke the internal [[GetOwnProperty]] method of named properties object">
     <p>When the [[GetOwnProperty]] internal method of a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-7">named properties object</a> <var>O</var> is called with property key <var>P</var>, the following steps are taken:</p>
     <ol>
@@ -9598,7 +9596,7 @@ of performing the steps listed in the description of <var>operation</var> with <
         <p>Set <var>desc</var>.[[Value]] to the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-40">converting</a> <var>value</var> to an ECMAScript value.</p>
        <li data-md="">
         <p>If <var>A</var> implements an interface with the
-[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-5">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-82">extended attribute</a>,
+[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-5">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-81">extended attribute</a>,
 then set <var>desc</var>.[[Enumerable]] to <emu-val>false</emu-val>,
 otherwise set it to <emu-val>true</emu-val>.</p>
        <li data-md="">
@@ -9610,7 +9608,7 @@ otherwise set it to <emu-val>true</emu-val>.</p>
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinarygetownproperty">OrdinaryGetOwnProperty</a>(<var>O</var>, <var>P</var>).</p>
     </ol>
    </div>
-   <h5 class="heading settled" data-level="3.6.4.2" id="named-properties-object-defineownproperty"><span class="secno">3.6.4.2. </span><span class="content">Named properties object [[DefineOwnProperty]] method</span><a class="self-link" href="#named-properties-object-defineownproperty"></a></h5>
+   <h5 class="heading settled" data-level="3.6.4.2" id="named-properties-object-defineownproperty"><span class="secno">3.6.4.2. </span><span class="content">[[DefineOwnProperty]]</span><a class="self-link" href="#named-properties-object-defineownproperty"></a></h5>
    <div class="algorithm" data-algorithm="to invoke the internal [[DefineOwnProperty]] method of named properties object">
     <p>When the [[DefineOwnProperty]] internal method of a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-9">named properties object</a> is called,
     the following steps are taken:</p>
@@ -9619,7 +9617,7 @@ otherwise set it to <emu-val>true</emu-val>.</p>
       <p>Return <emu-val>false</emu-val>.</p>
     </ol>
    </div>
-   <h5 class="heading settled" data-level="3.6.4.3" id="named-properties-object-delete"><span class="secno">3.6.4.3. </span><span class="content">Named properties object [[Delete]] method</span><a class="self-link" href="#named-properties-object-delete"></a></h5>
+   <h5 class="heading settled" data-level="3.6.4.3" id="named-properties-object-delete"><span class="secno">3.6.4.3. </span><span class="content">[[Delete]]</span><a class="self-link" href="#named-properties-object-delete"></a></h5>
    <div class="algorithm" data-algorithm="to invoke the internal [[Delete]] method of named properties object">
     <p>When the [[Delete]] internal method of a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-10">named properties object</a> is called,
     the following steps are taken:</p>
@@ -9628,10 +9626,10 @@ otherwise set it to <emu-val>true</emu-val>.</p>
       <p>Return <emu-val>false</emu-val>.</p>
     </ol>
    </div>
-   <h5 class="heading settled" data-level="3.6.4.4" id="named-properties-object-setprototypeof"><span class="secno">3.6.4.4. </span><span class="content">Named properties object [[SetPrototypeOf]] method</span><a class="self-link" href="#named-properties-object-setprototypeof"></a></h5>
+   <h5 class="heading settled" data-level="3.6.4.4" id="named-properties-object-setprototypeof"><span class="secno">3.6.4.4. </span><span class="content">[[SetPrototypeOf]]</span><a class="self-link" href="#named-properties-object-setprototypeof"></a></h5>
    <p>When the [[SetPrototypeOf]] internal method of a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-11">named properties object</a> is
 called, the same algorithm must be executed as is defined for the [[SetPrototypeOf]] internal method of an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">immutable prototype exotic object</a>.</p>
-   <h5 class="heading settled" data-level="3.6.4.5" id="named-properties-object-preventextensions"><span class="secno">3.6.4.5. </span><span class="content">Named properties object [[PreventExtensions]] method</span><a class="self-link" href="#named-properties-object-preventextensions"></a></h5>
+   <h5 class="heading settled" data-level="3.6.4.5" id="named-properties-object-preventextensions"><span class="secno">3.6.4.5. </span><span class="content">[[PreventExtensions]]</span><a class="self-link" href="#named-properties-object-preventextensions"></a></h5>
    <div class="algorithm" data-algorithm="to invoke the internal [[PreventExtensions]] method of named properties object">
     <p>When the [[PreventExtensions]] internal method of a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-12">named properties object</a> is called,
     the following steps are taken:</p>
@@ -9741,7 +9739,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <ol>
            <li data-md="">
             <p>If the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-53">attribute</a> was specified with the
-[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-8">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-83">extended attribute</a>,
+[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-8">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-82">extended attribute</a>,
 then return <emu-val>undefined</emu-val>.</p>
            <li data-md="">
             <p>Otherwise, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-30">throw a <emu-val>TypeError</emu-val></a>.</p>
@@ -9768,7 +9766,7 @@ concatenation of “get ” and the identifier of the attribute.</p>
     <li data-md="">
      <div class="algorithm" data-algorithm="attribute setter">
       <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-attribute-setter">attribute setter</dfn> is <emu-val>undefined</emu-val> if the attribute is declared <code>readonly</code> and does not have a
-    [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-9">LenientThis</a></code>], [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-15">PutForwards</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-11">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-84">extended attribute</a> declared on it.
+    [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-9">LenientThis</a></code>], [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-15">PutForwards</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-11">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-83">extended attribute</a> declared on it.
     Otherwise, it is a <emu-val>Function</emu-val> object whose behavior when invoked is as follows:</p>
       <ol>
        <li data-md="">
@@ -9797,7 +9795,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>Let <var>validThis</var> be <emu-val>true</emu-val> if <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-23">platform object</a> that implements <var>I</var>, or <emu-val>false</emu-val> otherwise.</p>
          <li data-md="">
           <p>If <var>validThis</var> is <emu-val>false</emu-val> and the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-56">attribute</a> was not specified with the
-[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-10">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-85">extended attribute</a>,
+[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-10">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-84">extended attribute</a>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-32">throw a <emu-val>TypeError</emu-val></a>.</p>
          <li data-md="">
           <p>If the attribute is declared with a [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-12">Replaceable</a></code>]
@@ -11135,9 +11133,9 @@ a platform object that implements one or more interfaces
 must be the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-81">identifier</a> of
 the <a data-link-type="dfn" href="#dfn-primary-interface" id="ref-for-dfn-primary-interface-3">primary interface</a> of the platform object.</p>
    <h3 class="heading settled" data-level="3.9" id="es-legacy-platform-objects"><span class="secno">3.9. </span><span class="content">Legacy platform objects</span><span id="indexed-and-named-properties"></span><a class="self-link" href="#es-legacy-platform-objects"></a></h3>
-   <p><a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-4">Legacy platform objects</a> will appear to have additional properties that correspond to the <a data-link-type="dfn" href="#idl-indexed-properties" id="ref-for-idl-indexed-properties-3">indexed</a> and <a data-link-type="dfn" href="#idl-named-properties" id="ref-for-idl-named-properties-3">named properties</a>.  These properties are not “real” own
+   <p><a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-4">Legacy platform objects</a> will appear to have additional properties that correspond to their <a data-link-type="dfn" href="#idl-indexed-properties" id="ref-for-idl-indexed-properties-3">indexed</a> and <a data-link-type="dfn" href="#idl-named-properties" id="ref-for-idl-named-properties-3">named properties</a>.  These properties are not “real” own
 properties on the object, but are made to look like they are by being exposed
-by the [[GetOwnProperty]] internal method.</p>
+by the <a href="#legacy-platform-object-getownproperty" id="ref-for-legacy-platform-object-getownproperty-2">[[GetOwnProperty]] internal method</a> .</p>
    <p>It is permissible for an object to implement multiple interfaces that support indexed properties.
 However, if so, and there are conflicting definitions as to the object’s <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-4">supported property indices</a>,
 or if one of the interfaces is a <a data-link-type="dfn" href="#dfn-supplemental-interface" id="ref-for-dfn-supplemental-interface-8">supplemental interface</a> for the
@@ -11146,220 +11144,25 @@ have, or what its exact behavior will be with regard to its indexed properties.
 The same applies for named properties.</p>
    <p>The <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-9">indexed property getter</a> that is defined on the derived-most interface that the
 legacy platform object implements is the one that defines the behavior
-when indexing the object with an array index.  Similarly for <a data-link-type="dfn" href="#dfn-indexed-property-setter" id="ref-for-dfn-indexed-property-setter-4">indexed property setters</a>.
+when indexing the object with an array index.  Similarly for <a data-link-type="dfn" href="#dfn-indexed-property-setter" id="ref-for-dfn-indexed-property-setter-5">indexed property setters</a>.
 This way, the definitions of these special operations from
 ancestor interfaces can be overridden.</p>
-   <div class="algorithm" data-algorithm="array index property name">
-    <p>The name of each property that appears to exist due to an object supporting indexed properties
-    is an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-array-index-property-name">array index property name</dfn>,
-    which is a property name <var>P</var> such that <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>P</var>) is String
-    and for which the following algorithm returns <emu-val>true</emu-val>:</p>
-    <ol>
-     <li data-md="">
-      <p>Let <var>i</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-touint32">ToUint32</a>(<var>P</var>).</p>
-     <li data-md="">
-      <p>Let <var>s</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a>(<var>i</var>).</p>
-     <li data-md="">
-      <p>If <var>s</var> ≠ <var>P</var> or <var>i</var> = 2<sup>32</sup> − 1, then return <emu-val>false</emu-val>.</p>
-     <li data-md="">
-      <p>Return <emu-val>true</emu-val>.</p>
-    </ol>
-   </div>
    <p>A property name is an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-unforgeable-property-name">unforgeable property name</dfn> on a
 given platform object if the object implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-131">interface</a> that
 has an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-26">interface member</a> with that identifier
 and that interface member is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-7">unforgeable</a> on any of
 the interfaces that <var>O</var> implements.</p>
-   <div class="algorithm" data-algorithm="named property visibility algorithm">
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-named-property-visibility">named property visibility algorithm</dfn> is used to determine if a given named property is exposed on an object.
-    Some named properties are not exposed on an object depending on whether
-    the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-8">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-86">extended attribute</a> was used.
-    The algorithm operates as follows, with property name <var>P</var> and object <var>O</var>:</p>
-    <ol>
-     <li data-md="">
-      <p>If <var>P</var> is not a <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-4">supported property name</a> of <var>O</var>, then return false.</p>
-     <li data-md="">
-      <p>If <var>O</var> has an own property named <var>P</var>, then return false.</p>
-      <p class="note" role="note">Note: This will include cases in which <var>O</var> has unforgeable properties,
-  because in practice those are always set up before objects have any supported property names,
-  and once set up will make the corresponding named properties invisible.</p>
-     <li data-md="">
-      <p>If <var>O</var> implements an interface that has the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-9">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-87">extended attribute</a>, then return true.</p>
-     <li data-md="">
-      <p>Initialize <var>prototype</var> to be the value of the internal [[Prototype]] property of <var>O</var>.</p>
-     <li data-md="">
-      <p>While <var>prototype</var> is not null:</p>
-      <ol>
-       <li data-md="">
-        <p>If <var>prototype</var> is not a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-14">named properties object</a>,
-and <var>prototype</var> has an own property named <var>P</var>, then return false.</p>
-       <li data-md="">
-        <p>Set <var>prototype</var> to be the value of the internal [[Prototype]] property of <var>prototype</var>.</p>
-      </ol>
-     <li data-md="">
-      <p>Return true.</p>
-    </ol>
-    <div class="note" role="note">
-     <p>This should ensure that for objects with named properties, property resolution is done in the following order:</p>
-     <ol>
-      <li data-md="">
-       <p>Indexed properties.</p>
-      <li data-md="">
-       <p>Own properties, including unforgeable attributes and operations.</p>
-      <li data-md="">
-       <p>Then, if [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-10">OverrideBuiltins</a></code>]:</p>
-       <ol>
-        <li data-md="">
-         <p>Named properties.</p>
-        <li data-md="">
-         <p>Properties from the prototype chain.</p>
-       </ol>
-      <li data-md="">
-       <p>Otherwise, if not [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-11">OverrideBuiltins</a></code>]:</p>
-       <ol>
-        <li data-md="">
-         <p>Properties from the prototype chain.</p>
-        <li data-md="">
-         <p>Named properties.</p>
-       </ol>
-     </ol>
-    </div>
-   </div>
-   <p>Support for <a data-link-type="dfn" href="#dfn-getter" id="ref-for-dfn-getter-1">getters</a> is handled by the <a href="#legacy-platform-object-getownproperty">legacy platform object [[GetOwnProperty]] method</a>,
-and for <a data-link-type="dfn" href="#dfn-setter" id="ref-for-dfn-setter-1">setters</a> by the <a href="#legacy-platform-object-defineownproperty">legacy platform object [[DefineOwnProperty]] method</a>,
-and the <a href="#legacy-platform-object-set">legacy platform object [[Set]] method</a>.</p>
-   <h4 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="3.9.1" data-lt="LegacyPlatformObjectGetOwnProperty" data-noexport="" id="getownproperty-guts"><span class="secno">3.9.1. </span><span class="content">The LegacyPlatformObjectGetOwnProperty abstract operation</span></h4>
-   <div class="algorithm" data-algorithm="LegacyPlatformObjectGetOwnProperty abstract operation">
-    <p>The LegacyPlatformObjectGetOwnProperty abstract operation performs the following steps when
-    called with an object <var>O</var>, a property name <var>P</var>, and a boolean <var>ignoreNamedProps</var> value:</p>
-    <ol>
-     <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-12">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-1">array index property name</a>, then:</p>
-      <ol>
-       <li data-md="">
-        <p>Let <var>index</var> be the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-touint32">ToUint32</a>(<var>P</var>).</p>
-       <li data-md="">
-        <p>If <var>index</var> is a <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-5">supported property index</a>, then:</p>
-        <ol>
-         <li data-md="">
-          <p>Let <var>operation</var> be the operation used to declare the indexed property getter.</p>
-         <li data-md="">
-          <p>Let <var>value</var> be an uninitialized variable.</p>
-         <li data-md="">
-          <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-82">identifier</a>, then
-set <var>value</var> to the result of performing the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-determine-the-value-of-an-indexed-property" id="ref-for-dfn-determine-the-value-of-an-indexed-property-1">determine the value of an indexed property</a> with <var>index</var> as the index.</p>
-         <li data-md="">
-          <p>Otherwise, <var>operation</var> was defined with an identifier.  Set <var>value</var> to the result
-of performing the steps listed in the description of <var>operation</var> with <var>index</var> as the only argument value.</p>
-         <li data-md="">
-          <p>Let <var>desc</var> be a newly created <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">Property Descriptor</a> with no fields.</p>
-         <li data-md="">
-          <p>Set <var>desc</var>.[[Value]] to the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-56">converting</a> <var>value</var> to an ECMAScript value.</p>
-         <li data-md="">
-          <p>If <var>O</var> implements an interface with an <a data-link-type="dfn" href="#dfn-indexed-property-setter" id="ref-for-dfn-indexed-property-setter-5">indexed property setter</a>, then set <var>desc</var>.[[Writable]] to <emu-val>true</emu-val>, otherwise set it to <emu-val>false</emu-val>.</p>
-         <li data-md="">
-          <p>Set <var>desc</var>.[[Enumerable]] and <var>desc</var>.[[Configurable]] to <emu-val>true</emu-val>.</p>
-         <li data-md="">
-          <p>Return <var>desc</var>.</p>
-        </ol>
-       <li data-md="">
-        <p>Set <var>ignoreNamedProps</var> to true.</p>
-      </ol>
-     <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-8">supports named properties</a>,
-the result of running the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-2">named property visibility algorithm</a> with
-property name <var>P</var> and object <var>O</var> is true, and <var>ignoreNamedProps</var> is false, then:</p>
-      <ol>
-       <li data-md="">
-        <p>Let <var>operation</var> be the operation used to declare the named property getter.</p>
-       <li data-md="">
-        <p>Let <var>value</var> be an uninitialized variable.</p>
-       <li data-md="">
-        <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-83">identifier</a>, then
-set <var>value</var> to the result of performing the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-determine-the-value-of-a-named-property" id="ref-for-dfn-determine-the-value-of-a-named-property-2">determine the value of a named property</a> with <var>P</var> as the name.</p>
-       <li data-md="">
-        <p>Otherwise, <var>operation</var> was defined with an identifier.  Set <var>value</var> to the result
-of performing the steps listed in the description of <var>operation</var> with <var>P</var> as the only argument value.</p>
-       <li data-md="">
-        <p>Let <var>desc</var> be a newly created <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">Property Descriptor</a> with no fields.</p>
-       <li data-md="">
-        <p>Set <var>desc</var>.[[Value]] to the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-57">converting</a> <var>value</var> to an ECMAScript value.</p>
-       <li data-md="">
-        <p>If <var>O</var> implements an interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="ref-for-dfn-named-property-setter-4">named property setter</a>, then set <var>desc</var>.[[Writable]] to <emu-val>true</emu-val>, otherwise set it to <emu-val>false</emu-val>.</p>
-       <li data-md="">
-        <p>If <var>O</var> implements an interface with the
-[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-6">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-88">extended attribute</a>,
-then set <var>desc</var>.[[Enumerable]] to <emu-val>false</emu-val>,
-otherwise set it to <emu-val>true</emu-val>.</p>
-       <li data-md="">
-        <p>Set <var>desc</var>.[[Configurable]] to <emu-val>true</emu-val>.</p>
-       <li data-md="">
-        <p>Return <var>desc</var>.</p>
-      </ol>
-     <li data-md="">
-      <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinarygetownproperty">OrdinaryGetOwnProperty</a>(<var>O</var>, <var>P</var>).</p>
-    </ol>
-   </div>
-   <h4 class="heading settled" data-level="3.9.2" id="legacy-platform-object-getownproperty"><span class="secno">3.9.2. </span><span class="content">Legacy platform object [[GetOwnProperty]] method</span><span id="getownproperty"></span><a class="self-link" href="#legacy-platform-object-getownproperty"></a></h4>
+   <p>Support for <a data-link-type="dfn" href="#dfn-getter" id="ref-for-dfn-getter-1">getters</a> is handled by the <a href="#legacy-platform-object-getownproperty" id="ref-for-legacy-platform-object-getownproperty-3">legacy platform object [[GetOwnProperty]] method</a>,
+and for <a data-link-type="dfn" href="#dfn-setter" id="ref-for-dfn-setter-1">setters</a> by the <a href="#legacy-platform-object-defineownproperty">legacy platform object [[DefineOwnProperty]] method</a> and the <a href="#legacy-platform-object-set">legacy platform object [[Set]] method</a>.</p>
+   <h4 class="heading settled dfn-paneled" data-dfn-for="legacy platform object" data-dfn-type="dfn" data-level="3.9.1" data-lt="GetOwnProperty" data-noexport="" id="legacy-platform-object-getownproperty"><span class="secno">3.9.1. </span><span class="content">[[GetOwnProperty]]</span><span id="getownproperty"></span></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[GetOwnProperty]] method of platform objects">
     <p>The internal [[GetOwnProperty]] method of every <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-5">legacy platform object</a> <var>O</var> must behave as follows when called with property name <var>P</var>:</p>
     <ol>
      <li data-md="">
-      <p>Return <a data-link-type="dfn" href="#getownproperty-guts" id="ref-for-getownproperty-guts-1">LegacyPlatformObjectGetOwnProperty</a>(<var>O</var>, <var>P</var>, <emu-val>false</emu-val>).</p>
+      <p>Return <a data-link-type="abstract-op" href="#LegacyPlatformObjectGetOwnProperty" id="ref-for-LegacyPlatformObjectGetOwnProperty-1">LegacyPlatformObjectGetOwnProperty</a>(<var>O</var>, <var>P</var>, <emu-val>false</emu-val>).</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.9.3" id="invoking-indexed-setter"><span class="secno">3.9.3. </span><span class="content">Invoking a legacy platform object indexed property setter</span><a class="self-link" href="#invoking-indexed-setter"></a></h4>
-   <div class="algorithm" data-algorithm="invoke an indexed property setter">
-    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="invoke the indexed property setter" id="invoke-indexed-setter">invoke an indexed property setter</dfn> with property name <var>P</var> and ECMAScript value <var>V</var>, the following steps must be performed:</p>
-    <ol>
-     <li data-md="">
-      <p>Let <var>index</var> be the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-touint32">ToUint32</a>(<var>P</var>).</p>
-     <li data-md="">
-      <p>Let <var>creating</var> be true if <var>index</var> is not a <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-6">supported property index</a>,
-and false otherwise.</p>
-     <li data-md="">
-      <p>Let <var>operation</var> be the operation used to declare the indexed property setter.</p>
-     <li data-md="">
-      <p>Let <var>T</var> be the type of the second argument of <var>operation</var>.</p>
-     <li data-md="">
-      <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-68">converting</a> <var>V</var> to an IDL value of type <var>T</var>.</p>
-     <li data-md="">
-      <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-84">identifier</a>, then:</p>
-      <ol>
-       <li data-md="">
-        <p>If <var>creating</var> is true, then perform the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-set-the-value-of-a-new-indexed-property" id="ref-for-dfn-set-the-value-of-a-new-indexed-property-1">set the value of a new indexed property</a> with <var>index</var> as the index and <var>value</var> as the value.</p>
-       <li data-md="">
-        <p>Otherwise, <var>creating</var> is false.  Perform the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-set-the-value-of-an-existing-indexed-property" id="ref-for-dfn-set-the-value-of-an-existing-indexed-property-1">set the value of an existing indexed property</a> with <var>index</var> as the index and <var>value</var> as the value.</p>
-      </ol>
-     <li data-md="">
-      <p>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</p>
-    </ol>
-   </div>
-   <h4 class="heading settled" data-level="3.9.4" id="invoking-named-setter"><span class="secno">3.9.4. </span><span class="content">Invoking a legacy platform object named property setter</span><a class="self-link" href="#invoking-named-setter"></a></h4>
-   <div class="algorithm" data-algorithm="invoke a named property setter">
-    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="invoke the named property setter" id="invoke-named-setter">invoke a named property setter</dfn> with property name <var>P</var> and ECMAScript value <var>V</var>, the following steps must be performed:</p>
-    <ol>
-     <li data-md="">
-      <p>Let <var>creating</var> be true if <var>P</var> is not a <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-5">supported property name</a>, and false otherwise.</p>
-     <li data-md="">
-      <p>Let <var>operation</var> be the operation used to declare the named property setter.</p>
-     <li data-md="">
-      <p>Let <var>T</var> be the type of the second argument of <var>operation</var>.</p>
-     <li data-md="">
-      <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-69">converting</a> <var>V</var> to an IDL value of type <var>T</var>.</p>
-     <li data-md="">
-      <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-85">identifier</a>, then:</p>
-      <ol>
-       <li data-md="">
-        <p>If <var>creating</var> is true, then perform the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-set-the-value-of-a-new-named-property" id="ref-for-dfn-set-the-value-of-a-new-named-property-1">set the value of a new named property</a> with <var>P</var> as the name and <var>value</var> as the value.</p>
-       <li data-md="">
-        <p>Otherwise, <var>creating</var> is false.  Perform the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-set-the-value-of-an-existing-named-property" id="ref-for-dfn-set-the-value-of-an-existing-named-property-1">set the value of an existing named property</a> with <var>P</var> as the name and <var>value</var> as the value.</p>
-      </ol>
-     <li data-md="">
-      <p>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of <var>operation</var> with <var>P</var> and <var>value</var> as the two argument values.</p>
-    </ol>
-   </div>
-   <h4 class="heading settled" data-level="3.9.5" id="legacy-platform-object-set"><span class="secno">3.9.5. </span><span class="content">Legacy platform object [[Set]] method</span><span id="platformobjectset"></span><a class="self-link" href="#legacy-platform-object-set"></a></h4>
+   <h4 class="heading settled" data-level="3.9.2" id="legacy-platform-object-set"><span class="secno">3.9.2. </span><span class="content">[[Set]]</span><span id="platformobjectset"></span><a class="self-link" href="#legacy-platform-object-set"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[Set]] method of legacy platform objects">
     <p>The internal [[Set]] method of every <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-6">legacy platform object</a> <var>O</var> must behave as follows when called with
     property name <var>P</var>, value <var>V</var>, and ECMAScript language value <var>Receiver</var>:</p>
@@ -11368,7 +11171,7 @@ and false otherwise.</p>
       <p>If <var>O</var> and <var>Receiver</var> are the same object, then:</p>
       <ol>
        <li data-md="">
-        <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-13">supports indexed properties</a>, <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-2">array index property name</a>, and <var>O</var> implements an interface with an <a data-link-type="dfn" href="#dfn-indexed-property-setter" id="ref-for-dfn-indexed-property-setter-6">indexed property setter</a>, then:</p>
+        <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-12">supports indexed properties</a>, <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-1">array index property name</a>, and <var>O</var> implements an interface with an <a data-link-type="dfn" href="#dfn-indexed-property-setter" id="ref-for-dfn-indexed-property-setter-6">indexed property setter</a>, then:</p>
         <ol>
          <li data-md="">
           <p><a data-link-type="dfn" href="#invoke-indexed-setter" id="ref-for-invoke-indexed-setter-1">Invoke the indexed property setter</a> with <var>P</var> and <var>V</var>.</p>
@@ -11376,8 +11179,8 @@ and false otherwise.</p>
           <p>Return <emu-val>true</emu-val>.</p>
         </ol>
        <li data-md="">
-        <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-9">supports named properties</a>, <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>P</var>) is String, <var>P</var> is not an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-3">array index property name</a>,
-and <var>O</var> implements an interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="ref-for-dfn-named-property-setter-5">named property setter</a>, then:</p>
+        <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-8">supports named properties</a>, <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>P</var>) is String, <var>P</var> is not an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-2">array index property name</a>,
+and <var>O</var> implements an interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="ref-for-dfn-named-property-setter-4">named property setter</a>, then:</p>
         <ol>
          <li data-md="">
           <p><a data-link-type="dfn" href="#invoke-named-setter" id="ref-for-invoke-named-setter-1">Invoke the named property setter</a> with <var>P</var> and <var>V</var>.</p>
@@ -11386,26 +11189,24 @@ and <var>O</var> implements an interface with a <a data-link-type="dfn" href="#d
         </ol>
       </ol>
      <li data-md="">
-      <p>Let <var>ownDesc</var> be <a data-link-type="dfn" href="#getownproperty-guts" id="ref-for-getownproperty-guts-2">LegacyPlatformObjectGetOwnProperty</a>(<var>O</var>, <var>P</var>, <emu-val>true</emu-val>).</p>
+      <p>Let <var>ownDesc</var> be <a data-link-type="abstract-op" href="#LegacyPlatformObjectGetOwnProperty" id="ref-for-LegacyPlatformObjectGetOwnProperty-2">LegacyPlatformObjectGetOwnProperty</a>(<var>O</var>, <var>P</var>, <emu-val>true</emu-val>).</p>
      <li data-md="">
       <p>Perform steps 3-11 of the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver">default [[Set]] internal method</a>.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.9.6" id="legacy-platform-object-setprototypeof"><span class="secno">3.9.6. </span><span class="content">Legacy platform object [[SetPrototypeOf]] method</span><span id="platformobjectsetprototypeof"></span><a class="self-link" href="#legacy-platform-object-setprototypeof"></a></h4>
-   <div class="algorithm" data-algorithm="to invoke the internal [[SetPrototypeOf]] method of legacy platform objects">
-    <p>The internal [[SetPrototypeOf]] method of every <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-7">legacy platform object</a> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-132">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-95">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-96">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-89">extended attribute</a> must execute the same algorithm as is defined for the
-    [[SetPrototypeOf]] internal method of an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">immutable prototype exotic object</a>.</p>
-   </div>
+   <h4 class="heading settled" data-level="3.9.3" id="legacy-platform-object-setprototypeof"><span class="secno">3.9.3. </span><span class="content">[[SetPrototypeOf]]</span><span id="platformobjectsetprototypeof"></span><a class="self-link" href="#legacy-platform-object-setprototypeof"></a></h4>
+   <p>The internal [[SetPrototypeOf]] method of every <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-7">legacy platform object</a> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-132">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-95">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-96">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-85">extended attribute</a> must execute the same algorithm as is defined for the
+[[SetPrototypeOf]] internal method of an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">immutable prototype exotic object</a>.</p>
    <p class="note" role="note">Note: For <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> objects, it is unobservable whether this is implemented, since the presence of
 the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#windowproxy">WindowProxy</a></code> object ensures that [[SetPrototypeOf]] is never called on a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> object
 directly. For other global objects, however, this is necessary.</p>
-   <h4 class="heading settled" data-level="3.9.7" id="legacy-platform-object-defineownproperty"><span class="secno">3.9.7. </span><span class="content">Legacy platform object [[DefineOwnProperty]] method</span><span id="defineownproperty"></span><a class="self-link" href="#legacy-platform-object-defineownproperty"></a></h4>
+   <h4 class="heading settled algorithm" data-algorithm="[[DefineOwnProperty]]" data-level="3.9.4" id="legacy-platform-object-defineownproperty"><span class="secno">3.9.4. </span><span class="content">[[DefineOwnProperty]]</span><span id="defineownproperty"></span><a class="self-link" href="#legacy-platform-object-defineownproperty"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[DefineOwnProperty]] method of legacy platform objects">
     <p>When the internal [[DefineOwnProperty]] method of a <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-8">legacy platform object</a> <var>O</var> is called with property key <var>P</var> and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">Property Descriptor</a> <var>Desc</var>,
     the following steps must be taken:</p>
     <ol>
      <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-14">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-4">array index property name</a>, then:</p>
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-13">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-3">array index property name</a>, then:</p>
       <ol>
        <li data-md="">
         <p>If the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-isdatadescriptor">IsDataDescriptor</a>(<var>Desc</var>) is <emu-val>false</emu-val>, then return <emu-val>false</emu-val>.</p>
@@ -11417,20 +11218,20 @@ directly. For other global objects, however, this is necessary.</p>
         <p>Return <emu-val>true</emu-val>.</p>
       </ol>
      <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-10">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-133">interface</a> with the
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-97">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-98">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-90">extended attribute</a> and <var>P</var> is not an <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-dfn-unforgeable-property-name-1">unforgeable property name</a> of <var>O</var>, then:</p>
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-9">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-133">interface</a> with the
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-97">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-98">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-86">extended attribute</a> and <var>P</var> is not an <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-dfn-unforgeable-property-name-1">unforgeable property name</a> of <var>O</var>, then:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>creating</var> be true if <var>P</var> is not a <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-6">supported property name</a>, and false otherwise.</p>
+        <p>Let <var>creating</var> be true if <var>P</var> is not a <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-4">supported property name</a>, and false otherwise.</p>
        <li data-md="">
-        <p>If <var>O</var> implements an interface with the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-12">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-91">extended attribute</a> or <var>O</var> does not have an own property
+        <p>If <var>O</var> implements an interface with the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-8">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-87">extended attribute</a> or <var>O</var> does not have an own property
 named <var>P</var>, then:</p>
         <ol>
          <li data-md="">
           <p>If <var>creating</var> is false and <var>O</var> does not implement an
-interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="ref-for-dfn-named-property-setter-6">named property setter</a>, then return <emu-val>false</emu-val>.</p>
+interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="ref-for-dfn-named-property-setter-5">named property setter</a>, then return <emu-val>false</emu-val>.</p>
          <li data-md="">
-          <p>If <var>O</var> implements an interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="ref-for-dfn-named-property-setter-7">named property setter</a>, then:</p>
+          <p>If <var>O</var> implements an interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="ref-for-dfn-named-property-setter-6">named property setter</a>, then:</p>
           <ol>
            <li data-md="">
             <p>If the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-isdatadescriptor">IsDataDescriptor</a>(<var>Desc</var>) is <emu-val>false</emu-val>, then return <emu-val>false</emu-val>.</p>
@@ -11444,35 +11245,35 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
      <li data-md="">
       <p>If <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-134">interface</a> with the
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-99">Global</a></code>] or
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-100">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-92">extended attribute</a>, then set <var>Desc</var>.[[Configurable]] to <emu-val>true</emu-val>.</p>
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-100">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-88">extended attribute</a>, then set <var>Desc</var>.[[Configurable]] to <emu-val>true</emu-val>.</p>
      <li data-md="">
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinarydefineownproperty">OrdinaryDefineOwnProperty</a>(<var>O</var>, <var>P</var>, <var>Desc</var>).</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.9.8" id="legacy-platform-object-delete"><span class="secno">3.9.8. </span><span class="content">Legacy platform object [[Delete]] method</span><span id="delete"></span><a class="self-link" href="#legacy-platform-object-delete"></a></h4>
+   <h4 class="heading settled" data-level="3.9.5" id="legacy-platform-object-delete"><span class="secno">3.9.5. </span><span class="content">[[Delete]]</span><span id="delete"></span><a class="self-link" href="#legacy-platform-object-delete"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[Delete]] method of legacy platform objects">
     <p>The internal [[Delete]] method of every <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-9">legacy platform object</a> <var>O</var> must behave as follows when called with property name <var>P</var>.</p>
     <ol>
      <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-15">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-5">array index property name</a>, then:</p>
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-14">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-4">array index property name</a>, then:</p>
       <ol>
        <li data-md="">
         <p>Let <var>index</var> be the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-touint32">ToUint32</a>(<var>P</var>).</p>
        <li data-md="">
-        <p>If <var>index</var> is not a <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-7">supported property index</a>, then return <emu-val>true</emu-val>.</p>
+        <p>If <var>index</var> is not a <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-5">supported property index</a>, then return <emu-val>true</emu-val>.</p>
        <li data-md="">
         <p>Return <emu-val>false</emu-val>.</p>
       </ol>
      <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-11">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-135">interface</a> with the
-[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-101">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-102">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-93">extended attribute</a> and the result of calling the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-3">named property visibility algorithm</a> with property name <var>P</var> and object <var>O</var> is true, then:</p>
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-10">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-135">interface</a> with the
+[<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-101">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-102">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-89">extended attribute</a> and the result of calling the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-2">named property visibility algorithm</a> with property name <var>P</var> and object <var>O</var> is true, then:</p>
       <ol>
        <li data-md="">
         <p>If <var>O</var> does not implement an interface with a <a data-link-type="dfn" href="#dfn-named-property-deleter" id="ref-for-dfn-named-property-deleter-5">named property deleter</a>, then return <emu-val>false</emu-val>.</p>
        <li data-md="">
         <p>Let <var>operation</var> be the operation used to declare the named property deleter.</p>
        <li data-md="">
-        <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-86">identifier</a>, then:</p>
+        <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-82">identifier</a>, then:</p>
         <ol>
          <li data-md="">
           <p>Perform the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-delete-an-existing-named-property" id="ref-for-dfn-delete-an-existing-named-property-1">delete an existing named property</a> with <var>P</var> as the name.</p>
@@ -11502,7 +11303,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
       <p>Return <emu-val>true</emu-val>.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.9.9" id="legacy-platform-object-call"><span class="secno">3.9.9. </span><span class="content">Legacy platform object [[Call]] method</span><span id="call"></span><a class="self-link" href="#legacy-platform-object-call"></a></h4>
+   <h4 class="heading settled" data-level="3.9.6" id="legacy-platform-object-call"><span class="secno">3.9.6. </span><span class="content">[[Call]]</span><span id="call"></span><a class="self-link" href="#legacy-platform-object-call"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[Call]] method of legacy platform objects">
     <p>The internal [[Call]] method of <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-10">legacy platform object</a> that implements
     an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-136">interface</a> <var>I</var> must behave as follows,
@@ -11517,21 +11318,21 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
      <li data-md="">
       <p>Perform the actions listed in the description of the legacy caller <var>operation</var> with <var>values</var> as the argument values.</p>
      <li data-md="">
-      <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-58">converting</a> the return value from those actions to an ECMAScript value of the type <var>operation</var> is declared to return (or <emu-val>undefined</emu-val> if <var>operation</var> is declared to return <code class="idl"><a data-link-type="idl" href="#idl-void" id="ref-for-idl-void-6">void</a></code>).</p>
+      <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-56">converting</a> the return value from those actions to an ECMAScript value of the type <var>operation</var> is declared to return (or <emu-val>undefined</emu-val> if <var>operation</var> is declared to return <code class="idl"><a data-link-type="idl" href="#idl-void" id="ref-for-idl-void-6">void</a></code>).</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.9.10" id="legacy-platform-object-preventextensions"><span class="secno">3.9.10. </span><span class="content">Legacy platform object [[PreventExtensions]] method</span><span id="preventextensions"></span><a class="self-link" href="#legacy-platform-object-preventextensions"></a></h4>
+   <h4 class="heading settled" data-level="3.9.7" id="legacy-platform-object-preventextensions"><span class="secno">3.9.7. </span><span class="content">[[PreventExtensions]]</span><span id="preventextensions"></span><a class="self-link" href="#legacy-platform-object-preventextensions"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[PreventExtensions]] method of legacy platform objects">
     <p>When the [[PreventExtensions]] internal method of a <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-11">legacy platform object</a> is called,
     the following steps are taken:</p>
     <ol>
      <li data-md="">
-      <p>return <emu-val>false</emu-val>.</p>
+      <p>Return <emu-val>false</emu-val>.</p>
     </ol>
     <p class="note" role="note">Note: this keeps <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-12">legacy platform objects</a> extensible by
     making [[PreventExtensions]] fail for them.</p>
    </div>
-   <h4 class="heading settled" data-level="3.9.11" id="property-enumeration"><span class="secno">3.9.11. </span><span class="content">Property enumeration</span><a class="self-link" href="#property-enumeration"></a></h4>
+   <h4 class="heading settled" data-level="3.9.8" id="legacy-platform-object-property-enumeration"><span class="secno">3.9.8. </span><span class="content">Property enumeration</span><span id="property-enumeration"></span><a class="self-link" href="#legacy-platform-object-property-enumeration"></a></h4>
    <p>This document does not define a complete property enumeration order
 for <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-52">platform objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-137">interfaces</a> (or for <a href="#es-exception-objects" id="ref-for-es-exception-objects-1">platform objects representing exceptions</a>).
 However, for <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-13">legacy platform objects</a>,
@@ -11539,19 +11340,211 @@ properties on the object must be
 enumerated in the following order:</p>
    <ol>
     <li data-md="">
-     <p>If the object <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-16">supports indexed properties</a>, then
-the object’s <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-8">supported property indices</a> are
+     <p>If the object <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-15">supports indexed properties</a>, then
+the object’s <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-6">supported property indices</a> are
 enumerated first, in numerical order.</p>
     <li data-md="">
-     <p>If the object <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-12">supports named properties</a> and doesn’t implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-138">interface</a> with the
-[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-7">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-94">extended attribute</a>, then
-the object’s <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-7">supported property names</a> that
-are visible according to the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-4">named property visibility algorithm</a> are enumerated next, in the order given in the definition of the set of supported property names.</p>
+     <p>If the object <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-11">supports named properties</a> and doesn’t implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-138">interface</a> with the
+[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-6">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-90">extended attribute</a>, then
+the object’s <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-5">supported property names</a> that
+are visible according to the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-3">named property visibility algorithm</a> are enumerated next, in the order given in the definition of the set of supported property names.</p>
     <li data-md="">
      <p>Finally, any enumerable own properties or properties from the object’s prototype chain are then enumerated,
 in no defined order.</p>
    </ol>
    <p class="note" role="note">Note: Future versions of the ECMAScript specification may define a total order for property enumeration.</p>
+   <h4 class="heading settled" data-level="3.9.9" id="legacy-platform-object-abstract-ops"><span class="secno">3.9.9. </span><span class="content">Abstract operations</span><a class="self-link" href="#legacy-platform-object-abstract-ops"></a></h4>
+   <div class="algorithm" data-algorithm="array index property name">
+    <p>The name of each property that appears to exist due to an object supporting indexed properties
+    is an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-array-index-property-name">array index property name</dfn>,
+    which is a property name <var>P</var> such that <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>P</var>) is String
+    and for which the following algorithm returns <emu-val>true</emu-val>:</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>i</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-touint32">ToUint32</a>(<var>P</var>).</p>
+     <li data-md="">
+      <p>Let <var>s</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a>(<var>i</var>).</p>
+     <li data-md="">
+      <p>If <var>s</var> ≠ <var>P</var> or <var>i</var> = 2<sup>32</sup> − 1, then return <emu-val>false</emu-val>.</p>
+     <li data-md="">
+      <p>Return <emu-val>true</emu-val>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="named property visibility algorithm">
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-named-property-visibility">named property visibility algorithm</dfn> is used to determine if a given named property is exposed on an object.
+    Some named properties are not exposed on an object depending on whether
+    the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-9">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-91">extended attribute</a> was used.
+    The algorithm operates as follows, with property name <var>P</var> and object <var>O</var>:</p>
+    <ol>
+     <li data-md="">
+      <p>If <var>P</var> is not a <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-6">supported property name</a> of <var>O</var>, then return false.</p>
+     <li data-md="">
+      <p>If <var>O</var> has an own property named <var>P</var>, then return false.</p>
+      <p class="note" role="note">Note: This will include cases in which <var>O</var> has unforgeable properties,
+  because in practice those are always set up before objects have any supported property names,
+  and once set up will make the corresponding named properties invisible.</p>
+     <li data-md="">
+      <p>If <var>O</var> implements an interface that has the [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-10">OverrideBuiltins</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-92">extended attribute</a>, then return true.</p>
+     <li data-md="">
+      <p>Initialize <var>prototype</var> to be the value of the internal [[Prototype]] property of <var>O</var>.</p>
+     <li data-md="">
+      <p>While <var>prototype</var> is not null:</p>
+      <ol>
+       <li data-md="">
+        <p>If <var>prototype</var> is not a <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-14">named properties object</a>,
+and <var>prototype</var> has an own property named <var>P</var>, then return false.</p>
+       <li data-md="">
+        <p>Set <var>prototype</var> to be the value of the internal [[Prototype]] property of <var>prototype</var>.</p>
+      </ol>
+     <li data-md="">
+      <p>Return true.</p>
+    </ol>
+   </div>
+   <div class="note" role="note">
+    <p>This should ensure that for objects with named properties, property resolution is done in the following order:</p>
+    <ol>
+     <li data-md="">
+      <p>Indexed properties.</p>
+     <li data-md="">
+      <p>Own properties, including unforgeable attributes and operations.</p>
+     <li data-md="">
+      <p>Then, if [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-11">OverrideBuiltins</a></code>]:</p>
+      <ol>
+       <li data-md="">
+        <p>Named properties.</p>
+       <li data-md="">
+        <p>Properties from the prototype chain.</p>
+      </ol>
+     <li data-md="">
+      <p>Otherwise, if not [<code class="idl"><a data-link-type="idl" href="#OverrideBuiltins" id="ref-for-OverrideBuiltins-12">OverrideBuiltins</a></code>]:</p>
+      <ol>
+       <li data-md="">
+        <p>Properties from the prototype chain.</p>
+       <li data-md="">
+        <p>Named properties.</p>
+      </ol>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="invoke an indexed property setter">
+    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="invoke the indexed property setter" id="invoke-indexed-setter">invoke an indexed property setter<span id="invoking-indexed-setter"></span></dfn> with property name <var>P</var> and ECMAScript value <var>V</var>, the following steps must be performed:</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>index</var> be the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-touint32">ToUint32</a>(<var>P</var>).</p>
+     <li data-md="">
+      <p>Let <var>creating</var> be true if <var>index</var> is not a <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-7">supported property index</a>,
+and false otherwise.</p>
+     <li data-md="">
+      <p>Let <var>operation</var> be the operation used to declare the indexed property setter.</p>
+     <li data-md="">
+      <p>Let <var>T</var> be the type of the second argument of <var>operation</var>.</p>
+     <li data-md="">
+      <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-68">converting</a> <var>V</var> to an IDL value of type <var>T</var>.</p>
+     <li data-md="">
+      <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-83">identifier</a>, then:</p>
+      <ol>
+       <li data-md="">
+        <p>If <var>creating</var> is true, then perform the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-set-the-value-of-a-new-indexed-property" id="ref-for-dfn-set-the-value-of-a-new-indexed-property-1">set the value of a new indexed property</a> with <var>index</var> as the index and <var>value</var> as the value.</p>
+       <li data-md="">
+        <p>Otherwise, <var>creating</var> is false.  Perform the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-set-the-value-of-an-existing-indexed-property" id="ref-for-dfn-set-the-value-of-an-existing-indexed-property-1">set the value of an existing indexed property</a> with <var>index</var> as the index and <var>value</var> as the value.</p>
+      </ol>
+     <li data-md="">
+      <p>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of <var>operation</var> with <var>index</var> and <var>value</var> as the two argument values.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="invoke a named property setter">
+    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="invoke the named property setter" id="invoke-named-setter">invoke a named property setter<span id="invoking-named-setter"></span></dfn> with property name <var>P</var> and ECMAScript value <var>V</var>, the following steps must be performed:</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>creating</var> be true if <var>P</var> is not a <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-7">supported property name</a>, and false otherwise.</p>
+     <li data-md="">
+      <p>Let <var>operation</var> be the operation used to declare the named property setter.</p>
+     <li data-md="">
+      <p>Let <var>T</var> be the type of the second argument of <var>operation</var>.</p>
+     <li data-md="">
+      <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-69">converting</a> <var>V</var> to an IDL value of type <var>T</var>.</p>
+     <li data-md="">
+      <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-84">identifier</a>, then:</p>
+      <ol>
+       <li data-md="">
+        <p>If <var>creating</var> is true, then perform the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-set-the-value-of-a-new-named-property" id="ref-for-dfn-set-the-value-of-a-new-named-property-1">set the value of a new named property</a> with <var>P</var> as the name and <var>value</var> as the value.</p>
+       <li data-md="">
+        <p>Otherwise, <var>creating</var> is false.  Perform the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-set-the-value-of-an-existing-named-property" id="ref-for-dfn-set-the-value-of-an-existing-named-property-1">set the value of an existing named property</a> with <var>P</var> as the name and <var>value</var> as the value.</p>
+      </ol>
+     <li data-md="">
+      <p>Otherwise, <var>operation</var> was defined with an identifier.  Perform the steps listed in the description of <var>operation</var> with <var>P</var> and <var>value</var> as the two argument values.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="LegacyPlatformObjectGetOwnProperty">
+    <p>The <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="LegacyPlatformObjectGetOwnProperty">LegacyPlatformObjectGetOwnProperty<span id="getownproperty-guts"></span></dfn> abstract operation performs the following steps when called with
+    an object <var>O</var>, a property name <var>P</var>, and a boolean <var>ignoreNamedProps</var> value:</p>
+    <ol>
+     <li data-md="">
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-16">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-5">array index property name</a>, then:</p>
+      <ol>
+       <li data-md="">
+        <p>Let <var>index</var> be the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-touint32">ToUint32</a>(<var>P</var>).</p>
+       <li data-md="">
+        <p>If <var>index</var> is a <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-8">supported property index</a>, then:</p>
+        <ol>
+         <li data-md="">
+          <p>Let <var>operation</var> be the operation used to declare the indexed property getter.</p>
+         <li data-md="">
+          <p>Let <var>value</var> be an uninitialized variable.</p>
+         <li data-md="">
+          <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-85">identifier</a>, then
+set <var>value</var> to the result of performing the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-determine-the-value-of-an-indexed-property" id="ref-for-dfn-determine-the-value-of-an-indexed-property-1">determine the value of an indexed property</a> with <var>index</var> as the index.</p>
+         <li data-md="">
+          <p>Otherwise, <var>operation</var> was defined with an identifier.  Set <var>value</var> to the result
+of performing the steps listed in the description of <var>operation</var> with <var>index</var> as the only argument value.</p>
+         <li data-md="">
+          <p>Let <var>desc</var> be a newly created <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">Property Descriptor</a> with no fields.</p>
+         <li data-md="">
+          <p>Set <var>desc</var>.[[Value]] to the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-57">converting</a> <var>value</var> to an ECMAScript value.</p>
+         <li data-md="">
+          <p>If <var>O</var> implements an interface with an <a data-link-type="dfn" href="#dfn-indexed-property-setter" id="ref-for-dfn-indexed-property-setter-8">indexed property setter</a>, then set <var>desc</var>.[[Writable]] to <emu-val>true</emu-val>, otherwise set it to <emu-val>false</emu-val>.</p>
+         <li data-md="">
+          <p>Set <var>desc</var>.[[Enumerable]] and <var>desc</var>.[[Configurable]] to <emu-val>true</emu-val>.</p>
+         <li data-md="">
+          <p>Return <var>desc</var>.</p>
+        </ol>
+       <li data-md="">
+        <p>Set <var>ignoreNamedProps</var> to true.</p>
+      </ol>
+     <li data-md="">
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-12">supports named properties</a>,
+the result of running the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-4">named property visibility algorithm</a> with
+property name <var>P</var> and object <var>O</var> is true, and <var>ignoreNamedProps</var> is false, then:</p>
+      <ol>
+       <li data-md="">
+        <p>Let <var>operation</var> be the operation used to declare the named property getter.</p>
+       <li data-md="">
+        <p>Let <var>value</var> be an uninitialized variable.</p>
+       <li data-md="">
+        <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-86">identifier</a>, then
+set <var>value</var> to the result of performing the steps listed in the interface description to <a data-link-type="dfn" href="#dfn-determine-the-value-of-a-named-property" id="ref-for-dfn-determine-the-value-of-a-named-property-2">determine the value of a named property</a> with <var>P</var> as the name.</p>
+       <li data-md="">
+        <p>Otherwise, <var>operation</var> was defined with an identifier.  Set <var>value</var> to the result
+of performing the steps listed in the description of <var>operation</var> with <var>P</var> as the only argument value.</p>
+       <li data-md="">
+        <p>Let <var>desc</var> be a newly created <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">Property Descriptor</a> with no fields.</p>
+       <li data-md="">
+        <p>Set <var>desc</var>.[[Value]] to the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-58">converting</a> <var>value</var> to an ECMAScript value.</p>
+       <li data-md="">
+        <p>If <var>O</var> implements an interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="ref-for-dfn-named-property-setter-7">named property setter</a>, then set <var>desc</var>.[[Writable]] to <emu-val>true</emu-val>, otherwise set it to <emu-val>false</emu-val>.</p>
+       <li data-md="">
+        <p>If <var>O</var> implements an interface with the
+[<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-7">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-93">extended attribute</a>,
+then set <var>desc</var>.[[Enumerable]] to <emu-val>false</emu-val>,
+otherwise set it to <emu-val>true</emu-val>.</p>
+       <li data-md="">
+        <p>Set <var>desc</var>.[[Configurable]] to <emu-val>true</emu-val>.</p>
+       <li data-md="">
+        <p>Return <var>desc</var>.</p>
+      </ol>
+     <li data-md="">
+      <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ordinarygetownproperty">OrdinaryGetOwnProperty</a>(<var>O</var>, <var>P</var>).</p>
+    </ol>
+   </div>
    <h3 class="heading settled" data-level="3.10" id="es-user-objects"><span class="secno">3.10. </span><span class="content">User objects implementing callback interfaces</span><a class="self-link" href="#es-user-objects"></a></h3>
    <p>As described in <a href="#idl-objects">§2.10 Objects implementing interfaces</a>, <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-26">callback interfaces</a> can be
 implemented in script by an ECMAScript object.
@@ -12200,7 +12193,7 @@ return any value.</p>
    <h2 class="heading settled" data-level="5" id="extensibility"><span class="secno">5. </span><span class="content">Extensibility</span><a class="self-link" href="#extensibility"></a></h2>
    <p><i>This section is informative.</i></p>
    <p>Extensions to language binding requirements can be specified
-using <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-95">extended attributes</a> that do not conflict with those defined in this document.  Extensions for
+using <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-94">extended attributes</a> that do not conflict with those defined in this document.  Extensions for
 private, project-specific use should not be included in <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-46">IDL fragments</a> appearing in other specifications.  It is recommended that extensions
 that are required for use in other specifications be coordinated
 with the group responsible for work on <cite>Web IDL</cite>, which
@@ -12359,7 +12352,7 @@ and “<span class="input">.</span>” is tokenized as the quoted terminal symbo
 used in the grammar and the values used for <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> terminals.  Thus, for
 example, the input text “<span class="input">Const</span>” is tokenized as
 an <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> rather than the
-terminal symbol <emu-t>const</emu-t>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-142">interface</a> with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-92">identifier</a> “A” is distinct from one named “a”, and an <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-96">extended attribute</a> [<code class="idl">constructor</code>] will not be recognized as
+terminal symbol <emu-t>const</emu-t>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-142">interface</a> with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-92">identifier</a> “A” is distinct from one named “a”, and an <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-95">extended attribute</a> [<code class="idl">constructor</code>] will not be recognized as
 the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-25">Constructor</a></code>]
 extended attribute.</p>
    <p>Implicitly, any number of <emu-t class="regex"><a href="#prod-whitespace">whitespace</a></emu-t> and <emu-t class="regex"><a href="#prod-comment">comment</a></emu-t> terminals are allowed between every other terminal
@@ -12371,7 +12364,7 @@ matches an <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-
    <p>While the <emu-nt><a href="#prod-ExtendedAttribute">ExtendedAttribute</a></emu-nt> non-terminal matches any non-empty sequence of terminal symbols (as long as any
 parentheses, square brackets or braces are balanced, and the <emu-t>,</emu-t> token appears only within those balanced brackets),
 only a subset of those
-possible sequences are used by the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-97">extended attributes</a> defined in this specification — see <a href="#idl-extended-attributes">§2.12 Extended attributes</a> for the syntaxes that are used by these extended attributes.</p>
+possible sequences are used by the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-96">extended attributes</a> defined in this specification — see <a href="#idl-extended-attributes">§2.12 Extended attributes</a> for the syntaxes that are used by these extended attributes.</p>
    <h2 class="no-num heading settled" id="conventions"><span class="content">Document conventions</span><a class="self-link" href="#conventions"></a></h2>
    <p>The following typographic conventions are used in this document:</p>
    <ul>
@@ -12647,7 +12640,7 @@ language binding.</p>
    <li><a href="#idl-any">any</a><span>, in §2.11</span>
    <li><a href="#idl-ArrayBuffer">ArrayBuffer</a><span>, in §2.11.30</span>
    <li><a href="#ArrayBufferView">ArrayBufferView</a><span>, in §4</span>
-   <li><a href="#dfn-array-index-property-name">array index property name</a><span>, in §3.9</span>
+   <li><a href="#dfn-array-index-property-name">array index property name</a><span>, in §3.9.9</span>
    <li><a href="#dfn-associated-realm">associated Realm</a><span>, in §3.1</span>
    <li><a href="#dfn-attribute">attribute</a><span>, in §2.2.2</span>
    <li><a href="#dfn-attribute-getter">attribute getter</a><span>, in §3.6.6</span>
@@ -12757,6 +12750,7 @@ language binding.</p>
    <li><a href="#dfn-get-buffer-source-copy">get a copy of the buffer source</a><span>, in §2.11.30</span>
    <li><a href="#dfn-get-buffer-source-reference">get a reference to the buffer source</a><span>, in §2.11.30</span>
    <li><a href="#get-a-user-objects-attribute-value">get a user object’s attribute value</a><span>, in §3.10</span>
+   <li><a href="#legacy-platform-object-getownproperty">GetOwnProperty</a><span>, in §3.9</span>
    <li><a href="#dfn-getter">getter</a><span>, in §2.2.4</span>
    <li><a href="#Global">Global</a><span>, in §3.3.4</span>
    <li><a href="#dfn-global-name">global names</a><span>, in §3.3.5</span>
@@ -12805,15 +12799,15 @@ language binding.</p>
    <li><a href="#dom-domexception-invalid_state_err">INVALID_STATE_ERR</a><span>, in §2.5.1</span>
    <li><a href="#invalidstateerror">InvalidStateError</a><span>, in §2.5.1</span>
    <li><a href="#invoke-a-callback-function">invoke</a><span>, in §3.11</span>
-   <li><a href="#invoke-indexed-setter">invoke the indexed property setter</a><span>, in §3.9.3</span>
-   <li><a href="#invoke-named-setter">invoke the named property setter</a><span>, in §3.9.4</span>
+   <li><a href="#invoke-indexed-setter">invoke the indexed property setter</a><span>, in §3.9.9</span>
+   <li><a href="#invoke-named-setter">invoke the named property setter</a><span>, in §3.9.9</span>
    <li><a href="#dfn-iterable">iterable</a><span>, in §2.2.7</span>
    <li><a href="#dfn-iterable-declaration">iterable declaration</a><span>, in §2.2.7</span>
    <li><a href="#dfn-iterator-prototype-object">iterator prototype object</a><span>, in §3.6.9.5</span>
    <li><a href="#dfn-legacy-caller">legacy</a><span>, in §2.2.4</span>
    <li><a href="#LegacyArrayClass">LegacyArrayClass</a><span>, in §3.3.5</span>
    <li><a href="#idl-legacy-callers">Legacy callers</a><span>, in §2.2.4</span>
-   <li><a href="#getownproperty-guts">LegacyPlatformObjectGetOwnProperty</a><span>, in §3.9</span>
+   <li><a href="#LegacyPlatformObjectGetOwnProperty">LegacyPlatformObjectGetOwnProperty</a><span>, in §3.9.9</span>
    <li><a href="#dfn-legacy-platform-object">Legacy platform objects</a><span>, in §2.10</span>
    <li><a href="#LegacyUnenumerableNamedProperties">LegacyUnenumerableNamedProperties</a><span>, in §3.3.6</span>
    <li><a href="#LenientSetter">LenientSetter</a><span>, in §3.3.7</span>
@@ -12835,7 +12829,7 @@ language binding.</p>
    <li><a href="#dfn-named-property-deleter">named property deleter</a><span>, in §2.2.4</span>
    <li><a href="#dfn-named-property-getter">named property getter</a><span>, in §2.2.4</span>
    <li><a href="#dfn-named-property-setter">named property setter</a><span>, in §2.2.4</span>
-   <li><a href="#dfn-named-property-visibility">named property visibility algorithm</a><span>, in §3.9</span>
+   <li><a href="#dfn-named-property-visibility">named property visibility algorithm</a><span>, in §3.9.9</span>
    <li><a href="#dfn-namespace">namespace</a><span>, in §2.3</span>
    <li><a href="#dom-domexception-namespace_err">NAMESPACE_ERR</a><span>, in §2.5.1</span>
    <li><a href="#namespaceerror">NamespaceError</a><span>, in §2.5.1</span>
@@ -13224,7 +13218,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-identifier-60">3.6.2. Named constructors</a> <a href="#ref-for-dfn-identifier-61">(2)</a> <a href="#ref-for-dfn-identifier-62">(3)</a>
     <li><a href="#ref-for-dfn-identifier-63">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-identifier-64">(2)</a>
     <li><a href="#ref-for-dfn-identifier-65">3.6.4. Named properties object</a>
-    <li><a href="#ref-for-dfn-identifier-66">3.6.4.1. Named properties object [[GetOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-identifier-66">3.6.4.1. [[GetOwnProperty]]</a>
     <li><a href="#ref-for-dfn-identifier-67">3.6.5. Constants</a>
     <li><a href="#ref-for-dfn-identifier-68">3.6.6. Attributes</a> <a href="#ref-for-dfn-identifier-69">(2)</a> <a href="#ref-for-dfn-identifier-70">(3)</a>
     <li><a href="#ref-for-dfn-identifier-71">3.6.7. Operations</a> <a href="#ref-for-dfn-identifier-72">(2)</a> <a href="#ref-for-dfn-identifier-73">(3)</a> <a href="#ref-for-dfn-identifier-74">(4)</a> <a href="#ref-for-dfn-identifier-75">(5)</a> <a href="#ref-for-dfn-identifier-76">(6)</a>
@@ -13233,10 +13227,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-identifier-79">3.6.9.4. Default iterator objects</a>
     <li><a href="#ref-for-dfn-identifier-80">3.6.9.5. Iterator prototype object</a>
     <li><a href="#ref-for-dfn-identifier-81">3.8. Platform objects implementing interfaces</a>
-    <li><a href="#ref-for-dfn-identifier-82">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a> <a href="#ref-for-dfn-identifier-83">(2)</a>
-    <li><a href="#ref-for-dfn-identifier-84">3.9.3. Invoking a legacy platform object indexed property setter</a>
-    <li><a href="#ref-for-dfn-identifier-85">3.9.4. Invoking a legacy platform object named property setter</a>
-    <li><a href="#ref-for-dfn-identifier-86">3.9.8. Legacy platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-identifier-82">3.9.5. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-identifier-83">3.9.9. Abstract operations</a> <a href="#ref-for-dfn-identifier-84">(2)</a> <a href="#ref-for-dfn-identifier-85">(3)</a> <a href="#ref-for-dfn-identifier-86">(4)</a>
     <li><a href="#ref-for-dfn-identifier-87">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-identifier-88">(2)</a> <a href="#ref-for-dfn-identifier-89">(3)</a>
     <li><a href="#ref-for-dfn-identifier-90">3.12. Namespaces</a>
     <li><a href="#ref-for-dfn-identifier-91">3.12.1. Namespace object</a>
@@ -13295,7 +13287,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-interface-85">3.6.2. Named constructors</a> <a href="#ref-for-dfn-interface-86">(2)</a> <a href="#ref-for-dfn-interface-87">(3)</a> <a href="#ref-for-dfn-interface-88">(4)</a>
     <li><a href="#ref-for-dfn-interface-89">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-interface-90">(2)</a> <a href="#ref-for-dfn-interface-91">(3)</a>
     <li><a href="#ref-for-dfn-interface-92">3.6.4. Named properties object</a> <a href="#ref-for-dfn-interface-93">(2)</a>
-    <li><a href="#ref-for-dfn-interface-94">3.6.4.1. Named properties object [[GetOwnProperty]] method</a> <a href="#ref-for-dfn-interface-95">(2)</a>
+    <li><a href="#ref-for-dfn-interface-94">3.6.4.1. [[GetOwnProperty]]</a> <a href="#ref-for-dfn-interface-95">(2)</a>
     <li><a href="#ref-for-dfn-interface-96">3.6.5. Constants</a>
     <li><a href="#ref-for-dfn-interface-97">3.6.6. Attributes</a> <a href="#ref-for-dfn-interface-98">(2)</a> <a href="#ref-for-dfn-interface-99">(3)</a>
     <li><a href="#ref-for-dfn-interface-100">3.6.7. Operations</a> <a href="#ref-for-dfn-interface-101">(2)</a> <a href="#ref-for-dfn-interface-102">(3)</a>
@@ -13312,11 +13304,11 @@ language binding.</p>
     <li><a href="#ref-for-dfn-interface-128">3.6.11. Setlike declarations</a> <a href="#ref-for-dfn-interface-129">(2)</a>
     <li><a href="#ref-for-dfn-interface-130">3.7. Implements statements</a>
     <li><a href="#ref-for-dfn-interface-131">3.9. Legacy platform objects</a>
-    <li><a href="#ref-for-dfn-interface-132">3.9.6. Legacy platform object [[SetPrototypeOf]] method</a>
-    <li><a href="#ref-for-dfn-interface-133">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-interface-134">(2)</a>
-    <li><a href="#ref-for-dfn-interface-135">3.9.8. Legacy platform object [[Delete]] method</a>
-    <li><a href="#ref-for-dfn-interface-136">3.9.9. Legacy platform object [[Call]] method</a>
-    <li><a href="#ref-for-dfn-interface-137">3.9.11. Property enumeration</a> <a href="#ref-for-dfn-interface-138">(2)</a>
+    <li><a href="#ref-for-dfn-interface-132">3.9.3. [[SetPrototypeOf]]</a>
+    <li><a href="#ref-for-dfn-interface-133">3.9.4. [[DefineOwnProperty]]</a> <a href="#ref-for-dfn-interface-134">(2)</a>
+    <li><a href="#ref-for-dfn-interface-135">3.9.5. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-interface-136">3.9.6. [[Call]]</a>
+    <li><a href="#ref-for-dfn-interface-137">3.9.8. Property enumeration</a> <a href="#ref-for-dfn-interface-138">(2)</a>
     <li><a href="#ref-for-dfn-interface-139">3.10. User objects implementing callback interfaces</a>
     <li><a href="#ref-for-dfn-interface-140">3.15. Creating and throwing exceptions</a>
     <li><a href="#ref-for-dfn-interface-141">3.16. Handling exceptions</a>
@@ -13574,7 +13566,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-return-type-3">3.2.2. void</a>
     <li><a href="#ref-for-dfn-return-type-4">3.3.11. [NewObject]</a>
     <li><a href="#ref-for-dfn-return-type-5">3.6.7. Operations</a>
-    <li><a href="#ref-for-dfn-return-type-6">3.9.8. Legacy platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-return-type-6">3.9.5. [[Delete]]</a>
     <li><a href="#ref-for-dfn-return-type-7">3.10. User objects implementing callback interfaces</a>
     <li><a href="#ref-for-dfn-return-type-8">3.11. Invoking callback functions</a>
    </ul>
@@ -13584,7 +13576,7 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-idl-void-1">3.2.2. void</a> <a href="#ref-for-idl-void-2">(2)</a> <a href="#ref-for-idl-void-3">(3)</a>
     <li><a href="#ref-for-idl-void-4">3.2.20. Promise types — Promise&lt;T></a> <a href="#ref-for-idl-void-5">(2)</a>
-    <li><a href="#ref-for-idl-void-6">3.9.9. Legacy platform object [[Call]] method</a>
+    <li><a href="#ref-for-idl-void-6">3.9.6. [[Call]]</a>
     <li><a href="#ref-for-idl-void-7">3.10. User objects implementing callback interfaces</a>
     <li><a href="#ref-for-idl-void-8">3.11. Invoking callback functions</a>
    </ul>
@@ -13686,9 +13678,9 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-dfn-named-property-setter-1">2.2.4.5. Named properties</a> <a href="#ref-for-dfn-named-property-setter-2">(2)</a>
     <li><a href="#ref-for-dfn-named-property-setter-3">3.3.5. [Global] and [PrimaryGlobal]</a>
-    <li><a href="#ref-for-dfn-named-property-setter-4">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-dfn-named-property-setter-5">3.9.5. Legacy platform object [[Set]] method</a>
-    <li><a href="#ref-for-dfn-named-property-setter-6">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-named-property-setter-7">(2)</a>
+    <li><a href="#ref-for-dfn-named-property-setter-4">3.9.2. [[Set]]</a>
+    <li><a href="#ref-for-dfn-named-property-setter-5">3.9.4. [[DefineOwnProperty]]</a> <a href="#ref-for-dfn-named-property-setter-6">(2)</a>
+    <li><a href="#ref-for-dfn-named-property-setter-7">3.9.9. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-indexed-property-getter">
@@ -13706,11 +13698,12 @@ language binding.</p>
    <b><a href="#dfn-indexed-property-setter">#dfn-indexed-property-setter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-indexed-property-setter-1">2.2.4.4. Indexed properties</a> <a href="#ref-for-dfn-indexed-property-setter-2">(2)</a>
-    <li><a href="#ref-for-dfn-indexed-property-setter-3">3.3.6. [LegacyArrayClass]</a>
-    <li><a href="#ref-for-dfn-indexed-property-setter-4">3.9. Legacy platform objects</a>
-    <li><a href="#ref-for-dfn-indexed-property-setter-5">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-dfn-indexed-property-setter-6">3.9.5. Legacy platform object [[Set]] method</a>
-    <li><a href="#ref-for-dfn-indexed-property-setter-7">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-indexed-property-setter-3">3.3.5. [Global] and [PrimaryGlobal]</a>
+    <li><a href="#ref-for-dfn-indexed-property-setter-4">3.3.6. [LegacyArrayClass]</a>
+    <li><a href="#ref-for-dfn-indexed-property-setter-5">3.9. Legacy platform objects</a>
+    <li><a href="#ref-for-dfn-indexed-property-setter-6">3.9.2. [[Set]]</a>
+    <li><a href="#ref-for-dfn-indexed-property-setter-7">3.9.4. [[DefineOwnProperty]]</a>
+    <li><a href="#ref-for-dfn-indexed-property-setter-8">3.9.9. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-named-property-deleter">
@@ -13718,7 +13711,7 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-dfn-named-property-deleter-1">2.2.4. Special operations</a> <a href="#ref-for-dfn-named-property-deleter-2">(2)</a>
     <li><a href="#ref-for-dfn-named-property-deleter-3">2.2.4.5. Named properties</a> <a href="#ref-for-dfn-named-property-deleter-4">(2)</a>
-    <li><a href="#ref-for-dfn-named-property-deleter-5">3.9.8. Legacy platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-named-property-deleter-5">3.9.5. [[Delete]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="idl-legacy-callers">
@@ -13727,7 +13720,7 @@ language binding.</p>
     <li><a href="#ref-for-idl-legacy-callers-1">2.2.4.1. Legacy callers</a> <a href="#ref-for-idl-legacy-callers-2">(2)</a> <a href="#ref-for-idl-legacy-callers-3">(3)</a> <a href="#ref-for-idl-legacy-callers-4">(4)</a>
     <li><a href="#ref-for-idl-legacy-callers-5">2.2.6. Overloading</a> <a href="#ref-for-idl-legacy-callers-6">(2)</a> <a href="#ref-for-idl-legacy-callers-7">(3)</a> <a href="#ref-for-idl-legacy-callers-8">(4)</a> <a href="#ref-for-idl-legacy-callers-9">(5)</a>
     <li><a href="#ref-for-idl-legacy-callers-10">2.10. Objects implementing interfaces</a>
-    <li><a href="#ref-for-idl-legacy-callers-11">3.9.9. Legacy platform object [[Call]] method</a>
+    <li><a href="#ref-for-idl-legacy-callers-11">3.9.6. [[Call]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-stringification-behavior">
@@ -13787,11 +13780,11 @@ language binding.</p>
     <li><a href="#ref-for-dfn-support-indexed-properties-9">2.10. Objects implementing interfaces</a>
     <li><a href="#ref-for-dfn-support-indexed-properties-10">3.3.6. [LegacyArrayClass]</a>
     <li><a href="#ref-for-dfn-support-indexed-properties-11">3.6.9.4. Default iterator objects</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-12">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-13">3.9.5. Legacy platform object [[Set]] method</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-14">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-15">3.9.8. Legacy platform object [[Delete]] method</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-16">3.9.11. Property enumeration</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-12">3.9.2. [[Set]]</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-13">3.9.4. [[DefineOwnProperty]]</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-14">3.9.5. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-15">3.9.8. Property enumeration</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-16">3.9.9. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-supported-property-indices">
@@ -13799,28 +13792,27 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-dfn-supported-property-indices-1">2.2.4.4. Indexed properties</a> <a href="#ref-for-dfn-supported-property-indices-2">(2)</a> <a href="#ref-for-dfn-supported-property-indices-3">(3)</a>
     <li><a href="#ref-for-dfn-supported-property-indices-4">3.9. Legacy platform objects</a>
-    <li><a href="#ref-for-dfn-supported-property-indices-5">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-dfn-supported-property-indices-6">3.9.3. Invoking a legacy platform object indexed property setter</a>
-    <li><a href="#ref-for-dfn-supported-property-indices-7">3.9.8. Legacy platform object [[Delete]] method</a>
-    <li><a href="#ref-for-dfn-supported-property-indices-8">3.9.11. Property enumeration</a>
+    <li><a href="#ref-for-dfn-supported-property-indices-5">3.9.5. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-supported-property-indices-6">3.9.8. Property enumeration</a>
+    <li><a href="#ref-for-dfn-supported-property-indices-7">3.9.9. Abstract operations</a> <a href="#ref-for-dfn-supported-property-indices-8">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-determine-the-value-of-an-indexed-property">
    <b><a href="#dfn-determine-the-value-of-an-indexed-property">#dfn-determine-the-value-of-an-indexed-property</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-determine-the-value-of-an-indexed-property-1">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
+    <li><a href="#ref-for-dfn-determine-the-value-of-an-indexed-property-1">3.9.9. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-set-the-value-of-an-existing-indexed-property">
    <b><a href="#dfn-set-the-value-of-an-existing-indexed-property">#dfn-set-the-value-of-an-existing-indexed-property</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-set-the-value-of-an-existing-indexed-property-1">3.9.3. Invoking a legacy platform object indexed property setter</a>
+    <li><a href="#ref-for-dfn-set-the-value-of-an-existing-indexed-property-1">3.9.9. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-set-the-value-of-a-new-indexed-property">
    <b><a href="#dfn-set-the-value-of-a-new-indexed-property">#dfn-set-the-value-of-a-new-indexed-property</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-set-the-value-of-a-new-indexed-property-1">3.9.3. Invoking a legacy platform object indexed property setter</a>
+    <li><a href="#ref-for-dfn-set-the-value-of-a-new-indexed-property-1">3.9.9. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="idl-named-properties">
@@ -13841,11 +13833,11 @@ language binding.</p>
     <li><a href="#ref-for-dfn-support-named-properties-5">3.3.7. [LegacyUnenumerableNamedProperties]</a>
     <li><a href="#ref-for-dfn-support-named-properties-6">3.6.3. Interface prototype object</a>
     <li><a href="#ref-for-dfn-support-named-properties-7">3.6.4. Named properties object</a>
-    <li><a href="#ref-for-dfn-support-named-properties-8">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-dfn-support-named-properties-9">3.9.5. Legacy platform object [[Set]] method</a>
-    <li><a href="#ref-for-dfn-support-named-properties-10">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-support-named-properties-11">3.9.8. Legacy platform object [[Delete]] method</a>
-    <li><a href="#ref-for-dfn-support-named-properties-12">3.9.11. Property enumeration</a>
+    <li><a href="#ref-for-dfn-support-named-properties-8">3.9.2. [[Set]]</a>
+    <li><a href="#ref-for-dfn-support-named-properties-9">3.9.4. [[DefineOwnProperty]]</a>
+    <li><a href="#ref-for-dfn-support-named-properties-10">3.9.5. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-support-named-properties-11">3.9.8. Property enumeration</a>
+    <li><a href="#ref-for-dfn-support-named-properties-12">3.9.9. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-supported-property-names">
@@ -13853,35 +13845,34 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-dfn-supported-property-names-1">2.2.4.5. Named properties</a> <a href="#ref-for-dfn-supported-property-names-2">(2)</a>
     <li><a href="#ref-for-dfn-supported-property-names-3">3.3.13. [OverrideBuiltins]</a>
-    <li><a href="#ref-for-dfn-supported-property-names-4">3.9. Legacy platform objects</a>
-    <li><a href="#ref-for-dfn-supported-property-names-5">3.9.4. Invoking a legacy platform object named property setter</a>
-    <li><a href="#ref-for-dfn-supported-property-names-6">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-supported-property-names-7">3.9.11. Property enumeration</a>
+    <li><a href="#ref-for-dfn-supported-property-names-4">3.9.4. [[DefineOwnProperty]]</a>
+    <li><a href="#ref-for-dfn-supported-property-names-5">3.9.8. Property enumeration</a>
+    <li><a href="#ref-for-dfn-supported-property-names-6">3.9.9. Abstract operations</a> <a href="#ref-for-dfn-supported-property-names-7">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-determine-the-value-of-a-named-property">
    <b><a href="#dfn-determine-the-value-of-a-named-property">#dfn-determine-the-value-of-a-named-property</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-determine-the-value-of-a-named-property-1">3.6.4.1. Named properties object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-determine-the-value-of-a-named-property-2">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
+    <li><a href="#ref-for-dfn-determine-the-value-of-a-named-property-1">3.6.4.1. [[GetOwnProperty]]</a>
+    <li><a href="#ref-for-dfn-determine-the-value-of-a-named-property-2">3.9.9. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-set-the-value-of-an-existing-named-property">
    <b><a href="#dfn-set-the-value-of-an-existing-named-property">#dfn-set-the-value-of-an-existing-named-property</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-set-the-value-of-an-existing-named-property-1">3.9.4. Invoking a legacy platform object named property setter</a>
+    <li><a href="#ref-for-dfn-set-the-value-of-an-existing-named-property-1">3.9.9. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-set-the-value-of-a-new-named-property">
    <b><a href="#dfn-set-the-value-of-a-new-named-property">#dfn-set-the-value-of-a-new-named-property</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-set-the-value-of-a-new-named-property-1">3.9.4. Invoking a legacy platform object named property setter</a>
+    <li><a href="#ref-for-dfn-set-the-value-of-a-new-named-property-1">3.9.9. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-delete-an-existing-named-property">
    <b><a href="#dfn-delete-an-existing-named-property">#dfn-delete-an-existing-named-property</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-delete-an-existing-named-property-1">3.9.8. Legacy platform object [[Delete]] method</a>
+    <li><a href="#ref-for-dfn-delete-an-existing-named-property-1">3.9.5. [[Delete]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-static-attribute">
@@ -13927,7 +13918,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-effective-overload-set-5">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-dfn-effective-overload-set-6">(2)</a>
     <li><a href="#ref-for-dfn-effective-overload-set-7">3.6.2. Named constructors</a> <a href="#ref-for-dfn-effective-overload-set-8">(2)</a>
     <li><a href="#ref-for-dfn-effective-overload-set-9">3.6.7. Operations</a> <a href="#ref-for-dfn-effective-overload-set-10">(2)</a> <a href="#ref-for-dfn-effective-overload-set-11">(3)</a>
-    <li><a href="#ref-for-dfn-effective-overload-set-12">3.9.9. Legacy platform object [[Call]] method</a>
+    <li><a href="#ref-for-dfn-effective-overload-set-12">3.9.6. [[Call]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-optionality-value">
@@ -14390,7 +14381,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-platform-object-46">3.6.11.4. has</a>
     <li><a href="#ref-for-dfn-platform-object-47">3.6.11.5. add and delete</a>
     <li><a href="#ref-for-dfn-platform-object-48">3.8. Platform objects implementing interfaces</a> <a href="#ref-for-dfn-platform-object-49">(2)</a> <a href="#ref-for-dfn-platform-object-50">(3)</a> <a href="#ref-for-dfn-platform-object-51">(4)</a>
-    <li><a href="#ref-for-dfn-platform-object-52">3.9.11. Property enumeration</a>
+    <li><a href="#ref-for-dfn-platform-object-52">3.9.8. Property enumeration</a>
     <li><a href="#ref-for-dfn-platform-object-53">3.14. Exception objects</a>
    </ul>
   </aside>
@@ -14413,14 +14404,14 @@ language binding.</p>
     <li><a href="#ref-for-dfn-legacy-platform-object-2">2.2.4.4. Indexed properties</a>
     <li><a href="#ref-for-dfn-legacy-platform-object-3">3.3.13. [OverrideBuiltins]</a>
     <li><a href="#ref-for-dfn-legacy-platform-object-4">3.9. Legacy platform objects</a>
-    <li><a href="#ref-for-dfn-legacy-platform-object-5">3.9.2. Legacy platform object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-legacy-platform-object-6">3.9.5. Legacy platform object [[Set]] method</a>
-    <li><a href="#ref-for-dfn-legacy-platform-object-7">3.9.6. Legacy platform object [[SetPrototypeOf]] method</a>
-    <li><a href="#ref-for-dfn-legacy-platform-object-8">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-legacy-platform-object-9">3.9.8. Legacy platform object [[Delete]] method</a>
-    <li><a href="#ref-for-dfn-legacy-platform-object-10">3.9.9. Legacy platform object [[Call]] method</a>
-    <li><a href="#ref-for-dfn-legacy-platform-object-11">3.9.10. Legacy platform object [[PreventExtensions]] method</a> <a href="#ref-for-dfn-legacy-platform-object-12">(2)</a>
-    <li><a href="#ref-for-dfn-legacy-platform-object-13">3.9.11. Property enumeration</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-5">3.9.1. [[GetOwnProperty]]</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-6">3.9.2. [[Set]]</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-7">3.9.3. [[SetPrototypeOf]]</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-8">3.9.4. [[DefineOwnProperty]]</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-9">3.9.5. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-10">3.9.6. [[Call]]</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-11">3.9.7. [[PreventExtensions]]</a> <a href="#ref-for-dfn-legacy-platform-object-12">(2)</a>
+    <li><a href="#ref-for-dfn-legacy-platform-object-13">3.9.8. Property enumeration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-integer-type">
@@ -14549,7 +14540,7 @@ language binding.</p>
     <li><a href="#ref-for-idl-boolean-11">3.2.3. boolean</a> <a href="#ref-for-idl-boolean-12">(2)</a> <a href="#ref-for-idl-boolean-13">(3)</a> <a href="#ref-for-idl-boolean-14">(4)</a>
     <li><a href="#ref-for-idl-boolean-15">3.2.21. Union types</a> <a href="#ref-for-idl-boolean-16">(2)</a> <a href="#ref-for-idl-boolean-17">(3)</a> <a href="#ref-for-idl-boolean-18">(4)</a>
     <li><a href="#ref-for-idl-boolean-19">3.5. Overload resolution algorithm</a> <a href="#ref-for-idl-boolean-20">(2)</a> <a href="#ref-for-idl-boolean-21">(3)</a> <a href="#ref-for-idl-boolean-22">(4)</a>
-    <li><a href="#ref-for-idl-boolean-23">3.9.8. Legacy platform object [[Delete]] method</a>
+    <li><a href="#ref-for-idl-boolean-23">3.9.5. [[Delete]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="idl-byte">
@@ -15076,54 +15067,52 @@ language binding.</p>
     <li><a href="#ref-for-dfn-extended-attribute-3">2.2. Interfaces</a> <a href="#ref-for-dfn-extended-attribute-4">(2)</a> <a href="#ref-for-dfn-extended-attribute-5">(3)</a> <a href="#ref-for-dfn-extended-attribute-6">(4)</a>
     <li><a href="#ref-for-dfn-extended-attribute-7">2.2.2. Attributes</a> <a href="#ref-for-dfn-extended-attribute-8">(2)</a>
     <li><a href="#ref-for-dfn-extended-attribute-9">2.2.3. Operations</a> <a href="#ref-for-dfn-extended-attribute-10">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-11">2.2.4.1. Legacy callers</a>
-    <li><a href="#ref-for-dfn-extended-attribute-12">2.2.6. Overloading</a> <a href="#ref-for-dfn-extended-attribute-13">(2)</a> <a href="#ref-for-dfn-extended-attribute-14">(3)</a> <a href="#ref-for-dfn-extended-attribute-15">(4)</a> <a href="#ref-for-dfn-extended-attribute-16">(5)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-17">2.2.8. Maplike declarations</a>
-    <li><a href="#ref-for-dfn-extended-attribute-18">2.2.9. Setlike declarations</a>
-    <li><a href="#ref-for-dfn-extended-attribute-19">2.6. Enumerations</a>
-    <li><a href="#ref-for-dfn-extended-attribute-20">2.8. Typedefs</a>
-    <li><a href="#ref-for-dfn-extended-attribute-21">2.9. Implements statements</a>
-    <li><a href="#ref-for-dfn-extended-attribute-22">2.10. Objects implementing interfaces</a>
-    <li><a href="#ref-for-dfn-extended-attribute-23">2.12. Extended attributes</a>
-    <li><a href="#ref-for-dfn-extended-attribute-24">3.2.4.9. Abstract operations</a> <a href="#ref-for-dfn-extended-attribute-25">(2)</a> <a href="#ref-for-dfn-extended-attribute-26">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-27">3.3. ECMAScript-specific extended attributes</a>
-    <li><a href="#ref-for-dfn-extended-attribute-28">3.3.1. [Clamp]</a> <a href="#ref-for-dfn-extended-attribute-29">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-30">3.3.2. [Constructor]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-31">3.3.3. [EnforceRange]</a> <a href="#ref-for-dfn-extended-attribute-32">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-33">3.3.4. [Exposed]</a> <a href="#ref-for-dfn-extended-attribute-34">(2)</a> <a href="#ref-for-dfn-extended-attribute-35">(3)</a> <a href="#ref-for-dfn-extended-attribute-36">(4)</a> <a href="#ref-for-dfn-extended-attribute-37">(5)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-38">3.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-extended-attribute-39">(2)</a> <a href="#ref-for-dfn-extended-attribute-40">(3)</a> <a href="#ref-for-dfn-extended-attribute-41">(4)</a> <a href="#ref-for-dfn-extended-attribute-42">(5)</a> <a href="#ref-for-dfn-extended-attribute-43">(6)</a> <a href="#ref-for-dfn-extended-attribute-44">(7)</a> <a href="#ref-for-dfn-extended-attribute-45">(8)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-46">3.3.6. [LegacyArrayClass]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-47">3.3.7. [LegacyUnenumerableNamedProperties]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-48">3.3.8. [LenientSetter]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-49">3.3.9. [LenientThis]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-50">3.3.10. [NamedConstructor]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-51">3.3.11. [NewObject]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-52">3.3.12. [NoInterfaceObject]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-53">3.3.13. [OverrideBuiltins]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-54">3.3.14. [PutForwards]</a> <a href="#ref-for-dfn-extended-attribute-55">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-56">3.3.15. [Replaceable]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-57">3.3.16. [SameObject]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-58">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-extended-attribute-59">(2)</a> <a href="#ref-for-dfn-extended-attribute-60">(3)</a> <a href="#ref-for-dfn-extended-attribute-61">(4)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-62">3.3.18. [TreatNonObjectAsNull]</a> <a href="#ref-for-dfn-extended-attribute-63">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-64">3.3.19. [TreatNullAs]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-65">3.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-extended-attribute-66">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-67">3.3.21. [Unscopable]</a>
-    <li><a href="#ref-for-dfn-extended-attribute-68">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-extended-attribute-69">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-70">3.6. Interfaces</a>
-    <li><a href="#ref-for-dfn-extended-attribute-71">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-dfn-extended-attribute-72">(2)</a> <a href="#ref-for-dfn-extended-attribute-73">(3)</a> <a href="#ref-for-dfn-extended-attribute-74">(4)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-75">3.6.2. Named constructors</a> <a href="#ref-for-dfn-extended-attribute-76">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-77">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-extended-attribute-78">(2)</a> <a href="#ref-for-dfn-extended-attribute-79">(3)</a> <a href="#ref-for-dfn-extended-attribute-80">(4)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-81">3.6.4. Named properties object</a>
-    <li><a href="#ref-for-dfn-extended-attribute-82">3.6.4.1. Named properties object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-extended-attribute-83">3.6.6. Attributes</a> <a href="#ref-for-dfn-extended-attribute-84">(2)</a> <a href="#ref-for-dfn-extended-attribute-85">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-86">3.9. Legacy platform objects</a> <a href="#ref-for-dfn-extended-attribute-87">(2)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-88">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-dfn-extended-attribute-89">3.9.6. Legacy platform object [[SetPrototypeOf]] method</a>
-    <li><a href="#ref-for-dfn-extended-attribute-90">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-dfn-extended-attribute-91">(2)</a> <a href="#ref-for-dfn-extended-attribute-92">(3)</a>
-    <li><a href="#ref-for-dfn-extended-attribute-93">3.9.8. Legacy platform object [[Delete]] method</a>
-    <li><a href="#ref-for-dfn-extended-attribute-94">3.9.11. Property enumeration</a>
-    <li><a href="#ref-for-dfn-extended-attribute-95">5. Extensibility</a>
-    <li><a href="#ref-for-dfn-extended-attribute-96">IDL grammar</a> <a href="#ref-for-dfn-extended-attribute-97">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-11">2.2.6. Overloading</a> <a href="#ref-for-dfn-extended-attribute-12">(2)</a> <a href="#ref-for-dfn-extended-attribute-13">(3)</a> <a href="#ref-for-dfn-extended-attribute-14">(4)</a> <a href="#ref-for-dfn-extended-attribute-15">(5)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-16">2.2.8. Maplike declarations</a>
+    <li><a href="#ref-for-dfn-extended-attribute-17">2.2.9. Setlike declarations</a>
+    <li><a href="#ref-for-dfn-extended-attribute-18">2.6. Enumerations</a>
+    <li><a href="#ref-for-dfn-extended-attribute-19">2.8. Typedefs</a>
+    <li><a href="#ref-for-dfn-extended-attribute-20">2.9. Implements statements</a>
+    <li><a href="#ref-for-dfn-extended-attribute-21">2.10. Objects implementing interfaces</a>
+    <li><a href="#ref-for-dfn-extended-attribute-22">2.12. Extended attributes</a>
+    <li><a href="#ref-for-dfn-extended-attribute-23">3.2.4.9. Abstract operations</a> <a href="#ref-for-dfn-extended-attribute-24">(2)</a> <a href="#ref-for-dfn-extended-attribute-25">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-26">3.3. ECMAScript-specific extended attributes</a>
+    <li><a href="#ref-for-dfn-extended-attribute-27">3.3.1. [Clamp]</a> <a href="#ref-for-dfn-extended-attribute-28">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-29">3.3.2. [Constructor]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-30">3.3.3. [EnforceRange]</a> <a href="#ref-for-dfn-extended-attribute-31">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-32">3.3.4. [Exposed]</a> <a href="#ref-for-dfn-extended-attribute-33">(2)</a> <a href="#ref-for-dfn-extended-attribute-34">(3)</a> <a href="#ref-for-dfn-extended-attribute-35">(4)</a> <a href="#ref-for-dfn-extended-attribute-36">(5)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-37">3.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-extended-attribute-38">(2)</a> <a href="#ref-for-dfn-extended-attribute-39">(3)</a> <a href="#ref-for-dfn-extended-attribute-40">(4)</a> <a href="#ref-for-dfn-extended-attribute-41">(5)</a> <a href="#ref-for-dfn-extended-attribute-42">(6)</a> <a href="#ref-for-dfn-extended-attribute-43">(7)</a> <a href="#ref-for-dfn-extended-attribute-44">(8)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-45">3.3.6. [LegacyArrayClass]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-46">3.3.7. [LegacyUnenumerableNamedProperties]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-47">3.3.8. [LenientSetter]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-48">3.3.9. [LenientThis]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-49">3.3.10. [NamedConstructor]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-50">3.3.11. [NewObject]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-51">3.3.12. [NoInterfaceObject]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-52">3.3.13. [OverrideBuiltins]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-53">3.3.14. [PutForwards]</a> <a href="#ref-for-dfn-extended-attribute-54">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-55">3.3.15. [Replaceable]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-56">3.3.16. [SameObject]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-57">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-extended-attribute-58">(2)</a> <a href="#ref-for-dfn-extended-attribute-59">(3)</a> <a href="#ref-for-dfn-extended-attribute-60">(4)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-61">3.3.18. [TreatNonObjectAsNull]</a> <a href="#ref-for-dfn-extended-attribute-62">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-63">3.3.19. [TreatNullAs]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-64">3.3.20. [Unforgeable]</a> <a href="#ref-for-dfn-extended-attribute-65">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-66">3.3.21. [Unscopable]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-67">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-extended-attribute-68">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-69">3.6. Interfaces</a>
+    <li><a href="#ref-for-dfn-extended-attribute-70">3.6.1.1. Constructible Interfaces</a> <a href="#ref-for-dfn-extended-attribute-71">(2)</a> <a href="#ref-for-dfn-extended-attribute-72">(3)</a> <a href="#ref-for-dfn-extended-attribute-73">(4)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-74">3.6.2. Named constructors</a> <a href="#ref-for-dfn-extended-attribute-75">(2)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-76">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-extended-attribute-77">(2)</a> <a href="#ref-for-dfn-extended-attribute-78">(3)</a> <a href="#ref-for-dfn-extended-attribute-79">(4)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-80">3.6.4. Named properties object</a>
+    <li><a href="#ref-for-dfn-extended-attribute-81">3.6.4.1. [[GetOwnProperty]]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-82">3.6.6. Attributes</a> <a href="#ref-for-dfn-extended-attribute-83">(2)</a> <a href="#ref-for-dfn-extended-attribute-84">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-85">3.9.3. [[SetPrototypeOf]]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-86">3.9.4. [[DefineOwnProperty]]</a> <a href="#ref-for-dfn-extended-attribute-87">(2)</a> <a href="#ref-for-dfn-extended-attribute-88">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-89">3.9.5. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-extended-attribute-90">3.9.8. Property enumeration</a>
+    <li><a href="#ref-for-dfn-extended-attribute-91">3.9.9. Abstract operations</a> <a href="#ref-for-dfn-extended-attribute-92">(2)</a> <a href="#ref-for-dfn-extended-attribute-93">(3)</a>
+    <li><a href="#ref-for-dfn-extended-attribute-94">5. Extensibility</a>
+    <li><a href="#ref-for-dfn-extended-attribute-95">IDL grammar</a> <a href="#ref-for-dfn-extended-attribute-96">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-xattr-no-arguments">
@@ -15250,7 +15239,7 @@ language binding.</p>
     <li><a href="#ref-for-ecmascript-throw-53">3.6.11.1. size</a>
     <li><a href="#ref-for-ecmascript-throw-54">3.6.11.4. has</a>
     <li><a href="#ref-for-ecmascript-throw-55">3.6.11.5. add and delete</a>
-    <li><a href="#ref-for-ecmascript-throw-56">3.9.9. Legacy platform object [[Call]] method</a>
+    <li><a href="#ref-for-ecmascript-throw-56">3.9.6. [[Call]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-initial-object">
@@ -15317,8 +15306,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-64">3.6.10.7. set</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-65">(2)</a>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-66">3.6.11.4. has</a>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-67">3.6.11.5. add and delete</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-68">3.9.3. Invoking a legacy platform object indexed property setter</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-69">3.9.4. Invoking a legacy platform object named property setter</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-68">3.9.9. Abstract operations</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-69">(2)</a>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-70">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-71">(2)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-72">(3)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-73">(4)</a>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-74">3.11. Invoking callback functions</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-75">(2)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-76">(3)</a>
    </ul>
@@ -15359,7 +15347,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-36">3.2.25. Frozen arrays — FrozenArray&lt;T></a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-37">(2)</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-38">3.6.1.1. Constructible Interfaces</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-39">3.6.2. Named constructors</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-40">3.6.4.1. Named properties object [[GetOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-40">3.6.4.1. [[GetOwnProperty]]</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-41">3.6.5. Constants</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-42">3.6.6. Attributes</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-43">3.6.7. Operations</a>
@@ -15371,8 +15359,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-52">3.6.10.7. set</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-53">(2)</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-54">3.6.11.4. has</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-55">3.6.11.5. add and delete</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-56">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-57">(2)</a>
-    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-58">3.9.9. Legacy platform object [[Call]] method</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-56">3.9.6. [[Call]]</a>
+    <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-57">3.9.9. Abstract operations</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-58">(2)</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-59">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-60">(2)</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-61">3.11. Invoking callback functions</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value-62">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value-63">(2)</a>
@@ -15516,9 +15504,9 @@ language binding.</p>
     <li><a href="#ref-for-Global-77">3.6.9.1. entries</a> <a href="#ref-for-Global-78">(2)</a> <a href="#ref-for-Global-79">(3)</a> <a href="#ref-for-Global-80">(4)</a> <a href="#ref-for-Global-81">(5)</a> <a href="#ref-for-Global-82">(6)</a>
     <li><a href="#ref-for-Global-83">3.6.9.2. keys</a> <a href="#ref-for-Global-84">(2)</a> <a href="#ref-for-Global-85">(3)</a> <a href="#ref-for-Global-86">(4)</a> <a href="#ref-for-Global-87">(5)</a> <a href="#ref-for-Global-88">(6)</a>
     <li><a href="#ref-for-Global-89">3.6.9.3. values</a> <a href="#ref-for-Global-90">(2)</a> <a href="#ref-for-Global-91">(3)</a> <a href="#ref-for-Global-92">(4)</a> <a href="#ref-for-Global-93">(5)</a> <a href="#ref-for-Global-94">(6)</a>
-    <li><a href="#ref-for-Global-95">3.9.6. Legacy platform object [[SetPrototypeOf]] method</a> <a href="#ref-for-Global-96">(2)</a>
-    <li><a href="#ref-for-Global-97">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a> <a href="#ref-for-Global-98">(2)</a> <a href="#ref-for-Global-99">(3)</a> <a href="#ref-for-Global-100">(4)</a>
-    <li><a href="#ref-for-Global-101">3.9.8. Legacy platform object [[Delete]] method</a> <a href="#ref-for-Global-102">(2)</a>
+    <li><a href="#ref-for-Global-95">3.9.3. [[SetPrototypeOf]]</a> <a href="#ref-for-Global-96">(2)</a>
+    <li><a href="#ref-for-Global-97">3.9.4. [[DefineOwnProperty]]</a> <a href="#ref-for-Global-98">(2)</a> <a href="#ref-for-Global-99">(3)</a> <a href="#ref-for-Global-100">(4)</a>
+    <li><a href="#ref-for-Global-101">3.9.5. [[Delete]]</a> <a href="#ref-for-Global-102">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-global-name">
@@ -15546,9 +15534,9 @@ language binding.</p>
    <b><a href="#LegacyUnenumerableNamedProperties">#LegacyUnenumerableNamedProperties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyUnenumerableNamedProperties-1">3.3.7. [LegacyUnenumerableNamedProperties]</a> <a href="#ref-for-LegacyUnenumerableNamedProperties-2">(2)</a> <a href="#ref-for-LegacyUnenumerableNamedProperties-3">(3)</a> <a href="#ref-for-LegacyUnenumerableNamedProperties-4">(4)</a>
-    <li><a href="#ref-for-LegacyUnenumerableNamedProperties-5">3.6.4.1. Named properties object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-LegacyUnenumerableNamedProperties-6">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-LegacyUnenumerableNamedProperties-7">3.9.11. Property enumeration</a>
+    <li><a href="#ref-for-LegacyUnenumerableNamedProperties-5">3.6.4.1. [[GetOwnProperty]]</a>
+    <li><a href="#ref-for-LegacyUnenumerableNamedProperties-6">3.9.8. Property enumeration</a>
+    <li><a href="#ref-for-LegacyUnenumerableNamedProperties-7">3.9.9. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="LenientSetter">
@@ -15605,8 +15593,8 @@ language binding.</p>
     <li><a href="#ref-for-OverrideBuiltins-1">2.2. Interfaces</a> <a href="#ref-for-OverrideBuiltins-2">(2)</a>
     <li><a href="#ref-for-OverrideBuiltins-3">3.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-OverrideBuiltins-4">(2)</a>
     <li><a href="#ref-for-OverrideBuiltins-5">3.3.13. [OverrideBuiltins]</a> <a href="#ref-for-OverrideBuiltins-6">(2)</a> <a href="#ref-for-OverrideBuiltins-7">(3)</a>
-    <li><a href="#ref-for-OverrideBuiltins-8">3.9. Legacy platform objects</a> <a href="#ref-for-OverrideBuiltins-9">(2)</a> <a href="#ref-for-OverrideBuiltins-10">(3)</a> <a href="#ref-for-OverrideBuiltins-11">(4)</a>
-    <li><a href="#ref-for-OverrideBuiltins-12">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a>
+    <li><a href="#ref-for-OverrideBuiltins-8">3.9.4. [[DefineOwnProperty]]</a>
+    <li><a href="#ref-for-OverrideBuiltins-9">3.9.9. Abstract operations</a> <a href="#ref-for-OverrideBuiltins-10">(2)</a> <a href="#ref-for-OverrideBuiltins-11">(3)</a> <a href="#ref-for-OverrideBuiltins-12">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="PutForwards">
@@ -15730,7 +15718,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-overload-resolution-algorithm-1">3.6.1.1. Constructible Interfaces</a>
     <li><a href="#ref-for-dfn-overload-resolution-algorithm-2">3.6.2. Named constructors</a>
     <li><a href="#ref-for-dfn-overload-resolution-algorithm-3">3.6.7. Operations</a>
-    <li><a href="#ref-for-dfn-overload-resolution-algorithm-4">3.9.9. Legacy platform object [[Call]] method</a>
+    <li><a href="#ref-for-dfn-overload-resolution-algorithm-4">3.9.6. [[Call]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-interface-object">
@@ -15807,12 +15795,12 @@ language binding.</p>
     <li><a href="#ref-for-dfn-named-properties-object-2">3.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-named-properties-object-3">(2)</a>
     <li><a href="#ref-for-dfn-named-properties-object-4">3.6.3. Interface prototype object</a>
     <li><a href="#ref-for-dfn-named-properties-object-5">3.6.4. Named properties object</a> <a href="#ref-for-dfn-named-properties-object-6">(2)</a>
-    <li><a href="#ref-for-dfn-named-properties-object-7">3.6.4.1. Named properties object [[GetOwnProperty]] method</a> <a href="#ref-for-dfn-named-properties-object-8">(2)</a>
-    <li><a href="#ref-for-dfn-named-properties-object-9">3.6.4.2. Named properties object [[DefineOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-named-properties-object-10">3.6.4.3. Named properties object [[Delete]] method</a>
-    <li><a href="#ref-for-dfn-named-properties-object-11">3.6.4.4. Named properties object [[SetPrototypeOf]] method</a>
-    <li><a href="#ref-for-dfn-named-properties-object-12">3.6.4.5. Named properties object [[PreventExtensions]] method</a> <a href="#ref-for-dfn-named-properties-object-13">(2)</a>
-    <li><a href="#ref-for-dfn-named-properties-object-14">3.9. Legacy platform objects</a>
+    <li><a href="#ref-for-dfn-named-properties-object-7">3.6.4.1. [[GetOwnProperty]]</a> <a href="#ref-for-dfn-named-properties-object-8">(2)</a>
+    <li><a href="#ref-for-dfn-named-properties-object-9">3.6.4.2. [[DefineOwnProperty]]</a>
+    <li><a href="#ref-for-dfn-named-properties-object-10">3.6.4.3. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-named-properties-object-11">3.6.4.4. [[SetPrototypeOf]]</a>
+    <li><a href="#ref-for-dfn-named-properties-object-12">3.6.4.5. [[PreventExtensions]]</a> <a href="#ref-for-dfn-named-properties-object-13">(2)</a>
+    <li><a href="#ref-for-dfn-named-properties-object-14">3.9.9. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-attribute-getter">
@@ -15893,49 +15881,56 @@ language binding.</p>
     <li><a href="#ref-for-dfn-primary-interface-1">3.8. Platform objects implementing interfaces</a> <a href="#ref-for-dfn-primary-interface-2">(2)</a> <a href="#ref-for-dfn-primary-interface-3">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-array-index-property-name">
-   <b><a href="#dfn-array-index-property-name">#dfn-array-index-property-name</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dfn-array-index-property-name-1">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-dfn-array-index-property-name-2">3.9.5. Legacy platform object [[Set]] method</a> <a href="#ref-for-dfn-array-index-property-name-3">(2)</a>
-    <li><a href="#ref-for-dfn-array-index-property-name-4">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-array-index-property-name-5">3.9.8. Legacy platform object [[Delete]] method</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="dfn-unforgeable-property-name">
    <b><a href="#dfn-unforgeable-property-name">#dfn-unforgeable-property-name</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-unforgeable-property-name-1">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a>
+    <li><a href="#ref-for-dfn-unforgeable-property-name-1">3.9.4. [[DefineOwnProperty]]</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="legacy-platform-object-getownproperty">
+   <b><a href="#legacy-platform-object-getownproperty">#legacy-platform-object-getownproperty</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-legacy-platform-object-getownproperty-1">3.3.5. [Global] and [PrimaryGlobal]</a>
+    <li><a href="#ref-for-legacy-platform-object-getownproperty-2">3.9. Legacy platform objects</a> <a href="#ref-for-legacy-platform-object-getownproperty-3">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-array-index-property-name">
+   <b><a href="#dfn-array-index-property-name">#dfn-array-index-property-name</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-array-index-property-name-1">3.9.2. [[Set]]</a> <a href="#ref-for-dfn-array-index-property-name-2">(2)</a>
+    <li><a href="#ref-for-dfn-array-index-property-name-3">3.9.4. [[DefineOwnProperty]]</a>
+    <li><a href="#ref-for-dfn-array-index-property-name-4">3.9.5. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-array-index-property-name-5">3.9.9. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-named-property-visibility">
    <b><a href="#dfn-named-property-visibility">#dfn-named-property-visibility</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-named-property-visibility-1">3.6.4.1. Named properties object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-dfn-named-property-visibility-2">3.9.1. The LegacyPlatformObjectGetOwnProperty abstract operation</a>
-    <li><a href="#ref-for-dfn-named-property-visibility-3">3.9.8. Legacy platform object [[Delete]] method</a>
-    <li><a href="#ref-for-dfn-named-property-visibility-4">3.9.11. Property enumeration</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="getownproperty-guts">
-   <b><a href="#getownproperty-guts">#getownproperty-guts</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-getownproperty-guts-1">3.9.2. Legacy platform object [[GetOwnProperty]] method</a>
-    <li><a href="#ref-for-getownproperty-guts-2">3.9.5. Legacy platform object [[Set]] method</a>
+    <li><a href="#ref-for-dfn-named-property-visibility-1">3.6.4.1. [[GetOwnProperty]]</a>
+    <li><a href="#ref-for-dfn-named-property-visibility-2">3.9.5. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-named-property-visibility-3">3.9.8. Property enumeration</a>
+    <li><a href="#ref-for-dfn-named-property-visibility-4">3.9.9. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="invoke-indexed-setter">
    <b><a href="#invoke-indexed-setter">#invoke-indexed-setter</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-invoke-indexed-setter-1">3.9.5. Legacy platform object [[Set]] method</a>
-    <li><a href="#ref-for-invoke-indexed-setter-2">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a>
+    <li><a href="#ref-for-invoke-indexed-setter-1">3.9.2. [[Set]]</a>
+    <li><a href="#ref-for-invoke-indexed-setter-2">3.9.4. [[DefineOwnProperty]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="invoke-named-setter">
    <b><a href="#invoke-named-setter">#invoke-named-setter</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-invoke-named-setter-1">3.9.5. Legacy platform object [[Set]] method</a>
-    <li><a href="#ref-for-invoke-named-setter-2">3.9.7. Legacy platform object [[DefineOwnProperty]] method</a>
+    <li><a href="#ref-for-invoke-named-setter-1">3.9.2. [[Set]]</a>
+    <li><a href="#ref-for-invoke-named-setter-2">3.9.4. [[DefineOwnProperty]]</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="LegacyPlatformObjectGetOwnProperty">
+   <b><a href="#LegacyPlatformObjectGetOwnProperty">#LegacyPlatformObjectGetOwnProperty</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-LegacyPlatformObjectGetOwnProperty-1">3.9.1. [[GetOwnProperty]]</a>
+    <li><a href="#ref-for-LegacyPlatformObjectGetOwnProperty-2">3.9.2. [[Set]]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-single-operation-callback-interface">
@@ -15977,7 +15972,7 @@ language binding.</p>
   <aside class="dfn-panel" data-for="es-exception-objects">
    <b><a href="#es-exception-objects">#es-exception-objects</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-es-exception-objects-1">3.9.11. Property enumeration</a>
+    <li><a href="#ref-for-es-exception-objects-1">3.9.8. Property enumeration</a>
     <li><a href="#ref-for-es-exception-objects-2">3.15. Creating and throwing exceptions</a>
    </ul>
   </aside>


### PR DESCRIPTION
* Add legacy platform object dfn.
* Only allow defining legacy callers on interfaces that support
  named/indexed props.
* Disallow indexed prop getters on globals.
* Move all named/indexed prop methods to legacy platform objects.
* Move legacy caller method to legacy platform objects.

Fixes #202.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
    #idl-legacy-callers, #idl-objects, #Global, #named-properties-object, #es-legacy-platform-objects
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://cdn.rawgit.com/tobie/webidl/8bc5df5/index.html) (<a href="https://cdn.rawgit.com/tobie/webidl/8bc5df5/index.html#idl-legacy-callers" title="#idl-legacy-callers">#idl-leg…</a>) (<a href="https://cdn.rawgit.com/tobie/webidl/8bc5df5/index.html#idl-objects" title="#idl-objects">#idl-obj…</a>) (<a href="https://cdn.rawgit.com/tobie/webidl/8bc5df5/index.html#Global" title="#Global">#Global</a>) (<a href="https://cdn.rawgit.com/tobie/webidl/8bc5df5/index.html#named-properties-object" title="#named-properties-object">#named-p…</a>) (<a href="https://cdn.rawgit.com/tobie/webidl/8bc5df5/index.html#es-legacy-platform-objects" title="#es-legacy-platform-objects">#es-lega…</a>) | [Diff w/ current ED](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fheycam.github.io%2Fwebidl%2F&doc2=https%3A%2F%2Fcdn.rawgit.com%2Ftobie%2Fwebidl%2F8bc5df5%2Findex.html) | [Diff w/ base](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2F274117f%2Findex.html&doc2=https%3A%2F%2Fcdn.rawgit.com%2Ftobie%2Fwebidl%2F8bc5df5%2Findex.html)