### PR TITLE
Deprecate InvalidAccessError.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4512,8 +4512,7 @@ entails in the ECMAScript language binding.
 <h4 id="idl-DOMException-error-names">Error names</h4>
 
 The <dfn id="dfn-error-names-table" export>error names table</dfn> below lists all the allowed error names
-for {{DOMException|DOMExceptions}}, a description,
-and legacy code values.
+for {{DOMException|DOMExceptions}}, a description, and legacy code values.
 
 Note: If an error name is not listed here, please file a bug as indicated at the top of this specification and it will be addressed shortly. Thanks!
 
@@ -4676,12 +4675,12 @@ Note: If an error name is not listed here, please file a bug as indicated at the
 </table>
 
 <div class=advisement>
-    Additionally, the following error names are kept for legacy reasons but their usage is discouraged:
+    Additionally, the following {{DOMException|DOMExceptions}} are kept for legacy purposes but their usage is discouraged:
 
     <table id="legacy-error-names" class="vert data">
         <thead>
             <tr>
-                <th>Name</th>
+                <th>DOMException</th>
                 <th>Alternative</th>
             </tr>
         </thead>
@@ -4692,8 +4691,9 @@ Note: If an error name is not listed here, please file a bug as indicated at the
                     <dfn id="dom-domexception-invalid_access_err" for="DOMException" const export><code>INVALID_ACCESS_ERR</code></dfn>&nbsp;(15)
                 </td>
                 <td>
-                    Use <emu-val>TypeError</emu-val> for invalid arguments and
-                    {{NotSupportedError}} for unsupported operations instead.
+                    Use <emu-val>TypeError</emu-val> for invalid arguments,
+                    "{{NotSupportedError!!exception}}" for unsupported operations, or
+                    "{{NotAllowedError!!exception}}" for denied requests instead.
                 </td>
             </tr>
         </tbody>

--- a/index.bs
+++ b/index.bs
@@ -4692,8 +4692,8 @@ Note: If an error name is not listed here, please file a bug as indicated at the
                 </td>
                 <td>
                     Use <emu-val>TypeError</emu-val> for invalid arguments,
-                    "{{NotSupportedError!!exception}}" for unsupported operations, or
-                    "{{NotAllowedError!!exception}}" for denied requests instead.
+                    "{{NotSupportedError!!exception}}" for unsupported operations, and
+                    "{{NotAllowedError!!exception}}" for denied requests.
                 </td>
             </tr>
         </tbody>

--- a/index.bs
+++ b/index.bs
@@ -4583,42 +4583,31 @@ Note: If an error name is not listed here, please file a bug as indicated at the
             <td><dfn id="dom-domexception-namespace_err" for="DOMException" const export><code>NAMESPACE_ERR</code></dfn> (14)</td>
         </tr>
         <tr>
-            <td>"<dfn id="invalidaccesserror" exception export><code>InvalidAccessError</code></dfn>"</td>
-            <td>The object does not support the operation or argument.</td>
-            <td><dfn id="dom-domexception-invalid_access_err" for="DOMException" const export><code>INVALID_ACCESS_ERR</code></dfn> (15)</td>
-        </tr>
-        <tr>
-
             <td>"<dfn id="securityerror" exception export><code>SecurityError</code></dfn>"</td>
             <td>The operation is insecure.</td>
             <td><dfn id="dom-domexception-security_err" for="DOMException" const export><code>SECURITY_ERR</code></dfn> (18)</td>
         </tr>
         <tr>
-
             <td>"<dfn id="networkerror" exception export><code>NetworkError</code></dfn>"</td>
             <td>A network error occurred.</td>
             <td><dfn id="dom-domexception-network_err" for="DOMException" const export><code>NETWORK_ERR</code></dfn> (19)</td>
         </tr>
         <tr>
-
             <td>"<dfn id="aborterror" exception export><code>AbortError</code></dfn>"</td>
             <td>The operation was aborted.</td>
             <td><dfn id="dom-domexception-abort_err" for="DOMException" const export><code>ABORT_ERR</code></dfn> (20)</td>
         </tr>
         <tr>
-
             <td>"<dfn id="urlmismatcherror" exception export><code>URLMismatchError</code></dfn>"</td>
             <td>The given URL does not match another URL.</td>
             <td><dfn id="dom-domexception-url_mismatch_err" for="DOMException" const export><code>URL_MISMATCH_ERR</code></dfn> (21)</td>
         </tr>
         <tr>
-
             <td>"<dfn id="quotaexceedederror" exception export><code>QuotaExceededError</code></dfn>"</td>
             <td>The quota has been exceeded.</td>
             <td><dfn id="dom-domexception-quota_exceeded_err" for="DOMException" const export><code>QUOTA_EXCEEDED_ERR</code></dfn> (22)</td>
         </tr>
         <tr>
