### PR TITLE
Meta: remove sequence<T> as Bikeshed definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5785,7 +5785,7 @@ the string “OrNull”.
 </div>
 
 
-<h4 oldids="dom-sequence" id="idl-sequence" lt="sequence|sequence&lt;T&gt;" dfn export>Sequence types — sequence&lt;|T|&gt;</h4>
+<h4 oldids="dom-sequence" id="idl-sequence" lt="sequence" dfn export>Sequence types — sequence&lt;|T|&gt;</h4>
 
 The <dfn lt="sequence type" export>sequence&lt;|T|&gt;</dfn>
 type is a parameterized type whose values are (possibly zero-length) sequences of

--- a/index.html
+++ b/index.html
@@ -1557,7 +1557,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web IDL</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-22">22 November 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-29">29 November 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -5861,7 +5861,7 @@ the string “OrNull”.</p>
 };
 </pre>
    </div>
-   <h4 class="heading settled" data-dfn-type="dfn" data-export="" data-level="2.11.24" data-lt="sequence|sequence<T>" id="idl-sequence"><span class="secno">2.11.24. </span><span class="content">Sequence types — sequence&lt;<var>T</var>></span><span id="dom-sequence"></span><a class="self-link" href="#idl-sequence"></a></h4>
+   <h4 class="heading settled" data-dfn-type="dfn" data-export="" data-level="2.11.24" data-lt="sequence" id="idl-sequence"><span class="secno">2.11.24. </span><span class="content">Sequence types — sequence&lt;<var>T</var>></span><span id="dom-sequence"></span><a class="self-link" href="#idl-sequence"></a></h4>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="sequence type" id="sequence-type">sequence&lt;<var>T</var>></dfn> type is a parameterized type whose values are (possibly zero-length) sequences of
 values of type <var>T</var>.</p>
    <p>Sequences are always passed by value.  In
@@ -12897,7 +12897,6 @@ language binding.</p>
    <li><a href="#dom-domexception-security_err">SECURITY_ERR</a><span>, in §2.5.1</span>
    <li><a href="#securityerror">SecurityError</a><span>, in §2.5.1</span>
    <li><a href="#idl-sequence">sequence</a><span>, in §2.11.23</span>
-   <li><a href="#idl-sequence">sequence&lt;T></a><span>, in §2.11.23</span>
    <li><a href="#sequence-type">sequence type</a><span>, in §2.11.24</span>
    <li><a href="#dfn-serializable-type">serializable type</a><span>, in §2.2.4.3</span>
    <li><a href="#dfn-serialization-behavior">serialization behavior</a><span>, in §2.2.4.3</span>


### PR DESCRIPTION
Since this is not done for records, confuses Shepherd, and is not used
by IDL itself, let’s get rid of it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
    
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://cdn.rawgit.com/heycam/webidl/6cf2daf/index.html) | [Diff w/ current ED](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fheycam.github.io%2Fwebidl%2F&doc2=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2F6cf2daf%2Findex.html) | [Diff w/ base](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2Fd99fdf9%2Findex.html&doc2=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2F6cf2daf%2Findex.html)