### PR TITLE
Split DOMException back into IDL type and DFN.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4443,19 +4443,19 @@ The meaning of each [=simple exception=] matches
 its corresponding error object in the
 ECMAScript specification.
 
-The second kind of exception is a <dfn id="dfn-DOMException" interface export>DOMException</dfn>,
-which is an exception that encapsulates a name and an optional integer code,
+The second kind of exceptions are <dfn id="dfn-DOMException" lt="DOM exception" export>DOM exceptions</dfn>,
+which are exceptions that encapsulates a name and an optional integer code,
 for compatibility with historically defined exceptions in the DOM.
 
 For [=simple exceptions=], the [=error name=] is the type of the exception.
-For {{DOMException|DOMExceptions}}, the [=error name=] must be one of the names
+For [=DOM exceptions=], the [=error name=] must be one of the names
 listed in the [=error names table=] below.
-The table also indicates the {{DOMException}}'s integer code for that error name,
+The table also indicates the [=DOM exceptions=]'s integer code for that error name,
 if it has one.
 
 There are two types that can be used to refer to exception objects:
 {{Error!!interface}}, which encompasses all exceptions,
-and {{DOMException}} which includes just DOMException objects.
+and {{DOMException}} which includes just [=DOM exception=] objects.
 This allows for example an [=operation=]
 to be declared to have a {{DOMException}}
 [=return type=] or an [=attribute=]
@@ -4463,7 +4463,7 @@ to be of type {{Error!!interface}}.
 
 [=Simple exceptions=] can be <dfn id="dfn-create-exception" for="exception" export>created</dfn>
 by providing their [=error name=].
-{{DOMException|DOMExceptions}} can be [=created=]
+[=DOM exceptions=] can be [=created=]
 by providing their [=error name=] followed by {{DOMException}}.
 Exceptions can also be <dfn id="dfn-throw" for="exception" export lt="throw">thrown</dfn>, by providing the
 same details required to [=created|create=] one.
@@ -4482,13 +4482,13 @@ entails in the ECMAScript language binding.
         [=exception/Throw=] a {{TypeError}}.
     </blockquote>
 
-    To throw a new {{DOMException}} with [=error name=] "{{IndexSizeError!!exception}}":
+    To throw a new [=DOM exception=] with [=error name=] "{{IndexSizeError!!exception}}":
 
     <blockquote>
         [=exception/Throw=] an "{{IndexSizeError!!exception}}" {{DOMException}}.
     </blockquote>
 
-    To create a new {{DOMException}} with [=error name=] "{{SyntaxError!!exception}}":
+    To create a new [=DOM exception=] with [=error name=] "{{SyntaxError!!exception}}":
 
     <blockquote>
         Let <var ignore>object</var> be a newly [=created=] "{{SyntaxError!!exception}}" {{DOMException}}.
@@ -4499,13 +4499,13 @@ entails in the ECMAScript language binding.
 <h4 id="idl-DOMException-error-names">Error names</h4>
 
 The <dfn id="dfn-error-names-table" export>error names table</dfn> below lists all the allowed error names
-for {{DOMException|DOMExceptions}}, a description, and legacy code values.
+for [=DOM exceptions=], a description, and legacy code values.
 
 Note: If an error name is not listed here, please file a bug as indicated at the top of this specification and it will be addressed shortly. Thanks!
 
 <table id="error-names" class="vert data">
     <thead>
-        <tr><th>Name</th><th>Description</th><th>Legacy {{DOMException|code}} name and value</th></tr>
+        <tr><th>Name</th><th>Description</th><th>Legacy [=DOM exception|code=] name and value</th></tr>
     </thead>
     <tbody>
         <tr>
@@ -4662,12 +4662,12 @@ Note: If an error name is not listed here, please file a bug as indicated at the
 </table>
 
 <div class=advisement>
-    Additionally, the following {{DOMException|DOMExceptions}} are kept for legacy purposes but their usage is discouraged:
+    Additionally, the following [=DOM exceptions=] are kept for legacy purposes but their usage is discouraged:
 
     <table id="legacy-error-names" class="vert data">
         <thead>
             <tr>
-                <th>DOMException</th>
+                <th>DOM exception</th>
                 <th>Alternative</th>
             </tr>
         </thead>
@@ -5100,7 +5100,7 @@ an object can be described as being a <dfn id="dfn-platform-object" export>platf
 object that are considered to be platform objects:
 
 *   objects that implement a non-[=callback interface|callback=] [=interface=];
-*   objects representing IDL {{DOMException|DOMExceptions}}.
+*   objects representing an IDL {{DOMException}}.
 
 <dfn id="dfn-legacy-platform-object" export>Legacy platform objects</dfn> are
 [=platform objects=] that implement an [=interface=] which
@@ -5999,8 +5999,7 @@ and joining them with the string “Or”.
 
 The {{Error!!interface}} type corresponds to the
 set of all possible non-null references to exception objects, including
-[=simple exceptions=]
-and {{DOMException|DOMExceptions}}.
+[=simple exceptions=] and [=DOM exceptions=].
 
 There is no way to represent a constant {{Error!!interface}}
 value in IDL.
@@ -6009,11 +6008,11 @@ The [=type name=] of the
 {{Error!!interface}} type is “Error”.
 
 
-<h4 id="idl-DOMException">DOMException</h4>
+<h4 id="idl-DOMException" interface>DOMException</h4>
 
 The {{DOMException}} type corresponds to the
 set of all possible non-null references to objects