-
             <td>"<dfn id="timeouterror" exception export><code>TimeoutError</code></dfn>"</td>
             <td>The operation timed out.</td>
             <td><dfn id="dom-domexception-timeout_err" for="DOMException" const export><code>TIMEOUT_ERR</code></dfn> (23)</td>
@@ -4629,74 +4618,87 @@ Note: If an error name is not listed here, please file a bug as indicated at the
             <td><dfn id="dom-domexception-invalid_node_type_err" for="DOMException" const export><code>INVALID_NODE_TYPE_ERR</code></dfn> (24)</td>
         </tr>
         <tr>
-
             <td>"<dfn id="datacloneerror" exception export><code>DataCloneError</code></dfn>"</td>
             <td>The object can not be cloned.</td>
             <td><dfn id="dom-domexception-data_clone_err" for="DOMException" const export><code>DATA_CLONE_ERR</code></dfn> (25)</td>
         </tr>
         <tr>
-
             <td>"<dfn id="encodingerror" exception export><code>EncodingError</code></dfn>"</td>
             <td>The encoding operation (either encoded or decoding) failed.</td>
             <td>—</td>
         </tr>
         <tr>
-
             <td>"<dfn id="notreadableerror" exception export><code>NotReadableError</code></dfn>"</td>
             <td>The I/O read operation failed.</td>
             <td>—</td>
         </tr>
         <tr>
-
             <td>"<dfn id="unknownerror" exception export><code>UnknownError</code></dfn>"</td>
             <td>The operation failed for an unknown transient reason (e.g. out of memory).</td>
-
             <td>—</td>
         </tr>
         <tr>
-
             <td>"<dfn id="constrainterror" exception export><code>ConstraintError</code></dfn>"</td>
             <td>A mutation operation in a transaction failed because a constraint was not satisfied.</td>
             <td>—</td>
         </tr>
         <tr>
-
             <td>"<dfn id="dataerror" exception export><code>DataError</code></dfn>"</td>
             <td>Provided data is inadequate.</td>
             <td>—</td>
         </tr>
         <tr>
-
             <td>"<dfn id="transactioninactiveerror" exception export><code>TransactionInactiveError</code></dfn>"</td>
             <td>A request was placed against a transaction which is currently not active, or which is finished.</td>
             <td>—</td>
         </tr>
         <tr>
-
             <td>"<dfn id="readonlyerror" exception export><code>ReadOnlyError</code></dfn>"</td>
             <td>The mutating operation was attempted in a "readonly" transaction.</td>
             <td>—</td>
         </tr>
         <tr>
-
             <td>"<dfn id="versionerror" exception export><code>VersionError</code></dfn>"</td>
             <td>An attempt was made to open a database using a lower version than the existing version.</td>
             <td>—</td>
         </tr>
         <tr>
-
             <td>"<dfn id="operationerror" exception export><code>OperationError</code></dfn>"</td>
             <td>The operation failed for an operation-specific reason.</td>
             <td>—</td>
         </tr>
         <tr>
-
             <td>"<dfn id="notallowederror" exception export><code>NotAllowedError</code></dfn>"</td>
             <td>The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.</td>
             <td>—</td>
         </tr>
     </tbody>
 </table>
+
+<div class=advisement>
+    Additionally, the following error names are kept for legacy reasons but their usage is discouraged:
+
+    <table id="legacy-error-names" class="vert data">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Alternative</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>
+                    "<dfn id="invalidaccesserror" exception export><code>InvalidAccessError</code></dfn>"<br>
+                    <dfn id="dom-domexception-invalid_access_err" for="DOMException" const export><code>INVALID_ACCESS_ERR</code></dfn>&nbsp;(15)
+                </td>
+                <td>
+                    Use <emu-val>TypeError</emu-val> for invalid arguments and
+                    {{NotSupportedError}} for unsupported operations instead.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 
 <h3 id="idl-enums">Enumerations</h3>

--- a/index.html
+++ b/index.html
@@ -5196,8 +5196,8 @@ for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-f
       <tr>
        <td> "<dfn class="idl-code" data-dfn-type="exception" data-export="" id="invalidaccesserror"><code>InvalidAccessError</code><a class="self-link" href="#invalidaccesserror"></a></dfn>"<br> <dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-invalid_access_err"><code>INVALID_ACCESS_ERR</code><a class="self-link" href="#dom-domexception-invalid_access_err"></a></dfn> (15) 
        <td> Use <emu-val>TypeError</emu-val> for invalid arguments,
