### PR TITLE
Attributes on namespaces

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1336,7 +1336,8 @@ be retrieved and (in some cases) changed.  There are two kinds of attributes:
 
 If an attribute has no <emu-t>static</emu-t> keyword, then it declares a
 <dfn id="dfn-regular-attribute" export>regular attribute</dfn>.  Otherwise,
-it declares a [=static attribute=].
+it declares a [=static attribute=]. Note that in addition to being [=interface members=],
+[=read only=] [=regular attributes=] can be [=namespace members=] as well.
 
 The [=identifier=] of an
 [=attribute=]
@@ -3942,8 +3943,11 @@ associated behaviors.
     };
 </pre>
 
-A namespace is a specification of a set of <dfn id="dfn-namespace-member" export lt="namespace             member">namespace members</dfn> (matching <emu-nt><a href="#prod-NamespaceMembers">NamespaceMembers</a></emu-nt>), which are the [=regular operations=] that appear between the braces in
-the namespace declaration. These operations describe the behaviors packaged into the
+A namespace is a specification of a set of
+<dfn id="dfn-namespace-member" export lt="namespace member">namespace members</dfn>
+(matching <emu-nt><a href="#prod-NamespaceMembers">NamespaceMembers</a></emu-nt>), which are the
+[=regular operations=] and [=read only=] [=regular attributes=] that appear between the braces in
+the namespace declaration. These operations and attributes describe the behaviors packaged into the
 namespace.
 
 As with interfaces, the IDL for namespaces can be split into multiple parts by using
@@ -3992,15 +3996,17 @@ namespaces.
 <pre class="grammar" id="prod-NamespaceMember">
     NamespaceMember :
         ReturnType OperationRest
+        "readonly" AttributeRest
 </pre>
 
-<div class="example">
+<div class="example" id="example-namespace">
 
     The following [=IDL fragment=] defines an
     [=namespace=].
 
     <pre highlight="webidl">
         namespace VectorUtils {
+          readonly attribute Vector unit;
           double dotProduct(Vector x, Vector y);
           Vector crossProduct(Vector x, Vector y);
         };
@@ -4008,12 +4014,14 @@ namespaces.
 
     An ECMAScript implementation would then expose a global property named
     <code>VectorUtils</code> which was a simple object (with prototype
-    [=%ObjectPrototype%=]) with enumerable data properties for each declared operation:
+    [=%ObjectPrototype%=]) with enumerable data properties for each declared operation, and
+    enumerable get-only accessors for each declared attribute:
 
     <pre highlight="js">
         Object.getPrototypeOf(VectorUtils);                         // Evaluates to Object.prototype.
         Object.keys(VectorUtils);                                   // Evaluates to ["dotProduct", "crossProduct"].
         Object.getOwnPropertyDescriptor(VectorUtils, "dotProduct"); // Evaluates to { value: &lt;a function&gt;, enumerable: true, configurable: true, writable: true }.
+        Object.getOwnPropertyDescriptor(VectorUtils, "unit");       // Evaluates to { get: &lt;a function&gt;, enumerable: true, configurable: true }.
     </pre>
 </div>
 
@@ -8607,6 +8615,9 @@ extended attribute must not also be declared
 with the [{{PutForwards}}]
 or [{{Replaceable}}] extended attributes.
 
+The [{{LenientSetter}}] extended attribute must not be used on an attribute declared on a
+[=namespace=].
+
 See the <a href="#es-attributes">Attributes</a> section for how
 [{{LenientSetter}}] is to be implemented.
 
@@ -8656,6 +8667,9 @@ must
 [=takes no arguments|take no arguments=].
 It must not be used on a
 [=static attribute=].
+
+The [{{LenientThis}}] extended attribute must not be used on an attribute declared on a
+[=namespace=].
 
 <p class="advisement">
     Specifications should not use [{{LenientThis}}]
@@ -9050,7 +9064,7 @@ must not be used on a
 
 The [{{PutForwards}}] extended attribute
 must not be used on an attribute declared on
-a [=callback interface=].
+a [=callback interface=] or [=namespace=].
 
 See the <a href="#es-attributes">Attributes</a> section for how
 [{{PutForwards}}]
@@ -9500,6 +9514,9 @@ appear on an [=operation=], then
 it must appear on all operations with
 the same [=identifier=] on that interface.
 
+The [{{Unforgeable}}] extended attribute must not be used on an attribute declared on a
+[=namespace=].
+
 If an attribute or operation |X| is [=unforgeable=]
 on an interface |A|, and |A| is one of the
 [=inherited interfaces=]
@@ -9599,6 +9616,9 @@ The [{{Unscopable}}]
 extended attribute must not appear on
 anything other than a [=regular attribute=]
 or [=regular operation=].