-representing {{DOMException|DOMExceptions}}.
+representing [=DOM exceptions=].
 
 There is no way to represent a constant {{DOMException}}
 value in IDL.
@@ -7754,7 +7753,7 @@ that correspond to the union’s [=member types=].
 
 IDL {{Error!!interface}} values are represented
 by native ECMAScript <emu-val>Error</emu-val> objects and
-platform objects for {{DOMException|DOMExceptions}}.
+platform objects for [=DOM exceptions}}.
 
 <div id="es-to-Error" algorithm="convert an ECMAScript value to Error">
 
@@ -7779,7 +7778,7 @@ platform objects for {{DOMException|DOMExceptions}}.
 <h4 id="es-DOMException">DOMException</h4>
 
 IDL {{DOMException}} values are represented
-by platform objects for {{DOMException|DOMExceptions}}.
+by platform objects for [=DOM exceptions=].
 
 <div id="es-to-DOMException" algorithm="convert an ECMAScript value to DOMException">
 
@@ -7787,7 +7786,7 @@ by platform objects for {{DOMException|DOMExceptions}}.
     to an IDL {{DOMException}} value by running the following algorithm:
 
     1.  If [=Type=](|V|) is not Object,
-        or |V| is not a platform object that represents a {{DOMException}},
+        or |V| is not a platform object that represents a [=DOM exception=],
         then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
     1.  Return the IDL {{DOMException}} value that is a reference
         to the same object as |V|.
@@ -12513,7 +12512,7 @@ attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>false</emu-val>, \[
 [=Simple exceptions=] are represented
 by native ECMAScript objects of the corresponding type.
 
-{{DOMException|DOMExceptions}} are represented by
+[=DOM exceptions=] are represented by
 [=platform objects=] that inherit from
 the [=DOMException prototype object=].
 
@@ -12575,9 +12574,9 @@ on exception objects too.
         exception field was defined.
 </div>
 
-<div algorithm="to create a simple exception or DOMException">
+<div algorithm="to create a simple exception or a DOM exception">
 
-    When a [=simple exception=] or {{DOMException}} |E| is to be [=created=],
+    When a [=simple exception=] or a [=DOM exception=] |E| is to be [=created=],
     with [=error name=] |N| and optional user agent-defined message |M|,
     the following steps must be followed:
 
@@ -12585,7 +12584,7 @@ on exception objects too.
     1.  Let |N| be the result of [=converted to an ECMAScript value|converting=] |N| to a <emu-val>String</emu-val> value.
     1.  Let |args| be a list of ECMAScript values.
         <dl class="switch">
-             :  |E| is {{DOMException}}
+             :  |E| is a [=DOM exception=]
              :: |args| is (<emu-val>undefined</emu-val>, |N|).
              :  |E| is a [=simple exception=]
              :: |args| is (|M|)
@@ -12593,7 +12592,7 @@ on exception objects too.
     1.  Let |G| be the [=current global environment=].
     1.  Let |X| be an object determined based on the type of |E|:
         <dl class="switch">
-             :  |E| is {{DOMException}}
+             :  |E| is a [=DOM exception=]
              :: |X| is the [=DOMException constructor object=]
                 from the global environment |G|.
              :  |E| is a [=simple exception=]
@@ -12607,7 +12606,7 @@ on exception objects too.
 
 <div algorithm="throw an exception">
 
-    When a [=simple exception=] or {{DOMException}} |E| is to be [=exception/throw|thrown=],
+    When a [=simple exception=] or a [=DOM exception=] |E| is to be [=exception/throw|thrown=],
     with [=error name=] |N| and optional user agent-defined message |M|,
     the following steps must be followed:
 

--- a/index.html
+++ b/index.html
@@ -1557,7 +1557,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web IDL</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-13">13 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-14">14 December 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -5015,43 +5015,43 @@ by the ECMAScript parser and by authors, respectively).
 The meaning of each <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-1">simple exception</a> matches
 its corresponding error object in the
 ECMAScript specification.</p>
-   <p>The second kind of exception is a <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="dfn-DOMException">DOMException</dfn>,
-which is an exception that encapsulates a name and an optional integer code,
+   <p>The second kind of exceptions are <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="DOM exception" id="dfn-DOMException">DOM exceptions</dfn>,
+which are exceptions that encapsulates a name and an optional integer code,
 for compatibility with historically defined exceptions in the DOM.</p>
    <p>For <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-2">simple exceptions</a>, the <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-1">error name</a> is the type of the exception.
-For <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-1">DOMExceptions</a></code>, the <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-2">error name</a> must be one of the names
+For <a data-link-type="dfn" href="#dfn-DOMException" id="ref-for-dfn-DOMException-1">DOM exceptions</a>, the <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-2">error name</a> must be one of the names
 listed in the <a data-link-type="dfn" href="#dfn-error-names-table" id="ref-for-dfn-error-names-table-1">error names table</a> below.
-The table also indicates the <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-2">DOMException</a></code>'s integer code for that error name,
+The table also indicates the <a data-link-type="dfn" href="#dfn-DOMException" id="ref-for-dfn-DOMException-2">DOM exceptions</a>'s integer code for that error name,
 if it has one.</p>
    <p>There are two types that can be used to refer to exception objects: <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-1">Error</a></code>, which encompasses all exceptions,