-                    "<code class="idl"><a class="idl-code" data-link-type="exception" href="#notsupportederror" id="ref-for-notsupportederror-1">NotSupportedError</a></code>" for unsupported operations, or
-                    "<code class="idl"><a class="idl-code" data-link-type="exception" href="#notallowederror" id="ref-for-notallowederror-1">NotAllowedError</a></code>" for denied requests instead. 
+                    "<code class="idl"><a class="idl-code" data-link-type="exception" href="#notsupportederror" id="ref-for-notsupportederror-1">NotSupportedError</a></code>" for unsupported operations, and
+                    "<code class="idl"><a class="idl-code" data-link-type="exception" href="#notallowederror" id="ref-for-notallowederror-1">NotAllowedError</a></code>" for denied requests. 
     </table>
    </div>
    <h3 class="heading settled" data-level="2.6" id="idl-enums"><span class="secno">2.6. </span><span class="content">Enumerations</span><a class="self-link" href="#idl-enums"></a></h3>

--- a/index.html
+++ b/index.html
@@ -1557,7 +1557,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web IDL</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-07">7 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-08">8 December 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -5055,8 +5055,7 @@ entails in the ECMAScript language binding.</p>
    </div>
    <h4 class="heading settled" data-level="2.5.1" id="idl-DOMException-error-names"><span class="secno">2.5.1. </span><span class="content">Error names</span><a class="self-link" href="#idl-DOMException-error-names"></a></h4>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-error-names-table">error names table</dfn> below lists all the allowed error names
-for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-7">DOMExceptions</a></code>, a description,
-and legacy code values.</p>
+for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-7">DOMExceptions</a></code>, a description, and legacy code values.</p>
    <p class="note" role="note">Note: If an error name is not listed here, please file a bug as indicated at the top of this specification and it will be addressed shortly. Thanks!</p>
    <table class="vert data" id="error-names">
     <thead>
@@ -5182,21 +5181,23 @@ and legacy code values.</p>
       <td>The operation failed for an operation-specific reason.
       <td>—
      <tr>
-      <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="notallowederror"><code>NotAllowedError</code><a class="self-link" href="#notallowederror"></a></dfn>"
+      <td>"<dfn class="dfn-paneled idl-code" data-dfn-type="exception" data-export="" id="notallowederror"><code>NotAllowedError</code></dfn>"
       <td>The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.
       <td>—
    </table>
    <div class="advisement">
-     Additionally, the following error names are kept for legacy reasons but their usage is discouraged: 
+     Additionally, the following <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-9">DOMExceptions</a></code> are kept for legacy purposes but their usage is discouraged: 
     <table class="vert data" id="legacy-error-names">
      <thead>
       <tr>
-       <th>Name
+       <th>DOMException
        <th>Alternative
      <tbody>
       <tr>
        <td> "<dfn class="idl-code" data-dfn-type="exception" data-export="" id="invalidaccesserror"><code>InvalidAccessError</code><a class="self-link" href="#invalidaccesserror"></a></dfn>"<br> <dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-invalid_access_err"><code>INVALID_ACCESS_ERR</code><a class="self-link" href="#dom-domexception-invalid_access_err"></a></dfn> (15) 
-       <td> Use <emu-val>TypeError</emu-val> for invalid arguments and <code class="idl"><a data-link-type="idl" href="#notsupportederror" id="ref-for-notsupportederror-1">NotSupportedError</a></code> for unsupported operations instead. 
+       <td> Use <emu-val>TypeError</emu-val> for invalid arguments,
+                    "<code class="idl"><a class="idl-code" data-link-type="exception" href="#notsupportederror" id="ref-for-notsupportederror-1">NotSupportedError</a></code>" for unsupported operations, or
+                    "<code class="idl"><a class="idl-code" data-link-type="exception" href="#notallowederror" id="ref-for-notallowederror-1">NotAllowedError</a></code>" for denied requests instead. 
     </table>
    </div>
    <h3 class="heading settled" data-level="2.6" id="idl-enums"><span class="secno">2.6. </span><span class="content">Enumerations</span><a class="self-link" href="#idl-enums"></a></h3>
@@ -5452,7 +5453,7 @@ object that are considered to be platform objects:</p>
     <li data-md="">
      <p>objects that implement a non-<a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-13">callback</a> <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-49">interface</a>;</p>
     <li data-md="">
-     <p>objects representing IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-9">DOMExceptions</a></code>.</p>
+     <p>objects representing IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-10">DOMExceptions</a></code>.</p>
    </ul>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-legacy-platform-object">Legacy platform objects</dfn> are <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-7">platform objects</a> that implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-50">interface</a> which
 does not have a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-5">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-6">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-21">extended attribute</a>, <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-9">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-4">named properties</a>,
