### PR TITLE
Modernize and clean up dictionary type conversions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7234,7 +7234,7 @@ the object (or its prototype chain) correspond to [=dictionary members=].
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL [=dictionary type=] value by
-    running the following algorithm (where |D| is the [=dictionary=]):
+    running the following algorithm (where |D| is the [=dictionary type=]):
 
     1.  If [=Type=](|V|) is not Undefined, Null or Object, then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
     1.  Let |dict| be an empty dictionary value of type |D|;
@@ -7249,19 +7249,18 @@ the object (or its prototype chain) correspond to [=dictionary members=].
                 <dl class="switch">
                      :  Undefined
                      :  Null
-                     :: |value| is <emu-val>undefined</emu-val>.
+                     :: <emu-val>undefined</emu-val>
                      :  anything else
-                     :: |value| is the result of calling the \[[Get]] internal method of |V| passing |key| and |V| as arguments.
+                     :: [=?=] [=Get=](|V|, |key|)
                 </dl>
             1.  If |value| is not <emu-val>undefined</emu-val>, then:
                 1.  Let |idlValue| be the result of [=converted to an IDL value|converting=] |value| to an IDL value whose type is the type |member| is declared to be of.
                 1.  Set the dictionary member on |dict| with key name |key| to the value |idlValue|.  This dictionary member is considered to be [=present=].
-            1.  Otherwise, if |value| is <emu-val>undefined</emu-val> but the [=dictionary member=] has a [=dictionary member/default value=], then:
-                1.  Let |idlValue| be the dictionary member’s default value.
+            1.  Otherwise, if |value| is <emu-val>undefined</emu-val> but |member| has a [=dictionary member/default value=], then:
+                1.  Let |idlValue| be |member|’s default value.
                 1.  Set the dictionary member on |dict| with key name |key| to the value |idlValue|.  This dictionary member is considered to be [=present=].
             1.  Otherwise, if |value| is
-                <emu-val>undefined</emu-val> and the
-                [=dictionary member=] is a
+                <emu-val>undefined</emu-val> and |member| is a
                 [=required dictionary member=], then throw a <emu-val>TypeError</emu-val>.
     1.  Return |dict|.
 </div>
@@ -7275,7 +7274,7 @@ up on the ECMAScript object are not necessarily the same as the object’s prope
     to an ECMAScript <emu-val>Object</emu-val> value by
     running the following algorithm (where |D| is the [=dictionary=]):
 
-    1.  Let |O| be a new <emu-val>Object</emu-val> value created as if by the expression <code>({})</code>.
+    1.  Let |O| be [=!=] [=ObjectCreate=]([=%ObjectPrototype%=]).
     1.  Let |dictionaries| be a list consisting of |D| and all of |D|’s [=inherited dictionaries=],
         in order from least to most derived.
     1.  For each dictionary |dictionary| in |dictionaries|, in order:
@@ -7284,7 +7283,7 @@ up on the ECMAScript object are not necessarily the same as the object’s prope
             1.  If the dictionary member named |key| is [=present=] in |V|, then:
                 1.  Let |idlValue| be the value of |member| on |V|.
                 1.  Let |value| be the result of [=converted to an ECMAScript value|converting=] |idlValue| to an ECMAScript value.
-                1.  Call [=CreateDataProperty=](|O|, |key|, |value|).
+                1.  Perform [=!=] [=CreateDataProperty=](|O|, |key|, |value|).
     1.  Return |O|.
 </div>
 

--- a/index.html
+++ b/index.html
@@ -969,6 +969,8 @@ Possible extra rowspan handling
 		/* Reverse color scheme */
 		color: black;
 		border-color: #3980B5;