-and <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-3">DOMException</a></code> which includes just DOMException objects.
-This allows for example an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-22">operation</a> to be declared to have a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-4">DOMException</a></code> <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-2">return type</a> or an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-15">attribute</a> to be of type <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-2">Error</a></code>.</p>
-   <p><a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-3">Simple exceptions</a> can be <dfn class="dfn-paneled" data-dfn-for="exception" data-dfn-type="dfn" data-export="" id="dfn-create-exception">created</dfn> by providing their <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-3">error name</a>. <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-5">DOMExceptions</a></code> can be <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-1">created</a> by providing their <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-4">error name</a> followed by <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-6">DOMException</a></code>.
+and <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-1">DOMException</a></code> which includes just <a data-link-type="dfn" href="#dfn-DOMException" id="ref-for-dfn-DOMException-3">DOM exception</a> objects.
+This allows for example an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-22">operation</a> to be declared to have a <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-2">DOMException</a></code> <a data-link-type="dfn" href="#dfn-return-type" id="ref-for-dfn-return-type-2">return type</a> or an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-15">attribute</a> to be of type <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-2">Error</a></code>.</p>
+   <p><a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-3">Simple exceptions</a> can be <dfn class="dfn-paneled" data-dfn-for="exception" data-dfn-type="dfn" data-export="" id="dfn-create-exception">created</dfn> by providing their <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-3">error name</a>. <a data-link-type="dfn" href="#dfn-DOMException" id="ref-for-dfn-DOMException-4">DOM exceptions</a> can be <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-1">created</a> by providing their <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-4">error name</a> followed by <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-3">DOMException</a></code>.
 Exceptions can also be <dfn class="dfn-paneled" data-dfn-for="exception" data-dfn-type="dfn" data-export="" data-lt="throw" id="dfn-throw">thrown</dfn>, by providing the
 same details required to <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-2">create</a> one.</p>
    <p>The resulting behavior from creating and throwing an exception is language binding-specific.</p>
    <p class="note" role="note">Note: See <a href="#es-creating-throwing-exceptions">§3.15 Creating and throwing exceptions</a> for details on what creating and throwing an exception
 entails in the ECMAScript language binding.</p>
-   <div class="example" id="example-83e44bc6">
-    <a class="self-link" href="#example-83e44bc6"></a> 
+   <div class="example" id="example-9beeffc0">
+    <a class="self-link" href="#example-9beeffc0"></a> 
     <p>Here is are some examples of wording to use to create and throw exceptions.
     To throw a new <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-4">simple exception</a> named <code class="idl"><a data-link-type="idl" href="#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror-1">TypeError</a></code>:</p>
     <blockquote> <a data-link-type="dfn" href="#dfn-throw" id="ref-for-dfn-throw-1">Throw</a> a <code class="idl"><a data-link-type="idl" href="#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror-2">TypeError</a></code>. </blockquote>
-    <p>To throw a new <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-7">DOMException</a></code> with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-5">error name</a> "<code class="idl"><a class="idl-code" data-link-type="exception" href="#indexsizeerror" id="ref-for-indexsizeerror-1">IndexSizeError</a></code>":</p>
-    <blockquote> <a data-link-type="dfn" href="#dfn-throw" id="ref-for-dfn-throw-2">Throw</a> an "<code class="idl"><a class="idl-code" data-link-type="exception" href="#indexsizeerror" id="ref-for-indexsizeerror-2">IndexSizeError</a></code>" <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-8">DOMException</a></code>. </blockquote>
-    <p>To create a new <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-9">DOMException</a></code> with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-6">error name</a> "<code class="idl"><a class="idl-code" data-link-type="exception" href="#syntaxerror" id="ref-for-syntaxerror-1">SyntaxError</a></code>":</p>
-    <blockquote> Let <var>object</var> be a newly <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-3">created</a> "<code class="idl"><a class="idl-code" data-link-type="exception" href="#syntaxerror" id="ref-for-syntaxerror-2">SyntaxError</a></code>" <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-10">DOMException</a></code>. </blockquote>
+    <p>To throw a new <a data-link-type="dfn" href="#dfn-DOMException" id="ref-for-dfn-DOMException-5">DOM exception</a> with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-5">error name</a> "<code class="idl"><a class="idl-code" data-link-type="exception" href="#indexsizeerror" id="ref-for-indexsizeerror-1">IndexSizeError</a></code>":</p>
+    <blockquote> <a data-link-type="dfn" href="#dfn-throw" id="ref-for-dfn-throw-2">Throw</a> an "<code class="idl"><a class="idl-code" data-link-type="exception" href="#indexsizeerror" id="ref-for-indexsizeerror-2">IndexSizeError</a></code>" <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-4">DOMException</a></code>. </blockquote>
+    <p>To create a new <a data-link-type="dfn" href="#dfn-DOMException" id="ref-for-dfn-DOMException-6">DOM exception</a> with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-6">error name</a> "<code class="idl"><a class="idl-code" data-link-type="exception" href="#syntaxerror" id="ref-for-syntaxerror-1">SyntaxError</a></code>":</p>
+    <blockquote> Let <var>object</var> be a newly <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-3">created</a> "<code class="idl"><a class="idl-code" data-link-type="exception" href="#syntaxerror" id="ref-for-syntaxerror-2">SyntaxError</a></code>" <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-5">DOMException</a></code>. </blockquote>
    </div>
    <h4 class="heading settled" data-level="2.5.1" id="idl-DOMException-error-names"><span class="secno">2.5.1. </span><span class="content">Error names</span><a class="self-link" href="#idl-DOMException-error-names"></a></h4>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-error-names-table">error names table</dfn> below lists all the allowed error names
