### PR TITLE
Exception cleanup

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4427,46 +4427,43 @@ user agent-defined value that provides human readable details of the error.
 
 There are two kinds of exceptions available to be thrown from specifications.
 The first is a <dfn id="dfn-simple-exception" export>simple exception</dfn>, which
-is identified by one of the following names:
+is identified by one of the following type values:
 
-*   "<dfn exception><code>Error</code></dfn>"
-*   "<dfn exception><code>EvalError</code></dfn>"
-*   "<dfn exception><code>RangeError</code></dfn>"
-*   "<dfn exception><code>ReferenceError</code></dfn>"
-*   "<dfn exception><code>TypeError</code></dfn>"
-*   "<dfn exception><code>URIError</code></dfn>"
+*   <emu-val>EvalError</emu-val>
+*   <emu-val>RangeError</emu-val>
+*   <emu-val>ReferenceError</emu-val>
+*   <emu-val>TypeError</emu-val>
+*   <emu-val>URIError</emu-val>
 
-These correspond to all of the [=ECMAScript error objects=] (apart from
-<emu-val>SyntaxError</emu-val>, which is deliberately omitted as
-it is for use only by the ECMAScript parser).
-The meaning of
-each [=simple exception=] matches
-its corresponding <emu-val>Error</emu-val> object in the
+These correspond to all of the [=ECMAScript error objects=]
+(apart from <emu-val>SyntaxError</emu-val> and <emu-val>Error</emu-val>,
+which are deliberately omitted as they are reserved for use
+by the ECMAScript parser and authors, respectively).
+The meaning of each [=simple exception=] matches
+its corresponding error object in the
 ECMAScript specification.
 
 The second kind of exception is a <dfn id="dfn-DOMException" interface export>DOMException</dfn>,
 which is an exception that encapsulates a name and an optional integer code,
 for compatibility with historically defined exceptions in the DOM.
 
-For [=simple exceptions=],
-the [=error name=] is the name
-of the exception.
-For a {{DOMException}},
-the [=error name=] must
-be one of the names listed in the [=error names table=]
-below.  The table also indicates the {{DOMException}}'s integer code
-for that error name, if it has one.
+For [=simple exceptions=], the [=error name=] is the name of the exception.
+For a {{DOMException}}, the [=error name=] must be one of the names
+listed in the [=error names table=] below.
+The table also indicates the {{DOMException}}'s integer code for that error name,
+if it has one.
 
-There are two types that can be used to refer to
-exception objects: {{Error!!interface}}, which encompasses all exceptions,
+There are two types that can be used to refer to exception objects:
+{{Error!!interface}}, which encompasses all exceptions,
 and {{DOMException}} which includes just DOMException objects.
 This allows for example an [=operation=]
 to be declared to have a {{DOMException}}
 [=return type=] or an [=attribute=]
 to be of type {{Error!!interface}}.
 
-Exceptions can be <dfn id="dfn-create-exception" for="exception" export>created</dfn> by providing its
-[=error name=].
+[=Simple exceptions=] can be <dfn id="dfn-create-exception" for="exception" export>created</dfn>
+by providing their [=error name=].
+{{DOMException|DOMExceptions}}, by providing their [=error name=] followed by {{DOMException}}.
 Exceptions can also be <dfn id="dfn-throw" for="exception" export lt="throw|thrown">thrown</dfn>, by providing the
 same details required to [=created|create=] one.
 
@@ -4478,33 +4475,22 @@ entails in the ECMAScript language binding.
 <div class="example">
 
     Here is are some examples of wording to use to create and throw exceptions.
-    To throw a new [=simple exception=] named
-    {{TypeError}}:
+    To throw a new [=simple exception=] named <emu-val>TypeError</emu-val>:
 
     <blockquote>
-
-        [=Throw=] a TypeError.
-
+        [=Throw=] a <emu-val>TypeError</emu-val>.
     </blockquote>
 
-    To throw a new {{DOMException}} with
-    [=error name=]
-    {{IndexSizeError}}:
+    To throw a new {{DOMException}} with [=error name=] "{{IndexSizeError!!exception}}":
 
     <blockquote>
-
-        [=Throw=] an IndexSizeError.
-
+        [=Throw=] an "{{IndexSizeError!!exception}}" {{DOMException}}.
     </blockquote>
 
-    To create a new {{DOMException}} with
-    [=error name=]
-    {{SyntaxError}}:
+    To create a new {{DOMException}} with [=error name=] "{{SyntaxError!!exception}}":
 
     <blockquote>
-
-        Let <var ignore>object</var> be a newly [=created=] SyntaxError.
-
+        Let <var ignore>object</var> be a newly [=created=] "{{SyntaxError!!exception}}" {{DOMException}}.
     </blockquote>
 </div>
 
@@ -11759,7 +11745,7 @@ and similarly with their setters.
     Attempting to call <code>B.prototype.f</code> on an object that implements
     <code class="idl">A</code> (but not <code class="idl">B</code>) or one
     that implements <code class="idl">C</code> will result in a