@@ -5486,7 +5487,7 @@ corresponding to each type, and how <a data-link-type="dfn" href="#dfn-constant"
 the <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-3">integer types</a>, <code class="idl"><a data-link-type="idl" href="#idl-float" id="ref-for-idl-float-4">float</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-unrestricted-float" id="ref-for-idl-unrestricted-float-5">unrestricted float</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-double" id="ref-for-idl-double-11">double</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-unrestricted-double" id="ref-for-idl-unrestricted-double-6">unrestricted double</a></code>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-primitive-type">primitive types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref-for-idl-boolean-6">boolean</a></code> and the <a data-link-type="dfn" href="#dfn-numeric-type" id="ref-for-dfn-numeric-type-5">numeric types</a>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-string-type">string types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-26">DOMString</a></code>, all <a data-link-type="dfn" href="#idl-enumeration" id="ref-for-idl-enumeration-1">enumeration types</a>, <code class="idl"><a data-link-type="idl" href="#idl-ByteString" id="ref-for-idl-ByteString-3">ByteString</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-USVString" id="ref-for-idl-USVString-4">USVString</a></code>.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exception-type">exception types</dfn> are <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-3">Error</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-10">DOMException</a></code>.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exception-type">exception types</dfn> are <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-3">Error</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-11">DOMException</a></code>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-typed-array-type">typed array types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-Int8Array" id="ref-for-idl-Int8Array-1">Int8Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Int16Array" id="ref-for-idl-Int16Array-1">Int16Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Int32Array" id="ref-for-idl-Int32Array-1">Int32Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint8Array" id="ref-for-idl-Uint8Array-1">Uint8Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint16Array" id="ref-for-idl-Uint16Array-1">Uint16Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint32Array" id="ref-for-idl-Uint32Array-1">Uint32Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint8ClampedArray" id="ref-for-idl-Uint8ClampedArray-1">Uint8ClampedArray</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Float32Array" id="ref-for-idl-Float32Array-1">Float32Array</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-Float64Array" id="ref-for-idl-Float64Array-1">Float64Array</a></code>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-buffer-source-type">buffer source types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-ArrayBuffer" id="ref-for-idl-ArrayBuffer-1">ArrayBuffer</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-DataView" id="ref-for-idl-DataView-1">DataView</a></code>,
 and the <a data-link-type="dfn" href="#dfn-typed-array-type" id="ref-for-dfn-typed-array-type-1">typed array types</a>.</p>
@@ -6016,15 +6017,15 @@ and joining them with the string “Or”.</p>
    <div data-fill-with="grammar-NonAnyType"></div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-level="2.11.28" data-lt="Error" id="idl-Error"><span class="secno">2.11.28. </span><span class="content">Error</span><span id="dom-Error"></span></h4>
    <p>The <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-4">Error</a></code> type corresponds to the
-set of all possible non-null references to exception objects, including <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-4">simple exceptions</a> and <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-11">DOMExceptions</a></code>.</p>
+set of all possible non-null references to exception objects, including <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-4">simple exceptions</a> and <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-12">DOMExceptions</a></code>.</p>
    <p>There is no way to represent a constant <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-5">Error</a></code> value in IDL.</p>
    <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-28">type name</a> of the <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-6">Error</a></code> type is “Error”.</p>
    <h4 class="heading settled" data-level="2.11.29" id="idl-DOMException"><span class="secno">2.11.29. </span><span class="content">DOMException</span><a class="self-link" href="#idl-DOMException"></a></h4>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-12">DOMException</a></code> type corresponds to the
+   <p>The <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-13">DOMException</a></code> type corresponds to the
 set of all possible non-null references to objects
-representing <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-13">DOMExceptions</a></code>.</p>
-   <p>There is no way to represent a constant <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-14">DOMException</a></code> value in IDL.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-29">type name</a> of the <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-15">DOMException</a></code> type is “DOMException”.</p>
+representing <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-14">DOMExceptions</a></code>.</p>
+   <p>There is no way to represent a constant <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-15">DOMException</a></code> value in IDL.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-29">type name</a> of the <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-16">DOMException</a></code> type is “DOMException”.</p>
    <h4 class="heading settled" data-level="2.11.30" id="idl-buffer-source-types"><span class="secno">2.11.30. </span><span class="content">Buffer source types</span><a class="self-link" href="#idl-buffer-source-types"></a></h4>
    <p>There are a number of types that correspond to sets of all possible non-null
 references to objects that represent a buffer of data or a view on to a buffer of