-for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-11">DOMExceptions</a></code>, a description, and legacy code values.</p>
+for <a data-link-type="dfn" href="#dfn-DOMException" id="ref-for-dfn-DOMException-7">DOM exceptions</a>, a description, and legacy code values.</p>
    <p class="note" role="note">Note: If an error name is not listed here, please file a bug as indicated at the top of this specification and it will be addressed shortly. Thanks!</p>
    <table class="vert data" id="error-names">
     <thead>
      <tr>
       <th>Name
       <th>Description
-      <th>Legacy <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-12">code</a></code> name and value
+      <th>Legacy <a data-link-type="dfn" href="#dfn-DOMException" id="ref-for-dfn-DOMException-8">code</a> name and value
     <tbody>
      <tr>
       <td>"<dfn class="dfn-paneled idl-code" data-dfn-type="exception" data-export="" id="indexsizeerror"><code>IndexSizeError</code></dfn>"
@@ -5175,11 +5175,11 @@ for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-f
       <td>—
    </table>
    <div class="advisement">
-     Additionally, the following <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-13">DOMExceptions</a></code> are kept for legacy purposes but their usage is discouraged: 
+     Additionally, the following <a data-link-type="dfn" href="#dfn-DOMException" id="ref-for-dfn-DOMException-9">DOM exceptions</a> are kept for legacy purposes but their usage is discouraged: 
     <table class="vert data" id="legacy-error-names">
      <thead>
       <tr>
-       <th>DOMException
+       <th>DOM exception
        <th>Alternative
      <tbody>
       <tr>
@@ -5191,8 +5191,8 @@ for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-f
       <tr>
        <td> "<dfn class="idl-code" data-dfn-type="exception" data-export="" id="invalidaccesserror"><code>InvalidAccessError</code><a class="self-link" href="#invalidaccesserror"></a></dfn>"<br> <dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-invalid_access_err"><code>INVALID_ACCESS_ERR</code><a class="self-link" href="#dom-domexception-invalid_access_err"></a></dfn> (15) 
        <td> Use <code class="idl"><a data-link-type="idl" href="#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror-3">TypeError</a></code> for invalid arguments,
-                    "<code class="idl"><a class="idl-code" data-link-type="exception" href="#notsupportederror" id="ref-for-notsupportederror-1">NotSupportedError</a></code>" <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-14">DOMException</a></code> for unsupported operations, and
-                    "<code class="idl"><a class="idl-code" data-link-type="exception" href="#notallowederror" id="ref-for-notallowederror-1">NotAllowedError</a></code>" <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-15">DOMException</a></code> for denied requests. 
+                    "<code class="idl"><a class="idl-code" data-link-type="exception" href="#notsupportederror" id="ref-for-notsupportederror-1">NotSupportedError</a></code>" <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-6">DOMException</a></code> for unsupported operations, and
+                    "<code class="idl"><a class="idl-code" data-link-type="exception" href="#notallowederror" id="ref-for-notallowederror-1">NotAllowedError</a></code>" <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-7">DOMException</a></code> for denied requests. 
       <tr>
        <td> "<dfn class="idl-code" data-dfn-type="exception" data-export="" id="validationerror"><code>ValidationError</code><a class="self-link" href="#validationerror"></a></dfn>"<br> <dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-validation_err"><code>VALIDATION_ERR</code><a class="self-link" href="#dom-domexception-validation_err"></a></dfn> (16) 
        <td>—
@@ -5454,7 +5454,7 @@ object that are considered to be platform objects:</p>
     <li data-md="">
      <p>objects that implement a non-<a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-13">callback</a> <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-49">interface</a>;</p>
     <li data-md="">
-     <p>objects representing IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-16">DOMExceptions</a></code>.</p>
+     <p>objects representing an IDL <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-8">DOMException</a></code>.</p>
    </ul>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-legacy-platform-object">Legacy platform objects</dfn> are <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-7">platform objects</a> that implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-50">interface</a> which
 does not have a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-5">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-6">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-21">extended attribute</a>, <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-9">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-4">named properties</a>,
@@ -5488,7 +5488,7 @@ corresponding to each type, and how <a data-link-type="dfn" href="#dfn-constant"
 the <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-3">integer types</a>, <code class="idl"><a data-link-type="idl" href="#idl-float" id="ref-for-idl-float-4">float</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-unrestricted-float" id="ref-for-idl-unrestricted-float-5">unrestricted float</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-double" id="ref-for-idl-double-11">double</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-unrestricted-double" id="ref-for-idl-unrestricted-double-6">unrestricted double</a></code>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-primitive-type">primitive types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref-for-idl-boolean-6">boolean</a></code> and the <a data-link-type="dfn" href="#dfn-numeric-type" id="ref-for-dfn-numeric-type-5">numeric types</a>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-string-type">string types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-26">DOMString</a></code>, all <a data-link-type="dfn" href="#idl-enumeration" id="ref-for-idl-enumeration-1">enumeration types</a>, <code class="idl"><a data-link-type="idl" href="#idl-ByteString" id="ref-for-idl-ByteString-3">ByteString</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-USVString" id="ref-for-idl-USVString-4">USVString</a></code>.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exception-type">exception types</dfn> are <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-3">Error</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-17">DOMException</a></code>.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exception-type">exception types</dfn> are <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-3">Error</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-9">DOMException</a></code>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-typed-array-type">typed array types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-Int8Array" id="ref-for-idl-Int8Array-1">Int8Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Int16Array" id="ref-for-idl-Int16Array-1">Int16Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Int32Array" id="ref-for-idl-Int32Array-1">Int32Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint8Array" id="ref-for-idl-Uint8Array-1">Uint8Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint16Array" id="ref-for-idl-Uint16Array-1">Uint16Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint32Array" id="ref-for-idl-Uint32Array-1">Uint32Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint8ClampedArray" id="ref-for-idl-Uint8ClampedArray-1">Uint8ClampedArray</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Float32Array" id="ref-for-idl-Float32Array-1">Float32Array</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-Float64Array" id="ref-for-idl-Float64Array-1">Float64Array</a></code>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-buffer-source-type">buffer source types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-ArrayBuffer" id="ref-for-idl-ArrayBuffer-1">ArrayBuffer</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-DataView" id="ref-for-idl-DataView-1">DataView</a></code>,
 and the <a data-link-type="dfn" href="#dfn-typed-array-type" id="ref-for-dfn-typed-array-type-1">typed array types</a>.</p>