+
+The [{{Unscopable}}] extended attribute must not be used on an attribute declared on a
+[=namespace=].
 
 See [[#interface-prototype-object]]
 for the specific requirements that the use of
@@ -10457,12 +10477,12 @@ The characteristics of this property are as follows:
 <div algorithm>
 
     The <dfn id="dfn-attribute-getter" export>attribute getter</dfn> is created as follows, given an
-    [=attribute=] |attribute|, an [=interface=] |target|, and a [=Realm=] |realm|:
+    [=attribute=] |attribute|, a [=namespace=] or [=interface=] |target|, and a [=Realm=] |realm|:
 
     1.  Let |steps| be the following series of steps:
         1.  Try running the following steps:
             1.  Let |O| be <emu-val>null</emu-val>.
-            1.  If |attribute| is a [=regular attribute=]:
+            1.  If |target| is an [=interface=], and |attribute| is a [=regular attribute=]:
                 1.  If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or
                     <emu-val>undefined</emu-val>, set |O| to |realm|'s [=Realm/global object=].
                     (This will subsequently cause a <emu-val>TypeError</emu-val> in a few steps, if
@@ -12371,6 +12391,12 @@ The characteristics of a namespace object are described in [[#namespace-object]]
 
     1.  Let |namespaceObject| be
         [=!=] [=ObjectCreate=](the [=%ObjectPrototype%=] of |realm|).
+    1.  For each [=exposed=] [=regular attribute=] |attr| that is a [=namespace member=] of this namespace,
+        1.  Let |F| be the result of creating an [=attribute getter=]
+            given |attr|, |namespace|,  and |realm|.
+        1.  Let |newDesc| be the PropertyDescriptor{\[[Get]]: |F|, \[[Enumerable]]: <emu-val>true</emu-val>,
+            \[[Configurable]]: <emu-val>true</emu-val>}.
+        1.  Perform [=!=] [=DefinePropertyOrThrow=](|namespaceObject|, |attr|'s [=identifier=], |newDesc|).
     1.  For each [=exposed=] [=regular operation=] |op| that is a [=namespace member=] of this namespace,
         1.  Let |F| be the result of [=creating an operation function|creating an operation function=]
             given |op|, |namespace|,  and |realm|.

--- a/index.html
+++ b/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 48f3e0ec257a756aad6df3ed37b6360b66ae5352" name="generator">
+  <meta content="Bikeshed version 237216488a585c6f0fbfeb6dc67a26c10fd1d88d" name="generator">
 <style>
         pre.set {
           font-size: 80%;
@@ -1558,7 +1558,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web IDL</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-20">20 January 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-21">21 January 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2673,9 +2673,9 @@ to declare attributes that are not associated with a particular object implement
 </pre>
    </ol>
    <p>If an attribute has no <emu-t>static</emu-t> keyword, then it declares a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-regular-attribute">regular attribute</dfn>.  Otherwise,
-it declares a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-3">static attribute</a>.</p>
+it declares a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-3">static attribute</a>. Note that in addition to being <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-4">interface members</a>, <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-2">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-2">regular attributes</a> can be <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-1">namespace members</a> as well.</p>
    <p>The <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-14">identifier</a> of an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-6">attribute</a> must not be the same as the identifier
-of another <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-4">interface member</a> defined on the same <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-18">interface</a>.
+of another <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-5">interface member</a> defined on the same <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-18">interface</a>.
 The identifier of a static attribute must not
 be “prototype”.</p>
    <p>The type of the attribute is given by the type (matching <emu-nt><a href="#prod-Type">Type</a></emu-nt>)
@@ -2705,17 +2705,17 @@ ignored or an exception is thrown.</p>
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="n">type</span> <span class="nv">identifier</span>;
 };
 </pre>
-   <p>Attributes whose type is a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-1">promise type</a> must be <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-2">read only</a>. Additionally, they cannot have
+   <p>Attributes whose type is a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-1">promise type</a> must be <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-3">read only</a>. Additionally, they cannot have
 any of the <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-7">extended attributes</a> [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-1">LenientSetter</a></code>], [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-1">PutForwards</a></code>], [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-1">Replaceable</a></code>], or
 [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-1">SameObject</a></code>].</p>
-   <p>A <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-2">regular attribute</a> that is not <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-3">read only</a> can be declared to <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-inherit-getter">inherit its getter</dfn> from an ancestor interface.  This can be used to make a read only attribute
+   <p>A <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-3">regular attribute</a> that is not <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-4">read only</a> can be declared to <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-inherit-getter">inherit its getter</dfn> from an ancestor interface.  This can be used to make a read only attribute
 in an ancestor interface be writable on a derived interface.  An attribute <a data-link-type="dfn" href="#dfn-inherit-getter" id="ref-for-dfn-inherit-getter-1">inherits its getter</a> if
 its declaration includes <emu-t>inherit</emu-t> in the declaration.
 The read only attribute from which the attribute inherits its getter
 is the attribute with the same identifier on the closest ancestor interface
 of the one on which the inheriting attribute is defined.  The attribute
 whose getter is being inherited must be
-of the same type as the inheriting attribute, and <emu-t>inherit</emu-t> must not appear on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-4">read only</a> attribute or a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-4">static attribute</a>.</p>
+of the same type as the inheriting attribute, and <emu-t>inherit</emu-t> must not appear on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-5">read only</a> attribute or a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-4">static attribute</a>.</p>
 <pre class="syntax highlight"><span class="kt">interface</span> <span class="nv">Ancestor</span> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="n">TheType</span> <span class="nv">theIdentifier</span>;
 };
@@ -2725,7 +2725,7 @@ of the same type as the inheriting attribute, and <emu-t>inherit</emu-t> must no
 };
 </pre>
    <p>When the <emu-t>stringifier</emu-t> keyword is used
-in a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-3">regular attribute</a> declaration, it indicates that objects implementing the
+in a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-4">regular attribute</a> declaration, it indicates that objects implementing the
 interface will be stringified to the value of the attribute.  See <a href="#idl-stringifiers">§2.2.4.2 Stringifiers</a> for details.</p>
 <pre class="syntax highlight"><span class="kt">interface</span> <span class="nv">interface_identifier</span> {
   <span class="kt">stringifier</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <span class="nv">identifier</span>;
@@ -2803,7 +2803,7 @@ interface will be stringified to the value of the attribute.  See <a href="#idl-
 </pre>
    </div>
    <h4 class="heading settled" data-level="2.2.3" id="idl-operations"><span class="secno">2.2.3. </span><span class="content">Operations</span><a class="self-link" href="#idl-operations"></a></h4>
-   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-operation">operation</dfn> is an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-5">interface member</a> (matching <emu-t>static</emu-t> <emu-nt><a href="#prod-OperationRest">OperationRest</a></emu-nt>, <emu-t>stringifier</emu-t> <emu-nt><a href="#prod-OperationRest">OperationRest</a></emu-nt>, <emu-t>serializer</emu-t> <emu-nt><a href="#prod-OperationRest">OperationRest</a></emu-nt>, <emu-nt><a href="#prod-ReturnType">ReturnType</a></emu-nt> <emu-nt><a href="#prod-OperationRest">OperationRest</a></emu-nt> or <emu-nt><a href="#prod-SpecialOperation">SpecialOperation</a></emu-nt>)
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-operation">operation</dfn> is an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-6">interface member</a> (matching <emu-t>static</emu-t> <emu-nt><a href="#prod-OperationRest">OperationRest</a></emu-nt>, <emu-t>stringifier</emu-t> <emu-nt><a href="#prod-OperationRest">OperationRest</a></emu-nt>, <emu-t>serializer</emu-t> <emu-nt><a href="#prod-OperationRest">OperationRest</a></emu-nt>, <emu-nt><a href="#prod-ReturnType">ReturnType</a></emu-nt> <emu-nt><a href="#prod-OperationRest">OperationRest</a></emu-nt> or <emu-nt><a href="#prod-SpecialOperation">SpecialOperation</a></emu-nt>)
 that defines a behavior that can be invoked on objects implementing the interface.
 There are three kinds of operation:</p>
    <ol>
@@ -2839,8 +2839,8 @@ the <emu-t>stringifier</emu-t> keyword),
 then it declares a special operation.  A single operation can declare
 both a regular operation and a special operation;
 see <a href="#idl-special-operations">§2.2.4 Special operations</a> for details on special operations.
-Note that in addition to being <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-6">interface members</a>,
-regular operations can also be <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-1">namespace members</a>.</p>
+Note that in addition to being <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-7">interface members</a>,
+regular operations can also be <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-2">namespace members</a>.</p>
    <p>If an operation has no identifier,
 then it must be declared to be a special operation
 using one of the special keywords.</p>
@@ -4497,7 +4497,7 @@ For interfaces that <a data-link-type="dfn" href="#dfn-support-indexed-propertie
 the iterator objects returned by “entries”, “keys”, “values” and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> are
 actual <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-iterator-objects">array iterator objects</a>.</p>
    <p>Interfaces with iterable declarations must not
-have any <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-7">interface members</a> named “entries”, “forEach”, “keys” or “values”,
+have any <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-8">interface members</a> named “entries”, “forEach”, “keys” or “values”,
 or have any <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces-3">inherited</a> or <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-2">consequential</a> interfaces that have interface members with these names.</p>
    <div class="example" id="example-3cfb2da1">
     <a class="self-link" href="#example-3cfb2da1"></a> 
@@ -4588,7 +4588,7 @@ with the map entries is similar to that available on ECMAScript <emu-val>Map</em
 For read–write maplikes, it also includes “clear”, “delete” and
 “set” methods.</p>
    <p>Maplike interfaces must not
-have any <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-8">interface members</a> named “entries”, “forEach”, “get”, “has”, “keys”, “size”, or “values”,
+have any <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-9">interface members</a> named “entries”, “forEach”, “get”, “has”, “keys”, “size”, or “values”,
 or have any <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces-6">inherited</a> or <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-5">consequential</a> interfaces that have interface members with these names.
 Read–write maplike interfaces must not
 have any <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-12">attributes</a> or <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-13">constants</a> named
@@ -4634,7 +4634,7 @@ with the set entries is similar to that available on ECMAScript <emu-val>Set</em
 “keys”, “values”, <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> methods and a “size” getter.
 For read–write setlikes, it also includes “add”, “clear”, and “delete” methods.</p>
    <p>Setlike interfaces must not
-have any <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-9">interface members</a> named “entries”, “forEach”, “has”, “keys”, “size”, or “values”,
+have any <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-10">interface members</a> named “entries”, “forEach”, “has”, “keys”, “size”, or “values”,
 or have any <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces-10">inherited</a> or <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-9">consequential</a> interfaces that have interface members with these names..
 Read–write setlike interfaces must not
 have any <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-13">attributes</a> or <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-14">constants</a> named
@@ -4664,8 +4664,8 @@ associated behaviors.</p>
   /* namespace_members... */
 };
 </pre>
-   <p>A namespace is a specification of a set of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="namespace             member" id="dfn-namespace-member">namespace members</dfn> (matching <emu-nt><a href="#prod-NamespaceMembers">NamespaceMembers</a></emu-nt>), which are the <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-8">regular operations</a> that appear between the braces in
-the namespace declaration. These operations describe the behaviors packaged into the
+   <p>A namespace is a specification of a set of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="namespace member" id="dfn-namespace-member">namespace members</dfn> (matching <emu-nt><a href="#prod-NamespaceMembers">NamespaceMembers</a></emu-nt>), which are the <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-8">regular operations</a> and <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-6">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-5">regular attributes</a> that appear between the braces in
+the namespace declaration. These operations and attributes describe the behaviors packaged into the
 namespace.</p>
    <p>As with interfaces, the IDL for namespaces can be split into multiple parts by using <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-partial-namespace">partial namespace</dfn> definitions
 (matching <emu-t>partial</emu-t> <emu-nt><a href="#prod-Namespace">Namespace</a></emu-nt>). The <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-32">identifier</a> of a partial namespace definition must be the same as the identifier of a namespace definition.
@@ -4698,19 +4698,23 @@ namespaces.</p>
 </pre>
 <pre class="grammar" id="prod-NamespaceMember">NamespaceMember :
     ReturnType OperationRest
+    "readonly" AttributeRest
 </pre>
-   <div class="example" id="example-b5268d73">
-    <a class="self-link" href="#example-b5268d73"></a> 
+   <div class="example" id="example-namespace">
+    <a class="self-link" href="#example-namespace"></a> 
     <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-24">IDL fragment</a> defines an <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-5">namespace</a>.</p>
 <pre class="highlight"><span class="kt">namespace</span> <span class="nv">VectorUtils</span> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="n">Vector</span> <span class="nv">unit</span>;
   <span class="kt">double</span> <span class="nv">dotProduct</span>(<span class="n">Vector</span> <span class="nv">x</span>, <span class="n">Vector</span> <span class="nv">y</span>);
   <span class="n">Vector</span> <span class="nv">crossProduct</span>(<span class="n">Vector</span> <span class="nv">x</span>, <span class="n">Vector</span> <span class="nv">y</span>);
 };
 </pre>
-    <p>An ECMAScript implementation would then expose a global property named <code>VectorUtils</code> which was a simple object (with prototype <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a>) with enumerable data properties for each declared operation:</p>
+    <p>An ECMAScript implementation would then expose a global property named <code>VectorUtils</code> which was a simple object (with prototype <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a>) with enumerable data properties for each declared operation, and
+    enumerable get-only accessors for each declared attribute:</p>
 <pre class="highlight">Object<span class="p">.</span>getPrototypeOf<span class="p">(</span>VectorUtils<span class="p">)</span><span class="p">;</span>                         <span class="c1">// Evaluates to Object.prototype.
 </span>Object<span class="p">.</span>keys<span class="p">(</span>VectorUtils<span class="p">)</span><span class="p">;</span>                                   <span class="c1">// Evaluates to ["dotProduct", "crossProduct"].
 </span>Object<span class="p">.</span>getOwnPropertyDescriptor<span class="p">(</span>VectorUtils<span class="p">,</span> <span class="s2">"dotProduct"</span><span class="p">)</span><span class="p">;</span> <span class="c1">// Evaluates to { value: &lt;a function>, enumerable: true, configurable: true, writable: true }.
+</span>Object<span class="p">.</span>getOwnPropertyDescriptor<span class="p">(</span>VectorUtils<span class="p">,</span> <span class="s2">"unit"</span><span class="p">)</span><span class="p">;</span>       <span class="c1">// Evaluates to { get: &lt;a function>, enumerable: true, configurable: true }.
 </span></pre>
    </div>
    <h3 class="heading settled" data-level="2.4" id="idl-dictionaries"><span class="secno">2.4. </span><span class="content">Dictionaries</span><a class="self-link" href="#idl-dictionaries"></a></h3>
@@ -6082,7 +6086,7 @@ type is the concatenation of the type name for <var>T</var> and the string
    <h3 class="heading settled" data-level="2.12" id="idl-extended-attributes"><span class="secno">2.12. </span><span class="content">Extended attributes</span><a class="self-link" href="#idl-extended-attributes"></a></h3>
    <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-extended-attribute">extended attribute</dfn> is an annotation
 that can appear on
-definitions, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-10">interface members</a>, <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-2">namespace members</a>, <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-13">dictionary members</a>,
+definitions, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-11">interface members</a>, <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-3">namespace members</a>, <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-13">dictionary members</a>,
 and <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-29">operation</a> arguments, and
 is used to control how language bindings will handle those constructs.
 Extended attributes are specified with an <emu-nt><a href="#prod-ExtendedAttributeList">ExtendedAttributeList</a></emu-nt>,
@@ -7666,7 +7670,7 @@ of valid values, rather than using the operators that use a modulo operation
    <p>The [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-9">Clamp</a></code>]
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-1">take no arguments</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-10">Clamp</a></code>] extended attribute
-must not appear on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-5">read only</a> attribute, or an attribute, operation argument or dictionary member
+must not appear on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-7">read only</a> attribute, or an attribute, operation argument or dictionary member
 that is not of an integer type.  It also must not
 be used in conjunction with the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-8">EnforceRange</a></code>]
 extended attribute.</p>
@@ -7759,7 +7763,7 @@ for an interface is to be implemented.</p>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.3" data-lt="EnforceRange" id="EnforceRange"><span class="secno">3.3.3. </span><span class="content">[EnforceRange]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-9">EnforceRange</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-31">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-37">operation</a> argument,
-writable <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-4">regular attribute</a> or <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-20">dictionary member</a> whose type is one of the <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-5">integer types</a>,
+writable <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-6">regular attribute</a> or <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-20">dictionary member</a> whose type is one of the <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-5">integer types</a>,
 it indicates that when an ECMAScript <emu-val>Number</emu-val> is
 converted to the IDL type, out of range values will cause an exception to
 be thrown, rather than converted to being a valid value using the operators that use a modulo operation
@@ -7767,7 +7771,7 @@ be thrown, rather than converted to being a valid value using the operators that
    <p>The [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-10">EnforceRange</a></code>]
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-3">take no arguments</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#EnforceRange" id="ref-for-EnforceRange-11">EnforceRange</a></code>] extended attribute
-must not appear on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-6">read only</a> attribute, a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-6">static attribute</a>,
+must not appear on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-8">read only</a> attribute, a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-6">static attribute</a>,
 or an attribute, operation argument or dictionary member
 that is not of an integer type.  It also must not
 be used in conjunction with the [<code class="idl"><a data-link-type="idl" href="#Clamp" id="ref-for-Clamp-13">Clamp</a></code>]
@@ -7806,7 +7810,7 @@ types in <a href="#es-type-mapping">§3.2 ECMAScript type mapping</a> for the sp
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.4" data-lt="Exposed" id="Exposed"><span class="secno">3.3.4. </span><span class="content">[Exposed]</span></h4>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#Exposed" id="ref-for-Exposed-9">Exposed</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-33">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-57">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-8">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-6">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-3">partial namespace</a>, or
-an individual <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-11">interface member</a> or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-3">namespace member</a>,
+an individual <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-12">interface member</a> or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-4">namespace member</a>,
 it indicates that the construct is exposed
 on a particular set of global interfaces, rather than the default of
 being exposed only on the <a data-link-type="dfn" href="#dfn-primary-global-interface" id="ref-for-dfn-primary-global-interface-1">primary global interface</a>.</p>
@@ -7867,7 +7871,7 @@ namespace or partial namespace it’s a member of.</p>
    <p>An interface’s <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-15">exposure set</a> must be a subset of the <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-16">exposure set</a> of all
 of the interface’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-13">consequential interfaces</a>.</p>
    <p>If an interface <var>X</var> <a data-link-type="dfn" href="#dfn-inherit" id="ref-for-dfn-inherit-9">inherits</a> from another interface <var>Y</var> then the <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-17">exposure set</a> of <var>X</var> must be a subset of the <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-18">exposure set</a> of <var>Y</var>.</p>
-   <p>An <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-59">interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-7">namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-12">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-4">namespace member</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exposed">exposed</dfn> in a given ECMAScript global environment if the
+   <p>An <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-59">interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-7">namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-13">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-5">namespace member</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exposed">exposed</dfn> in a given ECMAScript global environment if the
 ECMAScript global object implements an interface that is in the construct’s <a data-link-type="dfn" href="#dfn-exposure-set" id="ref-for-dfn-exposure-set-19">exposure set</a>, and either:</p>
    <ul>
     <li data-md="">
@@ -7952,14 +7956,14 @@ or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-
 it indicates that objects implementing this interface can
 be used as the global object in an ECMAScript environment,
 and that the structure of the prototype chain and how
-properties corresponding to <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-13">interface members</a> will be reflected on the prototype objects will be different from other
+properties corresponding to <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-14">interface members</a> will be reflected on the prototype objects will be different from other
 interfaces. Specifically:</p>
    <ol>
     <li data-md="">
      <p>Any <a data-link-type="dfn" href="#idl-named-properties" id="ref-for-idl-named-properties-2">named properties</a> will be exposed on an object in the prototype chain – the <a data-link-type="dfn" href="#dfn-named-properties-object" id="ref-for-dfn-named-properties-object-2">named properties object</a> –
 rather than on the object itself.</p>
     <li data-md="">
-     <p><a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-14">Interface members</a> from the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-61">interface</a> (or <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-14">consequential interfaces</a>)
+     <p><a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-15">Interface members</a> from the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-61">interface</a> (or <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-14">consequential interfaces</a>)
 will correspond to properties on the object itself rather than on <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-4">interface prototype objects</a>.</p>
    </ol>
    <div class="note" role="note">
@@ -8011,7 +8015,7 @@ sense for more than one object’s named properties to be exposed on an object t
 all of those objects inherit from.</p>
    <p>If an interface is declared with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-15">Global</a></code>] or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-16">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-41">extended attribute</a>, then
-there must not be more than one <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-15">interface member</a> across
+there must not be more than one <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-16">interface member</a> across
 the interface and its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-15">consequential interfaces</a> with the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-51">identifier</a>.
 There also must not be more than
 one <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-2">stringifier</a>,
@@ -8042,7 +8046,7 @@ is declared on, if any, is known as the <dfn class="dfn-paneled" data-dfn-type="
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-27">Global</a></code>] and [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-28">PrimaryGlobal</a></code>]
 entails for named properties,
 and <a href="#es-constants">§3.6.5 Constants</a>, <a href="#es-attributes">§3.6.6 Attributes</a> and <a href="#es-operations">§3.6.7 Operations</a> for the requirements relating to the location of properties
-corresponding to <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-16">interface members</a>.</p>
+corresponding to <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-17">interface members</a>.</p>
    <div class="example" id="example-2b45d97a">
     <a class="self-link" href="#example-2b45d97a"></a> 
     <p>The [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-29">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-45">extended attribute</a> is intended
@@ -8147,7 +8151,7 @@ must not be specified on any of them.</p>
 [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-4">LegacyUnenumerableNamedProperties</a></code>]
 entails.</p>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.8" data-lt="LenientSetter" id="LenientSetter"><span class="secno">3.3.8. </span><span class="content">[LenientSetter]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-3">LenientSetter</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-48">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-7">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-5">regular attribute</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-3">LenientSetter</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-48">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-9">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-7">regular attribute</a>,
 it indicates that a no-op setter will be generated for the attribute’s
 accessor property.  This results in erroneous assignments to the property
 in strict mode to be ignored rather than causing an exception to be thrown.</p>
@@ -8165,17 +8169,18 @@ in strict mode to be ignored rather than causing an exception to be thrown.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-2">LenientThis</a></code>] extended attribute
 must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-7">take no arguments</a>.
 It must not be used on anything other than
-a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-8">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-6">regular attribute</a>.</p>
+a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-10">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-8">regular attribute</a>.</p>
    <p>An attribute with the [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-6">LenientSetter</a></code>]
 extended attribute must not also be declared
 with the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-3">PutForwards</a></code>]
 or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-3">Replaceable</a></code>] extended attributes.</p>
+   <p>The [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-7">LenientSetter</a></code>] extended attribute must not be used on an attribute declared on a <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-8">namespace</a>.</p>
    <p>See the <a href="#es-attributes">Attributes</a> section for how
-[<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-7">LenientSetter</a></code>] is to be implemented.</p>
+[<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-8">LenientSetter</a></code>] is to be implemented.</p>
    <div class="example" id="example-c0b45430">
     <a class="self-link" href="#example-c0b45430"></a> 
     <p>The following IDL fragment defines an interface that uses the
-    [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-8">LenientSetter</a></code>] extended
+    [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-9">LenientSetter</a></code>] extended
     attribute.</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Example</span> {
   [<span class="nv">LenientSetter</span>] <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <span class="nv">x</span>;
@@ -8197,23 +8202,24 @@ or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Re
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.9" data-lt="LenientThis" id="LenientThis"><span class="secno">3.3.9. </span><span class="content">[LenientThis]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-3">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-49">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-7">regular attribute</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-3">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-49">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-9">regular attribute</a>,
 it indicates that invocations of the attribute’s getter or setter
 with a <emu-val>this</emu-val> value that is not an
 object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-67">interface</a> on which the attribute appears will be ignored.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-4">LenientThis</a></code>] extended attribute
 must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-8">take no arguments</a>.
 It must not be used on a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-7">static attribute</a>.</p>
-   <p class="advisement"> Specifications should not use [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-5">LenientThis</a></code>]
+   <p>The [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-5">LenientThis</a></code>] extended attribute must not be used on an attribute declared on a <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-9">namespace</a>.</p>
+   <p class="advisement"> Specifications should not use [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-6">LenientThis</a></code>]
     unless required for compatibility reasons.  Specification authors who
     wish to use this feature are strongly advised to discuss this on the <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a> mailing list before proceeding. </p>
    <p>See the <a href="#es-attributes">Attributes</a> section for how
-[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-6">LenientThis</a></code>]
+[<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-7">LenientThis</a></code>]
 is to be implemented.</p>
    <div class="example" id="example-9e113db6">
     <a class="self-link" href="#example-9e113db6"></a> 
     <p>The following IDL fragment defines an interface that uses the
-    [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-7">LenientThis</a></code>] extended
+    [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-8">LenientThis</a></code>] extended
     attribute.</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Example</span> {
   [<span class="nv">LenientThis</span>] <span class="kt">attribute</span> <span class="kt">DOMString</span> <span class="nv">x</span>;
@@ -8435,7 +8441,7 @@ the <a data-link-type="dfn" href="#dfn-named-property-getter" id="ref-for-dfn-na
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.14" data-lt="PutForwards" id="PutForwards"><span class="secno">3.3.14. </span><span class="content">[PutForwards]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-4">PutForwards</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-54">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-9">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-8">regular attribute</a> declaration whose type is
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-4">PutForwards</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-54">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-11">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-10">regular attribute</a> declaration whose type is
 an <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-12">interface type</a>,
 it indicates that assigning to the attribute will have specific behavior.
 Namely, the assignment is “forwarded” to the attribute (specified by
@@ -8466,17 +8472,17 @@ an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-73">i
 encountered more than once.</p>
    <p>An attribute with the [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-9">PutForwards</a></code>]
 extended attribute must not also be declared
-with the [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-9">LenientSetter</a></code>] or
+with the [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-10">LenientSetter</a></code>] or
 [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-4">Replaceable</a></code>] extended attributes.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-10">PutForwards</a></code>]
 extended attribute must not be used
 on an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-37">attribute</a> that
-is not <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-10">read only</a>.</p>
+is not <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-12">read only</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-11">PutForwards</a></code>] extended attribute
 must not be used on a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-8">static attribute</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-12">PutForwards</a></code>] extended attribute
 must not be used on an attribute declared on
-a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-21">callback interface</a>.</p>
+a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-21">callback interface</a> or <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-10">namespace</a>.</p>
    <p>See the <a href="#es-attributes">Attributes</a> section for how
 [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-13">PutForwards</a></code>]
 is to be implemented.</p>
@@ -8507,7 +8513,7 @@ p<span class="p">.</span>name <span class="o">=</span> <span class="s1">'John Ci
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.15" data-lt="Replaceable" id="Replaceable"><span class="secno">3.3.15. </span><span class="content">[Replaceable]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-5">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-56">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-11">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-9">regular attribute</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-5">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-56">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-13">read only</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-11">regular attribute</a>,
 it indicates that setting the corresponding property on the <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-16">platform object</a> will result in
 an own property with the same name being created on the object
 which has the value being assigned.  This property will shadow
@@ -8517,12 +8523,12 @@ exists on the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id=
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-12">take no arguments</a>.</p>
    <p>An attribute with the [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-7">Replaceable</a></code>]
 extended attribute must not also be declared
-with the [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-10">LenientSetter</a></code>] or
+with the [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-11">LenientSetter</a></code>] or
 [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-15">PutForwards</a></code>] extended attributes.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-8">Replaceable</a></code>]
 extended attribute must not be used
 on an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-38">attribute</a> that
-is not <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-12">read only</a>.</p>
+is not <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-14">read only</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-9">Replaceable</a></code>] extended attribute
 must not be used on a <a data-link-type="dfn" href="#dfn-static-attribute" id="ref-for-dfn-static-attribute-9">static attribute</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-10">Replaceable</a></code>] extended attribute
@@ -8563,7 +8569,7 @@ counter<span class="p">.</span>value<span class="p">;</span>                    
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.16" data-lt="SameObject" id="SameObject"><span class="secno">3.3.16. </span><span class="content">[SameObject]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-3">SameObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-57">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-13">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-41">attribute</a>, then it
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-3">SameObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-57">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-15">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-41">attribute</a>, then it
 indicates that when getting the value of the attribute on a given
 object, the same value must always
 be returned.</p>
@@ -8571,7 +8577,7 @@ be returned.</p>
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-13">take no arguments</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#SameObject" id="ref-for-SameObject-5">SameObject</a></code>]
 extended attribute must not
-be used on anything other than a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-14">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-42">attribute</a> whose type is an <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-14">interface type</a> or <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-23">object</a></code>.</p>
+be used on anything other than a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-16">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-42">attribute</a> whose type is an <a data-link-type="dfn" href="#idl-interface" id="ref-for-idl-interface-14">interface type</a> or <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-23">object</a></code>.</p>
    <div class="example" id="example-87c35b5d">
     <a class="self-link" href="#example-87c35b5d"></a> 
     <p>As an example, this extended attribute is suitable for use on
@@ -8584,14 +8590,14 @@ be used on anything other than a <a data-link-type="dfn" href="#dfn-read-only" i
 </pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.17" data-lt="SecureContext" id="SecureContext"><span class="secno">3.3.17. </span><span class="content">[SecureContext]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-9">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-58">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-75">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-11">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-8">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-4">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-17">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-5">namespace member</a>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-9">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-58">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-75">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-11">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-11">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-4">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-18">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-6">namespace member</a>,
 it indicates that the construct is exposed
 only within a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-10">SecureContext</a></code>]
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-14">take no arguments</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-11">SecureContext</a></code>]
 extended attribute must not
-be used on anything other than an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-76">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-12">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-9">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-5">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-18">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-6">namespace member</a>.</p>
+be used on anything other than an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-76">interface</a>, <a data-link-type="dfn" href="#dfn-partial-interface" id="ref-for-dfn-partial-interface-12">partial interface</a>, <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-12">namespace</a>, <a data-link-type="dfn" href="#dfn-partial-namespace" id="ref-for-dfn-partial-namespace-5">partial namespace</a>, <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-19">interface member</a>, or <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-7">namespace member</a>.</p>
    <p>Whether a construct that the [<code class="idl"><a data-link-type="idl" href="#SecureContext" id="ref-for-SecureContext-12">SecureContext</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-59">extended attribute</a> can be specified on is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-available-only-in-secure-contexts">available only in secure contexts</dfn> is defined as follows:</p>
    <ul>
     <li data-md="">
@@ -8775,6 +8781,7 @@ non-<a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-
 appear on an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-48">operation</a>, then
 it must appear on all operations with
 the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-54">identifier</a> on that interface.</p>
+   <p>The [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-7">Unforgeable</a></code>] extended attribute must not be used on an attribute declared on a <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-13">namespace</a>.</p>
    <p>If an attribute or operation <var>X</var> is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-1">unforgeable</a> on an interface <var>A</var>, and <var>A</var> is one of the <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces-15">inherited interfaces</a> of another interface <var>B</var>, then <var>B</var> and all of its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-17">consequential interfaces</a> must not have a non-static attribute or <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-11">regular operation</a> with the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-55">identifier</a> as <var>X</var>.</p>
    <div class="note" role="note">
     <p>For example, the following is disallowed:</p>
@@ -8793,12 +8800,12 @@ the same <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifi
 </pre>
    </div>
    <p>See <a href="#es-attributes">§3.6.6 Attributes</a>, <a href="#es-operations">§3.6.7 Operations</a>, <a href="#es-platform-objects">§3.8 Platform objects implementing interfaces</a>, <a href="#es-legacy-platform-objects">§3.9 Legacy platform objects</a> and <a href="#legacy-platform-object-defineownproperty">§3.9.3 [[DefineOwnProperty]]</a> for the specific requirements that the use of
-[<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-7">Unforgeable</a></code>] entails.</p>
+[<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-8">Unforgeable</a></code>] entails.</p>
    <div class="example" id="example-8fe6c799">
     <a class="self-link" href="#example-8fe6c799"></a> 
     <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-44">IDL fragment</a> defines
     an interface that has two <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-47">attributes</a>,
-    one of which is designated as [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-8">Unforgeable</a></code>]:</p>
+    one of which is designated as [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-9">Unforgeable</a></code>]:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">System</span> {
   [<span class="nv">Unforgeable</span>] <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <span class="nv">username</span>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <span class="kt">long</span> <span class="nv">loginTime</span>;
@@ -8827,7 +8834,7 @@ system<span class="p">.</span>loginTime<span class="p">;</span>  <span class="c1
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.21" data-lt="Unscopable" id="Unscopable"><span class="secno">3.3.21. </span><span class="content">[Unscopable]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-1">Unscopable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-67">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-10">regular attribute</a> or <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-12">regular operation</a>, it
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-1">Unscopable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-67">extended attribute</a> appears on a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-12">regular attribute</a> or <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-12">regular operation</a>, it
 indicates that an object that implements an interface with the given
 interface member will not include its property name in any object
 environment record with it as its base object.  The result of this is
@@ -8838,9 +8845,10 @@ including the property name on the <a data-link-type="dfn" href="#dfn-interface-
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-no-arguments" id="ref-for-dfn-xattr-no-arguments-16">take no arguments</a>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-3">Unscopable</a></code>]
 extended attribute must not appear on
-anything other than a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-11">regular attribute</a> or <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-13">regular operation</a>.</p>
+anything other than a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-13">regular attribute</a> or <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-13">regular operation</a>.</p>
+   <p>The [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-4">Unscopable</a></code>] extended attribute must not be used on an attribute declared on a <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-14">namespace</a>.</p>
    <p>See <a href="#interface-prototype-object">§3.6.3 Interface prototype object</a> for the specific requirements that the use of
-[<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-4">Unscopable</a></code>] entails.</p>
+[<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-5">Unscopable</a></code>] entails.</p>
    <div class="note" role="note">
     <p>For example, with the following IDL:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Thing</span> {
@@ -9312,7 +9320,7 @@ the value of [[Prototype]] is <a data-link-type="dfn" href="https://tc39.github.
 with attributes
 { [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }
 whose value is an object called the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-interface-prototype-object">interface prototype object</dfn>.  This object has properties
-that correspond to the <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-12">regular attributes</a> and <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-14">regular operations</a> defined on the interface,
+that correspond to the <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-14">regular attributes</a> and <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-14">regular operations</a> defined on the interface,
 and is described in more detail in <a href="#interface-prototype-object">§3.6.3 Interface prototype object</a>.</p>
    <p class="note" role="note">Note: Since an interface object for a non-callback interface is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-4">function object</a> the <code>typeof</code> operator will return
 "function" when applied to
@@ -9457,7 +9465,7 @@ whose value is the <a data-link-type="dfn" href="#dfn-interface-prototype-object
    <p>There must exist an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-10">interface prototype object</a> for every non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-88">interface</a> defined, regardless of whether the interface was declared with the
 [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-14">NoInterfaceObject</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-77">extended attribute</a>.
 The interface prototype object for a particular interface has
-properties that correspond to the <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-13">regular attributes</a> and <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-15">regular operations</a> defined on that interface.  These properties are described in more detail in
+properties that correspond to the <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-15">regular attributes</a> and <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-15">regular operations</a> defined on that interface.  These properties are described in more detail in
 sections <a href="#es-attributes">§3.6.6 Attributes</a> and <a href="#es-operations">§3.6.7 Operations</a>.</p>
    <p>As with the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-9">interface object</a>,
 the interface prototype object also has properties that correspond to the <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-24">constants</a> defined on that
@@ -9512,8 +9520,8 @@ extended attribute, then return <a data-link-type="dfn" href="https://tc39.githu
     it is an acceptable optimization for this object not to exist.</p>
    </div>
    <div class="algorithm" data-algorithm="value of @@unscopables symbol property of interface objects">
-    <p>If the interface or any of its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-18">consequential interfaces</a> has any <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-19">interface member</a> declared with
-    the [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-5">Unscopable</a></code>] extended attribute,
+    <p>If the interface or any of its <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-18">consequential interfaces</a> has any <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-20">interface member</a> declared with
+    the [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-6">Unscopable</a></code>] extended attribute,
     then there must be a property on the
     interface prototype object whose name is the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@unscopables</a> symbol
     and whose value is an object created as follows:</p>
@@ -9521,7 +9529,7 @@ extended attribute, then return <a data-link-type="dfn" href="https://tc39.githu
      <li data-md="">
       <p>Let <var>object</var> be a new object created as if by the expression <code>({})</code>.</p>
      <li data-md="">
-      <p>For each of the aforementioned <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-20">interface members</a> declared with the [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-6">Unscopable</a></code>] extended attribute,
+      <p>For each of the aforementioned <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-21">interface members</a> declared with the [<code class="idl"><a data-link-type="idl" href="#Unscopable" id="ref-for-Unscopable-7">Unscopable</a></code>] extended attribute,
 call <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createdataproperty">CreateDataProperty</a>(<var>object</var>,
 the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-63">identifier</a> of the
 interface member, <emu-val>true</emu-val>).</p>
@@ -9688,7 +9696,7 @@ where:</p>
      <ul>
       <li data-md="">
        <p><var>configurable</var> is <emu-val>false</emu-val> if the attribute was
-declared with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-9">Unforgeable</a></code>] extended attribute and <emu-val>true</emu-val> otherwise;</p>
+declared with the [<code class="idl"><a data-link-type="idl" href="#Unforgeable" id="ref-for-Unforgeable-10">Unforgeable</a></code>] extended attribute and <emu-val>true</emu-val> otherwise;</p>
       <li data-md="">
        <p><var>G</var> is the <a data-link-type="dfn" href="#dfn-attribute-getter" id="ref-for-dfn-attribute-getter-2">attribute getter</a> created given the attribute, the interface (or the interface
 it’s being mixed in to, if the interface is actually a mixin), and the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">relevant Realm</a> of
@@ -9700,7 +9708,7 @@ the object that is the location of the property.</p>
      </ul>
    </ul>
    <div class="algorithm" data-algorithm="attribute getter">
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-attribute-getter">attribute getter</dfn> is created as follows, given an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-51">attribute</a> <var>attribute</var>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-97">interface</a> <var>target</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>:</p>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-attribute-getter">attribute getter</dfn> is created as follows, given an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-51">attribute</a> <var>attribute</var>, a <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-15">namespace</a> or <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-97">interface</a> <var>target</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>:</p>
     <ol>
      <li data-md="">
       <p>Let <var>steps</var> be the following series of steps:</p>
@@ -9711,12 +9719,12 @@ the object that is the location of the property.</p>
          <li data-md="">
           <p>Let <var>O</var> be <emu-val>null</emu-val>.</p>
          <li data-md="">
-          <p>If <var>attribute</var> is a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-14">regular attribute</a>:</p>
+          <p>If <var>target</var> is an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-98">interface</a>, and <var>attribute</var> is a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-16">regular attribute</a>:</p>
           <ol>
            <li data-md="">
             <p>If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, set <var>O</var> to <var>realm</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global">global object</a>.
 (This will subsequently cause a <emu-val>TypeError</emu-val> in a few steps, if
-the global object does not implement <var>target</var> and [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-8">LenientThis</a></code>] is not
+the global object does not implement <var>target</var> and [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-9">LenientThis</a></code>] is not
 specified.)</p>
            <li data-md="">
             <p>Otherwise, set <var>O</var> to the <emu-val>this</emu-val> value.</p>
@@ -9727,7 +9735,7 @@ specified.)</p>
 then:</p>
             <ol>
              <li data-md="">
-              <p>If <var>attribute</var> was specified with the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-9">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-83">extended attribute</a>, then return <emu-val>undefined</emu-val>.</p>
+              <p>If <var>attribute</var> was specified with the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-10">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-83">extended attribute</a>, then return <emu-val>undefined</emu-val>.</p>
              <li data-md="">
               <p>Otherwise, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-30">throw</a> a <emu-val>TypeError</emu-val>.</p>
             </ol>
@@ -9768,11 +9776,11 @@ PropertyDescriptor{[[Value]]: 0, [[Writable]]: <emu-val>false</emu-val>, [[Enume
     </ol>
    </div>
    <div class="algorithm" data-algorithm="attribute setter">
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-attribute-setter">attribute setter</dfn> is created as follows, given an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-52">attribute</a> <var>attribute</var>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-98">interface</a> <var>target</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>:</p>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-attribute-setter">attribute setter</dfn> is created as follows, given an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-52">attribute</a> <var>attribute</var>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-99">interface</a> <var>target</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>:</p>
     <ol>
      <li data-md="">
-      <p>If <var>attribute</var> is <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-15">read only</a> and does not have a
-[<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-11">LenientSetter</a></code>], [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-16">PutForwards</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-12">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-84">extended attribute</a>, return <emu-val>undefined</emu-val>; there is no <a data-link-type="dfn" href="#dfn-attribute-setter" id="ref-for-dfn-attribute-setter-3">attribute setter</a> function.</p>
+      <p>If <var>attribute</var> is <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-17">read only</a> and does not have a
+[<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-12">LenientSetter</a></code>], [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-16">PutForwards</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-12">Replaceable</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-84">extended attribute</a>, return <emu-val>undefined</emu-val>; there is no <a data-link-type="dfn" href="#dfn-attribute-setter" id="ref-for-dfn-attribute-setter-3">attribute setter</a> function.</p>
      <li data-md="">
       <p class="assertion">Assert: <var>attribute</var>’s type is not a <a data-link-type="dfn" href="#dfn-promise-type" id="ref-for-dfn-promise-type-11">promise type</a>.</p>
      <li data-md="">
@@ -9787,12 +9795,12 @@ PropertyDescriptor{[[Value]]: 0, [[Writable]]: <emu-val>false</emu-val>, [[Enume
        <li data-md="">
         <p>Let <var>O</var> be <emu-val>null</emu-val>.</p>
        <li data-md="">
-        <p>If <var>attribute</var> is a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-15">regular attribute</a>:</p>
+        <p>If <var>attribute</var> is a <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-17">regular attribute</a>:</p>
         <ol>
          <li data-md="">
           <p>If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, set <var>O</var> to <var>realm</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global">global object</a>.
 (This will subsequently cause a <emu-val>TypeError</emu-val> in a few steps, if
-the global object does not implement <var>target</var> and [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-10">LenientThis</a></code>] is not
+the global object does not implement <var>target</var> and [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-11">LenientThis</a></code>] is not
 specified.)</p>
          <li data-md="">
           <p>Otherwise, set <var>O</var> to the <emu-val>this</emu-val> value.</p>
@@ -9802,7 +9810,7 @@ specified.)</p>
           <p>Let <var>validThis</var> be true if <var>O</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-23">platform object</a> that implements the
 interface <var>target</var>, or false otherwise.</p>
          <li data-md="">
-          <p>If <var>validThis</var> is false and <var>attribute</var> was not specified with the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-11">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-85">extended attribute</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-32">throw</a> a <emu-val>TypeError</emu-val>.</p>
+          <p>If <var>validThis</var> is false and <var>attribute</var> was not specified with the [<code class="idl"><a data-link-type="idl" href="#LenientThis" id="ref-for-LenientThis-12">LenientThis</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-85">extended attribute</a>, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-32">throw</a> a <emu-val>TypeError</emu-val>.</p>
          <li data-md="">
           <p>If <var>attribute</var> is declared with the [<code class="idl"><a data-link-type="idl" href="#Replaceable" id="ref-for-Replaceable-13">Replaceable</a></code>] extended attribute, then:</p>
           <ol>
@@ -9814,7 +9822,7 @@ interface <var>target</var>, or false otherwise.</p>
          <li data-md="">
           <p>If <var>validThis</var> is false, then return <emu-val>undefined</emu-val>.</p>
          <li data-md="">
-          <p>If <var>attribute</var> is declared with a [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-12">LenientSetter</a></code>] extended attribute, then
+          <p>If <var>attribute</var> is declared with a [<code class="idl"><a data-link-type="idl" href="#LenientSetter" id="ref-for-LenientSetter-13">LenientSetter</a></code>] extended attribute, then
 return <emu-val>undefined</emu-val>.</p>
          <li data-md="">
           <p>If <var>attribute</var> is declared with a [<code class="idl"><a data-link-type="idl" href="#PutForwards" id="ref-for-PutForwards-17">PutForwards</a></code>] extended attribute, then:</p>
@@ -9871,10 +9879,10 @@ PropertyDescriptor{[[Value]]: 1, [[Writable]]: <emu-val>false</emu-val>, [[Enume
    <p class="note" role="note">Note: Although there is only a single property for an IDL attribute, since
 accessor property getters and setters are passed a <emu-val>this</emu-val> value for the object on which property corresponding to the IDL attribute is
 accessed, they are able to expose instance-specific data.</p>
-   <p class="note" role="note">Note: Attempting to assign to a property corresponding to a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-16">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-53">attribute</a> results in different behavior depending on whether the script doing so is in strict mode.
+   <p class="note" role="note">Note: Attempting to assign to a property corresponding to a <a data-link-type="dfn" href="#dfn-read-only" id="ref-for-dfn-read-only-18">read only</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-53">attribute</a> results in different behavior depending on whether the script doing so is in strict mode.
 When in strict mode, such an assignment will result in a <emu-val>TypeError</emu-val> being thrown.  When not in strict mode, the assignment attempt will be ignored.</p>
    <h4 class="heading settled" data-level="3.6.7" id="es-operations"><span class="secno">3.6.7. </span><span class="content">Operations</span><a class="self-link" href="#es-operations"></a></h4>
-   <p>For each unique <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-72">identifier</a> of an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-6">exposed</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-52">operation</a> defined on the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-99">interface</a>, there
+   <p>For each unique <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-72">identifier</a> of an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-6">exposed</a> <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-52">operation</a> defined on the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-100">interface</a>, there
 must exist a corresponding property,
 unless the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-9">effective overload set</a> for that <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-73">identifier</a> and <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-53">operation</a> and with an argument count of 0 has no entries.</p>
    <p>The characteristics of this property are as follows:</p>
@@ -9913,11 +9921,11 @@ available on the interface, we pass in the interface on the left-hand side of th
 where the operation was originally declared.</p>
    </ul>
    <p class="advisement"> The above description has some bugs, especially around partial interfaces. See <a href="https://github.com/heycam/webidl/issues/164">issue #164</a>. </p>
-   <p>For <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-10">namespaces</a>, the properties corresponding to each declared operation are described in <a href="#namespace-object">§3.12.1 Namespace object</a>. (We hope to eventually move interfaces to the same explicit
+   <p>For <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-16">namespaces</a>, the properties corresponding to each declared operation are described in <a href="#namespace-object">§3.12.1 Namespace object</a>. (We hope to eventually move interfaces to the same explicit
 property-installation style as namespaces.)</p>
    <div class="algorithm" data-algorithm="create an operation function">
      To <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="creating an operation function" data-noexport="" id="dfn-create-operation-function">create an operation function</dfn>,
-    given an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-54">operation</a> <var>op</var>, a <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-11">namespace</a> or <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-100">interface</a> <var>target</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>: 
+    given an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-54">operation</a> <var>op</var>, a <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-17">namespace</a> or <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-101">interface</a> <var>target</var>, and a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var>: 
     <ol>
      <li data-md="">
       <p>Let <var>id</var> be <var>op</var>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-75">identifier</a>.</p>
@@ -9931,7 +9939,7 @@ values <var>arg</var><sub>0..<var>n</var>−1</sub>:</p>
          <li data-md="">
           <p>Let <var>O</var> be <emu-val>null</emu-val>.</p>
          <li data-md="">
-          <p>If <var>target</var> is an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-101">interface</a>, and <var>op</var> is not a <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-14">static operation</a>:</p>
+          <p>If <var>target</var> is an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-102">interface</a>, and <var>op</var> is not a <a data-link-type="dfn" href="#dfn-static-operation" id="ref-for-dfn-static-operation-14">static operation</a>:</p>
           <ol>
            <li data-md="">
             <p>If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, set <var>O</var> to <var>realm</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global">global object</a>. (This
@@ -9988,7 +9996,7 @@ PropertyDescriptor{[[Value]]: <var>length</var>, [[Writable]]: <emu-val>false</e
     </ol>
    </div>
    <h5 class="heading settled" data-level="3.6.7.1" id="es-stringifier"><span class="secno">3.6.7.1. </span><span class="content">Stringifiers</span><a class="self-link" href="#es-stringifier"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-102">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-7">exposed</a> <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-3">stringifier</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-103">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-7">exposed</a> <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-3">stringifier</a>,
 then there must exist a property with the following characteristics:</p>
    <ul>
     <li data-md="">
@@ -10021,7 +10029,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
           <p>the type “method”.</p>
         </ul>
        <li data-md="">
-        <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-103">interface</a> on which the stringifier was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-35">throw</a> a <emu-val>TypeError</emu-val>.</p>
+        <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-104">interface</a> on which the stringifier was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-35">throw</a> a <emu-val>TypeError</emu-val>.</p>
        <li data-md="">
         <p>Let <var>V</var> be an uninitialized variable.</p>
        <li data-md="">
@@ -10056,7 +10064,7 @@ property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
 property is the <emu-val>String</emu-val> value “toString”.</p>
    </ul>
    <h5 class="heading settled" data-level="3.6.7.2" id="es-serializer"><span class="secno">3.6.7.2. </span><span class="content">Serializers</span><a class="self-link" href="#es-serializer"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-104">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-8">exposed</a> <a data-link-type="dfn" href="#dfn-serializer" id="ref-for-dfn-serializer-5">serializer</a>, then
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-105">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-8">exposed</a> <a data-link-type="dfn" href="#dfn-serializer" id="ref-for-dfn-serializer-5">serializer</a>, then
 a property must exist whose name is “toJSON”, with attributes
 { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
 and whose value is a <emu-val>Function</emu-val> object.</p>
@@ -10091,7 +10099,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-105">interface</a> on which the serializer was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-36">throw</a> a <emu-val>TypeError</emu-val>.</p>
+      <p>If <var>O</var> is not an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-106">interface</a> on which the serializer was declared, then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-36">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>Depending on how <code>serializer</code> was specified:</p>
       <dl class="switch">
@@ -10108,7 +10116,7 @@ using <var>O</var> as the <emu-val>this</emu-val> value and passing no arguments
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-serialized-value" id="ref-for-dfn-serialized-value-8">serialized value</a> that is the result of invoking the <a data-link-type="dfn" href="#dfn-serialization-behavior" id="ref-for-dfn-serialization-behavior-15">serialization behavior</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-106">interface</a> for object <var>O</var>.</p>
+          <p>Let <var>S</var> be the <a data-link-type="dfn" href="#dfn-serialized-value" id="ref-for-dfn-serialized-value-8">serialized value</a> that is the result of invoking the <a data-link-type="dfn" href="#dfn-serialization-behavior" id="ref-for-dfn-serialization-behavior-15">serialization behavior</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-107">interface</a> for object <var>O</var>.</p>
          <li data-md="">
           <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-serialized-value-to-ecmascript-value" id="ref-for-dfn-convert-serialized-value-to-ecmascript-value-1">converting</a> <var>S</var> to an ECMAScript value.</p>
         </ol>
@@ -10181,7 +10189,7 @@ property is the <emu-val>String</emu-val> value “toJSON”.</p>
    </div>
    <h4 class="heading settled" data-level="3.6.8" id="es-iterators"><span class="secno">3.6.8. </span><span class="content">Common iterator behavior</span><a class="self-link" href="#es-iterators"></a></h4>
    <h5 class="heading settled" data-level="3.6.8.1" id="es-iterator"><span class="secno">3.6.8.1. </span><span class="content">@@iterator</span><a class="self-link" href="#es-iterator"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-107">interface</a> has any of the following:</p>
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-108">interface</a> has any of the following:</p>
    <ul>
     <li data-md="">
      <p>an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-9">iterable declaration</a></p>
@@ -10230,7 +10238,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-108">interface</a> the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-10">iterable declaration</a> is on.</p>
+      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-109">interface</a> the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-10">iterable declaration</a> is on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-29">platform object</a> that implements <var>interface</var>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-37">throw</a> a <emu-val>TypeError</emu-val>.</p>
@@ -10259,7 +10267,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-31">platform object</a> that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-109">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-9">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-9">setlike declaration</a> is defined,
+      <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-31">platform object</a> that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-110">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-9">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-9">setlike declaration</a> is defined,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-38">throw</a> a <emu-val>TypeError</emu-val>.</p>
      <li data-md="">
       <p>If the interface has a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-10">maplike declaration</a>, then:</p>
@@ -10286,7 +10294,7 @@ is the <emu-val>String</emu-val> value “entries”
 if the interface has a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-5">pair iterator</a> or a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-11">maplike declaration</a> and the <emu-val>String</emu-val> “values”
 if the interface has a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-10">setlike declaration</a>.</p>
    <h5 class="heading settled" data-level="3.6.8.2" id="es-forEach"><span class="secno">3.6.8.2. </span><span class="content">forEach</span><a class="self-link" href="#es-forEach"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-110">interface</a> has any of the following:</p>
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-111">interface</a> has any of the following:</p>
    <ul>
     <li data-md="">
      <p>an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-11">iterable declaration</a></p>
@@ -10368,7 +10376,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-111">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-14">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-13">setlike declaration</a> is declared.</p>
+      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-112">interface</a> on which the <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-14">maplike declaration</a> or <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-13">setlike declaration</a> is declared.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-33">platform object</a> that implements <var>interface</var>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-39">throw</a> a <emu-val>TypeError</emu-val>.</p>
@@ -10412,7 +10420,7 @@ property is the <emu-val>Number</emu-val> value <emu-val>1</emu-val>.</p>
 property is the <emu-val>String</emu-val> value “forEach”.</p>
    <h4 class="heading settled" data-level="3.6.9" id="es-iterable"><span class="secno">3.6.9. </span><span class="content">Iterable declarations</span><a class="self-link" href="#es-iterable"></a></h4>
    <h5 class="heading settled" data-level="3.6.9.1" id="es-iterable-entries"><span class="secno">3.6.9.1. </span><span class="content">entries</span><a class="self-link" href="#es-iterable-entries"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-112">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-13">iterable declaration</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-113">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-13">iterable declaration</a>,
 then a property named “entries” must exist with attributes
 { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
 and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-10">function object</a>.</p>
@@ -10436,7 +10444,7 @@ the initial value of the “entries” data property of <a data-link-type="dfn" 
 then the <emu-val>Function</emu-val> object is
 the value of the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> property.</p>
    <h5 class="heading settled" data-level="3.6.9.2" id="es-iterable-keys"><span class="secno">3.6.9.2. </span><span class="content">keys</span><a class="self-link" href="#es-iterable-keys"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-113">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-14">iterable declaration</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-114">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-14">iterable declaration</a>,
 then a property named “keys” must exist with attributes
 { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
 and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-11">function object</a>.</p>
@@ -10474,7 +10482,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-114">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-15">iterable declaration</a> is declared on.</p>
+      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-115">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-15">iterable declaration</a> is declared on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-35">platform object</a> that implements <var>interface</var>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-42">throw</a> a <emu-val>TypeError</emu-val>.</p>
@@ -10487,7 +10495,7 @@ then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-thr
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “keys”.</p>
    <h5 class="heading settled" data-level="3.6.9.3" id="es-iterable-values"><span class="secno">3.6.9.3. </span><span class="content">values</span><a class="self-link" href="#es-iterable-values"></a></h5>
-   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-115">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-16">iterable declaration</a>,
+   <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-116">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-16">iterable declaration</a>,
 then a property named “values” must exist
 with attributes { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
 and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-12">function object</a>.</p>
@@ -10525,7 +10533,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
         <p>the type “method”.</p>
       </ul>
      <li data-md="">
-      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-116">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-17">iterable declaration</a> is declared on.</p>
+      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-117">interface</a> on which the <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-17">iterable declaration</a> is declared on.</p>
      <li data-md="">
       <p>If <var>object</var> is not a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-37">platform object</a> that implements <var>interface</var>,
 then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-43">throw</a> a <emu-val>TypeError</emu-val>.</p>
@@ -10538,8 +10546,8 @@ then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-thr
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “values”.</p>
    <h5 class="heading settled" data-level="3.6.9.4" id="es-default-iterator-object"><span class="secno">3.6.9.4. </span><span class="content">Default iterator objects</span><a class="self-link" href="#es-default-iterator-object"></a></h5>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-default-iterator-object">default iterator object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-117">interface</a>, target and iteration kind
-is an object whose internal [[Prototype]] property is the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-2">iterator prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-118">interface</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-default-iterator-object">default iterator object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-118">interface</a>, target and iteration kind
+is an object whose internal [[Prototype]] property is the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-2">iterator prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-119">interface</a>.</p>
    <p>A <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-4">default iterator object</a> has three internal values:</p>
    <ol>
     <li data-md="">
@@ -10554,9 +10562,9 @@ restricted to iterating over an object’s <a data-link-type="dfn" href="#dfn-su
 use standard ECMAScript Array iterator objects.</p>
    <p>When a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-5">default iterator object</a> is first created,
 its index is set to 0.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-3">class string</a> of a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-6">default iterator object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-119">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-80">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-120">interface</a> and the string “Iterator”.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-3">class string</a> of a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-6">default iterator object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-120">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-80">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-121">interface</a> and the string “Iterator”.</p>
    <h5 class="heading settled" data-level="3.6.9.5" id="es-iterator-prototype-object"><span class="secno">3.6.9.5. </span><span class="content">Iterator prototype object</span><a class="self-link" href="#es-iterator-prototype-object"></a></h5>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-iterator-prototype-object">iterator prototype object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-121">interface</a> is an object that exists for every interface that has a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-11">pair iterator</a>.  It serves as the
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-iterator-prototype-object">iterator prototype object</dfn> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-122">interface</a> is an object that exists for every interface that has a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-11">pair iterator</a>.  It serves as the
 prototype for <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-7">default iterator objects</a> for the interface.</p>
    <p>The internal [[Prototype]] property of an <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-3">iterator prototype object</a> must be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%IteratorPrototype%</a>.</p>
    <div class="algorithm" data-algorithm="to invoke the next property of iterators">
@@ -10565,7 +10573,7 @@ prototype for <a data-link-type="dfn" href="#dfn-default-iterator-object" id="re
     and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-13">function object</a> that behaves as follows:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-122">interface</a> for which the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-5">iterator prototype object</a> exists.</p>
+      <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-123">interface</a> for which the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-5">iterator prototype object</a> exists.</p>
      <li data-md="">
       <p>Let <var>object</var> be the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-toobject">ToObject</a> on the <emu-val>this</emu-val> value.</p>
      <li data-md="">
@@ -10648,13 +10656,13 @@ return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createi
       <p>Return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createiterresultobject">CreateIterResultObject</a>(<var>result</var>, <emu-val>false</emu-val>).</p>
     </ol>
    </div>
-   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-4">class string</a> of an <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-6">iterator prototype object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-123">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-81">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-124">interface</a> and the string “Iterator”.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-4">class string</a> of an <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-6">iterator prototype object</a> for a given <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-124">interface</a> is the result of concatenting the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-81">identifier</a> of the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-125">interface</a> and the string “Iterator”.</p>
    <h4 class="heading settled" data-level="3.6.10" id="es-maplike"><span class="secno">3.6.10. </span><span class="content">Maplike declarations</span><a class="self-link" href="#es-maplike"></a></h4>
-   <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-125">interface</a> that has a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-16">maplike declaration</a> must have a [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
+   <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-126">interface</a> that has a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-16">maplike declaration</a> must have a [[BackingMap]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
 initially set to a newly created <emu-val>Map</emu-val> object.
 This <emu-val>Map</emu-val> object’s [[MapData]] internal slot is
 the object’s <a data-link-type="dfn" href="#dfn-map-entries" id="ref-for-dfn-map-entries-3">map entries</a>.</p>
-   <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-126">interface</a> <var>A</var> is declared with
+   <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-127">interface</a> <var>A</var> is declared with
 a <a data-link-type="dfn" href="#dfn-maplike-declaration" id="ref-for-dfn-maplike-declaration-17">maplike declaration</a>, then
 there exists a number of additional properties on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-36">interface prototype object</a>.
 These additional properties are described in the sub-sections below.</p>
@@ -10789,7 +10797,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
    <p>The value of the <emu-val>Function</emu-val> objects’ “length” properties is the <emu-val>Number</emu-val> value <emu-val>1</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “get” or “has”, correspondingly.</p>
    <h5 class="heading settled" data-level="3.6.10.5" id="es-map-clear"><span class="secno">3.6.10.5. </span><span class="content">clear</span><a class="self-link" href="#es-map-clear"></a></h5>
-   <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-29">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-21">interface member</a> with identifier “clear”, and <var>A</var> was declared with a read–write maplike declaration,
+   <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-29">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-22">interface member</a> with identifier “clear”, and <var>A</var> was declared with a read–write maplike declaration,
 then a property named “clear” and the following characteristics
 must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-41">interface prototype object</a>:</p>
    <ul>
@@ -10801,7 +10809,7 @@ must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prot
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “clear”.</p>
    <h5 class="heading settled" data-level="3.6.10.6" id="es-map-delete"><span class="secno">3.6.10.6. </span><span class="content">delete</span><a class="self-link" href="#es-map-delete"></a></h5>
-   <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-30">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-22">interface member</a> with identifier “delete”, and <var>A</var> was declared with a read–write maplike declaration,
+   <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-30">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-23">interface member</a> with identifier “delete”, and <var>A</var> was declared with a read–write maplike declaration,
 then a property named “delete” and the following characteristics
 must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-42">interface prototype object</a>:</p>
    <ul>
@@ -10846,7 +10854,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>1</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “delete”.</p>
    <h5 class="heading settled" data-level="3.6.10.7" id="es-map-set"><span class="secno">3.6.10.7. </span><span class="content">set</span><a class="self-link" href="#es-map-set"></a></h5>
-   <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-31">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-23">interface member</a> with identifier “set”,
+   <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-31">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-24">interface member</a> with identifier “set”,
 and <var>A</var> was declared with a read–write maplike declaration,
 then a property named “set” and the following characteristics
 must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-43">interface prototype object</a>:</p>
@@ -10901,11 +10909,11 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>2</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “set”.</p>
    <h4 class="heading settled" data-level="3.6.11" id="es-setlike"><span class="secno">3.6.11. </span><span class="content">Setlike declarations</span><a class="self-link" href="#es-setlike"></a></h4>
-   <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-127">interface</a> that has a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-14">setlike declaration</a> must have a [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
+   <p>Any object that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-128">interface</a> that has a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-14">setlike declaration</a> must have a [[BackingSet]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, which is
 initially set to a newly created <emu-val>Set</emu-val> object.
 This <emu-val>Set</emu-val> object’s [[SetData]] internal slot is
 the object’s <a data-link-type="dfn" href="#dfn-set-entries" id="ref-for-dfn-set-entries-3">set entries</a>.</p>
-   <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-128">interface</a> <var>A</var> is declared with a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-15">setlike declaration</a>, then
+   <p>If an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-129">interface</a> <var>A</var> is declared with a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-15">setlike declaration</a>, then
 there exists a number of additional properties
 on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-44">interface prototype object</a>.
 These additional properties are described in the sub-sections below.</p>
@@ -11045,7 +11053,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
    <p>For both of “add” and “delete”, if:</p>
    <ul>
     <li data-md="">
-     <p><var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-32">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-24">interface member</a> with a matching identifier, and</p>
+     <p><var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-32">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-25">interface member</a> with a matching identifier, and</p>
     <li data-md="">
      <p><var>A</var> was declared with a read–write setlike declaration,</p>
    </ul>
@@ -11099,7 +11107,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
    <p>The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>1</emu-val>.</p>
    <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “add” or “delete”, correspondingly.</p>
    <h5 class="heading settled" data-level="3.6.11.6" id="es-set-clear"><span class="secno">3.6.11.6. </span><span class="content">clear</span><a class="self-link" href="#es-set-clear"></a></h5>
-   <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-33">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-25">interface member</a> with a matching identifier, and <var>A</var> was declared with a read–write setlike declaration,
+   <p>If <var>A</var> and <var>A</var>’s <a data-link-type="dfn" href="#dfn-consequential-interfaces" id="ref-for-dfn-consequential-interfaces-33">consequential interfaces</a> do not declare an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-26">interface member</a> with a matching identifier, and <var>A</var> was declared with a read–write setlike declaration,
 then a property named “clear” and the following characteristics
 must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-50">interface prototype object</a>:</p>
    <ul>
@@ -11122,7 +11130,7 @@ and similarly with their setters.</p>
     <p>When invoking an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-60">operation</a> by calling
     a <emu-val>Function</emu-val> object that is the value of one of the copies that exists
     due to an implements statement, the <emu-val>this</emu-val> value is
-    checked to ensure that it is an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-129">interface</a> corresponding to the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-52">interface prototype object</a> that the property is on.</p>
+    checked to ensure that it is an object that implements the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-130">interface</a> corresponding to the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-52">interface prototype object</a> that the property is on.</p>
     <p>For example, consider the following IDL:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">A</span> {
   <span class="kt">void</span> <span class="nv">f</span>();
@@ -11158,7 +11166,7 @@ a platform object that implements one or more interfaces
 must be the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-82">identifier</a> of
 the <a data-link-type="dfn" href="#dfn-primary-interface" id="ref-for-dfn-primary-interface-3">primary interface</a> of the platform object.</p>
    <h4 class="heading settled" data-level="3.8.1" id="platform-object-setprototypeof"><span class="secno">3.8.1. </span><span class="content">[[SetPrototypeOf]]</span><span id="platformobjectsetprototypeof"></span><a class="self-link" href="#platform-object-setprototypeof"></a></h4>
-   <p>The internal [[SetPrototypeOf]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-52">platform object</a> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-130">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-95">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-96">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-86">extended attribute</a> must execute the same algorithm as is defined for the
+   <p>The internal [[SetPrototypeOf]] method of every <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-52">platform object</a> that implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-131">interface</a> with the [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-95">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-96">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-86">extended attribute</a> must execute the same algorithm as is defined for the
 [[SetPrototypeOf]] internal method of an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">immutable prototype exotic object</a>.</p>
    <p class="note" role="note">Note: For <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> objects, it is unobservable whether this is implemented, since the presence of
 the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#windowproxy">WindowProxy</a></code> object ensures that [[SetPrototypeOf]] is never called on a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> object
@@ -11179,8 +11187,8 @@ when indexing the object with an array index.  Similarly for <a data-link-type="
 This way, the definitions of these special operations from
 ancestor interfaces can be overridden.</p>
    <p>A property name is an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-unforgeable-property-name">unforgeable property name</dfn> on a
-given platform object if the object implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-131">interface</a> that
-has an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-26">interface member</a> with that identifier
+given platform object if the object implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-132">interface</a> that
+has an <a data-link-type="dfn" href="#dfn-interface-member" id="ref-for-dfn-interface-member-27">interface member</a> with that identifier
 and that interface member is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-7">unforgeable</a> on any of
 the interfaces that <var>O</var> implements.</p>
    <p>Support for <a data-link-type="dfn" href="#dfn-getter" id="ref-for-dfn-getter-1">getters</a> is handled in <a href="#legacy-platform-object-getownproperty" id="ref-for-legacy-platform-object-getownproperty-2">§3.9.1 [[GetOwnProperty]]</a>,
@@ -11243,7 +11251,7 @@ and <var>O</var> implements an interface with a <a data-link-type="dfn" href="#d
         <p>Return <emu-val>true</emu-val>.</p>
       </ol>
      <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-9">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-132">interface</a> with the
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-9">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-133">interface</a> with the
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-97">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-98">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-87">extended attribute</a> and <var>P</var> is not an <a data-link-type="dfn" href="#dfn-unforgeable-property-name" id="ref-for-dfn-unforgeable-property-name-1">unforgeable property name</a> of <var>O</var>, then:</p>
       <ol>
        <li data-md="">
@@ -11268,7 +11276,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
         </ol>
       </ol>
      <li data-md="">
-      <p>If <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-133">interface</a> with the
+      <p>If <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-134">interface</a> with the
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-99">Global</a></code>] or
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-100">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-89">extended attribute</a>, then set <var>Desc</var>.[[Configurable]] to <emu-val>true</emu-val>.</p>
      <li data-md="">
@@ -11290,7 +11298,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
         <p>Return <emu-val>false</emu-val>.</p>
       </ol>
      <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-10">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-134">interface</a> with the
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-10">supports named properties</a>, <var>O</var> does not implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-135">interface</a> with the
 [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-101">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-102">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-90">extended attribute</a> and the result of calling the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-2">named property visibility algorithm</a> with property name <var>P</var> and object <var>O</var> is true, then:</p>
       <ol>
        <li data-md="">
@@ -11331,7 +11339,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
    <h4 class="heading settled" data-level="3.9.5" id="legacy-platform-object-call"><span class="secno">3.9.5. </span><span class="content">[[Call]]</span><span id="call"></span><a class="self-link" href="#legacy-platform-object-call"></a></h4>
    <div class="algorithm" data-algorithm="to invoke the internal [[Call]] method of legacy platform objects">
     <p>The internal [[Call]] method of <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-9">legacy platform object</a> that implements
-    an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-135">interface</a> <var>I</var> must behave as follows,
+    an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-136">interface</a> <var>I</var> must behave as follows,
     assuming <var>arg</var><sub>0..<var>n</var>−1</sub> is the list of argument values passed to [[Call]]:</p>
     <ol>
      <li data-md="">
@@ -11359,7 +11367,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
    </div>
    <h4 class="heading settled" data-level="3.9.7" id="legacy-platform-object-property-enumeration"><span class="secno">3.9.7. </span><span class="content">Property enumeration</span><span id="property-enumeration"></span><a class="self-link" href="#legacy-platform-object-property-enumeration"></a></h4>
    <p>This document does not define a complete property enumeration order
-for <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-53">platform objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-136">interfaces</a> (or for <a href="#es-exception-objects" id="ref-for-es-exception-objects-1">platform objects representing exceptions</a>).
+for <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-53">platform objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-137">interfaces</a> (or for <a href="#es-exception-objects" id="ref-for-es-exception-objects-1">platform objects representing exceptions</a>).
 However, for <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-12">legacy platform objects</a>,
 properties on the object must be
 enumerated in the following order:</p>
@@ -11369,7 +11377,7 @@ enumerated in the following order:</p>
 the object’s <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-6">supported property indices</a> are
 enumerated first, in numerical order.</p>
     <li data-md="">
-     <p>If the object <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-11">supports named properties</a> and doesn’t implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-137">interface</a> with the
+     <p>If the object <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-11">supports named properties</a> and doesn’t implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-138">interface</a> with the
 [<code class="idl"><a data-link-type="idl" href="#LegacyUnenumerableNamedProperties" id="ref-for-LegacyUnenumerableNamedProperties-6">LegacyUnenumerableNamedProperties</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-91">extended attribute</a>, then
 the object’s <a data-link-type="dfn" href="#dfn-supported-property-names" id="ref-for-dfn-supported-property-names-5">supported property names</a> that
 are visible according to the <a data-link-type="dfn" href="#dfn-named-property-visibility" id="ref-for-dfn-named-property-visibility-3">named property visibility algorithm</a> are enumerated next, in the order given in the definition of the set of supported property names.</p>
@@ -11599,7 +11607,7 @@ is the result of invoking [[Get]] on the object with a
 property name that is that identifier.</p>
    </ul>
    <p>Note that ECMAScript objects need not have
-properties corresponding to <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-29">constants</a> on them to be considered as <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-9">user objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-138">interfaces</a> that happen
+properties corresponding to <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-29">constants</a> on them to be considered as <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-9">user objects</a> implementing <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-139">interfaces</a> that happen
 to have constants declared on them.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-single-operation-callback-interface">single operation callback interface</dfn> is
 a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-27">callback interface</a> that:</p>
@@ -11909,7 +11917,7 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
     </ol>
    </div>
    <h3 class="heading settled" data-level="3.12" id="es-namespaces"><span class="secno">3.12. </span><span class="content">Namespaces</span><a class="self-link" href="#es-namespaces"></a></h3>
-   <p>For every <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-12">namespace</a> that is <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-9">exposed</a> in a given ECMAScript global environment,
+   <p>For every <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-18">namespace</a> that is <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-9">exposed</a> in a given ECMAScript global environment,
 a corresponding property must exist on the ECMAScript
 environment’s global object. The name of the property is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-91">identifier</a> of the namespace, and its value is an object
 called the <dfn data-dfn-type="dfn" data-export="" id="dfn-namespace-object">namespace object<a class="self-link" href="#dfn-namespace-object"></a></dfn>.</p>
@@ -11918,17 +11926,28 @@ called the <dfn data-dfn-type="dfn" data-export="" id="dfn-namespace-object">nam
 The characteristics of a namespace object are described in <a href="#namespace-object">§3.12.1 Namespace object</a>.</p>
    <h4 class="heading settled" data-level="3.12.1" id="namespace-object"><span class="secno">3.12.1. </span><span class="content">Namespace object</span><a class="self-link" href="#namespace-object"></a></h4>
    <div class="algorithm" data-algorithm="to create a namespace object">
-    <p>The namespace object for a given <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-13">namespace</a> <var>namespace</var> and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var> is created as follows:</p>
+    <p>The namespace object for a given <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-19">namespace</a> <var>namespace</var> and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var> is created as follows:</p>
     <ol>
      <li data-md="">
       <p>Let <var>namespaceObject</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-objectcreate">ObjectCreate</a>(the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a> of <var>realm</var>).</p>
      <li data-md="">
-      <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-10">exposed</a> <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-19">regular operation</a> <var>op</var> that is a <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-7">namespace member</a> of this namespace,</p>
+      <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-10">exposed</a> <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-18">regular attribute</a> <var>attr</var> that is a <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-8">namespace member</a> of this namespace,</p>
+      <ol>
+       <li data-md="">
+        <p>Let <var>F</var> be the result of creating an <a data-link-type="dfn" href="#dfn-attribute-getter" id="ref-for-dfn-attribute-getter-3">attribute getter</a> given <var>attr</var>, <var>namespace</var>,  and <var>realm</var>.</p>
+       <li data-md="">
+        <p>Let <var>newDesc</var> be the PropertyDescriptor{[[Get]]: <var>F</var>, [[Enumerable]]: <emu-val>true</emu-val>,
+[[Configurable]]: <emu-val>true</emu-val>}.</p>
+       <li data-md="">
+        <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow">DefinePropertyOrThrow</a>(<var>namespaceObject</var>, <var>attr</var>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-92">identifier</a>, <var>newDesc</var>).</p>
+      </ol>
+     <li data-md="">
+      <p>For each <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-11">exposed</a> <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-19">regular operation</a> <var>op</var> that is a <a data-link-type="dfn" href="#dfn-namespace-member" id="ref-for-dfn-namespace-member-9">namespace member</a> of this namespace,</p>
       <ol>
        <li data-md="">
         <p>Let <var>F</var> be the result of <a data-link-type="dfn" href="#dfn-create-operation-function" id="ref-for-dfn-create-operation-function-2">creating an operation function</a> given <var>op</var>, <var>namespace</var>,  and <var>realm</var>.</p>
        <li data-md="">
-        <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createdataproperty">CreateDataProperty</a>(<var>namespaceObject</var>, <var>op</var>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-92">identifier</a>, <var>F</var>).</p>
+        <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createdataproperty">CreateDataProperty</a>(<var>namespaceObject</var>, <var>op</var>’s <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-93">identifier</a>, <var>F</var>).</p>
       </ol>
     </ol>
    </div>
@@ -12029,7 +12048,7 @@ as the <emu-val>this</emu-val> value in the top-most call
 on the ECMAScript call stack where <var>F</var> corresponds to an IDL <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-59">attribute</a>, <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-62">operation</a>, <a data-link-type="dfn" href="#idl-indexed-properties" id="ref-for-idl-indexed-properties-4">indexed property</a>, <a data-link-type="dfn" href="#idl-named-properties" id="ref-for-idl-named-properties-4">named property</a>, <a href="#Constructor" id="ref-for-Constructor-24">constructor</a>, <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-5">named constructor</a> or <a data-link-type="dfn" href="#dfn-stringifier" id="ref-for-dfn-stringifier-6">stringifier</a>.</p>
      <li data-md="">
       <p>If <var>F</var> corresponds to an attribute, operation or stringifier, then return
-the global environment associated with the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-139">interface</a> that definition appears on.</p>
+the global environment associated with the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-140">interface</a> that definition appears on.</p>
      <li data-md="">
       <p>Otherwise, if <var>F</var> corresponds to an indexed or named property, then return
 the global environment associated with the interface that
@@ -12150,7 +12169,7 @@ must propagate to the caller, and if
 not caught there, to its caller, and so on.</p>
    <div class="example" id="example-1432e05c">
     <a class="self-link" href="#example-1432e05c"></a> 
-    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-45">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-140">interfaces</a> and an <a data-link-type="dfn" href="#dfn-exception" id="ref-for-dfn-exception-1">exception</a>.
+    <p>The following <a data-link-type="dfn" href="#dfn-idl-fragment" id="ref-for-dfn-idl-fragment-45">IDL fragment</a> defines two <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-141">interfaces</a> and an <a data-link-type="dfn" href="#dfn-exception" id="ref-for-dfn-exception-1">exception</a>.
     The <code>valueOf</code> attribute on <code class="idl">ExceptionThrower</code> is defined to throw an exception whenever an attempt is made
     to get its value.</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Dahut</span> {
@@ -12381,7 +12400,7 @@ and “<span class="input">.</span>” is tokenized as the quoted terminal symbo
 used in the grammar and the values used for <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> terminals.  Thus, for
 example, the input text “<span class="input">Const</span>” is tokenized as
 an <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> rather than the
-terminal symbol <emu-t>const</emu-t>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-141">interface</a> with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-93">identifier</a> “A” is distinct from one named “a”, and an <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-96">extended attribute</a> [<code class="idl">constructor</code>] will not be recognized as
+terminal symbol <emu-t>const</emu-t>, an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-142">interface</a> with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-94">identifier</a> “A” is distinct from one named “a”, and an <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-96">extended attribute</a> [<code class="idl">constructor</code>] will not be recognized as
 the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-25">Constructor</a></code>]
 extended attribute.</p>
    <p>Implicitly, any number of <emu-t class="regex"><a href="#prod-whitespace">whitespace</a></emu-t> and <emu-t class="regex"><a href="#prod-comment">comment</a></emu-t> terminals are allowed between every other terminal
@@ -13266,8 +13285,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-identifier-84">3.9.8. Abstract operations</a> <a href="#ref-for-dfn-identifier-85">(2)</a> <a href="#ref-for-dfn-identifier-86">(3)</a> <a href="#ref-for-dfn-identifier-87">(4)</a>
     <li><a href="#ref-for-dfn-identifier-88">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-identifier-89">(2)</a> <a href="#ref-for-dfn-identifier-90">(3)</a>
     <li><a href="#ref-for-dfn-identifier-91">3.12. Namespaces</a>
-    <li><a href="#ref-for-dfn-identifier-92">3.12.1. Namespace object</a>
-    <li><a href="#ref-for-dfn-identifier-93">IDL grammar</a>
+    <li><a href="#ref-for-dfn-identifier-92">3.12.1. Namespace object</a> <a href="#ref-for-dfn-identifier-93">(2)</a>
+    <li><a href="#ref-for-dfn-identifier-94">IDL grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-reserved-identifier">
@@ -13324,30 +13343,30 @@ language binding.</p>
     <li><a href="#ref-for-dfn-interface-91">3.6.4. Named properties object</a> <a href="#ref-for-dfn-interface-92">(2)</a>
     <li><a href="#ref-for-dfn-interface-93">3.6.4.1. [[GetOwnProperty]]</a> <a href="#ref-for-dfn-interface-94">(2)</a>
     <li><a href="#ref-for-dfn-interface-95">3.6.5. Constants</a>
-    <li><a href="#ref-for-dfn-interface-96">3.6.6. Attributes</a> <a href="#ref-for-dfn-interface-97">(2)</a> <a href="#ref-for-dfn-interface-98">(3)</a>
-    <li><a href="#ref-for-dfn-interface-99">3.6.7. Operations</a> <a href="#ref-for-dfn-interface-100">(2)</a> <a href="#ref-for-dfn-interface-101">(3)</a>
-    <li><a href="#ref-for-dfn-interface-102">3.6.7.1. Stringifiers</a> <a href="#ref-for-dfn-interface-103">(2)</a>
-    <li><a href="#ref-for-dfn-interface-104">3.6.7.2. Serializers</a> <a href="#ref-for-dfn-interface-105">(2)</a> <a href="#ref-for-dfn-interface-106">(3)</a>
-    <li><a href="#ref-for-dfn-interface-107">3.6.8.1. @@iterator</a> <a href="#ref-for-dfn-interface-108">(2)</a> <a href="#ref-for-dfn-interface-109">(3)</a>
-    <li><a href="#ref-for-dfn-interface-110">3.6.8.2. forEach</a> <a href="#ref-for-dfn-interface-111">(2)</a>
-    <li><a href="#ref-for-dfn-interface-112">3.6.9.1. entries</a>
-    <li><a href="#ref-for-dfn-interface-113">3.6.9.2. keys</a> <a href="#ref-for-dfn-interface-114">(2)</a>
-    <li><a href="#ref-for-dfn-interface-115">3.6.9.3. values</a> <a href="#ref-for-dfn-interface-116">(2)</a>
-    <li><a href="#ref-for-dfn-interface-117">3.6.9.4. Default iterator objects</a> <a href="#ref-for-dfn-interface-118">(2)</a> <a href="#ref-for-dfn-interface-119">(3)</a> <a href="#ref-for-dfn-interface-120">(4)</a>
-    <li><a href="#ref-for-dfn-interface-121">3.6.9.5. Iterator prototype object</a> <a href="#ref-for-dfn-interface-122">(2)</a> <a href="#ref-for-dfn-interface-123">(3)</a> <a href="#ref-for-dfn-interface-124">(4)</a>
-    <li><a href="#ref-for-dfn-interface-125">3.6.10. Maplike declarations</a> <a href="#ref-for-dfn-interface-126">(2)</a>
-    <li><a href="#ref-for-dfn-interface-127">3.6.11. Setlike declarations</a> <a href="#ref-for-dfn-interface-128">(2)</a>
-    <li><a href="#ref-for-dfn-interface-129">3.7. Implements statements</a>
-    <li><a href="#ref-for-dfn-interface-130">3.8.1. [[SetPrototypeOf]]</a>
-    <li><a href="#ref-for-dfn-interface-131">3.9. Legacy platform objects</a>
-    <li><a href="#ref-for-dfn-interface-132">3.9.3. [[DefineOwnProperty]]</a> <a href="#ref-for-dfn-interface-133">(2)</a>
-    <li><a href="#ref-for-dfn-interface-134">3.9.4. [[Delete]]</a>
-    <li><a href="#ref-for-dfn-interface-135">3.9.5. [[Call]]</a>
-    <li><a href="#ref-for-dfn-interface-136">3.9.7. Property enumeration</a> <a href="#ref-for-dfn-interface-137">(2)</a>
-    <li><a href="#ref-for-dfn-interface-138">3.10. User objects implementing callback interfaces</a>
-    <li><a href="#ref-for-dfn-interface-139">3.15. Creating and throwing exceptions</a>
-    <li><a href="#ref-for-dfn-interface-140">3.16. Handling exceptions</a>
-    <li><a href="#ref-for-dfn-interface-141">IDL grammar</a>
+    <li><a href="#ref-for-dfn-interface-96">3.6.6. Attributes</a> <a href="#ref-for-dfn-interface-97">(2)</a> <a href="#ref-for-dfn-interface-98">(3)</a> <a href="#ref-for-dfn-interface-99">(4)</a>
+    <li><a href="#ref-for-dfn-interface-100">3.6.7. Operations</a> <a href="#ref-for-dfn-interface-101">(2)</a> <a href="#ref-for-dfn-interface-102">(3)</a>
+    <li><a href="#ref-for-dfn-interface-103">3.6.7.1. Stringifiers</a> <a href="#ref-for-dfn-interface-104">(2)</a>
+    <li><a href="#ref-for-dfn-interface-105">3.6.7.2. Serializers</a> <a href="#ref-for-dfn-interface-106">(2)</a> <a href="#ref-for-dfn-interface-107">(3)</a>
+    <li><a href="#ref-for-dfn-interface-108">3.6.8.1. @@iterator</a> <a href="#ref-for-dfn-interface-109">(2)</a> <a href="#ref-for-dfn-interface-110">(3)</a>
+    <li><a href="#ref-for-dfn-interface-111">3.6.8.2. forEach</a> <a href="#ref-for-dfn-interface-112">(2)</a>
+    <li><a href="#ref-for-dfn-interface-113">3.6.9.1. entries</a>
+    <li><a href="#ref-for-dfn-interface-114">3.6.9.2. keys</a> <a href="#ref-for-dfn-interface-115">(2)</a>
+    <li><a href="#ref-for-dfn-interface-116">3.6.9.3. values</a> <a href="#ref-for-dfn-interface-117">(2)</a>
+    <li><a href="#ref-for-dfn-interface-118">3.6.9.4. Default iterator objects</a> <a href="#ref-for-dfn-interface-119">(2)</a> <a href="#ref-for-dfn-interface-120">(3)</a> <a href="#ref-for-dfn-interface-121">(4)</a>
+    <li><a href="#ref-for-dfn-interface-122">3.6.9.5. Iterator prototype object</a> <a href="#ref-for-dfn-interface-123">(2)</a> <a href="#ref-for-dfn-interface-124">(3)</a> <a href="#ref-for-dfn-interface-125">(4)</a>
+    <li><a href="#ref-for-dfn-interface-126">3.6.10. Maplike declarations</a> <a href="#ref-for-dfn-interface-127">(2)</a>
+    <li><a href="#ref-for-dfn-interface-128">3.6.11. Setlike declarations</a> <a href="#ref-for-dfn-interface-129">(2)</a>
+    <li><a href="#ref-for-dfn-interface-130">3.7. Implements statements</a>
+    <li><a href="#ref-for-dfn-interface-131">3.8.1. [[SetPrototypeOf]]</a>
+    <li><a href="#ref-for-dfn-interface-132">3.9. Legacy platform objects</a>
+    <li><a href="#ref-for-dfn-interface-133">3.9.3. [[DefineOwnProperty]]</a> <a href="#ref-for-dfn-interface-134">(2)</a>
+    <li><a href="#ref-for-dfn-interface-135">3.9.4. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-interface-136">3.9.5. [[Call]]</a>
+    <li><a href="#ref-for-dfn-interface-137">3.9.7. Property enumeration</a> <a href="#ref-for-dfn-interface-138">(2)</a>
+    <li><a href="#ref-for-dfn-interface-139">3.10. User objects implementing callback interfaces</a>
+    <li><a href="#ref-for-dfn-interface-140">3.15. Creating and throwing exceptions</a>
+    <li><a href="#ref-for-dfn-interface-141">3.16. Handling exceptions</a>
+    <li><a href="#ref-for-dfn-interface-142">IDL grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-interface-member">
@@ -13355,22 +13374,22 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-dfn-interface-member-1">2.1. Names</a>
     <li><a href="#ref-for-dfn-interface-member-2">2.2.1. Constants</a>
-    <li><a href="#ref-for-dfn-interface-member-3">2.2.2. Attributes</a> <a href="#ref-for-dfn-interface-member-4">(2)</a>
-    <li><a href="#ref-for-dfn-interface-member-5">2.2.3. Operations</a> <a href="#ref-for-dfn-interface-member-6">(2)</a>
-    <li><a href="#ref-for-dfn-interface-member-7">2.2.7. Iterable declarations</a>
-    <li><a href="#ref-for-dfn-interface-member-8">2.2.8. Maplike declarations</a>
-    <li><a href="#ref-for-dfn-interface-member-9">2.2.9. Setlike declarations</a>
-    <li><a href="#ref-for-dfn-interface-member-10">2.12. Extended attributes</a>
-    <li><a href="#ref-for-dfn-interface-member-11">3.3.4. [Exposed]</a> <a href="#ref-for-dfn-interface-member-12">(2)</a>
-    <li><a href="#ref-for-dfn-interface-member-13">3.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-interface-member-14">(2)</a> <a href="#ref-for-dfn-interface-member-15">(3)</a> <a href="#ref-for-dfn-interface-member-16">(4)</a>
-    <li><a href="#ref-for-dfn-interface-member-17">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-interface-member-18">(2)</a>
-    <li><a href="#ref-for-dfn-interface-member-19">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-interface-member-20">(2)</a>
-    <li><a href="#ref-for-dfn-interface-member-21">3.6.10.5. clear</a>
-    <li><a href="#ref-for-dfn-interface-member-22">3.6.10.6. delete</a>
-    <li><a href="#ref-for-dfn-interface-member-23">3.6.10.7. set</a>
-    <li><a href="#ref-for-dfn-interface-member-24">3.6.11.5. add and delete</a>
-    <li><a href="#ref-for-dfn-interface-member-25">3.6.11.6. clear</a>
-    <li><a href="#ref-for-dfn-interface-member-26">3.9. Legacy platform objects</a>
+    <li><a href="#ref-for-dfn-interface-member-3">2.2.2. Attributes</a> <a href="#ref-for-dfn-interface-member-4">(2)</a> <a href="#ref-for-dfn-interface-member-5">(3)</a>
+    <li><a href="#ref-for-dfn-interface-member-6">2.2.3. Operations</a> <a href="#ref-for-dfn-interface-member-7">(2)</a>
+    <li><a href="#ref-for-dfn-interface-member-8">2.2.7. Iterable declarations</a>
+    <li><a href="#ref-for-dfn-interface-member-9">2.2.8. Maplike declarations</a>
+    <li><a href="#ref-for-dfn-interface-member-10">2.2.9. Setlike declarations</a>
+    <li><a href="#ref-for-dfn-interface-member-11">2.12. Extended attributes</a>
+    <li><a href="#ref-for-dfn-interface-member-12">3.3.4. [Exposed]</a> <a href="#ref-for-dfn-interface-member-13">(2)</a>
+    <li><a href="#ref-for-dfn-interface-member-14">3.3.5. [Global] and [PrimaryGlobal]</a> <a href="#ref-for-dfn-interface-member-15">(2)</a> <a href="#ref-for-dfn-interface-member-16">(3)</a> <a href="#ref-for-dfn-interface-member-17">(4)</a>
+    <li><a href="#ref-for-dfn-interface-member-18">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-interface-member-19">(2)</a>
+    <li><a href="#ref-for-dfn-interface-member-20">3.6.3. Interface prototype object</a> <a href="#ref-for-dfn-interface-member-21">(2)</a>
+    <li><a href="#ref-for-dfn-interface-member-22">3.6.10.5. clear</a>
+    <li><a href="#ref-for-dfn-interface-member-23">3.6.10.6. delete</a>
+    <li><a href="#ref-for-dfn-interface-member-24">3.6.10.7. set</a>
+    <li><a href="#ref-for-dfn-interface-member-25">3.6.11.5. add and delete</a>
+    <li><a href="#ref-for-dfn-interface-member-26">3.6.11.6. clear</a>
+    <li><a href="#ref-for-dfn-interface-member-27">3.9. Legacy platform objects</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-inherit">
@@ -13501,30 +13520,33 @@ language binding.</p>
   <aside class="dfn-panel" data-for="dfn-regular-attribute">
    <b><a href="#dfn-regular-attribute">#dfn-regular-attribute</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-regular-attribute-1">2.2.2. Attributes</a> <a href="#ref-for-dfn-regular-attribute-2">(2)</a> <a href="#ref-for-dfn-regular-attribute-3">(3)</a>
-    <li><a href="#ref-for-dfn-regular-attribute-4">3.3.3. [EnforceRange]</a>
-    <li><a href="#ref-for-dfn-regular-attribute-5">3.3.8. [LenientSetter]</a> <a href="#ref-for-dfn-regular-attribute-6">(2)</a>
-    <li><a href="#ref-for-dfn-regular-attribute-7">3.3.9. [LenientThis]</a>
-    <li><a href="#ref-for-dfn-regular-attribute-8">3.3.14. [PutForwards]</a>
-    <li><a href="#ref-for-dfn-regular-attribute-9">3.3.15. [Replaceable]</a>
-    <li><a href="#ref-for-dfn-regular-attribute-10">3.3.21. [Unscopable]</a> <a href="#ref-for-dfn-regular-attribute-11">(2)</a>
-    <li><a href="#ref-for-dfn-regular-attribute-12">3.6.1. Interface object</a>
-    <li><a href="#ref-for-dfn-regular-attribute-13">3.6.3. Interface prototype object</a>
-    <li><a href="#ref-for-dfn-regular-attribute-14">3.6.6. Attributes</a> <a href="#ref-for-dfn-regular-attribute-15">(2)</a>
+    <li><a href="#ref-for-dfn-regular-attribute-1">2.2.2. Attributes</a> <a href="#ref-for-dfn-regular-attribute-2">(2)</a> <a href="#ref-for-dfn-regular-attribute-3">(3)</a> <a href="#ref-for-dfn-regular-attribute-4">(4)</a>
+    <li><a href="#ref-for-dfn-regular-attribute-5">2.3. Namespaces</a>
+    <li><a href="#ref-for-dfn-regular-attribute-6">3.3.3. [EnforceRange]</a>
+    <li><a href="#ref-for-dfn-regular-attribute-7">3.3.8. [LenientSetter]</a> <a href="#ref-for-dfn-regular-attribute-8">(2)</a>
+    <li><a href="#ref-for-dfn-regular-attribute-9">3.3.9. [LenientThis]</a>
+    <li><a href="#ref-for-dfn-regular-attribute-10">3.3.14. [PutForwards]</a>
+    <li><a href="#ref-for-dfn-regular-attribute-11">3.3.15. [Replaceable]</a>
+    <li><a href="#ref-for-dfn-regular-attribute-12">3.3.21. [Unscopable]</a> <a href="#ref-for-dfn-regular-attribute-13">(2)</a>
+    <li><a href="#ref-for-dfn-regular-attribute-14">3.6.1. Interface object</a>
+    <li><a href="#ref-for-dfn-regular-attribute-15">3.6.3. Interface prototype object</a>
+    <li><a href="#ref-for-dfn-regular-attribute-16">3.6.6. Attributes</a> <a href="#ref-for-dfn-regular-attribute-17">(2)</a>
+    <li><a href="#ref-for-dfn-regular-attribute-18">3.12.1. Namespace object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-read-only">
    <b><a href="#dfn-read-only">#dfn-read-only</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-read-only-1">2. Interface definition language</a>
-    <li><a href="#ref-for-dfn-read-only-2">2.2.2. Attributes</a> <a href="#ref-for-dfn-read-only-3">(2)</a> <a href="#ref-for-dfn-read-only-4">(3)</a>
-    <li><a href="#ref-for-dfn-read-only-5">3.3.1. [Clamp]</a>
-    <li><a href="#ref-for-dfn-read-only-6">3.3.3. [EnforceRange]</a>
-    <li><a href="#ref-for-dfn-read-only-7">3.3.8. [LenientSetter]</a> <a href="#ref-for-dfn-read-only-8">(2)</a>
-    <li><a href="#ref-for-dfn-read-only-9">3.3.14. [PutForwards]</a> <a href="#ref-for-dfn-read-only-10">(2)</a>
-    <li><a href="#ref-for-dfn-read-only-11">3.3.15. [Replaceable]</a> <a href="#ref-for-dfn-read-only-12">(2)</a>
-    <li><a href="#ref-for-dfn-read-only-13">3.3.16. [SameObject]</a> <a href="#ref-for-dfn-read-only-14">(2)</a>
-    <li><a href="#ref-for-dfn-read-only-15">3.6.6. Attributes</a> <a href="#ref-for-dfn-read-only-16">(2)</a>
+    <li><a href="#ref-for-dfn-read-only-2">2.2.2. Attributes</a> <a href="#ref-for-dfn-read-only-3">(2)</a> <a href="#ref-for-dfn-read-only-4">(3)</a> <a href="#ref-for-dfn-read-only-5">(4)</a>
+    <li><a href="#ref-for-dfn-read-only-6">2.3. Namespaces</a>
+    <li><a href="#ref-for-dfn-read-only-7">3.3.1. [Clamp]</a>
+    <li><a href="#ref-for-dfn-read-only-8">3.3.3. [EnforceRange]</a>
+    <li><a href="#ref-for-dfn-read-only-9">3.3.8. [LenientSetter]</a> <a href="#ref-for-dfn-read-only-10">(2)</a>
+    <li><a href="#ref-for-dfn-read-only-11">3.3.14. [PutForwards]</a> <a href="#ref-for-dfn-read-only-12">(2)</a>
+    <li><a href="#ref-for-dfn-read-only-13">3.3.15. [Replaceable]</a> <a href="#ref-for-dfn-read-only-14">(2)</a>
+    <li><a href="#ref-for-dfn-read-only-15">3.3.16. [SameObject]</a> <a href="#ref-for-dfn-read-only-16">(2)</a>
+    <li><a href="#ref-for-dfn-read-only-17">3.6.6. Attributes</a> <a href="#ref-for-dfn-read-only-18">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-inherit-getter">
@@ -14086,20 +14108,27 @@ language binding.</p>
     <li><a href="#ref-for-dfn-namespace-2">2.1. Names</a> <a href="#ref-for-dfn-namespace-3">(2)</a> <a href="#ref-for-dfn-namespace-4">(3)</a>
     <li><a href="#ref-for-dfn-namespace-5">2.3. Namespaces</a>
     <li><a href="#ref-for-dfn-namespace-6">3.3.4. [Exposed]</a> <a href="#ref-for-dfn-namespace-7">(2)</a>
-    <li><a href="#ref-for-dfn-namespace-8">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-namespace-9">(2)</a>
-    <li><a href="#ref-for-dfn-namespace-10">3.6.7. Operations</a> <a href="#ref-for-dfn-namespace-11">(2)</a>
-    <li><a href="#ref-for-dfn-namespace-12">3.12. Namespaces</a>
-    <li><a href="#ref-for-dfn-namespace-13">3.12.1. Namespace object</a>
+    <li><a href="#ref-for-dfn-namespace-8">3.3.8. [LenientSetter]</a>
+    <li><a href="#ref-for-dfn-namespace-9">3.3.9. [LenientThis]</a>
+    <li><a href="#ref-for-dfn-namespace-10">3.3.14. [PutForwards]</a>
+    <li><a href="#ref-for-dfn-namespace-11">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-namespace-12">(2)</a>
+    <li><a href="#ref-for-dfn-namespace-13">3.3.20. [Unforgeable]</a>
+    <li><a href="#ref-for-dfn-namespace-14">3.3.21. [Unscopable]</a>
+    <li><a href="#ref-for-dfn-namespace-15">3.6.6. Attributes</a>
+    <li><a href="#ref-for-dfn-namespace-16">3.6.7. Operations</a> <a href="#ref-for-dfn-namespace-17">(2)</a>
+    <li><a href="#ref-for-dfn-namespace-18">3.12. Namespaces</a>
+    <li><a href="#ref-for-dfn-namespace-19">3.12.1. Namespace object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-namespace-member">
    <b><a href="#dfn-namespace-member">#dfn-namespace-member</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-namespace-member-1">2.2.3. Operations</a>
-    <li><a href="#ref-for-dfn-namespace-member-2">2.12. Extended attributes</a>
-    <li><a href="#ref-for-dfn-namespace-member-3">3.3.4. [Exposed]</a> <a href="#ref-for-dfn-namespace-member-4">(2)</a>
-    <li><a href="#ref-for-dfn-namespace-member-5">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-namespace-member-6">(2)</a>
-    <li><a href="#ref-for-dfn-namespace-member-7">3.12.1. Namespace object</a>
+    <li><a href="#ref-for-dfn-namespace-member-1">2.2.2. Attributes</a>
+    <li><a href="#ref-for-dfn-namespace-member-2">2.2.3. Operations</a>
+    <li><a href="#ref-for-dfn-namespace-member-3">2.12. Extended attributes</a>
+    <li><a href="#ref-for-dfn-namespace-member-4">3.3.4. [Exposed]</a> <a href="#ref-for-dfn-namespace-member-5">(2)</a>
+    <li><a href="#ref-for-dfn-namespace-member-6">3.3.17. [SecureContext]</a> <a href="#ref-for-dfn-namespace-member-7">(2)</a>
+    <li><a href="#ref-for-dfn-namespace-member-8">3.12.1. Namespace object</a> <a href="#ref-for-dfn-namespace-member-9">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-partial-namespace">
@@ -15543,7 +15572,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-exposed-7">3.6.7.1. Stringifiers</a>
     <li><a href="#ref-for-dfn-exposed-8">3.6.7.2. Serializers</a>
     <li><a href="#ref-for-dfn-exposed-9">3.12. Namespaces</a>
-    <li><a href="#ref-for-dfn-exposed-10">3.12.1. Namespace object</a>
+    <li><a href="#ref-for-dfn-exposed-10">3.12.1. Namespace object</a> <a href="#ref-for-dfn-exposed-11">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="Global">
@@ -15604,10 +15633,10 @@ language binding.</p>
    <b><a href="#LenientSetter">#LenientSetter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LenientSetter-1">2.2.2. Attributes</a> <a href="#ref-for-LenientSetter-2">(2)</a>
-    <li><a href="#ref-for-LenientSetter-3">3.3.8. [LenientSetter]</a> <a href="#ref-for-LenientSetter-4">(2)</a> <a href="#ref-for-LenientSetter-5">(3)</a> <a href="#ref-for-LenientSetter-6">(4)</a> <a href="#ref-for-LenientSetter-7">(5)</a> <a href="#ref-for-LenientSetter-8">(6)</a>
-    <li><a href="#ref-for-LenientSetter-9">3.3.14. [PutForwards]</a>
-    <li><a href="#ref-for-LenientSetter-10">3.3.15. [Replaceable]</a>
-    <li><a href="#ref-for-LenientSetter-11">3.6.6. Attributes</a> <a href="#ref-for-LenientSetter-12">(2)</a>
+    <li><a href="#ref-for-LenientSetter-3">3.3.8. [LenientSetter]</a> <a href="#ref-for-LenientSetter-4">(2)</a> <a href="#ref-for-LenientSetter-5">(3)</a> <a href="#ref-for-LenientSetter-6">(4)</a> <a href="#ref-for-LenientSetter-7">(5)</a> <a href="#ref-for-LenientSetter-8">(6)</a> <a href="#ref-for-LenientSetter-9">(7)</a>
+    <li><a href="#ref-for-LenientSetter-10">3.3.14. [PutForwards]</a>
+    <li><a href="#ref-for-LenientSetter-11">3.3.15. [Replaceable]</a>
+    <li><a href="#ref-for-LenientSetter-12">3.6.6. Attributes</a> <a href="#ref-for-LenientSetter-13">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="LenientThis">
@@ -15615,8 +15644,8 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-LenientThis-1">2.2.2. Attributes</a>
     <li><a href="#ref-for-LenientThis-2">3.3.8. [LenientSetter]</a>
-    <li><a href="#ref-for-LenientThis-3">3.3.9. [LenientThis]</a> <a href="#ref-for-LenientThis-4">(2)</a> <a href="#ref-for-LenientThis-5">(3)</a> <a href="#ref-for-LenientThis-6">(4)</a> <a href="#ref-for-LenientThis-7">(5)</a>
-    <li><a href="#ref-for-LenientThis-8">3.6.6. Attributes</a> <a href="#ref-for-LenientThis-9">(2)</a> <a href="#ref-for-LenientThis-10">(3)</a> <a href="#ref-for-LenientThis-11">(4)</a>
+    <li><a href="#ref-for-LenientThis-3">3.3.9. [LenientThis]</a> <a href="#ref-for-LenientThis-4">(2)</a> <a href="#ref-for-LenientThis-5">(3)</a> <a href="#ref-for-LenientThis-6">(4)</a> <a href="#ref-for-LenientThis-7">(5)</a> <a href="#ref-for-LenientThis-8">(6)</a>
+    <li><a href="#ref-for-LenientThis-9">3.6.6. Attributes</a> <a href="#ref-for-LenientThis-10">(2)</a> <a href="#ref-for-LenientThis-11">(3)</a> <a href="#ref-for-LenientThis-12">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="NamedConstructor">
@@ -15729,8 +15758,8 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-Unforgeable-1">2.2.2. Attributes</a>
     <li><a href="#ref-for-Unforgeable-2">2.2.3. Operations</a>
-    <li><a href="#ref-for-Unforgeable-3">3.3.20. [Unforgeable]</a> <a href="#ref-for-Unforgeable-4">(2)</a> <a href="#ref-for-Unforgeable-5">(3)</a> <a href="#ref-for-Unforgeable-6">(4)</a> <a href="#ref-for-Unforgeable-7">(5)</a> <a href="#ref-for-Unforgeable-8">(6)</a>
-    <li><a href="#ref-for-Unforgeable-9">3.6.6. Attributes</a>
+    <li><a href="#ref-for-Unforgeable-3">3.3.20. [Unforgeable]</a> <a href="#ref-for-Unforgeable-4">(2)</a> <a href="#ref-for-Unforgeable-5">(3)</a> <a href="#ref-for-Unforgeable-6">(4)</a> <a href="#ref-for-Unforgeable-7">(5)</a> <a href="#ref-for-Unforgeable-8">(6)</a> <a href="#ref-for-Unforgeable-9">(7)</a>
+    <li><a href="#ref-for-Unforgeable-10">3.6.6. Attributes</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-unforgeable-on-an-interface">
@@ -15746,8 +15775,8 @@ language binding.</p>
   <aside class="dfn-panel" data-for="Unscopable">
    <b><a href="#Unscopable">#Unscopable</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-Unscopable-1">3.3.21. [Unscopable]</a> <a href="#ref-for-Unscopable-2">(2)</a> <a href="#ref-for-Unscopable-3">(3)</a> <a href="#ref-for-Unscopable-4">(4)</a>
-    <li><a href="#ref-for-Unscopable-5">3.6.3. Interface prototype object</a> <a href="#ref-for-Unscopable-6">(2)</a>
+    <li><a href="#ref-for-Unscopable-1">3.3.21. [Unscopable]</a> <a href="#ref-for-Unscopable-2">(2)</a> <a href="#ref-for-Unscopable-3">(3)</a> <a href="#ref-for-Unscopable-4">(4)</a> <a href="#ref-for-Unscopable-5">(5)</a>
+    <li><a href="#ref-for-Unscopable-6">3.6.3. Interface prototype object</a> <a href="#ref-for-Unscopable-7">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-perform-a-security-check">
@@ -15869,6 +15898,7 @@ language binding.</p>
    <ul>
     <li><a href="#ref-for-dfn-attribute-getter-1">3.1. ECMAScript environment</a>
     <li><a href="#ref-for-dfn-attribute-getter-2">3.6.6. Attributes</a>
+    <li><a href="#ref-for-dfn-attribute-getter-3">3.12.1. Namespace object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-attribute-setter">


### PR DESCRIPTION
This is on top of #217 so only look at the second commit if you want an accurate diff of the feature.

The example has a commented out line until we can update Bikeshed's Web IDL parser. Probably we should not land things like this.

The main thing that would be helpful to review here is that I didn't forgot other places in the spec that need modifying. I did manage to remember to update all the extended attributes (basically disallowing them all except [NewObject]/[SameObject]).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
    
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://cdn.rawgit.com/heycam/webidl/4644d0d/index.html) | [Diff w/ current ED](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fheycam.github.io%2Fwebidl%2F&doc2=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2F4644d0d%2Findex.html) | [Diff w/ base](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2F89fc3a3%2Findex.html&doc2=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2F4644d0d%2Findex.html)