@@ -7406,10 +7407,10 @@ result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id
 that is a reference to the object <var>V</var>.</p>
       </ol>
      <li data-md="">
-      <p>If <var>V</var> is a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-16">DOMException</a></code> platform object, then:</p>
+      <p>If <var>V</var> is a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-17">DOMException</a></code> platform object, then:</p>
       <ol>
        <li data-md="">
-        <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-17">DOMException</a></code> or <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-7">Error</a></code>, then return the
+        <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-18">DOMException</a></code> or <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-7">Error</a></code>, then return the
 result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-38">converting</a> <var>V</var> to that type.</p>
        <li data-md="">
         <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-16">object</a></code>, then return the IDL value
@@ -7533,7 +7534,7 @@ then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-
    <h4 class="heading settled" data-level="3.2.22" id="es-Error"><span class="secno">3.2.22. </span><span class="content">Error</span><a class="self-link" href="#es-Error"></a></h4>
    <p>IDL <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-10">Error</a></code> values are represented
 by native ECMAScript <emu-val>Error</emu-val> objects and
-platform objects for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-18">DOMExceptions</a></code>.</p>
+platform objects for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-19">DOMExceptions</a></code>.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to Error" id="es-to-Error">
     <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-52">converted</a> to an IDL <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-11">Error</a></code> value by running the following algorithm:</p>
     <ol>
@@ -7550,23 +7551,23 @@ to the same object as <var>V</var>.</p>
     value is the <emu-val>Error</emu-val> value that represents a reference to the same object that the
     IDL <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-14">Error</a></code> represents. </p>
    <h4 class="heading settled" data-level="3.2.23" id="es-DOMException"><span class="secno">3.2.23. </span><span class="content">DOMException</span><a class="self-link" href="#es-DOMException"></a></h4>
-   <p>IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-19">DOMException</a></code> values are represented
-by platform objects for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-20">DOMExceptions</a></code>.</p>
+   <p>IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-20">DOMException</a></code> values are represented
+by platform objects for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-21">DOMExceptions</a></code>.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to DOMException" id="es-to-DOMException">
-    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-53">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-21">DOMException</a></code> value by running the following algorithm:</p>
+    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-53">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-22">DOMException</a></code> value by running the following algorithm:</p>
     <ol>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
-or <var>V</var> is not a platform object that represents a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-22">DOMException</a></code>,
+or <var>V</var> is not a platform object that represents a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-23">DOMException</a></code>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-19">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
-      <p>Return the IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-23">DOMException</a></code> value that is a reference
+      <p>Return the IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-24">DOMException</a></code> value that is a reference
 to the same object as <var>V</var>.</p>
     </ol>
    </div>
-   <p id="DOMException-to-es"> The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-34">converting</a> an IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-24">DOMException</a></code> value to an ECMAScript
+   <p id="DOMException-to-es"> The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-34">converting</a> an IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-25">DOMException</a></code> value to an ECMAScript
     value is the <emu-val>Object</emu-val> value that represents a reference to the same object that the
-    IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-25">DOMException</a></code> represents. </p>
+    IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-26">DOMException</a></code> represents. </p>
    <h4 class="heading settled" data-level="3.2.24" id="es-buffer-source-types"><span class="secno">3.2.24. </span><span class="content">Buffer source types</span><a class="self-link" href="#es-buffer-source-types"></a></h4>
    <p>Values of the IDL <a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-2">buffer source types</a> are represented by objects of the corresponding ECMAScript class.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to buffer source" id="es-to-buffer-source">
@@ -8997,11 +8998,11 @@ that has one of the above types in its <a data-link-type="dfn" href="#dfn-flatte
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
        <li data-md="">
-        <p>Otherwise: if <var>V</var> is a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-26">DOMException</a></code> platform object and
+        <p>Otherwise: if <var>V</var> is a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-27">DOMException</a></code> platform object and
 there is an entry in <var>S</var> that has one of the following types at position <var>i</var> of its type list,</p>
         <ul>
          <li data-md="">
-          <p><code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-27">DOMException</a></code></p>
+          <p><code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-28">DOMException</a></code></p>
          <li data-md="">
           <p><code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-15">Error</a></code></p>
          <li data-md="">