@@ -6027,15 +6027,15 @@ and joining them with the string “Or”.</p>
    <div data-fill-with="grammar-NonAnyType"></div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-level="2.11.28" data-lt="Error" id="idl-Error"><span class="secno">2.11.28. </span><span class="content">Error</span><span id="dom-Error"></span></h4>
    <p>The <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-4">Error</a></code> type corresponds to the
-set of all possible non-null references to exception objects, including <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-5">simple exceptions</a> and <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-18">DOMExceptions</a></code>.</p>
+set of all possible non-null references to exception objects, including <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-5">simple exceptions</a> and <a data-link-type="dfn" href="#dfn-DOMException" id="ref-for-dfn-DOMException-10">DOM exceptions</a>.</p>
    <p>There is no way to represent a constant <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-5">Error</a></code> value in IDL.</p>
    <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-28">type name</a> of the <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-6">Error</a></code> type is “Error”.</p>
-   <h4 class="heading settled" data-level="2.11.29" id="idl-DOMException"><span class="secno">2.11.29. </span><span class="content">DOMException</span><a class="self-link" href="#idl-DOMException"></a></h4>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-19">DOMException</a></code> type corresponds to the
+   <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-level="2.11.29" data-lt="DOMException" id="idl-DOMException"><span class="secno">2.11.29. </span><span class="content">DOMException</span></h4>
+   <p>The <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-10">DOMException</a></code> type corresponds to the
 set of all possible non-null references to objects
-representing <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-20">DOMExceptions</a></code>.</p>
-   <p>There is no way to represent a constant <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-21">DOMException</a></code> value in IDL.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-29">type name</a> of the <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-22">DOMException</a></code> type is “DOMException”.</p>
+representing <a data-link-type="dfn" href="#dfn-DOMException" id="ref-for-dfn-DOMException-11">DOM exceptions</a>.</p>
+   <p>There is no way to represent a constant <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-11">DOMException</a></code> value in IDL.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-29">type name</a> of the <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-12">DOMException</a></code> type is “DOMException”.</p>
    <h4 class="heading settled" data-level="2.11.30" id="idl-buffer-source-types"><span class="secno">2.11.30. </span><span class="content">Buffer source types</span><a class="self-link" href="#idl-buffer-source-types"></a></h4>
    <p>There are a number of types that correspond to sets of all possible non-null
 references to objects that represent a buffer of data or a view on to a buffer of
@@ -7417,10 +7417,10 @@ result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id
 that is a reference to the object <var>V</var>.</p>
       </ol>
      <li data-md="">
-      <p>If <var>V</var> is a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-23">DOMException</a></code> platform object, then:</p>
+      <p>If <var>V</var> is a <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-13">DOMException</a></code> platform object, then:</p>
       <ol>
        <li data-md="">
-        <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-24">DOMException</a></code> or <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-7">Error</a></code>, then return the
+        <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-14">DOMException</a></code> or <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-7">Error</a></code>, then return the
 result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-38">converting</a> <var>V</var> to that type.</p>
        <li data-md="">
         <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-16">object</a></code>, then return the IDL value
@@ -7544,7 +7544,7 @@ then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-
    <h4 class="heading settled" data-level="3.2.22" id="es-Error"><span class="secno">3.2.22. </span><span class="content">Error</span><a class="self-link" href="#es-Error"></a></h4>
    <p>IDL <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-10">Error</a></code> values are represented
 by native ECMAScript <emu-val>Error</emu-val> objects and
-platform objects for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-25">DOMExceptions</a></code>.</p>
+platform objects for [=DOM exceptions}}.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to Error" id="es-to-Error">
     <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-52">converted</a> to an IDL <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-11">Error</a></code> value by running the following algorithm:</p>
     <ol>
@@ -7561,23 +7561,23 @@ to the same object as <var>V</var>.</p>
     value is the <emu-val>Error</emu-val> value that represents a reference to the same object that the
     IDL <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-14">Error</a></code> represents. </p>
    <h4 class="heading settled" data-level="3.2.23" id="es-DOMException"><span class="secno">3.2.23. </span><span class="content">DOMException</span><a class="self-link" href="#es-DOMException"></a></h4>