+		border-bottom-width: 3px !important;
+		margin-bottom: 0px !important;
 	}
 	.toc a:visited {
 		border-color: #054572;
@@ -1555,7 +1557,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web IDL</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-08">8 November 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-10">10 November 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -7127,7 +7129,7 @@ by ECMAScript <emu-val>Object</emu-val> values.  Properties on
 the object (or its prototype chain) correspond to <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-30">dictionary members</a>.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to dictionary" id="es-to-dictionary">
     <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-21">converted</a> to an IDL <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-7">dictionary type</a> value by
-    running the following algorithm (where <var>D</var> is the <a data-link-type="dfn" href="#dfn-dictionary" id="ref-for-dfn-dictionary-11">dictionary</a>):</p>
+    running the following algorithm (where <var>D</var> is the <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-8">dictionary type</a>):</p>
     <ol>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Undefined, Null or Object, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-24">throw a <emu-val>TypeError</emu-val></a>.</p>
@@ -7153,11 +7155,11 @@ in order from least to most derived.</p>
            <dt data-md="">
             <p>Null</p>
            <dd data-md="">
-            <p><var>value</var> is <emu-val>undefined</emu-val>.</p>
+            <p><emu-val>undefined</emu-val></p>
            <dt data-md="">
             <p>anything else</p>
            <dd data-md="">
-            <p><var>value</var> is the result of calling the [[Get]] internal method of <var>V</var> passing <var>key</var> and <var>V</var> as arguments.</p>
+            <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>V</var>, <var>key</var>)</p>
           </dl>
          <li data-md="">
           <p>If <var>value</var> is not <emu-val>undefined</emu-val>, then:</p>
@@ -7168,29 +7170,29 @@ in order from least to most derived.</p>
             <p>Set the dictionary member on <var>dict</var> with key name <var>key</var> to the value <var>idlValue</var>.  This dictionary member is considered to be <a data-link-type="dfn" href="#dfn-present" id="ref-for-dfn-present-3">present</a>.</p>
           </ol>
          <li data-md="">
-          <p>Otherwise, if <var>value</var> is <emu-val>undefined</emu-val> but the <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-32">dictionary member</a> has a <a data-link-type="dfn" href="#dfn-dictionary-member-default-value" id="ref-for-dfn-dictionary-member-default-value-8">default value</a>, then:</p>
+          <p>Otherwise, if <var>value</var> is <emu-val>undefined</emu-val> but <var>member</var> has a <a data-link-type="dfn" href="#dfn-dictionary-member-default-value" id="ref-for-dfn-dictionary-member-default-value-8">default value</a>, then:</p>
           <ol>
            <li data-md="">
-            <p>Let <var>idlValue</var> be the dictionary member’s default value.</p>
+            <p>Let <var>idlValue</var> be <var>member</var>’s default value.</p>
            <li data-md="">
             <p>Set the dictionary member on <var>dict</var> with key name <var>key</var> to the value <var>idlValue</var>.  This dictionary member is considered to be <a data-link-type="dfn" href="#dfn-present" id="ref-for-dfn-present-4">present</a>.</p>
           </ol>
          <li data-md="">
-          <p>Otherwise, if <var>value</var> is <emu-val>undefined</emu-val> and the <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-33">dictionary member</a> is a <a data-link-type="dfn" href="#required-dictionary-member" id="ref-for-required-dictionary-member-3">required dictionary member</a>, then throw a <emu-val>TypeError</emu-val>.</p>
+          <p>Otherwise, if <var>value</var> is <emu-val>undefined</emu-val> and <var>member</var> is a <a data-link-type="dfn" href="#required-dictionary-member" id="ref-for-required-dictionary-member-3">required dictionary member</a>, then throw a <emu-val>TypeError</emu-val>.</p>
         </ol>
       </ol>
      <li data-md="">
       <p>Return <var>dict</var>.</p>
     </ol>
    </div>
-   <p class="note" role="note">Note: The order that <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-34">dictionary members</a> are looked
+   <p class="note" role="note">Note: The order that <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-32">dictionary members</a> are looked
 up on the ECMAScript object are not necessarily the same as the object’s property enumeration order.</p>
    <div class="algorithm" data-algorithm="convert a dictionary to an ECMAScript value" id="dictionary-to-es">
     <p>An IDL dictionary value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-20">converted</a> to an ECMAScript <emu-val>Object</emu-val> value by
-    running the following algorithm (where <var>D</var> is the <a data-link-type="dfn" href="#dfn-dictionary" id="ref-for-dfn-dictionary-12">dictionary</a>):</p>
+    running the following algorithm (where <var>D</var> is the <a data-link-type="dfn" href="#dfn-dictionary" id="ref-for-dfn-dictionary-11">dictionary</a>):</p>
     <ol>
      <li data-md="">
-      <p>Let <var>O</var> be a new <emu-val>Object</emu-val> value created as if by the expression <code>({})</code>.</p>
+      <p>Let <var>O</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-objectcreate">ObjectCreate</a>(<a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a>).</p>
      <li data-md="">
       <p>Let <var>dictionaries</var> be a list consisting of <var>D</var> and all of <var>D</var>’s <a data-link-type="dfn" href="#dfn-inherited-dictionaries" id="ref-for-dfn-inherited-dictionaries-5">inherited dictionaries</a>,
 in order from least to most derived.</p>
@@ -7210,7 +7212,7 @@ in order from least to most derived.</p>
            <li data-md="">
             <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-21">converting</a> <var>idlValue</var> to an ECMAScript value.</p>
            <li data-md="">
-            <p>Call <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createdataproperty">CreateDataProperty</a>(<var>O</var>, <var>key</var>, <var>value</var>).</p>
+            <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createdataproperty">CreateDataProperty</a>(<var>O</var>, <var>key</var>, <var>value</var>).</p>
           </ol>
         </ol>
       </ol>
@@ -7621,7 +7623,7 @@ then return the IDL value <emu-val>null</emu-val>.</p>
       <p>If <var>V</var> is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, then:</p>
       <ol>
        <li data-md="">
-        <p>If <var>types</var> includes a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-8">dictionary type</a>, then return the
+        <p>If <var>types</var> includes a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-9">dictionary type</a>, then return the
 result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-36">converting</a> <var>V</var> to that dictionary type.</p>
        <li data-md="">
         <p>If <var>types</var> includes a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-6">record type</a>, then return the
@@ -7721,7 +7723,7 @@ return the result of <a data-link-type="dfn" href="#create-sequence-from-iterabl
 return the result of <a data-link-type="dfn" href="#create-frozen-array-from-iterable" id="ref-for-create-frozen-array-from-iterable-1">creating a frozen array of that type from V and method</a>.</p>
         </ol>
        <li data-md="">
-        <p>If <var>types</var> includes a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-9">dictionary type</a>, then return the
+        <p>If <var>types</var> includes a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-10">dictionary type</a>, then return the
 result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-44">converting</a> <var>V</var> to that dictionary type.</p>
        <li data-md="">
         <p>If <var>types</var> includes a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-7">record type</a>, then return the
@@ -7924,7 +7926,7 @@ to the same object that the IDL <a class="idl-code" data-link-type="interface" h
    <p>This section defines a number of <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-38">extended attributes</a> whose presence affects only the ECMAScript binding.</p>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.1" data-lt="Clamp" id="Clamp"><span class="secno">3.3.1. </span><span class="content">[Clamp]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-28">Clamp</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-39">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-49">operation</a> argument,
-writable <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-45">attribute</a> or <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-35">dictionary member</a> whose type is one of the <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-4">integer types</a>,
+writable <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-45">attribute</a> or <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-33">dictionary member</a> whose type is one of the <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-4">integer types</a>,
 it indicates that when an ECMAScript <emu-val>Number</emu-val> is
 converted to the IDL type, out of range values will be clamped to the range
 of valid values, rather than using the operators that use a modulo operation
@@ -8025,7 +8027,7 @@ for an interface is to be implemented.</p>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.3" data-lt="EnforceRange" id="EnforceRange"><span class="secno">3.3.3. </span><span class="content">[EnforceRange]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-29">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-42">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-51">operation</a> argument,
-writable <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-4">regular attribute</a> or <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-36">dictionary member</a> whose type is one of the <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-5">integer types</a>,
+writable <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-4">regular attribute</a> or <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-34">dictionary member</a> whose type is one of the <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-5">integer types</a>,
 it indicates that when an ECMAScript <emu-val>Number</emu-val> is
 converted to the IDL type, out of range values will cause an exception to
 be thrown, rather than converted to being a valid value using the operators that use a modulo operation
@@ -9202,12 +9204,12 @@ and there is an entry in <var>S</var> that has one of the following types at pos
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-26">nullable type</a></p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-10">dictionary type</a></p>
+          <p>a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-11">dictionary type</a></p>
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-8">record type</a></p>
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-29">union type</a> that <a data-link-type="dfn" href="#dfn-includes-a-nullable-type" id="ref-for-dfn-includes-a-nullable-type-5">includes a nullable type</a> or that
-has a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-11">dictionary type</a> or a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-9">record type</a> in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-11">flattened members</a></p>
+has a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-12">dictionary type</a> or a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-9">record type</a> in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-11">flattened members</a></p>
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
        <li data-md="">
@@ -9349,7 +9351,7 @@ there is an entry in <var>S</var> that has one of the following types at positio
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-24">callback interface</a> type</p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-12">dictionary type</a></p>
+          <p>a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-13">dictionary type</a></p>
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-10">record type</a></p>
          <li data-md="">
@@ -14352,7 +14354,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-dictionary-8">2.2.4.3. Serializers</a>
     <li><a href="#ref-for-dfn-dictionary-9">2.4. Dictionaries</a>
     <li><a href="#ref-for-dfn-dictionary-10">2.11.20. Dictionary types</a>
-    <li><a href="#ref-for-dfn-dictionary-11">3.2.21. Dictionary types</a> <a href="#ref-for-dfn-dictionary-12">(2)</a>
+    <li><a href="#ref-for-dfn-dictionary-11">3.2.21. Dictionary types</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-dictionary-member">
@@ -14374,9 +14376,9 @@ language binding.</p>
     <li><a href="#ref-for-dfn-dictionary-member-24">3.2.9. unsigned long</a> <a href="#ref-for-dfn-dictionary-member-25">(2)</a>
     <li><a href="#ref-for-dfn-dictionary-member-26">3.2.10. long long</a> <a href="#ref-for-dfn-dictionary-member-27">(2)</a>
     <li><a href="#ref-for-dfn-dictionary-member-28">3.2.11. unsigned long long</a> <a href="#ref-for-dfn-dictionary-member-29">(2)</a>
-    <li><a href="#ref-for-dfn-dictionary-member-30">3.2.21. Dictionary types</a> <a href="#ref-for-dfn-dictionary-member-31">(2)</a> <a href="#ref-for-dfn-dictionary-member-32">(3)</a> <a href="#ref-for-dfn-dictionary-member-33">(4)</a> <a href="#ref-for-dfn-dictionary-member-34">(5)</a>
-    <li><a href="#ref-for-dfn-dictionary-member-35">3.3.1. [Clamp]</a>
-    <li><a href="#ref-for-dfn-dictionary-member-36">3.3.3. [EnforceRange]</a>
+    <li><a href="#ref-for-dfn-dictionary-member-30">3.2.21. Dictionary types</a> <a href="#ref-for-dfn-dictionary-member-31">(2)</a> <a href="#ref-for-dfn-dictionary-member-32">(3)</a>
+    <li><a href="#ref-for-dfn-dictionary-member-33">3.3.1. [Clamp]</a>
+    <li><a href="#ref-for-dfn-dictionary-member-34">3.3.3. [EnforceRange]</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-inherit-dictionary">
@@ -15027,9 +15029,9 @@ language binding.</p>
     <li><a href="#ref-for-idl-dictionary-2">2.2.3. Operations</a>
     <li><a href="#ref-for-idl-dictionary-3">2.2.6. Overloading</a> <a href="#ref-for-idl-dictionary-4">(2)</a>
     <li><a href="#ref-for-idl-dictionary-5">2.11.27. Union types</a>
-    <li><a href="#ref-for-idl-dictionary-6">3.2.21. Dictionary types</a> <a href="#ref-for-idl-dictionary-7">(2)</a>
-    <li><a href="#ref-for-idl-dictionary-8">3.2.28. Union types</a> <a href="#ref-for-idl-dictionary-9">(2)</a>
-    <li><a href="#ref-for-idl-dictionary-10">3.5. Overload resolution algorithm</a> <a href="#ref-for-idl-dictionary-11">(2)</a> <a href="#ref-for-idl-dictionary-12">(3)</a>
+    <li><a href="#ref-for-idl-dictionary-6">3.2.21. Dictionary types</a> <a href="#ref-for-idl-dictionary-7">(2)</a> <a href="#ref-for-idl-dictionary-8">(3)</a>
+    <li><a href="#ref-for-idl-dictionary-9">3.2.28. Union types</a> <a href="#ref-for-idl-dictionary-10">(2)</a>
+    <li><a href="#ref-for-idl-dictionary-11">3.5. Overload resolution algorithm</a> <a href="#ref-for-idl-dictionary-12">(2)</a> <a href="#ref-for-idl-dictionary-13">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="idl-enumeration">


### PR DESCRIPTION
Some Chrome devs were confused by the current phrasing of "value is the result of calling the [[Get]] internal method of V passing key and V as arguments" as it's not explicit about rethrowing exceptions. While I was there I cleaned up other stuff.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
    
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://cdn.rawgit.com/heycam/webidl/029b456/index.html) | [Diff w/ current ED](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fheycam.github.io%2Fwebidl%2F&doc2=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2F029b456%2Findex.html) | [Diff w/ base](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2F7dde1ff%2Findex.html&doc2=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2F029b456%2Findex.html)