-    {{TypeError}} being thrown.  However,
+    <emu-val>TypeError</emu-val> being thrown.  However,
     calling <code>A.prototype.f</code> on an object that implements
     <code class="idl">B</code> or one that implements <code class="idl">C</code>
     would succeed.  This is handled by the algorithm in [[#es-operations]]

--- a/index.bs
+++ b/index.bs
@@ -4676,7 +4676,7 @@ Note: If an error name is not listed here, please file a bug as indicated at the
                     "<dfn id="domstringsizeerror" exception><code>DOMStringSizeError</code></dfn>"<br>
                     <dfn id="dom-domexception-domstring_size_err" for="DOMException" const><code>DOMSTRING_SIZE_ERR</code></dfn>&nbsp;(2)
                 </td>
-                <td>Use <emu-val>RangeError</emu-val>.</td>
+                <td>Use {{RangeError}}.</td>
             </tr>
             <tr>
                 <td>
@@ -4691,9 +4691,9 @@ Note: If an error name is not listed here, please file a bug as indicated at the
                     <dfn id="dom-domexception-invalid_access_err" for="DOMException" const><code>INVALID_ACCESS_ERR</code></dfn>&nbsp;(15)
                 </td>
                 <td>
-                    Use <emu-val>TypeError</emu-val> for invalid arguments,
-                    "{{NotSupportedError!!exception}}" for unsupported operations, and
-                    "{{NotAllowedError!!exception}}" for denied requests.
+                    Use {{TypeError}} for invalid arguments,
+                    "{{NotSupportedError!!exception}}" {{DOMException}} for unsupported operations, and
+                    "{{NotAllowedError!!exception}}" {{DOMException}} for denied requests.
                 </td>
             </tr>
             <tr>
@@ -4708,7 +4708,7 @@ Note: If an error name is not listed here, please file a bug as indicated at the
                     "<dfn id="typemismatcherror" exception><code>TypeMismatchError</code></dfn>"<br>
                     <dfn id="dom-domexception-type_mismatch_err" for="DOMException" const><code>TYPE_MISMATCH_ERR</code></dfn>&nbsp;(17)
                 </td>
-                <td>Use <emu-val>TypeError</emu-val>.</td>
+                <td>Use {{TypeError}}.</td>
             </tr>
         </tbody>
     </table>

--- a/index.bs
+++ b/index.bs
@@ -4438,7 +4438,7 @@ is identified by one of the following types:
 These correspond to all of the [=ECMAScript error objects=]
 (apart from <emu-val>SyntaxError</emu-val> and <emu-val>Error</emu-val>,
 which are deliberately omitted as they are reserved for use
-by the ECMAScript parser and authors, respectively).
+by the ECMAScript parser and by authors, respectively).
 The meaning of each [=simple exception=] matches
 its corresponding error object in the
 ECMAScript specification.
@@ -4448,7 +4448,7 @@ which is an exception that encapsulates a name and an optional integer code,
 for compatibility with historically defined exceptions in the DOM.
 
 For [=simple exceptions=], the [=error name=] is the type of the exception.
-For a {{DOMException}}, the [=error name=] must be one of the names
+For {{DOMException|DOMExceptions}}, the [=error name=] must be one of the names
 listed in the [=error names table=] below.
 The table also indicates the {{DOMException}}'s integer code for that error name,
 if it has one.

--- a/index.bs
+++ b/index.bs
@@ -4463,7 +4463,8 @@ to be of type {{Error!!interface}}.
 
 [=Simple exceptions=] can be <dfn id="dfn-create-exception" for="exception" export>created</dfn>
 by providing their [=error name=].
-{{DOMException|DOMExceptions}}, by providing their [=error name=] followed by {{DOMException}}.
+{{DOMException|DOMExceptions}} can be [=created=]
+by providing their [=error name=] followed by {{DOMException}}.
 Exceptions can also be <dfn id="dfn-throw" for="exception" export lt="throw|thrown">thrown</dfn>, by providing the
 same details required to [=created|create=] one.
 

--- a/index.bs
+++ b/index.bs
@@ -4465,7 +4465,7 @@ to be of type {{Error!!interface}}.
 by providing their [=error name=].
 {{DOMException|DOMExceptions}} can be [=created=]
 by providing their [=error name=] followed by {{DOMException}}.
-Exceptions can also be <dfn id="dfn-throw" for="exception" export lt="throw|thrown">thrown</dfn>, by providing the
+Exceptions can also be <dfn id="dfn-throw" for="exception" export lt="throw">thrown</dfn>, by providing the
 same details required to [=created|create=] one.
 
 The resulting behavior from creating and throwing an exception is language binding-specific.
@@ -6427,7 +6427,7 @@ it has characteristics as follows:
 </p>
 
 When an algorithm says to
-<dfn lt="es throw" export id="ecmascript-throw">throw a <emu-val><i>Something</i>Error</emu-val></dfn>
+<dfn lt="es throw" id="ecmascript-throw">throw</dfn> a <emu-val><i>Something</i>Error</emu-val>
 then this means to construct a new ECMAScript <emu-val><i>Something</i>Error</emu-val> object
 and to throw it, just as the algorithms in ECMA-262 do.
 
@@ -6853,10 +6853,10 @@ may return any value, which will be discarded.
         then:
 
         1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
-            then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+            then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
         1.  Set |x| to [=!=] <a abstract-op>IntegerPart</a>(|x|).
         1.  If |x| &lt; |lowerBound| or |x| &gt; |upperBound|,
-            then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+            then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
         1.  Return |x|.
 
     1.  If |x| is not <emu-val>NaN</emu-val> and the conversion to an IDL value is being performed due to any of the following:
@@ -6889,7 +6889,7 @@ may return any value, which will be discarded.
 
     1.  Let |x| be [=?=] [=ToNumber=](|V|).
     1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
-        then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Let |S| be the set of finite IEEE 754 single-precision floating
         point values except −0, but with two special values added: 2<sup>128</sup> and
         −2<sup>128</sup>.
@@ -6898,7 +6898,7 @@ may return any value, which will be discarded.
         <em>even significand</em> if there are two [=equally close values=].
         (The two special values 2<sup>128</sup> and −2<sup>128</sup>
         are considered to have even significands for this purpose.)
-    1.  If |y| is 2<sup>128</sup> or −2<sup>128</sup>, then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+    1.  If |y| is 2<sup>128</sup> or −2<sup>128</sup>, then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  If |y| is +0 and |x| is negative, return −0.
     1.  Return |y|.
 </div>
@@ -6962,7 +6962,7 @@ value when its bit pattern is interpreted as an unsigned 32 bit integer.
 
     1.  Let |x| be [=?=] [=ToNumber=](|V|).
     1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
-        then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Return the IDL {{double}} value
         that has the same numeric value as |x|.
 </div>
@@ -7052,7 +7052,7 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
 
     1.  Let |x| be [=ToString=](|V|).
     1.  If the value of any [=element=]
-        of |x| is greater than 255, then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        of |x| is greater than 255, then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Return an IDL {{ByteString}} value
         whose length is the length of |x|, and where the value of each element is
         the value of the corresponding element of |x|.
@@ -7102,7 +7102,7 @@ values are represented by ECMAScript <emu-val>Object</emu-val> values.
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL {{object}} value by running the following algorithm:
 
-    1.  If [=Type=](|V|) is not Object, then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+    1.  If [=Type=](|V|) is not Object, then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Return the IDL {{object}} value that is a reference to the same object as |V|.
 </div>
 
@@ -7125,12 +7125,12 @@ values are represented by ECMAScript <emu-val>Object</emu-val> or
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL [=interface type=] value by running the following algorithm (where |I| is the [=interface=]):
 
-    1.  If [=Type=](|V|) is not Object, then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+    1.  If [=Type=](|V|) is not Object, then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  If |V| is a [=platform object=] that implements |I|, then return the IDL [=interface type=] value that represents a reference to that platform object.
     1.  If |V| is a [=user object=]
         that is considered to implement |I| according to the rules in [[#es-user-objects]], then return the IDL [=interface type=] value that represents a reference to that
         user object, with the [=incumbent settings object=] as the [=callback context=].
-    1.  <a lt="es throw">Throw a <emu-val>TypeError</emu-val></a>.
+    1.  [=es throw|Throw=] a <emu-val>TypeError</emu-val>.
 </div>
 
 <p id="interface-to-es">
@@ -7154,7 +7154,7 @@ the object (or its prototype chain) correspond to [=dictionary members=].
     to an IDL [=dictionary type=] value by
     running the following algorithm (where |D| is the [=dictionary type=]):
 
-    1.  If [=Type=](|V|) is not Undefined, Null or Object, then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+    1.  If [=Type=](|V|) is not Undefined, Null or Object, then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Let |dict| be an empty dictionary value of type |D|;
         every [=dictionary member=]
         is initially considered to be [=present|not present=].
@@ -7219,7 +7219,7 @@ values.
 
     1.  Let |S| be the result of calling [=ToString=](|V|).
     1.  If |S| is not one of |E|’s [=enumeration values=],
-        then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Return the enumeration value of type |E| that is equal to |S|.
 </div>
 
@@ -7250,7 +7250,7 @@ when they can be any object.
         whose type is a [=nullable type|nullable=]
         [=callback function=]
         that is annotated with [{{TreatNonObjectAsNull}}],
-        then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Return the IDL [=callback function type=] value
         that represents a reference to the same object that |V| represents, with the
         [=incumbent settings object=] as the [=callback context=].
@@ -7318,12 +7318,12 @@ ECMAScript <emu-val>Array</emu-val> values.
     to an IDL <a lt="sequence type">sequence&lt;<var ignore>T</var>&gt;</a> value as follows:
 
     1.  If |V| is not an object,
-        <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Let |method| be the result of
         [=GetMethod=](|V|, [=@@iterator=]).
     1.  [=ReturnIfAbrupt=](|method|).
     1.  If |method| is <emu-val>undefined</emu-val>,
-        <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Return the result of [=creating a sequence from an iterable|creating a sequence=]
         from |V| and |method|.
 </div>
@@ -7470,7 +7470,7 @@ ECMAScript <emu-val>Object</emu-val> values.
     1.  If [=Type=](|O|) is Undefined or Null,
         return |result|.
     1.  If [=Type=](|O|) is not Object,
-        <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Let |keys| be [=?=] |O|.\[[OwnPropertyKeys]]().
     1.  Repeat, for each element |key| of |keys| in [=List=] order:
         1.  Let |desc| be [=?=] |O|.\[[GetOwnProperty]](|key|).
@@ -7611,7 +7611,7 @@ objects.
         1.  Otherwise, return the result of performing any steps that were required to be run if the promise was rejected,
             with |reason| as the rejection reason.
     1.  Let |then| be the result of calling the internal \[[Get]] method of |promise| with property name “then”.
-    1.  If |then| is not [=callable=], then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+    1.  If |then| is not [=callable=], then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Return the result of calling |then| with |promise| as the <emu-val>this</emu-val> value and |onFulfilled| and |onRejected|
         as its two arguments.
 </div>
@@ -7735,7 +7735,7 @@ that correspond to the union’s [=member types=].
     1.  If |types| includes a {{boolean}},
         then return the result of [=converted to an IDL value|converting=]
         |V| to {{boolean}}.
-    1.  <a lt="es throw">Throw a <emu-val>TypeError</emu-val></a>.
+    1.  [=es throw|Throw=] a <emu-val>TypeError</emu-val>.
 </div>
 
 <p id="union-to-es">
@@ -7763,7 +7763,7 @@ platform objects for {{DOMException|DOMExceptions}}.
 
     1.  If [=Type=](|V|) is not Object,
         or |V| does not have an \[[ErrorData]] [=internal slot=],
-        then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Return the IDL {{Error!!interface}} value that is a reference
         to the same object as |V|.
 </div>
@@ -7788,7 +7788,7 @@ by platform objects for {{DOMException|DOMExceptions}}.
 
     1.  If [=Type=](|V|) is not Object,
         or |V| is not a platform object that represents a {{DOMException}},
-        then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Return the IDL {{DOMException}} value that is a reference
         to the same object as |V|.
 </div>
@@ -7814,7 +7814,7 @@ are represented by objects of the corresponding ECMAScript class.
     1.  If [=Type=](|V|) is not Object,
         or |V| does not have an \[[ArrayBufferData]] [=internal slot=],
         or [=IsDetachedBuffer=](|V|) is true,
-        then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Return the IDL {{ArrayBuffer}} value that is a reference
         to the same object as |V|.
 </div>
@@ -7826,7 +7826,7 @@ are represented by objects of the corresponding ECMAScript class.
 
     1.  If [=Type=](|V|) is not Object,
         or |V| does not have a \[[DataView]] [=internal slot=],
-        then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Return the IDL {{DataView}} value that is a reference
         to the same object as |V|.
 </div>
@@ -7850,7 +7850,7 @@ are represented by objects of the corresponding ECMAScript class.
     1.  If [=Type=](|V|) is not Object,
         or |V| does not have a \[[TypedArrayName]] [=internal slot=]
         with a value equal to the name of |T|,
-        then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Return the IDL value of type |T| that is a reference to the same object as |V|.
 </div>
 
@@ -7873,12 +7873,12 @@ a reference to the same object that the IDL value represents.
     1.  If |O| has a \[[ViewedArrayBuffer]] [=internal slot=], then:
         1.  Set |arrayBuffer| to the value of |O|’s \[[ViewedArrayBuffer]] [=internal slot=].
         1.  If |arrayBuffer| is <emu-val>undefined</emu-val>, then
-            <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+            [=es throw|throw=] a <emu-val>TypeError</emu-val>.
         1.  Set |offset| to the value of |O|’s \[[ByteOffset]] [=internal slot=].
         1.  Set |length| to the value of |O|’s \[[ByteLength]] [=internal slot=].
     1.  Otherwise, set |length| to the value of |O|’s \[[ArrayBufferByteLength]] [=internal slot=].
     1.  If [=IsDetachedBuffer=](|O|), then
-        <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Let |data| be the value of |O|’s \[[ArrayBufferData]] [=internal slot=].
     1.  Return a reference to or copy of (as required) the |length| bytes in |data|
         starting at byte offset |offset|.
@@ -9735,7 +9735,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
     1.  Let |maxarg| be the length of the longest type list of the entries in |S|.
     1.  Initialize |argcount| to be min(|maxarg|, |n|).
     1.  Remove from |S| all entries whose type list is not of length |argcount|.
-    1.  If |S| is empty, then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+    1.  If |S| is empty, then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Initialize |d| to −1.
     1.  Initialize |method| to <emu-val>undefined</emu-val>.
     1.  If there is more than one entry in |S|, then set
@@ -9923,7 +9923,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
 
         1.  Otherwise: if there is an entry in |S| that has {{any}} at position |i|
             of its type list, then remove from |S| all other entries.
-        1.  Otherwise: <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        1.  Otherwise: [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Let |callable| be the [=operation=] or [=extended attribute=]
         of the single entry in |S|.
     1.  If |i| = |d| and |method| is not <emu-val>undefined</emu-val>, then
@@ -10110,9 +10110,9 @@ both as a function and as a constructor.
 
     1.  If |I| was not declared with a [{{Constructor}}]
         [=extended attribute=], then
-        <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  If [=NewTarget=] is <emu-val>undefined</emu-val>, then
-        <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Let |id| be the identifier of interface |I|.
     1.  Initialize |S| to the
         [=effective overload set=]
@@ -10165,7 +10165,7 @@ whose value is the identifier of the corresponding interface.
 
     1.  If |V| is not an object, return <emu-val>false</emu-val>.
     1.  Let |O| be the result of calling the \[[Get]] method of |A| with property name “prototype”.
-    1.  If |O| is not an object, <a lt="es throw">throw a <emu-val>TypeError</emu-val></a> exception.
+    1.  If |O| is not an object, [=es throw|throw=] a <emu-val>TypeError</emu-val> exception.
     1.  If |V| is a platform object that implements the
         interface for which |O| is the [=interface prototype object=],
         return <emu-val>true</emu-val>.
@@ -10546,7 +10546,7 @@ The characteristics of this property are as follows:
                 1.  If the [=attribute=] was specified with the
                     [{{LenientThis}}] [=extended attribute=],
                     then return <emu-val>undefined</emu-val>.
-                1.  Otherwise, <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+                1.  Otherwise, [=es throw|throw=] a <emu-val>TypeError</emu-val>.
             1.  Set |idlValue| to be the result of performing the actions listed in the description of the attribute that occur when getting
                 (or those listed in the description of the inherited attribute, if this attribute is declared to
                 [=inherit its getter=]),
@@ -10574,7 +10574,7 @@ The characteristics of this property are as follows:
         Otherwise, it is a <emu-val>Function</emu-val> object whose behavior when invoked is as follows:
 
         1.  If no arguments were passed to the <emu-val>Function</emu-val>, then
-            <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+            [=es throw|throw=] a <emu-val>TypeError</emu-val>.
         1.  Let |V| be the value of the first argument passed to the <emu-val>Function</emu-val>.
         1.  If the [=attribute=] is a [=regular attribute=], then:
             1.  Let |I| be the [=interface=]
@@ -10592,7 +10592,7 @@ The characteristics of this property are as follows:
             1.  If |validThis| is <emu-val>false</emu-val> and the
                 [=attribute=] was not specified with the
                 [{{LenientThis}}] [=extended attribute=],
-                then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+                then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
             1.  If the attribute is declared with a [{{Replaceable}}]
                 extended attribute, then:
                 1.  Let |P| be the identifier of the attribute.
@@ -10605,7 +10605,7 @@ The characteristics of this property are as follows:
                 extended attribute, then:
                 1.  Let |Q| be the result of calling the \[[Get]] method
                     on |O| using the identifier of the attribute as the property name.
-                1.  If |Q| is not an object, then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+                1.  If |Q| is not an object, then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
                 1.  Let |A| be the attribute identified by the [{{PutForwards}}] extended attribute.
                 1.  Call the \[[Put]] method on |Q|
                     using the identifier of |A| as the property name and |V| as the value.
@@ -10711,7 +10711,7 @@ property-installation style as namespaces.)
                 1.  If |O| is a [=platform object=], then [=perform a security check=], passing |O|,
                     |id|, and "method".
                 1.  If |O| is not a [=platform object=] that implements the interface |target|,
-                    <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+                    [=es throw|throw=] a <emu-val>TypeError</emu-val>.
             1.  Let |S| be the [=effective overload set=] for [=regular operations=] (if |op| is a
                 regular operation) or for [=static operations=] (if |op| is a static operation) with
                 [=identifier=] |id| on |target| and with argument count |n|.
@@ -10768,7 +10768,7 @@ then there must exist a property with the following characteristics:
             *   the [=identifier=] of the [=stringifier=], and
             *   the type “method”.
         1.  If |O| is not an object that implements the [=interface=]
-            on which the stringifier was declared, then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+            on which the stringifier was declared, then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
         1.  Let |V| be an uninitialized variable.
         1.  Depending on where <code>stringifier</code> was specified:
             <dl class="switch">
@@ -10823,7 +10823,7 @@ The location of the property is determined as follows:
         *   the [=identifier=] of the [=serializer=], and
         *   the type “method”.
     1.  If |O| is not an object that implements the [=interface=]
-        on which the serializer was declared, then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        on which the serializer was declared, then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Depending on how <code>serializer</code> was specified:
         <dl class="switch">
              :  on an [=operation=] with an identifier
@@ -10922,7 +10922,7 @@ then the <emu-val>Function</emu-val> object is [=%ArrayProto_values%=].
     1.  Let |interface| be the [=interface=]
         the [=iterable declaration=] is on.
     1.  If |object| is not a [=platform object=] that implements |interface|,
-        then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Let |iterator| be a newly created [=default iterator object=]
         for |interface| with |object| as its target and iterator kind “key+value”.
     1.  Return |iterator|.
@@ -10944,7 +10944,7 @@ then the <emu-val>Function</emu-val> object is [=%ArrayProto_values%=].
         that implements the [=interface=]
         on which the [=maplike declaration=]
         or [=setlike declaration=] is defined,
-        then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  If the interface has a [=maplike declaration=], then:
         1.  Let |backing| be the value of the \[[BackingMap]] [=internal slot=] of |object|.
         1.  Return [=CreateMapIterator=](|backing|, <code>"key+value"</code>).
@@ -11037,9 +11037,9 @@ the initial value of the “forEach” data property of [=%ArrayPrototype%=].
         or [=setlike declaration=] is declared.
     1.  If |object| is not a [=platform object=]
         that implements |interface|,
-        then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Let |callbackFn| be the value of the first argument passed to the function, or <emu-val>undefined</emu-val> if the argument was not supplied.
-    1.  If [=IsCallable=](|callbackFn|) is <emu-val>false</emu-val>, <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+    1.  If [=IsCallable=](|callbackFn|) is <emu-val>false</emu-val>, [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Let |thisArg| be the value of the second argument passed to the function, or <emu-val>undefined</emu-val> if the argument was not supplied.
     1.  Let |backing| be the value of the \[[BackingMap]] [=internal slot=] of |object|,
         if the interface has a [=maplike declaration=],
@@ -11059,7 +11059,7 @@ the initial value of the “forEach” data property of [=%ArrayPrototype%=].
         </p>
     1.  Let |forEach| be the result of calling the \[[Get]] internal method of
         |backing| with “forEach” and |backing| as arguments.
-    1.  If [=IsCallable=](|forEach|) is <emu-val>false</emu-val>, <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+    1.  If [=IsCallable=](|forEach|) is <emu-val>false</emu-val>, [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  [=Call=](|forEach|, |backing|, «|callbackWrapper|, |thisArg|»).
     1.  Return <emu-val>undefined</emu-val>.
 </div>
@@ -11138,7 +11138,7 @@ the initial value of the “keys” data property of [=%ArrayPrototype%=].
         on which the [=iterable declaration=] is declared on.
     1.  If |object| is not a [=platform object=]
         that implements |interface|,
-        then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Let |iterator| be a newly created [=default iterator object=]
         for |interface| with |object| as its target and iterator kind “key”.
     1.  Return |iterator|.
@@ -11187,7 +11187,7 @@ the value of the [=@@iterator=] property.
         on which the [=iterable declaration=] is declared on.
     1.  If |object| is not a [=platform object=]
         that implements |interface|,
-        then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Let |iterator| be a newly created [=default iterator object=]
         for |interface| with |object| as its target and iterator kind “value”.
     1.  Return |iterator|.
@@ -11254,7 +11254,7 @@ must be [=%IteratorPrototype%=].
         *   the identifier “next”, and
         *   the type “method”.
     1.  If |object| is not a [=default iterator object=] for |interface|,
-        then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Let |index| be |object|’s index.
     1.  Let |kind| be |object|’s kind.
     1.  Let |values| be the list of [=value pairs to iterate over=].
@@ -11320,10 +11320,10 @@ These additional properties are described in the sub-sections below.
         *   the platform object |O|,
         *   an identifier equal to |name|, and
         *   the type “method”.
-    1.  If |O| is not an object that implements <var ignore>A</var>, then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+    1.  If |O| is not an object that implements <var ignore>A</var>, then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Let |map| be the <emu-val>Map</emu-val> object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
     1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing |name| and |map| as arguments.
-    1.  If [=IsCallable=](|function|) is <emu-val>false</emu-val>, then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+    1.  If [=IsCallable=](|function|) is <emu-val>false</emu-val>, then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Return [=Call=](|function|, |map|, |arguments|).
 </div>
 
@@ -11349,7 +11349,7 @@ with the following characteristics:
             *   the platform object |O|,
             *   the identifier “size”, and
             *   the type “getter”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
         1.  Let |map| be the <emu-val>Map</emu-val> object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Return the result of calling the \[[Get]] internal method of |map| passing “size” and |map| as arguments.
     </div>
@@ -11401,7 +11401,7 @@ For both of “get” and “has”, there must exist a property with that name 
             *   the platform object |O|,
             *   an identifier equal to |name|, and
             *   the type “method”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
         1.  Let |map| be the <emu-val>Map</emu-val> object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| be the key type specified in the [=maplike declaration=].
         1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing |name| and |map| as arguments.
@@ -11457,7 +11457,7 @@ must exist on |A|’s
             *   the platform object |O|,
             *   the identifier “delete”, and
             *   the type “method”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
         1.  Let |map| be the <emu-val>Map</emu-val> object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| be the key type specified in the [=maplike declaration=].
         1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing “delete” and |map| as arguments.
@@ -11492,7 +11492,7 @@ must exist on |A|’s [=interface prototype object=]:
             *   the platform object |O|,
             *   the identifier “set”, and
             *   the type “method”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
         1.  Let |map| be the <emu-val>Map</emu-val> object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| and |valueType| be the key and value types specified in the [=maplike declaration=].
         1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing “set” and |map| as arguments.
@@ -11540,13 +11540,13 @@ These additional properties are described in the sub-sections below.
         *   an identifier equal to |name|, and
         *   the type “method”.
     1.  If |O| is not an object that implements <var ignore>A</var>,
-        then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Let |set| be the <emu-val>Set</emu-val> object that is
         the value of |O|’s \[[BackingSet]] [=internal slot=].
     1.  Let |function| be the result of calling the \[[Get]] internal method of |set|
         passing |name| and |set| as arguments.
     1.  If [=IsCallable=](|function|) is <emu-val>false</emu-val>,
-        then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Return [=Call=](|function|, |set|, |arguments|).
 </div>
 
@@ -11570,7 +11570,7 @@ with the following characteristics:
             *   the platform object |O|,
             *   the identifier “size”, and
             *   the type “getter”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
         1.  Let |set| be the <emu-val>Set</emu-val> object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
         1.  Return the result of calling the \[[Get]] internal method of |set| passing “size” and |set| as arguments.
     </div>
@@ -11622,7 +11622,7 @@ with the following characteristics:
             *   the platform object |O|,
             *   the identifier “has”, and
             *   the type “method”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
         1.  Let |set| be the <emu-val>Set</emu-val> object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
         1.  Let |type| be the value type specified in the [=setlike declaration=].
         1.  Let |function| be the result of calling the \[[Get]] internal method of |set| passing “has” and |set| as arguments.
@@ -11663,7 +11663,7 @@ must exist on |A|’s
             *   the platform object |O|,
             *   an identifier equal to |name|, and
             *   the type “method”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=es throw|throw=] a <emu-val>TypeError</emu-val>.
         1.  Let |set| be the <emu-val>Set</emu-val> object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
         1.  Let |type| be the value type specified in the [=setlike declaration=].
         1.  Let |function| be the result of calling the \[[Get]] internal method of |set| passing |name| and |set| as arguments.
@@ -11959,7 +11959,7 @@ and [[#legacy-platform-object-set]].
     assuming |arg|<sub>0..|n|−1</sub> is the list of argument values passed to \[[Call]]:
 
     1.  If |I| has no [=legacy callers=],
-        <a lt="es throw">throw a <emu-val>TypeError</emu-val></a>.
+        [=es throw|throw=] a <emu-val>TypeError</emu-val>.
     1.  Initialize |S| to the [=effective overload set=]
         for legacy callers on |I| and with argument count |n|.
     1.  Let &lt;|operation|, |values|&gt; be the result of passing |S| and
@@ -12607,7 +12607,7 @@ on exception objects too.
 
 <div algorithm="throw an exception">
 
-    When a [=simple exception=] or {{DOMException}} |E| is to be [=thrown=],
+    When a [=simple exception=] or {{DOMException}} |E| is to be [=throw|thrown=],
     with [=error name=] |N| and optional user agent-defined message |M|,
     the following steps must be followed:
 

--- a/index.bs
+++ b/index.bs
@@ -4427,7 +4427,7 @@ user agent-defined value that provides human readable details of the error.
 
 There are two kinds of exceptions available to be thrown from specifications.
 The first is a <dfn id="dfn-simple-exception" export>simple exception</dfn>, which
-is identified by one of the following names:
+is identified by one of the following types:
 
 *   <dfn exception>EvalError</dfn>
 *   <dfn exception>RangeError</dfn>
@@ -4447,7 +4447,7 @@ The second kind of exception is a <dfn id="dfn-DOMException" interface export>DO
 which is an exception that encapsulates a name and an optional integer code,
 for compatibility with historically defined exceptions in the DOM.
 
-For [=simple exceptions=], the [=error name=] is the name of the exception.
+For [=simple exceptions=], the [=error name=] is the type of the exception.
 For a {{DOMException}}, the [=error name=] must be one of the names
 listed in the [=error names table=] below.
 The table also indicates the {{DOMException}}'s integer code for that error name,

--- a/index.bs
+++ b/index.bs
@@ -4427,13 +4427,13 @@ user agent-defined value that provides human readable details of the error.
 
 There are two kinds of exceptions available to be thrown from specifications.
 The first is a <dfn id="dfn-simple-exception" export>simple exception</dfn>, which
-is identified by one of the following type values:
+is identified by one of the following names:
 
-*   <emu-val>EvalError</emu-val>
-*   <emu-val>RangeError</emu-val>
-*   <emu-val>ReferenceError</emu-val>
-*   <emu-val>TypeError</emu-val>
-*   <emu-val>URIError</emu-val>
+*   <dfn exception>EvalError</dfn>
+*   <dfn exception>RangeError</dfn>
+*   <dfn exception>ReferenceError</dfn>
+*   <dfn exception>TypeError</dfn>
+*   <dfn exception>URIError</dfn>
 
 These correspond to all of the [=ECMAScript error objects=]
 (apart from <emu-val>SyntaxError</emu-val> and <emu-val>Error</emu-val>,
@@ -4475,10 +4475,10 @@ entails in the ECMAScript language binding.
 <div class="example">
 
     Here is are some examples of wording to use to create and throw exceptions.
-    To throw a new [=simple exception=] named <emu-val>TypeError</emu-val>:
+    To throw a new [=simple exception=] named {{TypeError}}:
 
     <blockquote>
-        [=Throw=] a <emu-val>TypeError</emu-val>.
+        [=Throw=] a {{TypeError}}.
     </blockquote>
 
     To throw a new {{DOMException}} with [=error name=] "{{IndexSizeError!!exception}}":

--- a/index.html
+++ b/index.html
@@ -1557,7 +1557,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web IDL</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-11">11 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-13">13 December 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -5011,7 +5011,7 @@ is identified by one of the following types:</p>
    </ul>
    <p>These correspond to all of the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-error-objects">ECMAScript error objects</a> (apart from <emu-val>SyntaxError</emu-val> and <emu-val>Error</emu-val>,
 which are deliberately omitted as they are reserved for use
-by the ECMAScript parser and authors, respectively).
+by the ECMAScript parser and by authors, respectively).
 The meaning of each <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-1">simple exception</a> matches
 its corresponding error object in the
 ECMAScript specification.</p>
@@ -5019,7 +5019,7 @@ ECMAScript specification.</p>
 which is an exception that encapsulates a name and an optional integer code,
 for compatibility with historically defined exceptions in the DOM.</p>
    <p>For <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-2">simple exceptions</a>, the <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-1">error name</a> is the type of the exception.
-For a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-1">DOMException</a></code>, the <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-2">error name</a> must be one of the names
+For <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-1">DOMExceptions</a></code>, the <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-2">error name</a> must be one of the names
 listed in the <a data-link-type="dfn" href="#dfn-error-names-table" id="ref-for-dfn-error-names-table-1">error names table</a> below.
 The table also indicates the <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-2">DOMException</a></code>'s integer code for that error name,
 if it has one.</p>

--- a/index.html
+++ b/index.html
@@ -5001,7 +5001,7 @@ is identified by one of the following names:</p>
     <li data-md="">
      <p><dfn class="idl-code" data-dfn-type="exception" data-export="" id="exceptiondef-evalerror">EvalError<a class="self-link" href="#exceptiondef-evalerror"></a></dfn></p>
     <li data-md="">
-     <p><dfn class="idl-code" data-dfn-type="exception" data-export="" id="exceptiondef-rangeerror">RangeError<a class="self-link" href="#exceptiondef-rangeerror"></a></dfn></p>
+     <p><dfn class="dfn-paneled idl-code" data-dfn-type="exception" data-export="" id="exceptiondef-rangeerror">RangeError</dfn></p>
     <li data-md="">
      <p><dfn class="idl-code" data-dfn-type="exception" data-export="" id="exceptiondef-referenceerror">ReferenceError<a class="self-link" href="#exceptiondef-referenceerror"></a></dfn></p>
     <li data-md="">
@@ -5184,21 +5184,21 @@ for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-f
      <tbody>
       <tr>
        <td> "<dfn class="idl-code" data-dfn-type="exception" data-export="" id="domstringsizeerror"><code>DOMStringSizeError</code><a class="self-link" href="#domstringsizeerror"></a></dfn>"<br> <dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-domstring_size_err"><code>DOMSTRING_SIZE_ERR</code><a class="self-link" href="#dom-domexception-domstring_size_err"></a></dfn> (2) 
-       <td>Use <emu-val>RangeError</emu-val>.
+       <td>Use <code class="idl"><a data-link-type="idl" href="#exceptiondef-rangeerror" id="ref-for-exceptiondef-rangeerror-1">RangeError</a></code>.
       <tr>
        <td> "<dfn class="idl-code" data-dfn-type="exception" data-export="" id="nodataallowederror"><code>NoDataAllowedError</code><a class="self-link" href="#nodataallowederror"></a></dfn>"<br> <dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-no_data_allowed_err"><code>NO_DATA_ALLOWED_ERR</code><a class="self-link" href="#dom-domexception-no_data_allowed_err"></a></dfn> (6) 
        <td>—
       <tr>
        <td> "<dfn class="idl-code" data-dfn-type="exception" data-export="" id="invalidaccesserror"><code>InvalidAccessError</code><a class="self-link" href="#invalidaccesserror"></a></dfn>"<br> <dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-invalid_access_err"><code>INVALID_ACCESS_ERR</code><a class="self-link" href="#dom-domexception-invalid_access_err"></a></dfn> (15) 
-       <td> Use <emu-val>TypeError</emu-val> for invalid arguments,
-                    "<code class="idl"><a class="idl-code" data-link-type="exception" href="#notsupportederror" id="ref-for-notsupportederror-1">NotSupportedError</a></code>" for unsupported operations, and
-                    "<code class="idl"><a class="idl-code" data-link-type="exception" href="#notallowederror" id="ref-for-notallowederror-1">NotAllowedError</a></code>" for denied requests. 
+       <td> Use <code class="idl"><a data-link-type="idl" href="#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror-3">TypeError</a></code> for invalid arguments,
+                    "<code class="idl"><a class="idl-code" data-link-type="exception" href="#notsupportederror" id="ref-for-notsupportederror-1">NotSupportedError</a></code>" <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-14">DOMException</a></code> for unsupported operations, and
+                    "<code class="idl"><a class="idl-code" data-link-type="exception" href="#notallowederror" id="ref-for-notallowederror-1">NotAllowedError</a></code>" <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-15">DOMException</a></code> for denied requests. 
       <tr>
        <td> "<dfn class="idl-code" data-dfn-type="exception" data-export="" id="validationerror"><code>ValidationError</code><a class="self-link" href="#validationerror"></a></dfn>"<br> <dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-validation_err"><code>VALIDATION_ERR</code><a class="self-link" href="#dom-domexception-validation_err"></a></dfn> (16) 
        <td>—
       <tr>
        <td> "<dfn class="idl-code" data-dfn-type="exception" data-export="" id="typemismatcherror"><code>TypeMismatchError</code><a class="self-link" href="#typemismatcherror"></a></dfn>"<br> <dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-type_mismatch_err"><code>TYPE_MISMATCH_ERR</code><a class="self-link" href="#dom-domexception-type_mismatch_err"></a></dfn> (17) 
-       <td>Use <emu-val>TypeError</emu-val>.
+       <td>Use <code class="idl"><a data-link-type="idl" href="#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror-4">TypeError</a></code>.
     </table>
    </div>
    <h3 class="heading settled" data-level="2.6" id="idl-enums"><span class="secno">2.6. </span><span class="content">Enumerations</span><a class="self-link" href="#idl-enums"></a></h3>
@@ -5454,7 +5454,7 @@ object that are considered to be platform objects:</p>
     <li data-md="">
      <p>objects that implement a non-<a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-13">callback</a> <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-49">interface</a>;</p>
     <li data-md="">
-     <p>objects representing IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-14">DOMExceptions</a></code>.</p>
+     <p>objects representing IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-16">DOMExceptions</a></code>.</p>
    </ul>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-legacy-platform-object">Legacy platform objects</dfn> are <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-7">platform objects</a> that implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-50">interface</a> which
 does not have a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-5">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-6">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-21">extended attribute</a>, <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-9">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-4">named properties</a>,
@@ -5488,7 +5488,7 @@ corresponding to each type, and how <a data-link-type="dfn" href="#dfn-constant"
 the <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-3">integer types</a>, <code class="idl"><a data-link-type="idl" href="#idl-float" id="ref-for-idl-float-4">float</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-unrestricted-float" id="ref-for-idl-unrestricted-float-5">unrestricted float</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-double" id="ref-for-idl-double-11">double</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-unrestricted-double" id="ref-for-idl-unrestricted-double-6">unrestricted double</a></code>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-primitive-type">primitive types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref-for-idl-boolean-6">boolean</a></code> and the <a data-link-type="dfn" href="#dfn-numeric-type" id="ref-for-dfn-numeric-type-5">numeric types</a>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-string-type">string types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-26">DOMString</a></code>, all <a data-link-type="dfn" href="#idl-enumeration" id="ref-for-idl-enumeration-1">enumeration types</a>, <code class="idl"><a data-link-type="idl" href="#idl-ByteString" id="ref-for-idl-ByteString-3">ByteString</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-USVString" id="ref-for-idl-USVString-4">USVString</a></code>.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exception-type">exception types</dfn> are <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-3">Error</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-15">DOMException</a></code>.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exception-type">exception types</dfn> are <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-3">Error</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-17">DOMException</a></code>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-typed-array-type">typed array types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-Int8Array" id="ref-for-idl-Int8Array-1">Int8Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Int16Array" id="ref-for-idl-Int16Array-1">Int16Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Int32Array" id="ref-for-idl-Int32Array-1">Int32Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint8Array" id="ref-for-idl-Uint8Array-1">Uint8Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint16Array" id="ref-for-idl-Uint16Array-1">Uint16Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint32Array" id="ref-for-idl-Uint32Array-1">Uint32Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint8ClampedArray" id="ref-for-idl-Uint8ClampedArray-1">Uint8ClampedArray</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Float32Array" id="ref-for-idl-Float32Array-1">Float32Array</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-Float64Array" id="ref-for-idl-Float64Array-1">Float64Array</a></code>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-buffer-source-type">buffer source types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-ArrayBuffer" id="ref-for-idl-ArrayBuffer-1">ArrayBuffer</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-DataView" id="ref-for-idl-DataView-1">DataView</a></code>,
 and the <a data-link-type="dfn" href="#dfn-typed-array-type" id="ref-for-dfn-typed-array-type-1">typed array types</a>.</p>
@@ -6027,15 +6027,15 @@ and joining them with the string “Or”.</p>
    <div data-fill-with="grammar-NonAnyType"></div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-level="2.11.28" data-lt="Error" id="idl-Error"><span class="secno">2.11.28. </span><span class="content">Error</span><span id="dom-Error"></span></h4>
    <p>The <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-4">Error</a></code> type corresponds to the
-set of all possible non-null references to exception objects, including <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-5">simple exceptions</a> and <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-16">DOMExceptions</a></code>.</p>
+set of all possible non-null references to exception objects, including <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-5">simple exceptions</a> and <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-18">DOMExceptions</a></code>.</p>
    <p>There is no way to represent a constant <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-5">Error</a></code> value in IDL.</p>
    <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-28">type name</a> of the <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-6">Error</a></code> type is “Error”.</p>
    <h4 class="heading settled" data-level="2.11.29" id="idl-DOMException"><span class="secno">2.11.29. </span><span class="content">DOMException</span><a class="self-link" href="#idl-DOMException"></a></h4>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-17">DOMException</a></code> type corresponds to the
+   <p>The <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-19">DOMException</a></code> type corresponds to the
 set of all possible non-null references to objects
-representing <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-18">DOMExceptions</a></code>.</p>
-   <p>There is no way to represent a constant <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-19">DOMException</a></code> value in IDL.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-29">type name</a> of the <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-20">DOMException</a></code> type is “DOMException”.</p>
+representing <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-20">DOMExceptions</a></code>.</p>
+   <p>There is no way to represent a constant <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-21">DOMException</a></code> value in IDL.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-29">type name</a> of the <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-22">DOMException</a></code> type is “DOMException”.</p>
    <h4 class="heading settled" data-level="2.11.30" id="idl-buffer-source-types"><span class="secno">2.11.30. </span><span class="content">Buffer source types</span><a class="self-link" href="#idl-buffer-source-types"></a></h4>
    <p>There are a number of types that correspond to sets of all possible non-null
 references to objects that represent a buffer of data or a view on to a buffer of
@@ -7417,10 +7417,10 @@ result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id
 that is a reference to the object <var>V</var>.</p>
       </ol>
      <li data-md="">
-      <p>If <var>V</var> is a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-21">DOMException</a></code> platform object, then:</p>
+      <p>If <var>V</var> is a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-23">DOMException</a></code> platform object, then:</p>
       <ol>
        <li data-md="">
-        <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-22">DOMException</a></code> or <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-7">Error</a></code>, then return the
+        <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-24">DOMException</a></code> or <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-7">Error</a></code>, then return the
 result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-38">converting</a> <var>V</var> to that type.</p>
        <li data-md="">
         <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-16">object</a></code>, then return the IDL value
@@ -7544,7 +7544,7 @@ then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-
    <h4 class="heading settled" data-level="3.2.22" id="es-Error"><span class="secno">3.2.22. </span><span class="content">Error</span><a class="self-link" href="#es-Error"></a></h4>
    <p>IDL <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-10">Error</a></code> values are represented
 by native ECMAScript <emu-val>Error</emu-val> objects and
-platform objects for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-23">DOMExceptions</a></code>.</p>
+platform objects for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-25">DOMExceptions</a></code>.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to Error" id="es-to-Error">
     <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-52">converted</a> to an IDL <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-11">Error</a></code> value by running the following algorithm:</p>
     <ol>
@@ -7561,23 +7561,23 @@ to the same object as <var>V</var>.</p>
     value is the <emu-val>Error</emu-val> value that represents a reference to the same object that the
     IDL <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-14">Error</a></code> represents. </p>
    <h4 class="heading settled" data-level="3.2.23" id="es-DOMException"><span class="secno">3.2.23. </span><span class="content">DOMException</span><a class="self-link" href="#es-DOMException"></a></h4>
-   <p>IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-24">DOMException</a></code> values are represented
-by platform objects for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-25">DOMExceptions</a></code>.</p>
+   <p>IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-26">DOMException</a></code> values are represented
+by platform objects for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-27">DOMExceptions</a></code>.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to DOMException" id="es-to-DOMException">
-    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-53">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-26">DOMException</a></code> value by running the following algorithm:</p>
+    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-53">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-28">DOMException</a></code> value by running the following algorithm:</p>
     <ol>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
-or <var>V</var> is not a platform object that represents a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-27">DOMException</a></code>,
+or <var>V</var> is not a platform object that represents a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-29">DOMException</a></code>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-19">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
-      <p>Return the IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-28">DOMException</a></code> value that is a reference
+      <p>Return the IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-30">DOMException</a></code> value that is a reference
 to the same object as <var>V</var>.</p>
     </ol>
    </div>
-   <p id="DOMException-to-es"> The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-34">converting</a> an IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-29">DOMException</a></code> value to an ECMAScript
+   <p id="DOMException-to-es"> The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-34">converting</a> an IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-31">DOMException</a></code> value to an ECMAScript
     value is the <emu-val>Object</emu-val> value that represents a reference to the same object that the
-    IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-30">DOMException</a></code> represents. </p>
+    IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-32">DOMException</a></code> represents. </p>
    <h4 class="heading settled" data-level="3.2.24" id="es-buffer-source-types"><span class="secno">3.2.24. </span><span class="content">Buffer source types</span><a class="self-link" href="#es-buffer-source-types"></a></h4>
    <p>Values of the IDL <a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-2">buffer source types</a> are represented by objects of the corresponding ECMAScript class.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to buffer source" id="es-to-buffer-source">
@@ -9008,11 +9008,11 @@ that has one of the above types in its <a data-link-type="dfn" href="#dfn-flatte
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
        <li data-md="">
-        <p>Otherwise: if <var>V</var> is a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-31">DOMException</a></code> platform object and
+        <p>Otherwise: if <var>V</var> is a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-33">DOMException</a></code> platform object and
 there is an entry in <var>S</var> that has one of the following types at position <var>i</var> of its type list,</p>
         <ul>
          <li data-md="">
-          <p><code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-32">DOMException</a></code></p>
+          <p><code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-34">DOMException</a></code></p>
          <li data-md="">
           <p><code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-15">Error</a></code></p>
          <li data-md="">
@@ -11993,7 +11993,7 @@ attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[E
    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="3.14" data-lt="Exception objects" data-noexport="" id="es-exception-objects"><span class="secno">3.14. </span><span class="content">Exception objects</span></h3>
    <p><a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-6">Simple exceptions</a> are represented
 by native ECMAScript objects of the corresponding type.</p>
-   <p><code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-33">DOMExceptions</a></code> are represented by <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-54">platform objects</a> that inherit from
+   <p><code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-35">DOMExceptions</a></code> are represented by <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-54">platform objects</a> that inherit from
 the <a data-link-type="dfn" href="#dfn-DOMException-prototype-object" id="ref-for-dfn-DOMException-prototype-object-3">DOMException prototype object</a>.</p>
    <p>Every platform object representing a DOMException in ECMAScript is associated with a global environment, just
 as the <a data-link-type="dfn" href="#dfn-initial-object" id="ref-for-dfn-initial-object-5">initial objects</a> are.
@@ -12001,8 +12001,8 @@ When an exception object is created by calling the <a data-link-type="dfn" href=
 either normally or as part of a <code>new</code> expression, then the global environment
 of the newly created object is associated with must be the same as for the <a data-link-type="dfn" href="#dfn-DOMException-constructor-object" id="ref-for-dfn-DOMException-constructor-object-4">DOMException constructor object</a> itself.</p>
    <p>The value of the internal [[Prototype]]
-property of a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-34">DOMException</a></code> object must be the <a data-link-type="dfn" href="#dfn-DOMException-prototype-object" id="ref-for-dfn-DOMException-prototype-object-4">DOMException prototype object</a> from the global environment the exception object is associated with.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-7">class string</a> of a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-35">DOMException</a></code> object
+property of a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-36">DOMException</a></code> object must be the <a data-link-type="dfn" href="#dfn-DOMException-prototype-object" id="ref-for-dfn-DOMException-prototype-object-4">DOMException prototype object</a> from the global environment the exception object is associated with.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-7">class string</a> of a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-37">DOMException</a></code> object
 must be “DOMException”.</p>
    <p class="note" role="note">Note: The intention is for DOMException objects to be just like the other
 various native <emu-val>Error</emu-val> objects that the
@@ -12038,7 +12038,7 @@ exception field was defined.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="to create a simple exception or DOMException">
-    <p>When a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-7">simple exception</a> or <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-36">DOMException</a></code> <var>E</var> is to be <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-3">created</a>,
+    <p>When a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-7">simple exception</a> or <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-38">DOMException</a></code> <var>E</var> is to be <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-3">created</a>,
     with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-7">error name</a> <var>N</var> and optional user agent-defined message <var>M</var>,
     the following steps must be followed:</p>
     <ol>
@@ -12050,7 +12050,7 @@ exception field was defined.</p>
       <p>Let <var>args</var> be a list of ECMAScript values.</p>
       <dl class="switch">
        <dt data-md="">
-        <p><var>E</var> is <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-37">DOMException</a></code></p>
+        <p><var>E</var> is <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-39">DOMException</a></code></p>
        <dd data-md="">
         <p><var>args</var> is (<emu-val>undefined</emu-val>, <var>N</var>).</p>
        <dt data-md="">
@@ -12064,7 +12064,7 @@ exception field was defined.</p>
       <p>Let <var>X</var> be an object determined based on the type of <var>E</var>:</p>
       <dl class="switch">
        <dt data-md="">
-        <p><var>E</var> is <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-38">DOMException</a></code></p>
+        <p><var>E</var> is <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-40">DOMException</a></code></p>
        <dd data-md="">
         <p><var>X</var> is the <a data-link-type="dfn" href="#dfn-DOMException-constructor-object" id="ref-for-dfn-DOMException-constructor-object-5">DOMException constructor object</a> from the global environment <var>G</var>.</p>
        <dt data-md="">
@@ -12081,7 +12081,7 @@ with <var>args</var> as the argument list.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="throw an exception">
-    <p>When a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-10">simple exception</a> or <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-39">DOMException</a></code> <var>E</var> is to be <a data-link-type="dfn" href="#dfn-throw" id="ref-for-dfn-throw-3">thrown</a>,
+    <p>When a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-10">simple exception</a> or <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-41">DOMException</a></code> <var>E</var> is to be <a data-link-type="dfn" href="#dfn-throw" id="ref-for-dfn-throw-3">thrown</a>,
     with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-8">error name</a> <var>N</var> and optional user agent-defined message <var>M</var>,
     the following steps must be followed:</p>
     <ol>
@@ -14196,27 +14196,34 @@ language binding.</p>
     <li><a href="#ref-for-dfn-simple-exception-7">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-simple-exception-8">(2)</a> <a href="#ref-for-dfn-simple-exception-9">(3)</a> <a href="#ref-for-dfn-simple-exception-10">(4)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="exceptiondef-rangeerror">
+   <b><a href="#exceptiondef-rangeerror">#exceptiondef-rangeerror</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-exceptiondef-rangeerror-1">2.5.1. Error names</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="exceptiondef-typeerror">
    <b><a href="#exceptiondef-typeerror">#exceptiondef-typeerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror-1">2.5. Exceptions</a> <a href="#ref-for-exceptiondef-typeerror-2">(2)</a>
+    <li><a href="#ref-for-exceptiondef-typeerror-3">2.5.1. Error names</a> <a href="#ref-for-exceptiondef-typeerror-4">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-DOMException">
    <b><a href="#dfn-DOMException">#dfn-DOMException</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-DOMException-1">2.5. Exceptions</a> <a href="#ref-for-dfn-DOMException-2">(2)</a> <a href="#ref-for-dfn-DOMException-3">(3)</a> <a href="#ref-for-dfn-DOMException-4">(4)</a> <a href="#ref-for-dfn-DOMException-5">(5)</a> <a href="#ref-for-dfn-DOMException-6">(6)</a> <a href="#ref-for-dfn-DOMException-7">(7)</a> <a href="#ref-for-dfn-DOMException-8">(8)</a> <a href="#ref-for-dfn-DOMException-9">(9)</a> <a href="#ref-for-dfn-DOMException-10">(10)</a>
-    <li><a href="#ref-for-dfn-DOMException-11">2.5.1. Error names</a> <a href="#ref-for-dfn-DOMException-12">(2)</a> <a href="#ref-for-dfn-DOMException-13">(3)</a>
-    <li><a href="#ref-for-dfn-DOMException-14">2.10. Objects implementing interfaces</a>
-    <li><a href="#ref-for-dfn-DOMException-15">2.11. Types</a>
-    <li><a href="#ref-for-dfn-DOMException-16">2.11.28. Error</a>
-    <li><a href="#ref-for-dfn-DOMException-17">2.11.29. DOMException</a> <a href="#ref-for-dfn-DOMException-18">(2)</a> <a href="#ref-for-dfn-DOMException-19">(3)</a> <a href="#ref-for-dfn-DOMException-20">(4)</a>
-    <li><a href="#ref-for-dfn-DOMException-21">3.2.21. Union types</a> <a href="#ref-for-dfn-DOMException-22">(2)</a>
-    <li><a href="#ref-for-dfn-DOMException-23">3.2.22. Error</a>
-    <li><a href="#ref-for-dfn-DOMException-24">3.2.23. DOMException</a> <a href="#ref-for-dfn-DOMException-25">(2)</a> <a href="#ref-for-dfn-DOMException-26">(3)</a> <a href="#ref-for-dfn-DOMException-27">(4)</a> <a href="#ref-for-dfn-DOMException-28">(5)</a> <a href="#ref-for-dfn-DOMException-29">(6)</a> <a href="#ref-for-dfn-DOMException-30">(7)</a>
-    <li><a href="#ref-for-dfn-DOMException-31">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-DOMException-32">(2)</a>
-    <li><a href="#ref-for-dfn-DOMException-33">3.14. Exception objects</a> <a href="#ref-for-dfn-DOMException-34">(2)</a> <a href="#ref-for-dfn-DOMException-35">(3)</a>
-    <li><a href="#ref-for-dfn-DOMException-36">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-DOMException-37">(2)</a> <a href="#ref-for-dfn-DOMException-38">(3)</a> <a href="#ref-for-dfn-DOMException-39">(4)</a>
+    <li><a href="#ref-for-dfn-DOMException-11">2.5.1. Error names</a> <a href="#ref-for-dfn-DOMException-12">(2)</a> <a href="#ref-for-dfn-DOMException-13">(3)</a> <a href="#ref-for-dfn-DOMException-14">(4)</a> <a href="#ref-for-dfn-DOMException-15">(5)</a>
+    <li><a href="#ref-for-dfn-DOMException-16">2.10. Objects implementing interfaces</a>
+    <li><a href="#ref-for-dfn-DOMException-17">2.11. Types</a>
+    <li><a href="#ref-for-dfn-DOMException-18">2.11.28. Error</a>
+    <li><a href="#ref-for-dfn-DOMException-19">2.11.29. DOMException</a> <a href="#ref-for-dfn-DOMException-20">(2)</a> <a href="#ref-for-dfn-DOMException-21">(3)</a> <a href="#ref-for-dfn-DOMException-22">(4)</a>
+    <li><a href="#ref-for-dfn-DOMException-23">3.2.21. Union types</a> <a href="#ref-for-dfn-DOMException-24">(2)</a>
+    <li><a href="#ref-for-dfn-DOMException-25">3.2.22. Error</a>
+    <li><a href="#ref-for-dfn-DOMException-26">3.2.23. DOMException</a> <a href="#ref-for-dfn-DOMException-27">(2)</a> <a href="#ref-for-dfn-DOMException-28">(3)</a> <a href="#ref-for-dfn-DOMException-29">(4)</a> <a href="#ref-for-dfn-DOMException-30">(5)</a> <a href="#ref-for-dfn-DOMException-31">(6)</a> <a href="#ref-for-dfn-DOMException-32">(7)</a>
+    <li><a href="#ref-for-dfn-DOMException-33">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-DOMException-34">(2)</a>
+    <li><a href="#ref-for-dfn-DOMException-35">3.14. Exception objects</a> <a href="#ref-for-dfn-DOMException-36">(2)</a> <a href="#ref-for-dfn-DOMException-37">(3)</a>
+    <li><a href="#ref-for-dfn-DOMException-38">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-DOMException-39">(2)</a> <a href="#ref-for-dfn-DOMException-40">(3)</a> <a href="#ref-for-dfn-DOMException-41">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-create-exception">

--- a/index.html
+++ b/index.html
@@ -4996,7 +4996,7 @@ which is the type of error the exception represents, and a <dfn data-dfn-for="ex
 user agent-defined value that provides human readable details of the error.</p>
    <p>There are two kinds of exceptions available to be thrown from specifications.
 The first is a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-simple-exception">simple exception</dfn>, which
-is identified by one of the following names:</p>
+is identified by one of the following types:</p>
    <ul>
     <li data-md="">
      <p><dfn class="idl-code" data-dfn-type="exception" data-export="" id="exceptiondef-evalerror">EvalError<a class="self-link" href="#exceptiondef-evalerror"></a></dfn></p>
@@ -5018,7 +5018,7 @@ ECMAScript specification.</p>
    <p>The second kind of exception is a <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="dfn-DOMException">DOMException</dfn>,
 which is an exception that encapsulates a name and an optional integer code,
 for compatibility with historically defined exceptions in the DOM.</p>
-   <p>For <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-2">simple exceptions</a>, the <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-1">error name</a> is the name of the exception.
+   <p>For <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-2">simple exceptions</a>, the <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-1">error name</a> is the type of the exception.
 For a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-1">DOMException</a></code>, the <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-2">error name</a> must be one of the names
 listed in the <a data-link-type="dfn" href="#dfn-error-names-table" id="ref-for-dfn-error-names-table-1">error names table</a> below.
 The table also indicates the <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-2">DOMException</a></code>'s integer code for that error name,

--- a/index.html
+++ b/index.html
@@ -4996,73 +4996,62 @@ which is the type of error the exception represents, and a <dfn data-dfn-for="ex
 user agent-defined value that provides human readable details of the error.</p>
    <p>There are two kinds of exceptions available to be thrown from specifications.
 The first is a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-simple-exception">simple exception</dfn>, which
-is identified by one of the following names:</p>
+is identified by one of the following type values:</p>
    <ul>
     <li data-md="">
-     <p>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="exceptiondef-error"><code>Error</code><a class="self-link" href="#exceptiondef-error"></a></dfn>"</p>
+     <p><emu-val>EvalError</emu-val></p>
     <li data-md="">
-     <p>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="exceptiondef-evalerror"><code>EvalError</code><a class="self-link" href="#exceptiondef-evalerror"></a></dfn>"</p>
+     <p><emu-val>RangeError</emu-val></p>
     <li data-md="">
-     <p>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="exceptiondef-rangeerror"><code>RangeError</code><a class="self-link" href="#exceptiondef-rangeerror"></a></dfn>"</p>
+     <p><emu-val>ReferenceError</emu-val></p>
     <li data-md="">
-     <p>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="exceptiondef-referenceerror"><code>ReferenceError</code><a class="self-link" href="#exceptiondef-referenceerror"></a></dfn>"</p>
+     <p><emu-val>TypeError</emu-val></p>
     <li data-md="">
-     <p>"<dfn class="dfn-paneled idl-code" data-dfn-type="exception" data-export="" id="exceptiondef-typeerror"><code>TypeError</code></dfn>"</p>
-    <li data-md="">
-     <p>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="exceptiondef-urierror"><code>URIError</code><a class="self-link" href="#exceptiondef-urierror"></a></dfn>"</p>
+     <p><emu-val>URIError</emu-val></p>
    </ul>
-   <p>These correspond to all of the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-error-objects">ECMAScript error objects</a> (apart from <emu-val>SyntaxError</emu-val>, which is deliberately omitted as
-it is for use only by the ECMAScript parser).
-The meaning of
-each <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-1">simple exception</a> matches
-its corresponding <emu-val>Error</emu-val> object in the
+   <p>These correspond to all of the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-error-objects">ECMAScript error objects</a> (apart from <emu-val>SyntaxError</emu-val> and <emu-val>Error</emu-val>,
+which are deliberately omitted as they are reserved for use
+by the ECMAScript parser and authors, respectively).
+The meaning of each <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-1">simple exception</a> matches
+its corresponding error object in the
 ECMAScript specification.</p>
    <p>The second kind of exception is a <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="dfn-DOMException">DOMException</dfn>,
 which is an exception that encapsulates a name and an optional integer code,
 for compatibility with historically defined exceptions in the DOM.</p>
-   <p>For <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-2">simple exceptions</a>,
-the <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-1">error name</a> is the name
-of the exception.
-For a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-1">DOMException</a></code>,
-the <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-2">error name</a> must
-be one of the names listed in the <a data-link-type="dfn" href="#dfn-error-names-table" id="ref-for-dfn-error-names-table-1">error names table</a> below.  The table also indicates the <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-2">DOMException</a></code>'s integer code
-for that error name, if it has one.</p>
-   <p>There are two types that can be used to refer to
-exception objects: <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-1">Error</a></code>, which encompasses all exceptions,
+   <p>For <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-2">simple exceptions</a>, the <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-1">error name</a> is the name of the exception.
+For a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-1">DOMException</a></code>, the <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-2">error name</a> must be one of the names
+listed in the <a data-link-type="dfn" href="#dfn-error-names-table" id="ref-for-dfn-error-names-table-1">error names table</a> below.
+The table also indicates the <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-2">DOMException</a></code>'s integer code for that error name,
+if it has one.</p>
+   <p>There are two types that can be used to refer to exception objects: <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-1">Error</a></code>, which encompasses all exceptions,
 and <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-3">DOMException</a></code> which includes just DOMException objects.
 This allows for example an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-22">operation</a> to be declared to have a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-4">DOMException</a></code> <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-2">return type</a> or an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-15">attribute</a> to be of type <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-2">Error</a></code>.</p>
-   <p>Exceptions can be <dfn class="dfn-paneled" data-dfn-for="exception" data-dfn-type="dfn" data-export="" id="dfn-create-exception">created</dfn> by providing its <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-3">error name</a>.
+   <p><a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-3">Simple exceptions</a> can be <dfn class="dfn-paneled" data-dfn-for="exception" data-dfn-type="dfn" data-export="" id="dfn-create-exception">created</dfn> by providing their <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-3">error name</a>. <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-5">DOMExceptions</a></code>, by providing their <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-4">error name</a> followed by <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-6">DOMException</a></code>.
 Exceptions can also be <dfn class="dfn-paneled" data-dfn-for="exception" data-dfn-type="dfn" data-export="" data-lt="throw|thrown" id="dfn-throw">thrown</dfn>, by providing the
 same details required to <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-1">create</a> one.</p>
    <p>The resulting behavior from creating and throwing an exception is language binding-specific.</p>
    <p class="note" role="note">Note: See <a href="#es-creating-throwing-exceptions">§3.15 Creating and throwing exceptions</a> for details on what creating and throwing an exception
 entails in the ECMAScript language binding.</p>
-   <div class="example" id="example-06d9c7e7">
-    <a class="self-link" href="#example-06d9c7e7"></a> 
+   <div class="example" id="example-f05b58d5">
+    <a class="self-link" href="#example-f05b58d5"></a> 
     <p>Here is are some examples of wording to use to create and throw exceptions.
-    To throw a new <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-3">simple exception</a> named <code class="idl"><a data-link-type="idl" href="#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror-1">TypeError</a></code>:</p>
-    <blockquote>
-     <p><a data-link-type="dfn" href="#dfn-throw" id="ref-for-dfn-throw-1">Throw</a> a TypeError.</p>
-    </blockquote>
-    <p>To throw a new <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-5">DOMException</a></code> with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-4">error name</a> <code class="idl"><a data-link-type="idl" href="#indexsizeerror" id="ref-for-indexsizeerror-1">IndexSizeError</a></code>:</p>
-    <blockquote>
-     <p><a data-link-type="dfn" href="#dfn-throw" id="ref-for-dfn-throw-2">Throw</a> an IndexSizeError.</p>
-    </blockquote>
-    <p>To create a new <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-6">DOMException</a></code> with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-5">error name</a> <code class="idl"><a data-link-type="idl" href="#syntaxerror" id="ref-for-syntaxerror-1">SyntaxError</a></code>:</p>
-    <blockquote>
-     <p>Let <var>object</var> be a newly <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-2">created</a> SyntaxError.</p>
-    </blockquote>
+    To throw a new <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-4">simple exception</a> named <emu-val>TypeError</emu-val>:</p>
+    <blockquote> <a data-link-type="dfn" href="#dfn-throw" id="ref-for-dfn-throw-1">Throw</a> a <emu-val>TypeError</emu-val>. </blockquote>
+    <p>To throw a new <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-7">DOMException</a></code> with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-5">error name</a> "<code class="idl"><a class="idl-code" data-link-type="exception" href="#indexsizeerror" id="ref-for-indexsizeerror-1">IndexSizeError</a></code>":</p>
+    <blockquote> <a data-link-type="dfn" href="#dfn-throw" id="ref-for-dfn-throw-2">Throw</a> an "<code class="idl"><a class="idl-code" data-link-type="exception" href="#indexsizeerror" id="ref-for-indexsizeerror-2">IndexSizeError</a></code>" <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-8">DOMException</a></code>. </blockquote>
+    <p>To create a new <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-9">DOMException</a></code> with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-6">error name</a> "<code class="idl"><a class="idl-code" data-link-type="exception" href="#syntaxerror" id="ref-for-syntaxerror-1">SyntaxError</a></code>":</p>
+    <blockquote> Let <var>object</var> be a newly <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-2">created</a> "<code class="idl"><a class="idl-code" data-link-type="exception" href="#syntaxerror" id="ref-for-syntaxerror-2">SyntaxError</a></code>" <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-10">DOMException</a></code>. </blockquote>
    </div>
    <h4 class="heading settled" data-level="2.5.1" id="idl-DOMException-error-names"><span class="secno">2.5.1. </span><span class="content">Error names</span><a class="self-link" href="#idl-DOMException-error-names"></a></h4>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-error-names-table">error names table</dfn> below lists all the allowed error names
-for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-7">DOMExceptions</a></code>, a description, and legacy code values.</p>
+for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-11">DOMExceptions</a></code>, a description, and legacy code values.</p>
    <p class="note" role="note">Note: If an error name is not listed here, please file a bug as indicated at the top of this specification and it will be addressed shortly. Thanks!</p>
    <table class="vert data" id="error-names">
     <thead>
      <tr>
       <th>Name
       <th>Description
-      <th>Legacy <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-8">code</a></code> name and value
+      <th>Legacy <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-12">code</a></code> name and value
     <tbody>
      <tr>
       <td>"<dfn class="dfn-paneled idl-code" data-dfn-type="exception" data-export="" id="indexsizeerror"><code>IndexSizeError</code></dfn>"
@@ -5186,7 +5175,7 @@ for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-f
       <td>—
    </table>
    <div class="advisement">
-     Additionally, the following <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-9">DOMExceptions</a></code> are kept for legacy purposes but their usage is discouraged: 
+     Additionally, the following <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-13">DOMExceptions</a></code> are kept for legacy purposes but their usage is discouraged: 
     <table class="vert data" id="legacy-error-names">
      <thead>
       <tr>
@@ -5465,7 +5454,7 @@ object that are considered to be platform objects:</p>
     <li data-md="">
      <p>objects that implement a non-<a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-13">callback</a> <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-49">interface</a>;</p>
     <li data-md="">
-     <p>objects representing IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-10">DOMExceptions</a></code>.</p>
+     <p>objects representing IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-14">DOMExceptions</a></code>.</p>
    </ul>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-legacy-platform-object">Legacy platform objects</dfn> are <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-7">platform objects</a> that implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-50">interface</a> which
 does not have a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-5">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-6">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-21">extended attribute</a>, <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-9">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-4">named properties</a>,
@@ -5499,7 +5488,7 @@ corresponding to each type, and how <a data-link-type="dfn" href="#dfn-constant"
 the <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-3">integer types</a>, <code class="idl"><a data-link-type="idl" href="#idl-float" id="ref-for-idl-float-4">float</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-unrestricted-float" id="ref-for-idl-unrestricted-float-5">unrestricted float</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-double" id="ref-for-idl-double-11">double</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-unrestricted-double" id="ref-for-idl-unrestricted-double-6">unrestricted double</a></code>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-primitive-type">primitive types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref-for-idl-boolean-6">boolean</a></code> and the <a data-link-type="dfn" href="#dfn-numeric-type" id="ref-for-dfn-numeric-type-5">numeric types</a>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-string-type">string types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-26">DOMString</a></code>, all <a data-link-type="dfn" href="#idl-enumeration" id="ref-for-idl-enumeration-1">enumeration types</a>, <code class="idl"><a data-link-type="idl" href="#idl-ByteString" id="ref-for-idl-ByteString-3">ByteString</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-USVString" id="ref-for-idl-USVString-4">USVString</a></code>.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exception-type">exception types</dfn> are <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-3">Error</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-11">DOMException</a></code>.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exception-type">exception types</dfn> are <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-3">Error</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-15">DOMException</a></code>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-typed-array-type">typed array types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-Int8Array" id="ref-for-idl-Int8Array-1">Int8Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Int16Array" id="ref-for-idl-Int16Array-1">Int16Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Int32Array" id="ref-for-idl-Int32Array-1">Int32Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint8Array" id="ref-for-idl-Uint8Array-1">Uint8Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint16Array" id="ref-for-idl-Uint16Array-1">Uint16Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint32Array" id="ref-for-idl-Uint32Array-1">Uint32Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint8ClampedArray" id="ref-for-idl-Uint8ClampedArray-1">Uint8ClampedArray</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Float32Array" id="ref-for-idl-Float32Array-1">Float32Array</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-Float64Array" id="ref-for-idl-Float64Array-1">Float64Array</a></code>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-buffer-source-type">buffer source types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-ArrayBuffer" id="ref-for-idl-ArrayBuffer-1">ArrayBuffer</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-DataView" id="ref-for-idl-DataView-1">DataView</a></code>,
 and the <a data-link-type="dfn" href="#dfn-typed-array-type" id="ref-for-dfn-typed-array-type-1">typed array types</a>.</p>
@@ -6038,15 +6027,15 @@ and joining them with the string “Or”.</p>
    <div data-fill-with="grammar-NonAnyType"></div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-level="2.11.28" data-lt="Error" id="idl-Error"><span class="secno">2.11.28. </span><span class="content">Error</span><span id="dom-Error"></span></h4>
    <p>The <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-4">Error</a></code> type corresponds to the
-set of all possible non-null references to exception objects, including <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-4">simple exceptions</a> and <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-12">DOMExceptions</a></code>.</p>
+set of all possible non-null references to exception objects, including <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-5">simple exceptions</a> and <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-16">DOMExceptions</a></code>.</p>
    <p>There is no way to represent a constant <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-5">Error</a></code> value in IDL.</p>
    <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-28">type name</a> of the <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-6">Error</a></code> type is “Error”.</p>
    <h4 class="heading settled" data-level="2.11.29" id="idl-DOMException"><span class="secno">2.11.29. </span><span class="content">DOMException</span><a class="self-link" href="#idl-DOMException"></a></h4>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-13">DOMException</a></code> type corresponds to the
+   <p>The <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-17">DOMException</a></code> type corresponds to the
 set of all possible non-null references to objects
-representing <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-14">DOMExceptions</a></code>.</p>
-   <p>There is no way to represent a constant <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-15">DOMException</a></code> value in IDL.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-29">type name</a> of the <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-16">DOMException</a></code> type is “DOMException”.</p>
+representing <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-18">DOMExceptions</a></code>.</p>
+   <p>There is no way to represent a constant <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-19">DOMException</a></code> value in IDL.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-29">type name</a> of the <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-20">DOMException</a></code> type is “DOMException”.</p>
    <h4 class="heading settled" data-level="2.11.30" id="idl-buffer-source-types"><span class="secno">2.11.30. </span><span class="content">Buffer source types</span><a class="self-link" href="#idl-buffer-source-types"></a></h4>
    <p>There are a number of types that correspond to sets of all possible non-null
 references to objects that represent a buffer of data or a view on to a buffer of
@@ -7428,10 +7417,10 @@ result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id
 that is a reference to the object <var>V</var>.</p>
       </ol>
      <li data-md="">
-      <p>If <var>V</var> is a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-17">DOMException</a></code> platform object, then:</p>
+      <p>If <var>V</var> is a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-21">DOMException</a></code> platform object, then:</p>
       <ol>
        <li data-md="">
-        <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-18">DOMException</a></code> or <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-7">Error</a></code>, then return the
+        <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-22">DOMException</a></code> or <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-7">Error</a></code>, then return the
 result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-38">converting</a> <var>V</var> to that type.</p>
        <li data-md="">
         <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-16">object</a></code>, then return the IDL value
@@ -7555,7 +7544,7 @@ then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-
    <h4 class="heading settled" data-level="3.2.22" id="es-Error"><span class="secno">3.2.22. </span><span class="content">Error</span><a class="self-link" href="#es-Error"></a></h4>
    <p>IDL <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-10">Error</a></code> values are represented
 by native ECMAScript <emu-val>Error</emu-val> objects and
-platform objects for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-19">DOMExceptions</a></code>.</p>
+platform objects for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-23">DOMExceptions</a></code>.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to Error" id="es-to-Error">
     <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-52">converted</a> to an IDL <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-11">Error</a></code> value by running the following algorithm:</p>
     <ol>
@@ -7572,23 +7561,23 @@ to the same object as <var>V</var>.</p>
     value is the <emu-val>Error</emu-val> value that represents a reference to the same object that the
     IDL <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-14">Error</a></code> represents. </p>
    <h4 class="heading settled" data-level="3.2.23" id="es-DOMException"><span class="secno">3.2.23. </span><span class="content">DOMException</span><a class="self-link" href="#es-DOMException"></a></h4>
-   <p>IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-20">DOMException</a></code> values are represented
-by platform objects for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-21">DOMExceptions</a></code>.</p>
+   <p>IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-24">DOMException</a></code> values are represented
+by platform objects for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-25">DOMExceptions</a></code>.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to DOMException" id="es-to-DOMException">
-    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-53">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-22">DOMException</a></code> value by running the following algorithm:</p>
+    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-53">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-26">DOMException</a></code> value by running the following algorithm:</p>
     <ol>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
-or <var>V</var> is not a platform object that represents a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-23">DOMException</a></code>,
+or <var>V</var> is not a platform object that represents a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-27">DOMException</a></code>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-19">throw a <emu-val>TypeError</emu-val></a>.</p>
      <li data-md="">
-      <p>Return the IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-24">DOMException</a></code> value that is a reference
+      <p>Return the IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-28">DOMException</a></code> value that is a reference
 to the same object as <var>V</var>.</p>
     </ol>
    </div>
-   <p id="DOMException-to-es"> The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-34">converting</a> an IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-25">DOMException</a></code> value to an ECMAScript
+   <p id="DOMException-to-es"> The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-34">converting</a> an IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-29">DOMException</a></code> value to an ECMAScript
     value is the <emu-val>Object</emu-val> value that represents a reference to the same object that the
-    IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-26">DOMException</a></code> represents. </p>
+    IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-30">DOMException</a></code> represents. </p>
    <h4 class="heading settled" data-level="3.2.24" id="es-buffer-source-types"><span class="secno">3.2.24. </span><span class="content">Buffer source types</span><a class="self-link" href="#es-buffer-source-types"></a></h4>
    <p>Values of the IDL <a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-2">buffer source types</a> are represented by objects of the corresponding ECMAScript class.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to buffer source" id="es-to-buffer-source">
@@ -9019,11 +9008,11 @@ that has one of the above types in its <a data-link-type="dfn" href="#dfn-flatte
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
        <li data-md="">
-        <p>Otherwise: if <var>V</var> is a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-27">DOMException</a></code> platform object and
+        <p>Otherwise: if <var>V</var> is a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-31">DOMException</a></code> platform object and
 there is an entry in <var>S</var> that has one of the following types at position <var>i</var> of its type list,</p>
         <ul>
          <li data-md="">
-          <p><code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-28">DOMException</a></code></p>
+          <p><code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-32">DOMException</a></code></p>
          <li data-md="">
           <p><code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-15">Error</a></code></p>
          <li data-md="">
@@ -11142,7 +11131,7 @@ and similarly with their setters.</p>
 <span class="n">C</span> <span class="kt">implements</span> <span class="n">A</span>;
 </pre>
     <p>Attempting to call <code>B.prototype.f</code> on an object that implements <code class="idl">A</code> (but not <code class="idl">B</code>) or one
-    that implements <code class="idl">C</code> will result in a <code class="idl"><a data-link-type="idl" href="#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror-2">TypeError</a></code> being thrown.  However,
+    that implements <code class="idl">C</code> will result in a <emu-val>TypeError</emu-val> being thrown.  However,
     calling <code>A.prototype.f</code> on an object that implements <code class="idl">B</code> or one that implements <code class="idl">C</code> would succeed.  This is handled by the algorithm in <a href="#es-operations">§3.6.7 Operations</a> that defines how IDL operation invocation works in ECMAScript.</p>
     <p>Similar behavior is required for the getter and setter <emu-val>Function</emu-val> objects that correspond to an IDL <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-61">attributes</a>,
     and this is handled in <a href="#es-attributes">§3.6.6 Attributes</a>.</p>
@@ -12002,9 +11991,9 @@ there must be a property on the DOMException prototype object
 whose name and value are as indicated in the table.  The property has
 attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span>.</p>
    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="3.14" data-lt="Exception objects" data-noexport="" id="es-exception-objects"><span class="secno">3.14. </span><span class="content">Exception objects</span></h3>
-   <p><a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-5">Simple exceptions</a> are represented
+   <p><a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-6">Simple exceptions</a> are represented
 by native ECMAScript objects of the corresponding type.</p>
-   <p><code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-29">DOMExceptions</a></code> are represented by <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-54">platform objects</a> that inherit from
+   <p><code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-33">DOMExceptions</a></code> are represented by <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-54">platform objects</a> that inherit from
 the <a data-link-type="dfn" href="#dfn-DOMException-prototype-object" id="ref-for-dfn-DOMException-prototype-object-3">DOMException prototype object</a>.</p>
    <p>Every platform object representing a DOMException in ECMAScript is associated with a global environment, just
 as the <a data-link-type="dfn" href="#dfn-initial-object" id="ref-for-dfn-initial-object-5">initial objects</a> are.
@@ -12012,8 +12001,8 @@ When an exception object is created by calling the <a data-link-type="dfn" href=
 either normally or as part of a <code>new</code> expression, then the global environment
 of the newly created object is associated with must be the same as for the <a data-link-type="dfn" href="#dfn-DOMException-constructor-object" id="ref-for-dfn-DOMException-constructor-object-4">DOMException constructor object</a> itself.</p>
    <p>The value of the internal [[Prototype]]
-property of a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-30">DOMException</a></code> object must be the <a data-link-type="dfn" href="#dfn-DOMException-prototype-object" id="ref-for-dfn-DOMException-prototype-object-4">DOMException prototype object</a> from the global environment the exception object is associated with.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-7">class string</a> of a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-31">DOMException</a></code> object
+property of a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-34">DOMException</a></code> object must be the <a data-link-type="dfn" href="#dfn-DOMException-prototype-object" id="ref-for-dfn-DOMException-prototype-object-4">DOMException prototype object</a> from the global environment the exception object is associated with.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-7">class string</a> of a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-35">DOMException</a></code> object
 must be “DOMException”.</p>
    <p class="note" role="note">Note: The intention is for DOMException objects to be just like the other
 various native <emu-val>Error</emu-val> objects that the
@@ -12049,8 +12038,8 @@ exception field was defined.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="to create a simple exception or DOMException">
-    <p>When a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-6">simple exception</a> or <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-32">DOMException</a></code> <var>E</var> is to be <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-3">created</a>,
-    with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-6">error name</a> <var>N</var> and optional user agent-defined message <var>M</var>,
+    <p>When a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-7">simple exception</a> or <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-36">DOMException</a></code> <var>E</var> is to be <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-3">created</a>,
+    with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-7">error name</a> <var>N</var> and optional user agent-defined message <var>M</var>,
     the following steps must be followed:</p>
     <ol>
      <li data-md="">
@@ -12061,11 +12050,11 @@ exception field was defined.</p>
       <p>Let <var>args</var> be a list of ECMAScript values.</p>
       <dl class="switch">
        <dt data-md="">
-        <p><var>E</var> is <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-33">DOMException</a></code></p>
+        <p><var>E</var> is <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-37">DOMException</a></code></p>
        <dd data-md="">
         <p><var>args</var> is (<emu-val>undefined</emu-val>, <var>N</var>).</p>
        <dt data-md="">
-        <p><var>E</var> is a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-7">simple exception</a></p>
+        <p><var>E</var> is a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-8">simple exception</a></p>
        <dd data-md="">
         <p><var>args</var> is (<var>M</var>)</p>
       </dl>
@@ -12075,11 +12064,11 @@ exception field was defined.</p>
       <p>Let <var>X</var> be an object determined based on the type of <var>E</var>:</p>
       <dl class="switch">
        <dt data-md="">
-        <p><var>E</var> is <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-34">DOMException</a></code></p>
+        <p><var>E</var> is <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-38">DOMException</a></code></p>
        <dd data-md="">
         <p><var>X</var> is the <a data-link-type="dfn" href="#dfn-DOMException-constructor-object" id="ref-for-dfn-DOMException-constructor-object-5">DOMException constructor object</a> from the global environment <var>G</var>.</p>
        <dt data-md="">
-        <p><var>E</var> is a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-8">simple exception</a></p>
+        <p><var>E</var> is a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-9">simple exception</a></p>
        <dd data-md="">
         <p><var>X</var> is the constructor for the corresponding ECMAScript error
 from the global environment <var>G</var>.</p>
@@ -12092,12 +12081,12 @@ with <var>args</var> as the argument list.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="throw an exception">
-    <p>When a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-9">simple exception</a> or <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-35">DOMException</a></code> <var>E</var> is to be <a data-link-type="dfn" href="#dfn-throw" id="ref-for-dfn-throw-3">thrown</a>,
-    with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-7">error name</a> <var>N</var> and optional user agent-defined message <var>M</var>,
+    <p>When a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-10">simple exception</a> or <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-39">DOMException</a></code> <var>E</var> is to be <a data-link-type="dfn" href="#dfn-throw" id="ref-for-dfn-throw-3">thrown</a>,
+    with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-8">error name</a> <var>N</var> and optional user agent-defined message <var>M</var>,
     the following steps must be followed:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>O</var> be the result of <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-4">creating</a> the specified exception <var>E</var> with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-8">error name</a> <var>N</var> and
+      <p>Let <var>O</var> be the result of <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-4">creating</a> the specified exception <var>E</var> with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-9">error name</a> <var>N</var> and
 optional user agent-defined message <var>M</var>.</p>
      <li data-md="">
       <p>Throw <var>O</var>.</p>
@@ -12751,16 +12740,10 @@ language binding.</p>
    <li><a href="#dfn-enumeration">enumeration</a><span>, in §2.6</span>
    <li><a href="#idl-enumeration">Enumeration types</a><span>, in §2.11.20</span>
    <li><a href="#dfn-enumeration-value">enumeration value</a><span>, in §2.6</span>
-   <li>
-    Error
-    <ul>
-     <li><a href="#exceptiondef-error">(exception)</a><span>, in §2.5</span>
-     <li><a href="#idl-Error">(interface)</a><span>, in §2.11.27</span>
-    </ul>
+   <li><a href="#idl-Error">Error</a><span>, in §2.11.27</span>
    <li><a href="#dfn-exception-error-name">error name</a><span>, in §2.5</span>
    <li><a href="#dfn-error-names-table">error names table</a><span>, in §2.5.1</span>
    <li><a href="#ecmascript-throw">es throw</a><span>, in §3</span>
-   <li><a href="#exceptiondef-evalerror">EvalError</a><span>, in §2.5</span>
    <li><a href="#dfn-example-term">example term</a><span>, in §Unnumbered section</span>
    <li><a href="#dfn-exception">exception</a><span>, in §2.5</span>
    <li><a href="#es-exception-objects">Exception objects</a><span>, in §3.13.2</span>
@@ -12915,12 +12898,10 @@ language binding.</p>
    <li><a href="#PutForwards">PutForwards</a><span>, in §3.3.13</span>
    <li><a href="#dom-domexception-quota_exceeded_err">QUOTA_EXCEEDED_ERR</a><span>, in §2.5.1</span>
    <li><a href="#quotaexceedederror">QuotaExceededError</a><span>, in §2.5.1</span>
-   <li><a href="#exceptiondef-rangeerror">RangeError</a><span>, in §2.5</span>
    <li><a href="#dfn-read-only">read only</a><span>, in §2.2.2</span>
    <li><a href="#readonlyerror">ReadOnlyError</a><span>, in §2.5.1</span>
    <li><a href="#idl-record">record</a><span>, in §2.11.24</span>
    <li><a href="#record-type">record type</a><span>, in §2.11.25</span>
-   <li><a href="#exceptiondef-referenceerror">ReferenceError</a><span>, in §2.5</span>
    <li><a href="#dfn-regular-attribute">regular attribute</a><span>, in §2.2.2</span>
    <li><a href="#dfn-regular-operation">regular operation</a><span>, in §2.2.3</span>
    <li><a href="#Replaceable">Replaceable</a><span>, in §3.3.14</span>
@@ -12980,7 +12961,6 @@ language binding.</p>
    <li><a href="#TreatNullAs">TreatNullAs</a><span>, in §3.3.18</span>
    <li><a href="#dfn-typed-array-type">typed array types</a><span>, in §2.11</span>
    <li><a href="#dfn-typedef">typedef</a><span>, in §2.8</span>
-   <li><a href="#exceptiondef-typeerror">TypeError</a><span>, in §2.5</span>
    <li><a href="#dom-domexception-type_mismatch_err">TYPE_MISMATCH_ERR</a><span>, in §2.5.1</span>
    <li><a href="#typemismatcherror">TypeMismatchError</a><span>, in §2.5.1</span>
    <li><a href="#dfn-type-name">type name</a><span>, in §2.11</span>
@@ -13000,7 +12980,6 @@ language binding.</p>
    <li><a href="#idl-unsigned-long-long">unsigned long long</a><span>, in §2.11.9</span>
    <li><a href="#idl-unsigned-short">unsigned short</a><span>, in §2.11.5</span>
    <li><a href="#dfn-perform-steps-once-promise-is-settled">upon settling</a><span>, in §3.2.20</span>
-   <li><a href="#exceptiondef-urierror">URIError</a><span>, in §2.5</span>
    <li><a href="#dom-domexception-url_mismatch_err">URL_MISMATCH_ERR</a><span>, in §2.5.1</span>
    <li><a href="#urlmismatcherror">URLMismatchError</a><span>, in §2.5.1</span>
    <li><a href="#dfn-user-object">user object</a><span>, in §2.10</span>
@@ -14199,41 +14178,34 @@ language binding.</p>
   <aside class="dfn-panel" data-for="dfn-exception-error-name">
    <b><a href="#dfn-exception-error-name">#dfn-exception-error-name</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-exception-error-name-1">2.5. Exceptions</a> <a href="#ref-for-dfn-exception-error-name-2">(2)</a> <a href="#ref-for-dfn-exception-error-name-3">(3)</a> <a href="#ref-for-dfn-exception-error-name-4">(4)</a> <a href="#ref-for-dfn-exception-error-name-5">(5)</a>
-    <li><a href="#ref-for-dfn-exception-error-name-6">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-exception-error-name-7">(2)</a> <a href="#ref-for-dfn-exception-error-name-8">(3)</a>
+    <li><a href="#ref-for-dfn-exception-error-name-1">2.5. Exceptions</a> <a href="#ref-for-dfn-exception-error-name-2">(2)</a> <a href="#ref-for-dfn-exception-error-name-3">(3)</a> <a href="#ref-for-dfn-exception-error-name-4">(4)</a> <a href="#ref-for-dfn-exception-error-name-5">(5)</a> <a href="#ref-for-dfn-exception-error-name-6">(6)</a>
+    <li><a href="#ref-for-dfn-exception-error-name-7">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-exception-error-name-8">(2)</a> <a href="#ref-for-dfn-exception-error-name-9">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-simple-exception">
    <b><a href="#dfn-simple-exception">#dfn-simple-exception</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-simple-exception-1">2.5. Exceptions</a> <a href="#ref-for-dfn-simple-exception-2">(2)</a> <a href="#ref-for-dfn-simple-exception-3">(3)</a>
-    <li><a href="#ref-for-dfn-simple-exception-4">2.11.28. Error</a>
-    <li><a href="#ref-for-dfn-simple-exception-5">3.14. Exception objects</a>
-    <li><a href="#ref-for-dfn-simple-exception-6">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-simple-exception-7">(2)</a> <a href="#ref-for-dfn-simple-exception-8">(3)</a> <a href="#ref-for-dfn-simple-exception-9">(4)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="exceptiondef-typeerror">
-   <b><a href="#exceptiondef-typeerror">#exceptiondef-typeerror</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-exceptiondef-typeerror-1">2.5. Exceptions</a>
-    <li><a href="#ref-for-exceptiondef-typeerror-2">3.7. Implements statements</a>
+    <li><a href="#ref-for-dfn-simple-exception-1">2.5. Exceptions</a> <a href="#ref-for-dfn-simple-exception-2">(2)</a> <a href="#ref-for-dfn-simple-exception-3">(3)</a> <a href="#ref-for-dfn-simple-exception-4">(4)</a>
+    <li><a href="#ref-for-dfn-simple-exception-5">2.11.28. Error</a>
+    <li><a href="#ref-for-dfn-simple-exception-6">3.14. Exception objects</a>
+    <li><a href="#ref-for-dfn-simple-exception-7">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-simple-exception-8">(2)</a> <a href="#ref-for-dfn-simple-exception-9">(3)</a> <a href="#ref-for-dfn-simple-exception-10">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-DOMException">
    <b><a href="#dfn-DOMException">#dfn-DOMException</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-DOMException-1">2.5. Exceptions</a> <a href="#ref-for-dfn-DOMException-2">(2)</a> <a href="#ref-for-dfn-DOMException-3">(3)</a> <a href="#ref-for-dfn-DOMException-4">(4)</a> <a href="#ref-for-dfn-DOMException-5">(5)</a> <a href="#ref-for-dfn-DOMException-6">(6)</a>
-    <li><a href="#ref-for-dfn-DOMException-7">2.5.1. Error names</a> <a href="#ref-for-dfn-DOMException-8">(2)</a> <a href="#ref-for-dfn-DOMException-9">(3)</a>
-    <li><a href="#ref-for-dfn-DOMException-10">2.10. Objects implementing interfaces</a>
-    <li><a href="#ref-for-dfn-DOMException-11">2.11. Types</a>
-    <li><a href="#ref-for-dfn-DOMException-12">2.11.28. Error</a>
-    <li><a href="#ref-for-dfn-DOMException-13">2.11.29. DOMException</a> <a href="#ref-for-dfn-DOMException-14">(2)</a> <a href="#ref-for-dfn-DOMException-15">(3)</a> <a href="#ref-for-dfn-DOMException-16">(4)</a>
-    <li><a href="#ref-for-dfn-DOMException-17">3.2.21. Union types</a> <a href="#ref-for-dfn-DOMException-18">(2)</a>
-    <li><a href="#ref-for-dfn-DOMException-19">3.2.22. Error</a>
-    <li><a href="#ref-for-dfn-DOMException-20">3.2.23. DOMException</a> <a href="#ref-for-dfn-DOMException-21">(2)</a> <a href="#ref-for-dfn-DOMException-22">(3)</a> <a href="#ref-for-dfn-DOMException-23">(4)</a> <a href="#ref-for-dfn-DOMException-24">(5)</a> <a href="#ref-for-dfn-DOMException-25">(6)</a> <a href="#ref-for-dfn-DOMException-26">(7)</a>
-    <li><a href="#ref-for-dfn-DOMException-27">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-DOMException-28">(2)</a>
-    <li><a href="#ref-for-dfn-DOMException-29">3.14. Exception objects</a> <a href="#ref-for-dfn-DOMException-30">(2)</a> <a href="#ref-for-dfn-DOMException-31">(3)</a>
-    <li><a href="#ref-for-dfn-DOMException-32">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-DOMException-33">(2)</a> <a href="#ref-for-dfn-DOMException-34">(3)</a> <a href="#ref-for-dfn-DOMException-35">(4)</a>
+    <li><a href="#ref-for-dfn-DOMException-1">2.5. Exceptions</a> <a href="#ref-for-dfn-DOMException-2">(2)</a> <a href="#ref-for-dfn-DOMException-3">(3)</a> <a href="#ref-for-dfn-DOMException-4">(4)</a> <a href="#ref-for-dfn-DOMException-5">(5)</a> <a href="#ref-for-dfn-DOMException-6">(6)</a> <a href="#ref-for-dfn-DOMException-7">(7)</a> <a href="#ref-for-dfn-DOMException-8">(8)</a> <a href="#ref-for-dfn-DOMException-9">(9)</a> <a href="#ref-for-dfn-DOMException-10">(10)</a>
+    <li><a href="#ref-for-dfn-DOMException-11">2.5.1. Error names</a> <a href="#ref-for-dfn-DOMException-12">(2)</a> <a href="#ref-for-dfn-DOMException-13">(3)</a>
+    <li><a href="#ref-for-dfn-DOMException-14">2.10. Objects implementing interfaces</a>
+    <li><a href="#ref-for-dfn-DOMException-15">2.11. Types</a>
+    <li><a href="#ref-for-dfn-DOMException-16">2.11.28. Error</a>
+    <li><a href="#ref-for-dfn-DOMException-17">2.11.29. DOMException</a> <a href="#ref-for-dfn-DOMException-18">(2)</a> <a href="#ref-for-dfn-DOMException-19">(3)</a> <a href="#ref-for-dfn-DOMException-20">(4)</a>
+    <li><a href="#ref-for-dfn-DOMException-21">3.2.21. Union types</a> <a href="#ref-for-dfn-DOMException-22">(2)</a>
+    <li><a href="#ref-for-dfn-DOMException-23">3.2.22. Error</a>
+    <li><a href="#ref-for-dfn-DOMException-24">3.2.23. DOMException</a> <a href="#ref-for-dfn-DOMException-25">(2)</a> <a href="#ref-for-dfn-DOMException-26">(3)</a> <a href="#ref-for-dfn-DOMException-27">(4)</a> <a href="#ref-for-dfn-DOMException-28">(5)</a> <a href="#ref-for-dfn-DOMException-29">(6)</a> <a href="#ref-for-dfn-DOMException-30">(7)</a>
+    <li><a href="#ref-for-dfn-DOMException-31">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-DOMException-32">(2)</a>
+    <li><a href="#ref-for-dfn-DOMException-33">3.14. Exception objects</a> <a href="#ref-for-dfn-DOMException-34">(2)</a> <a href="#ref-for-dfn-DOMException-35">(3)</a>
+    <li><a href="#ref-for-dfn-DOMException-36">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-DOMException-37">(2)</a> <a href="#ref-for-dfn-DOMException-38">(3)</a> <a href="#ref-for-dfn-DOMException-39">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-create-exception">
@@ -14262,7 +14234,7 @@ language binding.</p>
   <aside class="dfn-panel" data-for="indexsizeerror">
    <b><a href="#indexsizeerror">#indexsizeerror</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-indexsizeerror-1">2.5. Exceptions</a>
+    <li><a href="#ref-for-indexsizeerror-1">2.5. Exceptions</a> <a href="#ref-for-indexsizeerror-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="notsupportederror">
@@ -14275,7 +14247,7 @@ language binding.</p>
   <aside class="dfn-panel" data-for="syntaxerror">
    <b><a href="#syntaxerror">#syntaxerror</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-syntaxerror-1">2.5. Exceptions</a>
+    <li><a href="#ref-for-syntaxerror-1">2.5. Exceptions</a> <a href="#ref-for-syntaxerror-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="notallowederror">

--- a/index.html
+++ b/index.html
@@ -1557,7 +1557,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web IDL</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-09">9 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-11">11 December 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -5027,7 +5027,7 @@ if it has one.</p>
 and <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-3">DOMException</a></code> which includes just DOMException objects.
 This allows for example an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-22">operation</a> to be declared to have a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-4">DOMException</a></code> <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-2">return type</a> or an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-15">attribute</a> to be of type <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-2">Error</a></code>.</p>
    <p><a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-3">Simple exceptions</a> can be <dfn class="dfn-paneled" data-dfn-for="exception" data-dfn-type="dfn" data-export="" id="dfn-create-exception">created</dfn> by providing their <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-3">error name</a>. <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-5">DOMExceptions</a></code> can be <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-1">created</a> by providing their <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-4">error name</a> followed by <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-6">DOMException</a></code>.
-Exceptions can also be <dfn class="dfn-paneled" data-dfn-for="exception" data-dfn-type="dfn" data-export="" data-lt="throw|thrown" id="dfn-throw">thrown</dfn>, by providing the
+Exceptions can also be <dfn class="dfn-paneled" data-dfn-for="exception" data-dfn-type="dfn" data-export="" data-lt="throw" id="dfn-throw">thrown</dfn>, by providing the
 same details required to <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-2">create</a> one.</p>
    <p>The resulting behavior from creating and throwing an exception is language binding-specific.</p>
    <p class="note" role="note">Note: See <a href="#es-creating-throwing-exceptions">§3.15 Creating and throwing exceptions</a> for details on what creating and throwing an exception
@@ -6295,7 +6295,7 @@ it has characteristics as follows:</p>
    <p class="issue" id="issue-459a816a"><a class="self-link" href="#issue-459a816a"></a> The list above needs updating for the latest ES6 draft. </p>
    <p id="ecmascript-abstractop"> Algorithms in this section use the conventions described in <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">ECMA-262 section 5.2</a>, such as the use of steps and substeps, the use of mathematical
     operations, and so on.  The <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-toboolean">ToBoolean</a>, <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-tonumber">ToNumber</a>, <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-touint16">ToUint16</a>, <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-toint32">ToInt32</a>, <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-touint32">ToUint32</a>, <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a>, <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-toobject">ToObject</a>, <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-isaccessordescriptor">IsAccessorDescriptor</a> and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-isdatadescriptor">IsDataDescriptor</a> abstract operations and the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type(x)</a> notation referenced in this section are defined in ECMA-262 sections 6 and 7. </p>
-   <p>When an algorithm says to <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="es throw" id="ecmascript-throw">throw a <emu-val><i>Something</i>Error</emu-val></dfn> then this means to construct a new ECMAScript <emu-val><i>Something</i>Error</emu-val> object
+   <p>When an algorithm says to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="es throw" data-noexport="" id="ecmascript-throw">throw</dfn> a <emu-val><i>Something</i>Error</emu-val> then this means to construct a new ECMAScript <emu-val><i>Something</i>Error</emu-val> object
 and to throw it, just as the algorithms in ECMA-262 do.</p>
    <p>Note that algorithm steps can call in to other algorithms and abstract operations and
 not explicitly handle exceptions that are thrown from them.  When an exception
@@ -6642,12 +6642,12 @@ ECMAScript <emu-val>Boolean</emu-val> value <var>x</var>.</p>
       <ol>
        <li data-md="">
         <p>If <var>x</var> is <emu-val>NaN</emu-val>, +∞, or −∞,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-1">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-1">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Set <var>x</var> to <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="abstract-op" href="#abstract-opdef-integerpart" id="ref-for-abstract-opdef-integerpart-1">IntegerPart</a>(<var>x</var>).</p>
        <li data-md="">
         <p>If <var>x</var> &lt; <var>lowerBound</var> or <var>x</var> > <var>upperBound</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-2">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-2">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Return <var>x</var>.</p>
       </ol>
@@ -6693,7 +6693,7 @@ then return <var>x</var> − 2<sup><var>bitLength</var></sup>.</p>
       <p>Let <var>x</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-tonumber">ToNumber</a>(<var>V</var>).</p>
      <li data-md="">
       <p>If <var>x</var> is <emu-val>NaN</emu-val>, +∞, or −∞,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-3">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-3">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>S</var> be the set of finite IEEE 754 single-precision floating
 point values except −0, but with two special values added: 2<sup>128</sup> and
@@ -6703,7 +6703,7 @@ point values except −0, but with two special values added: 2<sup>128</sup> and
 to <var>x</var>, selecting the number with an <em>even significand</em> if there are two <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">equally close values</a>.
 (The two special values 2<sup>128</sup> and −2<sup>128</sup> are considered to have even significands for this purpose.)</p>
      <li data-md="">
-      <p>If <var>y</var> is 2<sup>128</sup> or −2<sup>128</sup>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-4">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <var>y</var> is 2<sup>128</sup> or −2<sup>128</sup>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-4">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>If <var>y</var> is +0 and <var>x</var> is negative, return −0.</p>
      <li data-md="">
@@ -6762,7 +6762,7 @@ the one that represents the same numeric value as the IDL <code class="idl"><a d
       <p>Let <var>x</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-tonumber">ToNumber</a>(<var>V</var>).</p>
      <li data-md="">
       <p>If <var>x</var> is <emu-val>NaN</emu-val>, +∞, or −∞,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-5">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-5">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Return the IDL <code class="idl"><a data-link-type="idl" href="#idl-double" id="ref-for-idl-double-18">double</a></code> value
 that has the same numeric value as <var>x</var>.</p>
@@ -6838,7 +6838,7 @@ attribute annotated with [<code class="idl"><a data-link-type="idl" href="#Treat
      <li data-md="">
       <p>Let <var>x</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a>(<var>V</var>).</p>
      <li data-md="">
-      <p>If the value of any <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type">element</a> of <var>x</var> is greater than 255, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-6">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If the value of any <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type">element</a> of <var>x</var> is greater than 255, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-6">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Return an IDL <code class="idl"><a data-link-type="idl" href="#idl-ByteString" id="ref-for-idl-ByteString-12">ByteString</a></code> value
 whose length is the length of <var>x</var>, and where the value of each element is
@@ -6876,7 +6876,7 @@ the value of the corresponding element of <var>x</var>.</p>
     <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-19">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-11">object</a></code> value by running the following algorithm:</p>
     <ol>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-7">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-7">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Return the IDL <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-12">object</a></code> value that is a reference to the same object as <var>V</var>.</p>
     </ol>
@@ -6890,14 +6890,14 @@ the value of the corresponding element of <var>x</var>.</p>
     <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-20">converted</a> to an IDL <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-5">interface type</a> value by running the following algorithm (where <var>I</var> is the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-55">interface</a>):</p>
     <ol>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-8">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-8">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>If <var>V</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-14">platform object</a> that implements <var>I</var>, then return the IDL <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-6">interface type</a> value that represents a reference to that platform object.</p>
      <li data-md="">
       <p>If <var>V</var> is a <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-8">user object</a> that is considered to implement <var>I</var> according to the rules in <a href="#es-user-objects">§3.10 User objects implementing callback interfaces</a>, then return the IDL <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-7">interface type</a> value that represents a reference to that
 user object, with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a> as the <a data-link-type="dfn" href="#dfn-callback-context" id="ref-for-dfn-callback-context-5">callback context</a>.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-9">Throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p><a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-9">Throw</a> a <emu-val>TypeError</emu-val>.</p>
     </ol>
    </div>
    <p id="interface-to-es"> The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-19">converting</a> an IDL <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-8">interface type</a> value to an ECMAScript value is the <emu-val>Object</emu-val> value that represents a reference to the same object that the IDL <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-9">interface type</a> value represents. </p>
@@ -6910,7 +6910,7 @@ the object (or its prototype chain) correspond to <a data-link-type="dfn" href="
     running the following algorithm (where <var>D</var> is the <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-8">dictionary type</a>):</p>
     <ol>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Undefined, Null or Object, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-10">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Undefined, Null or Object, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-10">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>dict</var> be an empty dictionary value of type <var>D</var>;
 every <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-17">dictionary member</a> is initially considered to be <a data-link-type="dfn" href="#dfn-present" id="ref-for-dfn-present-2">not present</a>.</p>
@@ -7008,7 +7008,7 @@ in order from least to most derived.</p>
       <p>Let <var>S</var> be the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a>(<var>V</var>).</p>
      <li data-md="">
       <p>If <var>S</var> is not one of <var>E</var>’s <a data-link-type="dfn" href="#dfn-enumeration-value" id="ref-for-dfn-enumeration-value-5">enumeration values</a>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-11">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-11">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Return the enumeration value of type <var>E</var> that is equal to <var>S</var>.</p>
     </ol>
@@ -7026,7 +7026,7 @@ when they can be any object.</p>
       <p>If the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>V</var>) is <emu-val>false</emu-val> and the conversion to an IDL value
 is not being performed due
 to <var>V</var> being assigned to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-28">attribute</a> whose type is a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-16">nullable</a> <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-19">callback function</a> that is annotated with [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-3">TreatNonObjectAsNull</a></code>],
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-12">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-12">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Return the IDL <a data-link-type="dfn" href="#idl-callback-function" id="ref-for-idl-callback-function-3">callback function type</a> value
 that represents a reference to the same object that <var>V</var> represents, with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a> as the <a data-link-type="dfn" href="#dfn-callback-context" id="ref-for-dfn-callback-context-6">callback context</a>.</p>
@@ -7070,13 +7070,13 @@ ECMAScript <emu-val>Array</emu-val> values.</p>
     <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-27">converted</a> to an IDL <a data-link-type="dfn" href="#sequence-type" id="ref-for-sequence-type-11">sequence&lt;<var>T</var>></a> value as follows:</p>
     <ol>
      <li data-md="">
-      <p>If <var>V</var> is not an object, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-13">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <var>V</var> is not an object, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-13">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>method</var> be the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-getmethod">GetMethod</a>(<var>V</var>, <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a>).</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>method</var>).</p>
      <li data-md="">
-      <p>If <var>method</var> is <emu-val>undefined</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-14">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <var>method</var> is <emu-val>undefined</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-14">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Return the result of <a data-link-type="dfn" href="#create-sequence-from-iterable" id="ref-for-create-sequence-from-iterable-1">creating a sequence</a> from <var>V</var> and <var>method</var>.</p>
     </ol>
@@ -7216,7 +7216,7 @@ ECMAScript <emu-val>Object</emu-val> values.</p>
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>O</var>) is Undefined or Null,
 return <var>result</var>.</p>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>O</var>) is not Object, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-15">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>O</var>) is not Object, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-15">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>keys</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a> <var>O</var>.[[OwnPropertyKeys]]().</p>
      <li data-md="">
@@ -7380,7 +7380,7 @@ with <var>reason</var> as the rejection reason.</p>
      <li data-md="">
       <p>Let <var>then</var> be the result of calling the internal [[Get]] method of <var>promise</var> with property name “then”.</p>
      <li data-md="">
-      <p>If <var>then</var> is not <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">callable</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-16">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <var>then</var> is not <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">callable</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-16">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Return the result of calling <var>then</var> with <var>promise</var> as the <emu-val>this</emu-val> value and <var>onFulfilled</var> and <var>onRejected</var> as its two arguments.</p>
     </ol>
@@ -7536,7 +7536,7 @@ then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-
       <p>If <var>types</var> includes a <code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref-for-idl-boolean-17">boolean</a></code>,
 then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-51">converting</a> <var>V</var> to <code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref-for-idl-boolean-18">boolean</a></code>.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-17">Throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p><a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-17">Throw</a> a <emu-val>TypeError</emu-val>.</p>
     </ol>
    </div>
    <p id="union-to-es"> An IDL union type value is <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-32">converted to an ECMAScript value</a> as follows.  If the value is an <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-23">object</a></code> reference to a special object that represents an ECMAScript <emu-val>undefined</emu-val> value, then it is converted to the ECMAScript <emu-val>undefined</emu-val> value.  Otherwise,
@@ -7551,7 +7551,7 @@ platform objects for <code class="idl"><a data-link-type="idl" href="#dfn-DOMExc
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
 or <var>V</var> does not have an [[ErrorData]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-18">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-18">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Return the IDL <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-12">Error</a></code> value that is a reference
 to the same object as <var>V</var>.</p>
@@ -7569,7 +7569,7 @@ by platform objects for <code class="idl"><a data-link-type="idl" href="#dfn-DOM
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
 or <var>V</var> is not a platform object that represents a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-29">DOMException</a></code>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-19">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-19">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Return the IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-30">DOMException</a></code> value that is a reference
 to the same object as <var>V</var>.</p>
@@ -7587,7 +7587,7 @@ to the same object as <var>V</var>.</p>
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
 or <var>V</var> does not have an [[ArrayBufferData]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>,
 or <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer">IsDetachedBuffer</a>(<var>V</var>) is true,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-20">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-20">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Return the IDL <code class="idl"><a data-link-type="idl" href="#idl-ArrayBuffer" id="ref-for-idl-ArrayBuffer-13">ArrayBuffer</a></code> value that is a reference
 to the same object as <var>V</var>.</p>
@@ -7599,7 +7599,7 @@ to the same object as <var>V</var>.</p>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
 or <var>V</var> does not have a [[DataView]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-21">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-21">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Return the IDL <code class="idl"><a data-link-type="idl" href="#idl-DataView" id="ref-for-idl-DataView-5">DataView</a></code> value that is a reference
 to the same object as <var>V</var>.</p>
@@ -7614,7 +7614,7 @@ to the same object as <var>V</var>.</p>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
 or <var>V</var> does not have a [[TypedArrayName]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a> with a value equal to the name of <var>T</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-22">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-22">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Return the IDL value of type <var>T</var> that is a reference to the same object as <var>V</var>.</p>
     </ol>
@@ -7638,7 +7638,7 @@ a reference to the same object that the IDL value represents.</p>
        <li data-md="">
         <p>Set <var>arrayBuffer</var> to the value of <var>O</var>’s [[ViewedArrayBuffer]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
-        <p>If <var>arrayBuffer</var> is <emu-val>undefined</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-23">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If <var>arrayBuffer</var> is <emu-val>undefined</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-23">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Set <var>offset</var> to the value of <var>O</var>’s [[ByteOffset]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -7647,7 +7647,7 @@ a reference to the same object that the IDL value represents.</p>
      <li data-md="">
       <p>Otherwise, set <var>length</var> to the value of <var>O</var>’s [[ArrayBufferByteLength]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer">IsDetachedBuffer</a>(<var>O</var>), then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-24">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer">IsDetachedBuffer</a>(<var>O</var>), then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-24">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>data</var> be the value of <var>O</var>’s [[ArrayBufferData]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
      <li data-md="">
@@ -8933,7 +8933,7 @@ getter or setter function of an IDL attribute).</p>
      <li data-md="">
       <p>Remove from <var>S</var> all entries whose type list is not of length <var>argcount</var>.</p>
      <li data-md="">
-      <p>If <var>S</var> is empty, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-25">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <var>S</var> is empty, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-25">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Initialize <var>d</var> to −1.</p>
      <li data-md="">
@@ -9208,7 +9208,7 @@ that has one of the above types in its <a data-link-type="dfn" href="#dfn-flatte
        <li data-md="">
         <p>Otherwise: if there is an entry in <var>S</var> that has <code class="idl"><a data-link-type="idl" href="#idl-any" id="ref-for-idl-any-14">any</a></code> at position <var>i</var> of its type list, then remove from <var>S</var> all other entries.</p>
        <li data-md="">
-        <p>Otherwise: <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-26">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>Otherwise: <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-26">throw</a> a <emu-val>TypeError</emu-val>.</p>
       </ol>
      <li data-md="">
       <p>Let <var>callable</var> be the <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-51">operation</a> or <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-68">extended attribute</a> of the single entry in <var>S</var>.</p>
@@ -9380,9 +9380,9 @@ both as a function and as a constructor.</p>
     the following steps must be taken:</p>
     <ol>
      <li data-md="">
-      <p>If <var>I</var> was not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-22">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-72">extended attribute</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-27">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <var>I</var> was not declared with a [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-22">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-72">extended attribute</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-27">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-built-in-function-objects">NewTarget</a> is <emu-val>undefined</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-28">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-built-in-function-objects">NewTarget</a> is <emu-val>undefined</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-28">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>id</var> be the identifier of interface <var>I</var>.</p>
      <li data-md="">
@@ -9427,7 +9427,7 @@ property named “name” with attributes <span class="prop-desc">{ [[Writable]]
      <li data-md="">
       <p>Let <var>O</var> be the result of calling the [[Get]] method of <var>A</var> with property name “prototype”.</p>
      <li data-md="">
-      <p>If <var>O</var> is not an object, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-29">throw a <emu-val>TypeError</emu-val></a> exception.</p>
+      <p>If <var>O</var> is not an object, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-29">throw</a> a <emu-val>TypeError</emu-val> exception.</p>
      <li data-md="">
       <p>If <var>V</var> is a platform object that implements the
 interface for which <var>O</var> is the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-8">interface prototype object</a>,
@@ -9765,7 +9765,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
 [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-8">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-82">extended attribute</a>,
 then return <emu-val>undefined</emu-val>.</p>
            <li data-md="">
-            <p>Otherwise, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-30">throw a <emu-val>TypeError</emu-val></a>.</p>
+            <p>Otherwise, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-30">throw</a> a <emu-val>TypeError</emu-val>.</p>
           </ol>
          <li data-md="">
           <p>Set <var>idlValue</var> to be the result of performing the actions listed in the description of the attribute that occur when getting
@@ -9793,7 +9793,7 @@ concatenation of “get ” and the identifier of the attribute.</p>
     Otherwise, it is a <emu-val>Function</emu-val> object whose behavior when invoked is as follows:</p>
       <ol>
        <li data-md="">
-        <p>If no arguments were passed to the <emu-val>Function</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-31">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If no arguments were passed to the <emu-val>Function</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-31">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>V</var> be the value of the first argument passed to the <emu-val>Function</emu-val>.</p>
        <li data-md="">
@@ -9819,7 +9819,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
          <li data-md="">
           <p>If <var>validThis</var> is <emu-val>false</emu-val> and the <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-56">attribute</a> was not specified with the
 [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-10">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-84">extended attribute</a>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-32">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-32">throw</a> a <emu-val>TypeError</emu-val>.</p>
          <li data-md="">
           <p>If the attribute is declared with a [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-12">Replaceable</a></code>]
 extended attribute, then:</p>
@@ -9844,7 +9844,7 @@ extended attribute, then:</p>
             <p>Let <var>Q</var> be the result of calling the [[Get]] method
 on <var>O</var> using the identifier of the attribute as the property name.</p>
            <li data-md="">
-            <p>If <var>Q</var> is not an object, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-33">throw a <emu-val>TypeError</emu-val></a>.</p>
+            <p>If <var>Q</var> is not an object, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-33">throw</a> a <emu-val>TypeError</emu-val>.</p>
            <li data-md="">
             <p>Let <var>A</var> be the attribute identified by the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-17">PutForwards</a></code>] extended attribute.</p>
            <li data-md="">
@@ -9959,7 +9959,7 @@ object does not implement <var>target</var>.)</p>
            <li data-md="">
             <p>If <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-24">platform object</a>, then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-dfn-perform-a-security-check-3">perform a security check</a>, passing <var>O</var>, <var>id</var>, and "method".</p>
            <li data-md="">
-            <p>If <var>O</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-25">platform object</a> that implements the interface <var>target</var>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-34">throw a <emu-val>TypeError</emu-val></a>.</p>
+            <p>If <var>O</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-25">platform object</a> that implements the interface <var>target</var>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-34">throw</a> a <emu-val>TypeError</emu-val>.</p>
           </ol>
          <li data-md="">
           <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-10">effective overload set</a> for <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-16">regular operations</a> (if <var>op</var> is a
@@ -10037,7 +10037,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-104">interface</a> on which the stringifier was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-35">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-104">interface</a> on which the stringifier was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-35">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>V</var> be an uninitialized variable.</p>
        <li data-md="">
@@ -10105,7 +10105,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-106">interface</a> on which the serializer was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-36">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-106">interface</a> on which the serializer was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-36">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Depending on how <code>serializer</code> was specified:</p>
       <dl class="switch">
@@ -10245,7 +10245,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-109">interface</a> the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-10">iterable declaration</a> is on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-29">platform object</a> that implements <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-37">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-37">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>iterator</var> be a newly created <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-1">default iterator object</a> for <var>interface</var> with <var>object</var> as its target and iterator kind “key+value”.</p>
      <li data-md="">
@@ -10272,7 +10272,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       </ul>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-31">platform object</a> that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-110">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-9">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-9">setlike declaration</a> is defined,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-38">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-38">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>If the interface has a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-10">maplike declaration</a>, then:</p>
       <ol>
@@ -10381,11 +10381,11 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-112">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-14">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-13">setlike declaration</a> is declared.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-33">platform object</a> that implements <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-39">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-39">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>callbackFn</var> be the value of the first argument passed to the function, or <emu-val>undefined</emu-val> if the argument was not supplied.</p>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>callbackFn</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-40">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>callbackFn</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-40">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>thisArg</var> be the value of the second argument passed to the function, or <emu-val>undefined</emu-val> if the argument was not supplied.</p>
      <li data-md="">
@@ -10409,7 +10409,7 @@ or the [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma2
      <li data-md="">
       <p>Let <var>forEach</var> be the result of calling the [[Get]] internal method of <var>backing</var> with “forEach” and <var>backing</var> as arguments.</p>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>forEach</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-41">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>forEach</var>) is <emu-val>false</emu-val>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-41">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-call">Call</a>(<var>forEach</var>, <var>backing</var>, «<var>callbackWrapper</var>, <var>thisArg</var>»).</p>
      <li data-md="">
@@ -10483,7 +10483,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-115">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-15">iterable declaration</a> is declared on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-35">platform object</a> that implements <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-42">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-42">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>iterator</var> be a newly created <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-2">default iterator object</a> for <var>interface</var> with <var>object</var> as its target and iterator kind “key”.</p>
      <li data-md="">
@@ -10533,7 +10533,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-117">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-17">iterable declaration</a> is declared on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-37">platform object</a> that implements <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-43">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-43">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>iterator</var> be a newly created <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-3">default iterator object</a> for <var>interface</var> with <var>object</var> as its target and iterator kind “value”.</p>
      <li data-md="">
@@ -10584,7 +10584,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       </ul>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-8">default iterator object</a> for <var>interface</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-44">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-44">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>index</var> be <var>object</var>’s index.</p>
      <li data-md="">
@@ -10682,13 +10682,13 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-45">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-45">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
      <li data-md="">
       <p>Let <var>function</var> be the result of calling the [[Get]] internal method of <var>map</var> passing <var>name</var> and <var>map</var> as arguments.</p>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>function</var>) is <emu-val>false</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-46">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>function</var>) is <emu-val>false</emu-val>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-46">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-call">Call</a>(<var>function</var>, <var>map</var>, <var>arguments</var>).</p>
     </ol>
@@ -10719,7 +10719,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “getter”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-47">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-47">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -10768,7 +10768,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-48">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-48">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -10825,7 +10825,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-49">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-49">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -10871,7 +10871,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-50">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-50">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>map</var> be the <emu-val>Map</emu-val> object that is the value of <var>O</var>’s [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -10930,7 +10930,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
       </ul>
      <li data-md="">
       <p>If <var>O</var> is not an object that implements <var>A</var>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-51">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-51">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Let <var>set</var> be the <emu-val>Set</emu-val> object that is
 the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
@@ -10938,7 +10938,7 @@ the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https
       <p>Let <var>function</var> be the result of calling the [[Get]] internal method of <var>set</var> passing <var>name</var> and <var>set</var> as arguments.</p>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>function</var>) is <emu-val>false</emu-val>,
-then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-52">throw a <emu-val>TypeError</emu-val></a>.</p>
+then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-52">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-call">Call</a>(<var>function</var>, <var>set</var>, <var>arguments</var>).</p>
     </ol>
@@ -10969,7 +10969,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “getter”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-53">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-53">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>set</var> be the <emu-val>Set</emu-val> object that is the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -11017,7 +11017,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-54">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-54">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>set</var> be the <emu-val>Set</emu-val> object that is the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -11070,7 +11070,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-55">throw a <emu-val>TypeError</emu-val></a>.</p>
+        <p>If <var>O</var> is not an object that implements <var>A</var>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-55">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>set</var> be the <emu-val>Set</emu-val> object that is the value of <var>O</var>’s [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>.</p>
        <li data-md="">
@@ -11331,7 +11331,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
     assuming <var>arg</var><sub>0..<var>n</var>−1</sub> is the list of argument values passed to [[Call]]:</p>
     <ol>
      <li data-md="">
-      <p>If <var>I</var> has no <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-11">legacy callers</a>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-56">throw a <emu-val>TypeError</emu-val></a>.</p>
+      <p>If <var>I</var> has no <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-11">legacy callers</a>, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-56">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-12">effective overload set</a> for legacy callers on <var>I</var> and with argument count <var>n</var>.</p>
      <li data-md="">
@@ -12956,7 +12956,6 @@ language binding.</p>
    <li><a href="#dfn-xattr-identifier-list">takes an identifier list</a><span>, in §2.12</span>
    <li><a href="#dfn-xattr-no-arguments">takes no arguments</a><span>, in §2.12</span>
    <li><a href="#dfn-throw">throw</a><span>, in §2.5</span>
-   <li><a href="#dfn-throw">thrown</a><span>, in §2.5</span>
    <li><a href="#dom-domexception-timeout_err">TIMEOUT_ERR</a><span>, in §2.5.1</span>
    <li><a href="#timeouterror">TimeoutError</a><span>, in §2.5.1</span>
    <li><a href="#transactioninactiveerror">TransactionInactiveError</a><span>, in §2.5.1</span>

--- a/index.html
+++ b/index.html
@@ -4996,18 +4996,18 @@ which is the type of error the exception represents, and a <dfn data-dfn-for="ex
 user agent-defined value that provides human readable details of the error.</p>
    <p>There are two kinds of exceptions available to be thrown from specifications.
 The first is a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-simple-exception">simple exception</dfn>, which
-is identified by one of the following type values:</p>
+is identified by one of the following names:</p>
    <ul>
     <li data-md="">
-     <p><emu-val>EvalError</emu-val></p>
+     <p><dfn class="idl-code" data-dfn-type="exception" data-export="" id="exceptiondef-evalerror">EvalError<a class="self-link" href="#exceptiondef-evalerror"></a></dfn></p>
     <li data-md="">
-     <p><emu-val>RangeError</emu-val></p>
+     <p><dfn class="idl-code" data-dfn-type="exception" data-export="" id="exceptiondef-rangeerror">RangeError<a class="self-link" href="#exceptiondef-rangeerror"></a></dfn></p>
     <li data-md="">
-     <p><emu-val>ReferenceError</emu-val></p>
+     <p><dfn class="idl-code" data-dfn-type="exception" data-export="" id="exceptiondef-referenceerror">ReferenceError<a class="self-link" href="#exceptiondef-referenceerror"></a></dfn></p>
     <li data-md="">
-     <p><emu-val>TypeError</emu-val></p>
+     <p><dfn class="dfn-paneled idl-code" data-dfn-type="exception" data-export="" id="exceptiondef-typeerror">TypeError</dfn></p>
     <li data-md="">
-     <p><emu-val>URIError</emu-val></p>
+     <p><dfn class="idl-code" data-dfn-type="exception" data-export="" id="exceptiondef-urierror">URIError<a class="self-link" href="#exceptiondef-urierror"></a></dfn></p>
    </ul>
    <p>These correspond to all of the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-error-objects">ECMAScript error objects</a> (apart from <emu-val>SyntaxError</emu-val> and <emu-val>Error</emu-val>,
 which are deliberately omitted as they are reserved for use
@@ -5032,11 +5032,11 @@ same details required to <a data-link-type="dfn" href="#dfn-create-exception" id
    <p>The resulting behavior from creating and throwing an exception is language binding-specific.</p>
    <p class="note" role="note">Note: See <a href="#es-creating-throwing-exceptions">§3.15 Creating and throwing exceptions</a> for details on what creating and throwing an exception
 entails in the ECMAScript language binding.</p>
-   <div class="example" id="example-f05b58d5">
-    <a class="self-link" href="#example-f05b58d5"></a> 
+   <div class="example" id="example-6936289a">
+    <a class="self-link" href="#example-6936289a"></a> 
     <p>Here is are some examples of wording to use to create and throw exceptions.
-    To throw a new <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-4">simple exception</a> named <emu-val>TypeError</emu-val>:</p>
-    <blockquote> <a data-link-type="dfn" href="#dfn-throw" id="ref-for-dfn-throw-1">Throw</a> a <emu-val>TypeError</emu-val>. </blockquote>
+    To throw a new <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-4">simple exception</a> named <code class="idl"><a data-link-type="idl" href="#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror-1">TypeError</a></code>:</p>
+    <blockquote> <a data-link-type="dfn" href="#dfn-throw" id="ref-for-dfn-throw-1">Throw</a> a <code class="idl"><a data-link-type="idl" href="#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror-2">TypeError</a></code>. </blockquote>
     <p>To throw a new <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-7">DOMException</a></code> with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-5">error name</a> "<code class="idl"><a class="idl-code" data-link-type="exception" href="#indexsizeerror" id="ref-for-indexsizeerror-1">IndexSizeError</a></code>":</p>
     <blockquote> <a data-link-type="dfn" href="#dfn-throw" id="ref-for-dfn-throw-2">Throw</a> an "<code class="idl"><a class="idl-code" data-link-type="exception" href="#indexsizeerror" id="ref-for-indexsizeerror-2">IndexSizeError</a></code>" <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-8">DOMException</a></code>. </blockquote>
     <p>To create a new <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-9">DOMException</a></code> with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-6">error name</a> "<code class="idl"><a class="idl-code" data-link-type="exception" href="#syntaxerror" id="ref-for-syntaxerror-1">SyntaxError</a></code>":</p>
@@ -12744,6 +12744,7 @@ language binding.</p>
    <li><a href="#dfn-exception-error-name">error name</a><span>, in §2.5</span>
    <li><a href="#dfn-error-names-table">error names table</a><span>, in §2.5.1</span>
    <li><a href="#ecmascript-throw">es throw</a><span>, in §3</span>
+   <li><a href="#exceptiondef-evalerror">EvalError</a><span>, in §2.5</span>
    <li><a href="#dfn-example-term">example term</a><span>, in §Unnumbered section</span>
    <li><a href="#dfn-exception">exception</a><span>, in §2.5</span>
    <li><a href="#es-exception-objects">Exception objects</a><span>, in §3.13.2</span>
@@ -12898,10 +12899,12 @@ language binding.</p>
    <li><a href="#PutForwards">PutForwards</a><span>, in §3.3.13</span>
    <li><a href="#dom-domexception-quota_exceeded_err">QUOTA_EXCEEDED_ERR</a><span>, in §2.5.1</span>
    <li><a href="#quotaexceedederror">QuotaExceededError</a><span>, in §2.5.1</span>
+   <li><a href="#exceptiondef-rangeerror">RangeError</a><span>, in §2.5</span>
    <li><a href="#dfn-read-only">read only</a><span>, in §2.2.2</span>
    <li><a href="#readonlyerror">ReadOnlyError</a><span>, in §2.5.1</span>
    <li><a href="#idl-record">record</a><span>, in §2.11.24</span>
    <li><a href="#record-type">record type</a><span>, in §2.11.25</span>
+   <li><a href="#exceptiondef-referenceerror">ReferenceError</a><span>, in §2.5</span>
    <li><a href="#dfn-regular-attribute">regular attribute</a><span>, in §2.2.2</span>
    <li><a href="#dfn-regular-operation">regular operation</a><span>, in §2.2.3</span>
    <li><a href="#Replaceable">Replaceable</a><span>, in §3.3.14</span>
@@ -12961,6 +12964,7 @@ language binding.</p>
    <li><a href="#TreatNullAs">TreatNullAs</a><span>, in §3.3.18</span>
    <li><a href="#dfn-typed-array-type">typed array types</a><span>, in §2.11</span>
    <li><a href="#dfn-typedef">typedef</a><span>, in §2.8</span>
+   <li><a href="#exceptiondef-typeerror">TypeError</a><span>, in §2.5</span>
    <li><a href="#dom-domexception-type_mismatch_err">TYPE_MISMATCH_ERR</a><span>, in §2.5.1</span>
    <li><a href="#typemismatcherror">TypeMismatchError</a><span>, in §2.5.1</span>
    <li><a href="#dfn-type-name">type name</a><span>, in §2.11</span>
@@ -12980,6 +12984,7 @@ language binding.</p>
    <li><a href="#idl-unsigned-long-long">unsigned long long</a><span>, in §2.11.9</span>
    <li><a href="#idl-unsigned-short">unsigned short</a><span>, in §2.11.5</span>
    <li><a href="#dfn-perform-steps-once-promise-is-settled">upon settling</a><span>, in §3.2.20</span>
+   <li><a href="#exceptiondef-urierror">URIError</a><span>, in §2.5</span>
    <li><a href="#dom-domexception-url_mismatch_err">URL_MISMATCH_ERR</a><span>, in §2.5.1</span>
    <li><a href="#urlmismatcherror">URLMismatchError</a><span>, in §2.5.1</span>
    <li><a href="#dfn-user-object">user object</a><span>, in §2.10</span>
@@ -14189,6 +14194,12 @@ language binding.</p>
     <li><a href="#ref-for-dfn-simple-exception-5">2.11.28. Error</a>
     <li><a href="#ref-for-dfn-simple-exception-6">3.14. Exception objects</a>
     <li><a href="#ref-for-dfn-simple-exception-7">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-simple-exception-8">(2)</a> <a href="#ref-for-dfn-simple-exception-9">(3)</a> <a href="#ref-for-dfn-simple-exception-10">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="exceptiondef-typeerror">
+   <b><a href="#exceptiondef-typeerror">#exceptiondef-typeerror</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-exceptiondef-typeerror-1">2.5. Exceptions</a> <a href="#ref-for-exceptiondef-typeerror-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-DOMException">

--- a/index.html
+++ b/index.html
@@ -5026,9 +5026,9 @@ if it has one.</p>
    <p>There are two types that can be used to refer to exception objects: <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-1">Error</a></code>, which encompasses all exceptions,
 and <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-3">DOMException</a></code> which includes just DOMException objects.
 This allows for example an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-22">operation</a> to be declared to have a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-4">DOMException</a></code> <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-2">return type</a> or an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-15">attribute</a> to be of type <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-2">Error</a></code>.</p>
-   <p><a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-3">Simple exceptions</a> can be <dfn class="dfn-paneled" data-dfn-for="exception" data-dfn-type="dfn" data-export="" id="dfn-create-exception">created</dfn> by providing their <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-3">error name</a>. <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-5">DOMExceptions</a></code>, by providing their <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-4">error name</a> followed by <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-6">DOMException</a></code>.
+   <p><a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-3">Simple exceptions</a> can be <dfn class="dfn-paneled" data-dfn-for="exception" data-dfn-type="dfn" data-export="" id="dfn-create-exception">created</dfn> by providing their <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-3">error name</a>. <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-5">DOMExceptions</a></code> can be <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-1">created</a> by providing their <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-4">error name</a> followed by <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-6">DOMException</a></code>.
 Exceptions can also be <dfn class="dfn-paneled" data-dfn-for="exception" data-dfn-type="dfn" data-export="" data-lt="throw|thrown" id="dfn-throw">thrown</dfn>, by providing the
-same details required to <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-1">create</a> one.</p>
+same details required to <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-2">create</a> one.</p>
    <p>The resulting behavior from creating and throwing an exception is language binding-specific.</p>
    <p class="note" role="note">Note: See <a href="#es-creating-throwing-exceptions">§3.15 Creating and throwing exceptions</a> for details on what creating and throwing an exception
 entails in the ECMAScript language binding.</p>
@@ -5040,7 +5040,7 @@ entails in the ECMAScript language binding.</p>
     <p>To throw a new <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-7">DOMException</a></code> with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-5">error name</a> "<code class="idl"><a class="idl-code" data-link-type="exception" href="#indexsizeerror" id="ref-for-indexsizeerror-1">IndexSizeError</a></code>":</p>
     <blockquote> <a data-link-type="dfn" href="#dfn-throw" id="ref-for-dfn-throw-2">Throw</a> an "<code class="idl"><a class="idl-code" data-link-type="exception" href="#indexsizeerror" id="ref-for-indexsizeerror-2">IndexSizeError</a></code>" <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-8">DOMException</a></code>. </blockquote>
     <p>To create a new <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-9">DOMException</a></code> with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-6">error name</a> "<code class="idl"><a class="idl-code" data-link-type="exception" href="#syntaxerror" id="ref-for-syntaxerror-1">SyntaxError</a></code>":</p>
-    <blockquote> Let <var>object</var> be a newly <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-2">created</a> "<code class="idl"><a class="idl-code" data-link-type="exception" href="#syntaxerror" id="ref-for-syntaxerror-2">SyntaxError</a></code>" <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-10">DOMException</a></code>. </blockquote>
+    <blockquote> Let <var>object</var> be a newly <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-3">created</a> "<code class="idl"><a class="idl-code" data-link-type="exception" href="#syntaxerror" id="ref-for-syntaxerror-2">SyntaxError</a></code>" <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-10">DOMException</a></code>. </blockquote>
    </div>
    <h4 class="heading settled" data-level="2.5.1" id="idl-DOMException-error-names"><span class="secno">2.5.1. </span><span class="content">Error names</span><a class="self-link" href="#idl-DOMException-error-names"></a></h4>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-error-names-table">error names table</dfn> below lists all the allowed error names
@@ -12038,7 +12038,7 @@ exception field was defined.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="to create a simple exception or DOMException">
-    <p>When a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-7">simple exception</a> or <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-38">DOMException</a></code> <var>E</var> is to be <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-3">created</a>,
+    <p>When a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-7">simple exception</a> or <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-38">DOMException</a></code> <var>E</var> is to be <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-4">created</a>,
     with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-7">error name</a> <var>N</var> and optional user agent-defined message <var>M</var>,
     the following steps must be followed:</p>
     <ol>
@@ -12086,7 +12086,7 @@ with <var>args</var> as the argument list.</p>
     the following steps must be followed:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>O</var> be the result of <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-4">creating</a> the specified exception <var>E</var> with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-9">error name</a> <var>N</var> and
+      <p>Let <var>O</var> be the result of <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-5">creating</a> the specified exception <var>E</var> with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-9">error name</a> <var>N</var> and
 optional user agent-defined message <var>M</var>.</p>
      <li data-md="">
       <p>Throw <var>O</var>.</p>
@@ -14229,8 +14229,8 @@ language binding.</p>
   <aside class="dfn-panel" data-for="dfn-create-exception">
    <b><a href="#dfn-create-exception">#dfn-create-exception</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-create-exception-1">2.5. Exceptions</a> <a href="#ref-for-dfn-create-exception-2">(2)</a>
-    <li><a href="#ref-for-dfn-create-exception-3">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-create-exception-4">(2)</a>
+    <li><a href="#ref-for-dfn-create-exception-1">2.5. Exceptions</a> <a href="#ref-for-dfn-create-exception-2">(2)</a> <a href="#ref-for-dfn-create-exception-3">(3)</a>
+    <li><a href="#ref-for-dfn-create-exception-4">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-create-exception-5">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-throw">


### PR DESCRIPTION
* Don't define simple exception names in WebIDL.
* Make Error exclusively for authors.
* Fix syntax for throwing and creating DomExceptions.
* Fix examples.

Closes #247.

**NOTE:** This doesn't address the distinction between [#throw](https://heycam.github.io/webidl/#dfn-throw) and [#ecmascript-throw](https://heycam.github.io/webidl/#ecmascript-throw), which I think needs fixing before we merge this.

I'd be tempted not to export [#ecmascript-throw](https://heycam.github.io/webidl/#ecmascript-throw) and make everything use [#throw](https://heycam.github.io/webidl/#dfn-throw) instead. (Currently all simple exceptions in the spec reference [#ecmascript-throw](https://heycam.github.io/webidl/#ecmascript-throw), which I don't think is the right thing to do.)
We'd then only use the text around [#ecmascript-throw](https://heycam.github.io/webidl/#ecmascript-throw) in the bindings to describe the behavior of all exceptions (or just simple ones?) in an ES environment. Thoughts?

**NOTE 2:** I opted for an `"ExceptionName" {{DOMException}}` syntax because it reads better, but I'm happy to switch it around if that makes more sense.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
    
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://cdn.rawgit.com/tobie/webidl/793b67f/index.html) | [Diff w/ current ED](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fheycam.github.io%2Fwebidl%2F&doc2=https%3A%2F%2Fcdn.rawgit.com%2Ftobie%2Fwebidl%2F793b67f%2Findex.html) | [Diff w/ base](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2Fb4bc602%2Findex.html&doc2=https%3A%2F%2Fcdn.rawgit.com%2Ftobie%2Fwebidl%2F793b67f%2Findex.html)