-   <p>IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-26">DOMException</a></code> values are represented
-by platform objects for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-27">DOMExceptions</a></code>.</p>
+   <p>IDL <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-15">DOMException</a></code> values are represented
+by platform objects for <a data-link-type="dfn" href="#dfn-DOMException" id="ref-for-dfn-DOMException-12">DOM exceptions</a>.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to DOMException" id="es-to-DOMException">
-    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-53">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-28">DOMException</a></code> value by running the following algorithm:</p>
+    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-53">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-16">DOMException</a></code> value by running the following algorithm:</p>
     <ol>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
-or <var>V</var> is not a platform object that represents a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-29">DOMException</a></code>,
+or <var>V</var> is not a platform object that represents a <a data-link-type="dfn" href="#dfn-DOMException" id="ref-for-dfn-DOMException-13">DOM exception</a>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-19">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
-      <p>Return the IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-30">DOMException</a></code> value that is a reference
+      <p>Return the IDL <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-17">DOMException</a></code> value that is a reference
 to the same object as <var>V</var>.</p>
     </ol>
    </div>
-   <p id="DOMException-to-es"> The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-34">converting</a> an IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-31">DOMException</a></code> value to an ECMAScript
+   <p id="DOMException-to-es"> The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-34">converting</a> an IDL <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-18">DOMException</a></code> value to an ECMAScript
     value is the <emu-val>Object</emu-val> value that represents a reference to the same object that the
-    IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-32">DOMException</a></code> represents. </p>
+    IDL <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-19">DOMException</a></code> represents. </p>
    <h4 class="heading settled" data-level="3.2.24" id="es-buffer-source-types"><span class="secno">3.2.24. </span><span class="content">Buffer source types</span><a class="self-link" href="#es-buffer-source-types"></a></h4>
    <p>Values of the IDL <a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-2">buffer source types</a> are represented by objects of the corresponding ECMAScript class.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to buffer source" id="es-to-buffer-source">
@@ -9008,11 +9008,11 @@ that has one of the above types in its <a data-link-type="dfn" href="#dfn-flatte
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
        <li data-md="">
-        <p>Otherwise: if <var>V</var> is a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-33">DOMException</a></code> platform object and
+        <p>Otherwise: if <var>V</var> is a <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-20">DOMException</a></code> platform object and
 there is an entry in <var>S</var> that has one of the following types at position <var>i</var> of its type list,</p>
         <ul>
          <li data-md="">
-          <p><code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-34">DOMException</a></code></p>
+          <p><code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-21">DOMException</a></code></p>
          <li data-md="">
           <p><code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-15">Error</a></code></p>
          <li data-md="">