@@ -11982,7 +11983,7 @@ attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[E
    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="3.14" data-lt="Exception objects" data-noexport="" id="es-exception-objects"><span class="secno">3.14. </span><span class="content">Exception objects</span></h3>
    <p><a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-5">Simple exceptions</a> are represented
 by native ECMAScript objects of the corresponding type.</p>
-   <p><code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-28">DOMExceptions</a></code> are represented by <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-54">platform objects</a> that inherit from
+   <p><code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-29">DOMExceptions</a></code> are represented by <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-54">platform objects</a> that inherit from
 the <a data-link-type="dfn" href="#dfn-DOMException-prototype-object" id="ref-for-dfn-DOMException-prototype-object-3">DOMException prototype object</a>.</p>
    <p>Every platform object representing a DOMException in ECMAScript is associated with a global environment, just
 as the <a data-link-type="dfn" href="#dfn-initial-object" id="ref-for-dfn-initial-object-5">initial objects</a> are.
@@ -11990,8 +11991,8 @@ When an exception object is created by calling the <a data-link-type="dfn" href=
 either normally or as part of a <code>new</code> expression, then the global environment
 of the newly created object is associated with must be the same as for the <a data-link-type="dfn" href="#dfn-DOMException-constructor-object" id="ref-for-dfn-DOMException-constructor-object-4">DOMException constructor object</a> itself.</p>
    <p>The value of the internal [[Prototype]]
-property of a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-29">DOMException</a></code> object must be the <a data-link-type="dfn" href="#dfn-DOMException-prototype-object" id="ref-for-dfn-DOMException-prototype-object-4">DOMException prototype object</a> from the global environment the exception object is associated with.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-7">class string</a> of a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-30">DOMException</a></code> object
+property of a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-30">DOMException</a></code> object must be the <a data-link-type="dfn" href="#dfn-DOMException-prototype-object" id="ref-for-dfn-DOMException-prototype-object-4">DOMException prototype object</a> from the global environment the exception object is associated with.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-7">class string</a> of a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-31">DOMException</a></code> object
 must be “DOMException”.</p>
    <p class="note" role="note">Note: The intention is for DOMException objects to be just like the other
 various native <emu-val>Error</emu-val> objects that the
@@ -12027,7 +12028,7 @@ exception field was defined.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="to create a simple exception or DOMException">
-    <p>When a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-6">simple exception</a> or <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-31">DOMException</a></code> <var>E</var> is to be <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-3">created</a>,
+    <p>When a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-6">simple exception</a> or <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-32">DOMException</a></code> <var>E</var> is to be <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-3">created</a>,
     with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-6">error name</a> <var>N</var> and optional user agent-defined message <var>M</var>,
     the following steps must be followed:</p>
     <ol>
@@ -12039,7 +12040,7 @@ exception field was defined.</p>
       <p>Let <var>args</var> be a list of ECMAScript values.</p>
       <dl class="switch">
        <dt data-md="">
-        <p><var>E</var> is <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-32">DOMException</a></code></p>
+        <p><var>E</var> is <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-33">DOMException</a></code></p>
        <dd data-md="">
         <p><var>args</var> is (<emu-val>undefined</emu-val>, <var>N</var>).</p>
        <dt data-md="">
@@ -12053,7 +12054,7 @@ exception field was defined.</p>
       <p>Let <var>X</var> be an object determined based on the type of <var>E</var>:</p>
       <dl class="switch">
        <dt data-md="">
-        <p><var>E</var> is <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-33">DOMException</a></code></p>
+        <p><var>E</var> is <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-34">DOMException</a></code></p>
        <dd data-md="">
         <p><var>X</var> is the <a data-link-type="dfn" href="#dfn-DOMException-constructor-object" id="ref-for-dfn-DOMException-constructor-object-5">DOMException constructor object</a> from the global environment <var>G</var>.</p>
        <dt data-md="">
@@ -12070,7 +12071,7 @@ with <var>args</var> as the argument list.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="throw an exception">
-    <p>When a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-9">simple exception</a> or <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-34">DOMException</a></code> <var>E</var> is to be <a data-link-type="dfn" href="#dfn-throw" id="ref-for-dfn-throw-3">thrown</a>,
+    <p>When a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-9">simple exception</a> or <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-35">DOMException</a></code> <var>E</var> is to be <a data-link-type="dfn" href="#dfn-throw" id="ref-for-dfn-throw-3">thrown</a>,
     with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-7">error name</a> <var>N</var> and optional user agent-defined message <var>M</var>,
     the following steps must be followed:</p>
     <ol>
@@ -14193,17 +14194,17 @@ language binding.</p>
    <b><a href="#dfn-DOMException">#dfn-DOMException</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-DOMException-1">2.5. Exceptions</a> <a href="#ref-for-dfn-DOMException-2">(2)</a> <a href="#ref-for-dfn-DOMException-3">(3)</a> <a href="#ref-for-dfn-DOMException-4">(4)</a> <a href="#ref-for-dfn-DOMException-5">(5)</a> <a href="#ref-for-dfn-DOMException-6">(6)</a>
-    <li><a href="#ref-for-dfn-DOMException-7">2.5.1. Error names</a> <a href="#ref-for-dfn-DOMException-8">(2)</a>
-    <li><a href="#ref-for-dfn-DOMException-9">2.10. Objects implementing interfaces</a>
-    <li><a href="#ref-for-dfn-DOMException-10">2.11. Types</a>
-    <li><a href="#ref-for-dfn-DOMException-11">2.11.28. Error</a>
-    <li><a href="#ref-for-dfn-DOMException-12">2.11.29. DOMException</a> <a href="#ref-for-dfn-DOMException-13">(2)</a> <a href="#ref-for-dfn-DOMException-14">(3)</a> <a href="#ref-for-dfn-DOMException-15">(4)</a>
-    <li><a href="#ref-for-dfn-DOMException-16">3.2.21. Union types</a> <a href="#ref-for-dfn-DOMException-17">(2)</a>
-    <li><a href="#ref-for-dfn-DOMException-18">3.2.22. Error</a>
-    <li><a href="#ref-for-dfn-DOMException-19">3.2.23. DOMException</a> <a href="#ref-for-dfn-DOMException-20">(2)</a> <a href="#ref-for-dfn-DOMException-21">(3)</a> <a href="#ref-for-dfn-DOMException-22">(4)</a> <a href="#ref-for-dfn-DOMException-23">(5)</a> <a href="#ref-for-dfn-DOMException-24">(6)</a> <a href="#ref-for-dfn-DOMException-25">(7)</a>
-    <li><a href="#ref-for-dfn-DOMException-26">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-DOMException-27">(2)</a>
-    <li><a href="#ref-for-dfn-DOMException-28">3.14. Exception objects</a> <a href="#ref-for-dfn-DOMException-29">(2)</a> <a href="#ref-for-dfn-DOMException-30">(3)</a>
-    <li><a href="#ref-for-dfn-DOMException-31">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-DOMException-32">(2)</a> <a href="#ref-for-dfn-DOMException-33">(3)</a> <a href="#ref-for-dfn-DOMException-34">(4)</a>
+    <li><a href="#ref-for-dfn-DOMException-7">2.5.1. Error names</a> <a href="#ref-for-dfn-DOMException-8">(2)</a> <a href="#ref-for-dfn-DOMException-9">(3)</a>
+    <li><a href="#ref-for-dfn-DOMException-10">2.10. Objects implementing interfaces</a>
+    <li><a href="#ref-for-dfn-DOMException-11">2.11. Types</a>
+    <li><a href="#ref-for-dfn-DOMException-12">2.11.28. Error</a>
+    <li><a href="#ref-for-dfn-DOMException-13">2.11.29. DOMException</a> <a href="#ref-for-dfn-DOMException-14">(2)</a> <a href="#ref-for-dfn-DOMException-15">(3)</a> <a href="#ref-for-dfn-DOMException-16">(4)</a>
+    <li><a href="#ref-for-dfn-DOMException-17">3.2.21. Union types</a> <a href="#ref-for-dfn-DOMException-18">(2)</a>
+    <li><a href="#ref-for-dfn-DOMException-19">3.2.22. Error</a>
+    <li><a href="#ref-for-dfn-DOMException-20">3.2.23. DOMException</a> <a href="#ref-for-dfn-DOMException-21">(2)</a> <a href="#ref-for-dfn-DOMException-22">(3)</a> <a href="#ref-for-dfn-DOMException-23">(4)</a> <a href="#ref-for-dfn-DOMException-24">(5)</a> <a href="#ref-for-dfn-DOMException-25">(6)</a> <a href="#ref-for-dfn-DOMException-26">(7)</a>
+    <li><a href="#ref-for-dfn-DOMException-27">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-DOMException-28">(2)</a>
+    <li><a href="#ref-for-dfn-DOMException-29">3.14. Exception objects</a> <a href="#ref-for-dfn-DOMException-30">(2)</a> <a href="#ref-for-dfn-DOMException-31">(3)</a>
+    <li><a href="#ref-for-dfn-DOMException-32">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-DOMException-33">(2)</a> <a href="#ref-for-dfn-DOMException-34">(3)</a> <a href="#ref-for-dfn-DOMException-35">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-create-exception">
@@ -14246,6 +14247,12 @@ language binding.</p>
    <b><a href="#syntaxerror">#syntaxerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntaxerror-1">2.5. Exceptions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="notallowederror">
+   <b><a href="#notallowederror">#notallowederror</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-notallowederror-1">2.5.1. Error names</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-enumeration">

--- a/index.html
+++ b/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 645534c1532bca4fdb4f3859efc66268a218d7c8" name="generator">
+  <meta content="Bikeshed version 0feafaae1a97b66d9da46b325858f9805ac01fb2" name="generator">
 <style>
         pre.set {
           font-size: 80%;
@@ -1557,7 +1557,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web IDL</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-29">29 November 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-07">7 December 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -5114,10 +5114,6 @@ and legacy code values.</p>
       <td>The operation is not allowed by <cite>Namespaces in XML</cite>. <a data-link-type="biblio" href="#biblio-xml-names">[XML-NAMES]</a>
       <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-namespace_err"><code>NAMESPACE_ERR</code><a class="self-link" href="#dom-domexception-namespace_err"></a></dfn> (14)
      <tr>
-      <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="invalidaccesserror"><code>InvalidAccessError</code><a class="self-link" href="#invalidaccesserror"></a></dfn>"
-      <td>The object does not support the operation or argument.
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-invalid_access_err"><code>INVALID_ACCESS_ERR</code><a class="self-link" href="#dom-domexception-invalid_access_err"></a></dfn> (15)
-     <tr>
       <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="securityerror"><code>SecurityError</code><a class="self-link" href="#securityerror"></a></dfn>"
       <td>The operation is insecure.
       <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-security_err"><code>SECURITY_ERR</code><a class="self-link" href="#dom-domexception-security_err"></a></dfn> (18)
@@ -5190,6 +5186,19 @@ and legacy code values.</p>
       <td>The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.
       <td>—
    </table>
+   <div class="advisement">
+     Additionally, the following error names are kept for legacy reasons but their usage is discouraged: 
+    <table class="vert data" id="legacy-error-names">
+     <thead>
+      <tr>
+       <th>Name
+       <th>Alternative
+     <tbody>
+      <tr>
+       <td> "<dfn class="idl-code" data-dfn-type="exception" data-export="" id="invalidaccesserror"><code>InvalidAccessError</code><a class="self-link" href="#invalidaccesserror"></a></dfn>"<br> <dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-invalid_access_err"><code>INVALID_ACCESS_ERR</code><a class="self-link" href="#dom-domexception-invalid_access_err"></a></dfn> (15) 
+       <td> Use <emu-val>TypeError</emu-val> for invalid arguments and <code class="idl"><a data-link-type="idl" href="#notsupportederror" id="ref-for-notsupportederror-1">NotSupportedError</a></code> for unsupported operations instead. 
+    </table>
+   </div>
    <h3 class="heading settled" data-level="2.6" id="idl-enums"><span class="secno">2.6. </span><span class="content">Enumerations</span><a class="self-link" href="#idl-enums"></a></h3>
    <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-enumeration">enumeration</dfn> is a definition (matching <emu-nt><a href="#prod-Enum">Enum</a></emu-nt>) used to declare a type
 whose valid values are a set of predefined strings.  Enumerations
@@ -12087,7 +12096,7 @@ optional user agent-defined message <var>M</var>.</p>
 
 <span class="kt">interface</span> <span class="nv">MathUtils</span> {
   /**
-   * If x is negative, throws a <a href="#notsupportederror" id="ref-for-notsupportederror-1">NotSupportedError</a>.  Otherwise, returns
+   * If x is negative, throws a <a href="#notsupportederror" id="ref-for-notsupportederror-2">NotSupportedError</a>.  Otherwise, returns
    * the square root of x.
    */
   <span class="kt">double</span> <span class="nv">computeSquareRoot</span>(<span class="kt">double</span> <span class="nv">x</span>);
@@ -14229,7 +14238,8 @@ language binding.</p>
   <aside class="dfn-panel" data-for="notsupportederror">
    <b><a href="#notsupportederror">#notsupportederror</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-notsupportederror-1">3.15. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-notsupportederror-1">2.5.1. Error names</a>
+    <li><a href="#ref-for-notsupportederror-2">3.15. Creating and throwing exceptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="syntaxerror">


### PR DESCRIPTION
Closes https://www.w3.org/Bugs/Public/show_bug.cgi?id=27284.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
    #invalidaccesserror
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://cdn.rawgit.com/tobie/webidl/c124a10/index.html#invalidaccesserror) | [Diff w/ current ED](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fheycam.github.io%2Fwebidl%2F&doc2=https%3A%2F%2Fcdn.rawgit.com%2Ftobie%2Fwebidl%2Fc124a10%2Findex.html#invalidaccesserror) | [Diff w/ base](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2Fafcc257%2Findex.html&doc2=https%3A%2F%2Fcdn.rawgit.com%2Ftobie%2Fwebidl%2Fc124a10%2Findex.html#invalidaccesserror)