@@ -11993,7 +11993,7 @@ attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[E
    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="3.14" data-lt="Exception objects" data-noexport="" id="es-exception-objects"><span class="secno">3.14. </span><span class="content">Exception objects</span></h3>
    <p><a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-6">Simple exceptions</a> are represented
 by native ECMAScript objects of the corresponding type.</p>
-   <p><code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-35">DOMExceptions</a></code> are represented by <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-54">platform objects</a> that inherit from
+   <p><a data-link-type="dfn" href="#dfn-DOMException" id="ref-for-dfn-DOMException-14">DOM exceptions</a> are represented by <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-54">platform objects</a> that inherit from
 the <a data-link-type="dfn" href="#dfn-DOMException-prototype-object" id="ref-for-dfn-DOMException-prototype-object-3">DOMException prototype object</a>.</p>
    <p>Every platform object representing a DOMException in ECMAScript is associated with a global environment, just
 as the <a data-link-type="dfn" href="#dfn-initial-object" id="ref-for-dfn-initial-object-5">initial objects</a> are.
@@ -12001,8 +12001,8 @@ When an exception object is created by calling the <a data-link-type="dfn" href=
 either normally or as part of a <code>new</code> expression, then the global environment
 of the newly created object is associated with must be the same as for the <a data-link-type="dfn" href="#dfn-DOMException-constructor-object" id="ref-for-dfn-DOMException-constructor-object-4">DOMException constructor object</a> itself.</p>
    <p>The value of the internal [[Prototype]]
-property of a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-36">DOMException</a></code> object must be the <a data-link-type="dfn" href="#dfn-DOMException-prototype-object" id="ref-for-dfn-DOMException-prototype-object-4">DOMException prototype object</a> from the global environment the exception object is associated with.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-7">class string</a> of a <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-37">DOMException</a></code> object
+property of a <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-22">DOMException</a></code> object must be the <a data-link-type="dfn" href="#dfn-DOMException-prototype-object" id="ref-for-dfn-DOMException-prototype-object-4">DOMException prototype object</a> from the global environment the exception object is associated with.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-7">class string</a> of a <code class="idl"><a data-link-type="idl" href="#idl-DOMException" id="ref-for-idl-DOMException-23">DOMException</a></code> object
 must be “DOMException”.</p>
    <p class="note" role="note">Note: The intention is for DOMException objects to be just like the other
 various native <emu-val>Error</emu-val> objects that the
@@ -12037,8 +12037,8 @@ the global environment associated with the exception on which the
 exception field was defined.</p>
     </ol>
    </div>
-   <div class="algorithm" data-algorithm="to create a simple exception or DOMException">
-    <p>When a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-7">simple exception</a> or <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-38">DOMException</a></code> <var>E</var> is to be <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-4">created</a>,
+   <div class="algorithm" data-algorithm="to create a simple exception or a DOM exception">
+    <p>When a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-7">simple exception</a> or a <a data-link-type="dfn" href="#dfn-DOMException" id="ref-for-dfn-DOMException-15">DOM exception</a> <var>E</var> is to be <a data-link-type="dfn" href="#dfn-create-exception" id="ref-for-dfn-create-exception-4">created</a>,
     with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-7">error name</a> <var>N</var> and optional user agent-defined message <var>M</var>,
     the following steps must be followed:</p>
     <ol>
@@ -12050,7 +12050,7 @@ exception field was defined.</p>
       <p>Let <var>args</var> be a list of ECMAScript values.</p>
       <dl class="switch">
        <dt data-md="">
-        <p><var>E</var> is <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-39">DOMException</a></code></p>
+        <p><var>E</var> is a <a data-link-type="dfn" href="#dfn-DOMException" id="ref-for-dfn-DOMException-16">DOM exception</a></p>
        <dd data-md="">
         <p><var>args</var> is (<emu-val>undefined</emu-val>, <var>N</var>).</p>
        <dt data-md="">
@@ -12064,7 +12064,7 @@ exception field was defined.</p>
       <p>Let <var>X</var> be an object determined based on the type of <var>E</var>:</p>
       <dl class="switch">
        <dt data-md="">
-        <p><var>E</var> is <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-40">DOMException</a></code></p>
+        <p><var>E</var> is a <a data-link-type="dfn" href="#dfn-DOMException" id="ref-for-dfn-DOMException-17">DOM exception</a></p>
        <dd data-md="">
         <p><var>X</var> is the <a data-link-type="dfn" href="#dfn-DOMException-constructor-object" id="ref-for-dfn-DOMException-constructor-object-5">DOMException constructor object</a> from the global environment <var>G</var>.</p>
        <dt data-md="">
@@ -12081,7 +12081,7 @@ with <var>args</var> as the argument list.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="throw an exception">
-    <p>When a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-10">simple exception</a> or <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-41">DOMException</a></code> <var>E</var> is to be <a data-link-type="dfn" href="#dfn-throw" id="ref-for-dfn-throw-3">thrown</a>,
+    <p>When a <a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-10">simple exception</a> or a <a data-link-type="dfn" href="#dfn-DOMException" id="ref-for-dfn-DOMException-18">DOM exception</a> <var>E</var> is to be <a data-link-type="dfn" href="#dfn-throw" id="ref-for-dfn-throw-3">thrown</a>,
     with <a data-link-type="dfn" href="#dfn-exception-error-name" id="ref-for-dfn-exception-error-name-8">error name</a> <var>N</var> and optional user agent-defined message <var>M</var>,
     the following steps must be followed:</p>
     <ol>
@@ -12726,7 +12726,8 @@ language binding.</p>
    <li><a href="#idl-dictionary">Dictionary types</a><span>, in §2.11.19</span>
    <li><a href="#dfn-distinguishable">distinguishable</a><span>, in §2.2.6</span>
    <li><a href="#dfn-distinguishing-argument-index">distinguishing argument index</a><span>, in §2.2.6</span>
-   <li><a href="#dfn-DOMException">DOMException</a><span>, in §2.5</span>
+   <li><a href="#dfn-DOMException">DOM exception</a><span>, in §2.5</span>
+   <li><a href="#idl-DOMException">DOMException</a><span>, in §2.11.28</span>
    <li><a href="#dfn-DOMException-constructor-object">DOMException constructor object</a><span>, in §3.13</span>
    <li><a href="#dfn-DOMException-prototype-object">DOMException prototype object</a><span>, in §3.13.1</span>
    <li><a href="#idl-DOMString">DOMString</a><span>, in §2.11.14</span>
@@ -14216,18 +14217,13 @@ language binding.</p>
   <aside class="dfn-panel" data-for="dfn-DOMException">
    <b><a href="#dfn-DOMException">#dfn-DOMException</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-DOMException-1">2.5. Exceptions</a> <a href="#ref-for-dfn-DOMException-2">(2)</a> <a href="#ref-for-dfn-DOMException-3">(3)</a> <a href="#ref-for-dfn-DOMException-4">(4)</a> <a href="#ref-for-dfn-DOMException-5">(5)</a> <a href="#ref-for-dfn-DOMException-6">(6)</a> <a href="#ref-for-dfn-DOMException-7">(7)</a> <a href="#ref-for-dfn-DOMException-8">(8)</a> <a href="#ref-for-dfn-DOMException-9">(9)</a> <a href="#ref-for-dfn-DOMException-10">(10)</a>
-    <li><a href="#ref-for-dfn-DOMException-11">2.5.1. Error names</a> <a href="#ref-for-dfn-DOMException-12">(2)</a> <a href="#ref-for-dfn-DOMException-13">(3)</a> <a href="#ref-for-dfn-DOMException-14">(4)</a> <a href="#ref-for-dfn-DOMException-15">(5)</a>
-    <li><a href="#ref-for-dfn-DOMException-16">2.10. Objects implementing interfaces</a>
-    <li><a href="#ref-for-dfn-DOMException-17">2.11. Types</a>
-    <li><a href="#ref-for-dfn-DOMException-18">2.11.28. Error</a>
-    <li><a href="#ref-for-dfn-DOMException-19">2.11.29. DOMException</a> <a href="#ref-for-dfn-DOMException-20">(2)</a> <a href="#ref-for-dfn-DOMException-21">(3)</a> <a href="#ref-for-dfn-DOMException-22">(4)</a>
-    <li><a href="#ref-for-dfn-DOMException-23">3.2.21. Union types</a> <a href="#ref-for-dfn-DOMException-24">(2)</a>
-    <li><a href="#ref-for-dfn-DOMException-25">3.2.22. Error</a>
-    <li><a href="#ref-for-dfn-DOMException-26">3.2.23. DOMException</a> <a href="#ref-for-dfn-DOMException-27">(2)</a> <a href="#ref-for-dfn-DOMException-28">(3)</a> <a href="#ref-for-dfn-DOMException-29">(4)</a> <a href="#ref-for-dfn-DOMException-30">(5)</a> <a href="#ref-for-dfn-DOMException-31">(6)</a> <a href="#ref-for-dfn-DOMException-32">(7)</a>
-    <li><a href="#ref-for-dfn-DOMException-33">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-DOMException-34">(2)</a>
-    <li><a href="#ref-for-dfn-DOMException-35">3.14. Exception objects</a> <a href="#ref-for-dfn-DOMException-36">(2)</a> <a href="#ref-for-dfn-DOMException-37">(3)</a>
-    <li><a href="#ref-for-dfn-DOMException-38">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-DOMException-39">(2)</a> <a href="#ref-for-dfn-DOMException-40">(3)</a> <a href="#ref-for-dfn-DOMException-41">(4)</a>
+    <li><a href="#ref-for-dfn-DOMException-1">2.5. Exceptions</a> <a href="#ref-for-dfn-DOMException-2">(2)</a> <a href="#ref-for-dfn-DOMException-3">(3)</a> <a href="#ref-for-dfn-DOMException-4">(4)</a> <a href="#ref-for-dfn-DOMException-5">(5)</a> <a href="#ref-for-dfn-DOMException-6">(6)</a>
+    <li><a href="#ref-for-dfn-DOMException-7">2.5.1. Error names</a> <a href="#ref-for-dfn-DOMException-8">(2)</a> <a href="#ref-for-dfn-DOMException-9">(3)</a>
+    <li><a href="#ref-for-dfn-DOMException-10">2.11.28. Error</a>
+    <li><a href="#ref-for-dfn-DOMException-11">2.11.29. DOMException</a>
+    <li><a href="#ref-for-dfn-DOMException-12">3.2.23. DOMException</a> <a href="#ref-for-dfn-DOMException-13">(2)</a>
+    <li><a href="#ref-for-dfn-DOMException-14">3.14. Exception objects</a>
+    <li><a href="#ref-for-dfn-DOMException-15">3.15. Creating and throwing exceptions</a> <a href="#ref-for-dfn-DOMException-16">(2)</a> <a href="#ref-for-dfn-DOMException-17">(3)</a> <a href="#ref-for-dfn-DOMException-18">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-create-exception">
@@ -14983,6 +14979,20 @@ language binding.</p>
     <li><a href="#ref-for-idl-Error-7">3.2.21. Union types</a> <a href="#ref-for-idl-Error-8">(2)</a> <a href="#ref-for-idl-Error-9">(3)</a>
     <li><a href="#ref-for-idl-Error-10">3.2.22. Error</a> <a href="#ref-for-idl-Error-11">(2)</a> <a href="#ref-for-idl-Error-12">(3)</a> <a href="#ref-for-idl-Error-13">(4)</a> <a href="#ref-for-idl-Error-14">(5)</a>
     <li><a href="#ref-for-idl-Error-15">3.5. Overload resolution algorithm</a> <a href="#ref-for-idl-Error-16">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="idl-DOMException">
+   <b><a href="#idl-DOMException">#idl-DOMException</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-DOMException-1">2.5. Exceptions</a> <a href="#ref-for-idl-DOMException-2">(2)</a> <a href="#ref-for-idl-DOMException-3">(3)</a> <a href="#ref-for-idl-DOMException-4">(4)</a> <a href="#ref-for-idl-DOMException-5">(5)</a>
+    <li><a href="#ref-for-idl-DOMException-6">2.5.1. Error names</a> <a href="#ref-for-idl-DOMException-7">(2)</a>
+    <li><a href="#ref-for-idl-DOMException-8">2.10. Objects implementing interfaces</a>
+    <li><a href="#ref-for-idl-DOMException-9">2.11. Types</a>
+    <li><a href="#ref-for-idl-DOMException-10">2.11.29. DOMException</a> <a href="#ref-for-idl-DOMException-11">(2)</a> <a href="#ref-for-idl-DOMException-12">(3)</a>
+    <li><a href="#ref-for-idl-DOMException-13">3.2.21. Union types</a> <a href="#ref-for-idl-DOMException-14">(2)</a>
+    <li><a href="#ref-for-idl-DOMException-15">3.2.23. DOMException</a> <a href="#ref-for-idl-DOMException-16">(2)</a> <a href="#ref-for-idl-DOMException-17">(3)</a> <a href="#ref-for-idl-DOMException-18">(4)</a> <a href="#ref-for-idl-DOMException-19">(5)</a>
+    <li><a href="#ref-for-idl-DOMException-20">3.5. Overload resolution algorithm</a> <a href="#ref-for-idl-DOMException-21">(2)</a>
+    <li><a href="#ref-for-idl-DOMException-22">3.14. Exception objects</a> <a href="#ref-for-idl-DOMException-23">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="idl-ArrayBuffer">


### PR DESCRIPTION
Fixes #255.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tobie/webidl/fix-255.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/7c1eab6..tobie:fix-255:a54081d.html)