### PR TITLE
Meta: remove unnecessary spans around property descriptors.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10036,7 +10036,7 @@ ECMAScript environment's global object.
 The name of the property is the [=identifier=] of the interface,
 and its value is an object called the <dfn id="dfn-interface-object" export>interface object</dfn>.
 
-The property has the attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>.
+The property has the attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 The characteristics of an interface object are described in [[#interface-object]].
 
 In addition, for every [{{NamedConstructor}}]
@@ -10046,7 +10046,7 @@ exist on the ECMAScript global object.  The name of the property is the
 “<emu-t>=</emu-t>”, and its value is an object called a
 <dfn id="dfn-named-constructor" export>named constructor</dfn>, which allows
 construction of objects that implement the interface.  The property has the
-attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>.
+attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 The characteristics of a named constructor are described in
 [[#named-constructors]].
 
@@ -10075,7 +10075,7 @@ follows:
 
 An interface object for a non-callback interface must have a property named “prototype”
 with attributes
-<span class="prop-desc">{ \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>false</emu-val> }</span>
+{ \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>false</emu-val> }
 whose value is an object called the <dfn id="dfn-interface-prototype-object" export>interface prototype object</dfn>.  This object has properties
 that correspond to the [=regular attributes=] and
 [=regular operations=] defined on the interface,
@@ -10138,7 +10138,7 @@ both as a function and as a constructor.
 <div algorithm="determine value of length property of non-callback interfaces">
 
     Interface objects for non-callback interfaces must have a property named “length” with attributes
-    <span class="prop-desc">{ \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>
+    { \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
     whose value is a <emu-val>Number</emu-val>.
     If the [{{Constructor}}] [=extended attribute=]
     does not appear on the interface definition, then the value is 0.
@@ -10155,7 +10155,7 @@ both as a function and as a constructor.
 </div>
 
 All interface objects must have a
-property named “name” with attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>
+property named “name” with attributes { \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 whose value is the identifier of the corresponding interface.
 
 
@@ -10225,7 +10225,7 @@ with the [=named constructor=].
 <div algorithm="determine value of length property of named constructors">
 
     A named constructor must have a property named “length” with attributes
-    <span class="prop-desc">{ \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>
+    { \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
     whose value is a <emu-val>Number</emu-val> determined as follows:
 
     1.  Initialize |S| to the [=effective overload set=] for constructors with
@@ -10234,12 +10234,12 @@ with the [=named constructor=].
 </div>
 
 A named constructor must have a property named “name”
-with attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>
+with attributes { \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 whose value is the identifier used for the named constructor.
 
 A named constructor must also have a property named
 “prototype” with attributes
-<span class="prop-desc">{ \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>false</emu-val> }</span>
+{ \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>false</emu-val> }
 whose value is the [=interface prototype object=]
 for the [=interface=] on which the
 [{{NamedConstructor}}]
@@ -10270,7 +10270,7 @@ If the [{{NoInterfaceObject}}]
 extended attribute was not specified on the interface, then
 the interface prototype object must
 also have a property named “constructor” with attributes
-<span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span> whose value
+{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> } whose value
 is a reference to the interface object for the interface.
 
 <div algorithm="value of internal prototype property">
@@ -10491,7 +10491,7 @@ The property has the following characteristics:
         the consequential interface’s [=interface prototype object=].
     *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 *   The value of the property is that which is obtained by [=converted to an ECMAScript value|converting=] the [=constant=]’s IDL value to an ECMAScript value.
-*   The property has attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>false</emu-val> }</span>.
+*   The property has attributes { \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>false</emu-val> }.
 
 In addition, a property with the same characteristics must
 exist on the [=interface object=], if that object exists.
@@ -10518,7 +10518,7 @@ The characteristics of this property are as follows:
         [{{PrimaryGlobal}}]-annotated interface as well as on
         the consequential interface’s [=interface prototype object=].
     *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
-*   The property has attributes <span class="prop-desc">{ \[[Get]]: |G|, \[[Set]]: |S|, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: |configurable| }</span>,
+*   The property has attributes { \[[Get]]: |G|, \[[Set]]: |S|, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: |configurable| },
     where:
     *   |configurable| is <emu-val>false</emu-val> if the attribute was
         declared with the [{{Unforgeable}}] extended attribute and <emu-val>true</emu-val> otherwise;
@@ -10571,7 +10571,7 @@ The characteristics of this property are as follows:
     1.  Let |name| be the string "get " prepended to |attribute|'s [=identifier=].
     1.  Perform [=!=] [=SetFunctionName=](|F|, |name|).
     1.  Perform [=!=] [=DefinePropertyOrThrow=](|F|, "length",
-        PropertyDescriptor<span class="prop-desc">{\[[Value]]: 0, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}</span>).
+        PropertyDescriptor{\[[Value]]: 0, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
     1. Return |F|.
 
 </div>
@@ -10644,7 +10644,7 @@ The characteristics of this property are as follows:
     1.  Let |name| be the string "set " prepended to |id|.
     1.  Perform [=!=] [=SetFunctionName=](|F|, |name|).
     1.  Perform [=!=] [=DefinePropertyOrThrow=](|F|, "length",
-        PropertyDescriptor<span class="prop-desc">{\[[Value]]: 1, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}</span>).
+        PropertyDescriptor{\[[Value]]: 1, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
     1. Return |F|.
 </div>
 
@@ -10686,7 +10686,7 @@ The characteristics of this property are as follows:
         the consequential interface’s [=interface prototype object=].
     *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 *   The property has attributes
-    <span class="prop-desc">{ \[[Writable]]: |B|, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: |B| }</span>,
+    { \[[Writable]]: |B|, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: |B| },
     where |B| is <emu-val>false</emu-val> if the operation is
     [=unforgeable=] on the interface,
     and <emu-val>true</emu-val> otherwise.
@@ -10755,7 +10755,7 @@ property-installation style as namespaces.)
         on |target| and with argument count 0.
     1.  Let |length| be the length of the shortest argument list in the entries in |S|.
     1.  Perform [=!=] [=DefinePropertyOrThrow=](|F|, "length",
-        PropertyDescriptor<span class="prop-desc">{\[[Value]]: |length|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}</span>).
+        PropertyDescriptor{\[[Value]]: |length|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
     1.  Return |F|.
 </div>
 
@@ -10770,7 +10770,7 @@ then there must exist a property with the following characteristics:
     then the property exists on every object that implements the interface.
     Otherwise, the property exists on the [=interface prototype object=].
 *   The property has attributes
-    <span class="prop-desc">{ \[[Writable]]: |B|, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: |B| }</span>,
+    { \[[Writable]]: |B|, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: |B| },
     where |B| is <emu-val>false</emu-val> if the stringifier is [=unforgeable=] on the interface,
     and <emu-val>true</emu-val> otherwise.
 *   <div algorithm="to invoke the toString method of interfaces">
@@ -10813,7 +10813,7 @@ then there must exist a property with the following characteristics:
 
 If the [=interface=] has an [=exposed=] [=serializer=], then
 a property must exist whose name is “toJSON”, with attributes
-<span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>
+{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 and whose value is a <emu-val>Function</emu-val> object.
 
 The location of the property is determined as follows:
@@ -10907,7 +10907,7 @@ If the [=interface=] has any of the following:
 
 then a property must exist
 whose name is the [=@@iterator=] symbol, with attributes
-<span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>
+{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 and whose value is a [=function object=].
 
 The location of the property is determined as follows:
@@ -10988,7 +10988,7 @@ If the [=interface=] has any of the following:
 *   a [=setlike declaration=]
 
 then a property named “forEach” must exist with attributes
-<span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>
+{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 and whose value is a [=function object=].
 
 The location of the property is determined as follows:
@@ -11094,7 +11094,7 @@ property is the <emu-val>String</emu-val> value “forEach”.
 
 If the [=interface=] has an [=iterable declaration=],
 then a property named “entries” must exist with attributes
-<span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>
+{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 and whose value is a [=function object=].
 
 The location of the property is determined as follows:
@@ -11121,7 +11121,7 @@ the value of the [=@@iterator=] property.
 
 If the [=interface=] has an [=iterable declaration=],
 then a property named “keys” must exist with attributes
-<span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>
+{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 and whose value is a [=function object=].
 
 The location of the property is determined as follows:
@@ -11170,7 +11170,7 @@ The value of the <emu-val>Function</emu-val> object’s “name” property is t
 If the [=interface=] has an
 [=iterable declaration=],
 then a property named “values” must exist
-with attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>
+with attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 and whose value is a [=function object=].
 
 The location of the property is determined as follows:
@@ -11258,7 +11258,7 @@ must be [=%IteratorPrototype%=].
 <div algorithm="to invoke the next property of iterators">
 
     An [=iterator prototype object=] must have a property named “next” with attributes
-    <span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>
+    { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
     and whose value is a [=function object=] that behaves as follows:
 
     1.  Let |interface| be the [=interface=] for which the
@@ -11351,7 +11351,7 @@ There must exist a property named “size” on
 with the following characteristics:
 
 *   The property has attributes
-    <span class="prop-desc">{ \[[Get]]: |G|, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>,
+    { \[[Get]]: |G|, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> },
     where |G| is the interface’s <dfn id="dfn-map-size-getter" export>map size getter</dfn>,
     defined below.
 *   <div algorithm="to invoke the size method of Maps">
@@ -11379,7 +11379,7 @@ with the following characteristics:
 
 A property named “entries” must exist on
 |A|’s [=interface prototype object=]
-with attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>
+with attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 and whose value is the [=function object=] that is the value of
 the [=@@iterator=] property.
 
@@ -11390,7 +11390,7 @@ For both of “keys” and “values”, there must exist a property with that n
 |A|’s [=interface prototype object=]
 with the following characteristics:
 
-*   The property has attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>.
+*   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 *   The value of the property is a <emu-val>Function</emu-val> object that [=forwards to the internal map object|forwards that name to the internal map object=].
 
 The value of the <emu-val>Function</emu-val> objects’ “length” properties is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.
@@ -11404,7 +11404,7 @@ For both of “get” and “has”, there must exist a property with that name 
 |A|’s [=interface prototype object=] with the following characteristics:
 
 *   The property has attributes
-    <span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>.
+    { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 *   <div algorithm="to invoke the get and has methods of Maps">
 
         The value of the property is a <emu-val>Function</emu-val> object
@@ -11443,7 +11443,7 @@ then a property named “clear” and the following characteristics
 must exist on |A|’s
 [=interface prototype object=]:
 
-*   The property has attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>.
+*   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 *   The value of the property is a <emu-val>Function</emu-val> object that [=forwards to the internal map object|forwards “clear” to the internal map object=].
 
 The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.
@@ -11462,7 +11462,7 @@ then a property named “delete” and the following characteristics
 must exist on |A|’s
 [=interface prototype object=]:
 
-*   The property has attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>.
+*   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 *   <div algorithm="to invoke the delete method of Maps">
 
         The value of the property is a <emu-val>Function</emu-val> object that behaves as follows when invoked:
@@ -11497,7 +11497,7 @@ then a property named “set” and the following characteristics
 must exist on |A|’s [=interface prototype object=]:
 
 *   The property has attributes
-    <span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>.
+    { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 *   <div algorithm="to invoke the set method of Maps">
 
         The value of the property is a <emu-val>Function</emu-val> object that behaves as follows when invoked:
@@ -11572,7 +11572,7 @@ These additional properties are described in the sub-sections below.
 There must exist a property named “size” on |A|’s [=interface prototype object=]
 with the following characteristics:
 
-*   The property has attributes <span class="prop-desc">{ \[[Get]]: |G|, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>,
+*   The property has attributes { \[[Get]]: |G|, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> },
     where |G| is the interface’s <dfn id="dfn-set-size-getter" export>set size getter</dfn>,
     defined below.
 *   <div algorithm="to invoke the size method of Sets">
@@ -11599,7 +11599,7 @@ with the following characteristics:
 <h5 id="es-set-values">values</h5>
 
 A property named “values” must exist on |A|’s [=interface prototype object=]
-with attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>
+with attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 and whose value is the [=function object=] that is the value of
 the [=@@iterator=] property.
 
@@ -11610,7 +11610,7 @@ For both of “entries” and “keys”, there must exist a property with that 
 |A|’s [=interface prototype object=] with the following characteristics:
 
 *   The property has attributes
-    <span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>.
+    { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 *   The value of the property is a <emu-val>Function</emu-val> object that
     [=forwards to the internal set object|forwards that name to the internal set object=].
 
@@ -11627,7 +11627,7 @@ There must exist a property with named “has” on |A|’s [=interface prototyp
 with the following characteristics:
 
 *   The property has attributes
-    <span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>.
+    { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 *   <div algorithm="to invoke the has method of Sets">
 
         The value of the property is a <emu-val>Function</emu-val> object that behaves as follows when invoked:
@@ -11667,7 +11667,7 @@ then a property with that name and the following characteristics
 must exist on |A|’s
 [=interface prototype object=]:
 
-*   The property has attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>.
+*   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 *   <div algorithm="to invoke the add and delete methods of Sets">
 
         The value of the property is a <emu-val>Function</emu-val> object that behaves as follows when invoked:
@@ -11707,7 +11707,7 @@ then a property named “clear” and the following characteristics
 must exist on |A|’s
 [=interface prototype object=]:
 
-*   The property has attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>.
+*   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 *   The value of the property is a <emu-val>Function</emu-val> object that [=forwards to the internal set object|forwards “clear” to the internal set object=].
 
 The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.
@@ -12432,9 +12432,9 @@ a corresponding property must exist on the ECMAScript
 environment's global object. The name of the property is the [=identifier=] of the namespace, and its value is an object
 called the <dfn id="dfn-namespace-object" export>namespace object</dfn>.
 
-The property has the attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>,
-\[[Configurable]]: <emu-val>true</emu-val> }</span>. The characteristics of a
-namespace object are described in [[#namespace-object]].
+The property has the attributes
+{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
+The characteristics of a namespace object are described in [[#namespace-object]].
 
 
 <h4 id="namespace-object">Namespace object</h4>
@@ -12460,7 +12460,7 @@ whose name is “DOMException” and value is an object called the
 <dfn id="dfn-DOMException-constructor-object" for="DOMException" export>DOMException constructor object</dfn>,
 which provides access to legacy DOMException code constants and allows construction of
 DOMException instances.
-The property has the attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>.
+The property has the attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 
 
 <h4 id="es-DOMException-constructor-object">DOMException constructor object</h4>
@@ -12471,11 +12471,11 @@ but with a \[[Prototype]] value of [=%Error%=].
 For every legacy code listed in the <a href="#dfn-error-names-table">error names table</a>,
 there must be a property on the DOMException constructor object
 whose name and value are as indicated in the table.  The property has
-attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>false</emu-val> }</span>.
+attributes { \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>false</emu-val> }.
 
 The DOMException constructor object must also have a property named
 “prototype” with attributes
-<span class="prop-desc">{ \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>false</emu-val> }</span>
+{ \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>false</emu-val> }
 whose value is an object called the <dfn id="dfn-DOMException-prototype-object" for="DOMException" export>DOMException prototype object</dfn>.
 This object also provides access to the legacy code values.
 
@@ -12495,10 +12495,10 @@ This object also provides access to the legacy code values.
     1.  Let |O| be [=Construct=](|super|, «|message|», |newTarget|).
     1.  If |name| is not <emu-val>undefined</emu-val>, then
         1.  Let |name| be [=ToString=](|name|).
-        1.  Let |status| be [=DefinePropertyOrThrow=](|O|, <code>"name"</code>, PropertyDescriptor<span class="prop-desc">{\[[Value]]: |name|, \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}</span>).
+        1.  Let |status| be [=DefinePropertyOrThrow=](|O|, <code>"name"</code>, PropertyDescriptor{\[[Value]]: |name|, \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
         1.  [=ReturnIfAbrupt=](|status|).
         1.  Let |code| be the legacy code indicated in the [=error names table=] for error name |name|, or <emu-val>0</emu-val> if there is none.
-        1.  Let |status| be [=DefinePropertyOrThrow=](|O|, <code>"code"</code>, PropertyDescriptor<span class="prop-desc">{\[[Value]]: |code|, \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}</span>).
+        1.  Let |status| be [=DefinePropertyOrThrow=](|O|, <code>"code"</code>, PropertyDescriptor{\[[Value]]: |code|, \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
         1.  [=ReturnIfAbrupt=](|status|).
     1.  Return |O|.
 </div>
@@ -12515,13 +12515,13 @@ is “DOMExceptionPrototype”.
 
 There must be a property named “constructor”
 on the DOMException prototype object with attributes
-<span class="prop-desc">{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }</span>
+{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 and whose value is the [=DOMException constructor object=].
 
 For every legacy code listed in the <a href="#dfn-error-names-table">error names table</a>,
 there must be a property on the DOMException prototype object
 whose name and value are as indicated in the table.  The property has
-attributes <span class="prop-desc">{ \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>false</emu-val> }</span>.
+attributes { \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>false</emu-val> }.
 
 
 <h3 id="es-exception-objects" dfn>Exception objects</h3>

--- a/index.html
+++ b/index.html
@@ -9332,14 +9332,14 @@ ECMAScript global environment and:</p>
 ECMAScript environment’s global object.
 The name of the property is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-57">identifier</a> of the interface,
 and its value is an object called the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-interface-object">interface object</dfn>.</p>
-   <p>The property has the attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.
+   <p>The property has the attributes { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }.
 The characteristics of an interface object are described in <a href="#interface-object">§3.6.1 Interface object</a>.</p>
    <p>In addition, for every [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-16">NamedConstructor</a></code>]
 extended attribute on an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-3">exposed</a> interface, a corresponding property must
 exist on the ECMAScript global object.  The name of the property is the <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> that occurs directly after the
 “<emu-t>=</emu-t>”, and its value is an object called a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-named-constructor">named constructor</dfn>, which allows
 construction of objects that implement the interface.  The property has the
-attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.
+attributes { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }.
 The characteristics of a named constructor are described in <a href="#named-constructors">§3.6.2 Named constructors</a>.</p>
    <h4 class="heading settled" data-level="3.6.1" id="interface-object"><span class="secno">3.6.1. </span><span class="content">Interface object</span><a class="self-link" href="#interface-object"></a></h4>
    <p>The interface object for a given non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-80">interface</a> is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-3">function object</a>.
@@ -9358,7 +9358,9 @@ object for that other interface.</p>
 the value of [[Prototype]] is <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-function-prototype-object">%FunctionPrototype%</a>.</p>
    </ol>
    <p>An interface object for a non-callback interface must have a property named “prototype”
-with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span> whose value is an object called the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-interface-prototype-object">interface prototype object</dfn>.  This object has properties
+with attributes
+{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }
+whose value is an object called the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-interface-prototype-object">interface prototype object</dfn>.  This object has properties
 that correspond to the <a data-link-type="dfn" href="#dfn-regular-attribute" id="ref-for-dfn-regular-attribute-12">regular attributes</a> and <a data-link-type="dfn" href="#dfn-regular-operation" id="ref-for-dfn-regular-operation-14">regular operations</a> defined on the interface,
 and is described in more detail in <a href="#interface-prototype-object">§3.6.3 Interface prototype object</a>.</p>
    <p class="note" role="note">Note: Since an interface object for a non-callback interface is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-4">function object</a> the <code>typeof</code> operator will return
@@ -9405,7 +9407,9 @@ both as a function and as a constructor.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="determine value of length property of non-callback interfaces">
-    <p>Interface objects for non-callback interfaces must have a property named “length” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> whose value is a <emu-val>Number</emu-val>.
+    <p>Interface objects for non-callback interfaces must have a property named “length” with attributes
+    { [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
+    whose value is a <emu-val>Number</emu-val>.
     If the [<code class="idl"><a data-link-type="idl" href="#Constructor" id="ref-for-Constructor-23">Constructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-74">extended attribute</a> does not appear on the interface definition, then the value is 0.
     Otherwise, the value is determined as follows:</p>
     <ol>
@@ -9418,7 +9422,8 @@ both as a function and as a constructor.</p>
     </ol>
    </div>
    <p>All interface objects must have a
-property named “name” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> whose value is the identifier of the corresponding interface.</p>
+property named “name” with attributes { [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
+whose value is the identifier of the corresponding interface.</p>
    <h5 class="heading settled" data-level="3.6.1.2" id="es-interface-hasinstance"><span class="secno">3.6.1.2. </span><span class="content">Interface object [[HasInstance]] method</span><a class="self-link" href="#es-interface-hasinstance"></a></h5>
    <div class="algorithm" data-algorithm="to invoke the internal [[HasInstance]] method of interface objects">
     <p>The internal [[HasInstance]] method of
@@ -9479,7 +9484,9 @@ This object also must be
 associated with the ECMAScript global environment associated
 with the <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-named-constructor-4">named constructor</a>.</p>
    <div class="algorithm" data-algorithm="determine value of length property of named constructors">
-    <p>A named constructor must have a property named “length” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> whose value is a <emu-val>Number</emu-val> determined as follows:</p>
+    <p>A named constructor must have a property named “length” with attributes
+    { [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
+    whose value is a <emu-val>Number</emu-val> determined as follows:</p>
     <ol>
      <li data-md="">
       <p>Initialize <var>S</var> to the <a data-link-type="dfn" href="#dfn-effective-overload-set" id="ref-for-dfn-effective-overload-set-8">effective overload set</a> for constructors with <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-62">identifier</a> <var>id</var> on <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-87">interface</a> <var>I</var> and with argument count 0.</p>
@@ -9488,9 +9495,12 @@ with the <a data-link-type="dfn" href="#dfn-named-constructor" id="ref-for-dfn-n
     </ol>
    </div>
    <p>A named constructor must have a property named “name”
-with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> whose value is the identifier used for the named constructor.</p>
+with attributes { [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
+whose value is the identifier used for the named constructor.</p>
    <p>A named constructor must also have a property named
-“prototype” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span> whose value is the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-9">interface prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-88">interface</a> on which the
+“prototype” with attributes
+{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }
+whose value is the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-9">interface prototype object</a> for the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-88">interface</a> on which the
 [<code class="idl"><a data-link-type="idl" href="#NamedConstructor" id="ref-for-NamedConstructor-20">NamedConstructor</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-76">extended attribute</a> appears.</p>
    <h4 class="heading settled" data-level="3.6.3" id="interface-prototype-object"><span class="secno">3.6.3. </span><span class="content">Interface prototype object</span><a class="self-link" href="#interface-prototype-object"></a></h4>
    <p>There must exist an <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-10">interface prototype object</a> for every non-callback <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-89">interface</a> defined, regardless of whether the interface was declared with the
@@ -9504,7 +9514,8 @@ interface, described in <a href="#es-operations">§3.6.7 Operations</a>.</p>
    <p>If the [<code class="idl"><a data-link-type="idl" href="#NoInterfaceObject" id="ref-for-NoInterfaceObject-15">NoInterfaceObject</a></code>]
 extended attribute was not specified on the interface, then
 the interface prototype object must
-also have a property named “constructor” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> whose value
+also have a property named “constructor” with attributes
+{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> } whose value
 is a reference to the interface object for the interface.</p>
    <div class="algorithm" data-algorithm="value of internal prototype property">
     <p>The <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-11">interface prototype object</a> for a given interface <var>A</var> must have an internal
@@ -9690,7 +9701,7 @@ the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-pro
     <li data-md="">
      <p>The value of the property is that which is obtained by <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-41">converting</a> the <a data-link-type="dfn" href="#dfn-constant" id="ref-for-dfn-constant-27">constant</a>’s IDL value to an ECMAScript value.</p>
     <li data-md="">
-     <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span>.</p>
+     <p>The property has attributes { [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }.</p>
    </ul>
    <p>In addition, a property with the same characteristics must
 exist on the <a data-link-type="dfn" href="#dfn-interface-object" id="ref-for-dfn-interface-object-11">interface object</a>, if that object exists.</p>
@@ -9721,7 +9732,7 @@ the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-pro
        <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-20">interface prototype object</a>.</p>
      </ul>
     <li data-md="">
-     <p>The property has attributes <span class="prop-desc">{ [[Get]]: <var>G</var>, [[Set]]: <var>S</var>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <var>configurable</var> }</span>,
+     <p>The property has attributes { [[Get]]: <var>G</var>, [[Set]]: <var>S</var>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <var>configurable</var> },
 where:</p>
      <ul>
       <li data-md="">
@@ -9800,7 +9811,7 @@ ECMAScript value of the type <var>attribute</var> is declared as.</p>
       <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-setfunctionname">SetFunctionName</a>(<var>F</var>, <var>name</var>).</p>
      <li data-md="">
       <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow">DefinePropertyOrThrow</a>(<var>F</var>, "length",
-PropertyDescriptor<span class="prop-desc">{[[Value]]: 0, [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val>}</span>).</p>
+PropertyDescriptor{[[Value]]: 0, [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val>}).</p>
      <li data-md="">
       <p>Return <var>F</var>.</p>
     </ol>
@@ -9901,7 +9912,7 @@ return <emu-val>undefined</emu-val>.</p>
       <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-setfunctionname">SetFunctionName</a>(<var>F</var>, <var>name</var>).</p>
      <li data-md="">
       <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow">DefinePropertyOrThrow</a>(<var>F</var>, "length",
-PropertyDescriptor<span class="prop-desc">{[[Value]]: 1, [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val>}</span>).</p>
+PropertyDescriptor{[[Value]]: 1, [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val>}).</p>
      <li data-md="">
       <p>Return <var>F</var>.</p>
     </ol>
@@ -9938,7 +9949,8 @@ the consequential interface’s <a data-link-type="dfn" href="#dfn-interface-pro
        <p>Otherwise, the property exists solely on the interface’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-22">interface prototype object</a>.</p>
      </ul>
     <li data-md="">
-     <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <var>B</var>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <var>B</var> }</span>,
+     <p>The property has attributes
+{ [[Writable]]: <var>B</var>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <var>B</var> },
 where <var>B</var> is <emu-val>false</emu-val> if the operation is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-4">unforgeable</a> on the interface,
 and <emu-val>true</emu-val> otherwise.</p>
     <li data-md="">
@@ -10019,7 +10031,7 @@ operation) or for <a data-link-type="dfn" href="#dfn-static-operation" id="ref-f
       <p>Let <var>length</var> be the length of the shortest argument list in the entries in <var>S</var>.</p>
      <li data-md="">
       <p>Perform <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow">DefinePropertyOrThrow</a>(<var>F</var>, "length",
-PropertyDescriptor<span class="prop-desc">{[[Value]]: <var>length</var>, [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val>}</span>).</p>
+PropertyDescriptor{[[Value]]: <var>length</var>, [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val>}).</p>
      <li data-md="">
       <p>Return <var>F</var>.</p>
     </ol>
@@ -10036,7 +10048,8 @@ or if the interface was declared with the [<code class="idl"><a data-link-type="
 then the property exists on every object that implements the interface.
 Otherwise, the property exists on the <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-23">interface prototype object</a>.</p>
     <li data-md="">
-     <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <var>B</var>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <var>B</var> }</span>,
+     <p>The property has attributes
+{ [[Writable]]: <var>B</var>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <var>B</var> },
 where <var>B</var> is <emu-val>false</emu-val> if the stringifier is <a data-link-type="dfn" href="#dfn-unforgeable-on-an-interface" id="ref-for-dfn-unforgeable-on-an-interface-6">unforgeable</a> on the interface,
 and <emu-val>true</emu-val> otherwise.</p>
     <li data-md="">
@@ -10093,7 +10106,9 @@ property is the <emu-val>String</emu-val> value “toString”.</p>
    </ul>
    <h5 class="heading settled" data-level="3.6.7.2" id="es-serializer"><span class="secno">3.6.7.2. </span><span class="content">Serializers</span><a class="self-link" href="#es-serializer"></a></h5>
    <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-105">interface</a> has an <a data-link-type="dfn" href="#dfn-exposed" id="ref-for-dfn-exposed-8">exposed</a> <a data-link-type="dfn" href="#dfn-serializer" id="ref-for-dfn-serializer-5">serializer</a>, then
-a property must exist whose name is “toJSON”, with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <emu-val>Function</emu-val> object.</p>
+a property must exist whose name is “toJSON”, with attributes
+{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
+and whose value is a <emu-val>Function</emu-val> object.</p>
    <p>The location of the property is determined as follows:</p>
    <ul>
     <li data-md="">
@@ -10228,7 +10243,9 @@ an <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type
      <p>a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-7">setlike declaration</a></p>
    </ul>
    <p>then a property must exist
-whose name is the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> symbol, with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-8">function object</a>.</p>
+whose name is the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> symbol, with attributes
+{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
+and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-8">function object</a>.</p>
    <p>The location of the property is determined as follows:</p>
    <ul>
     <li data-md="">
@@ -10327,7 +10344,9 @@ if the interface has a <a data-link-type="dfn" href="#dfn-setlike-declaration" i
     <li data-md="">
      <p>a <a data-link-type="dfn" href="#dfn-setlike-declaration" id="ref-for-dfn-setlike-declaration-11">setlike declaration</a></p>
    </ul>
-   <p>then a property named “forEach” must exist with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-9">function object</a>.</p>
+   <p>then a property named “forEach” must exist with attributes
+{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
+and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-9">function object</a>.</p>
    <p>The location of the property is determined as follows:</p>
    <ul>
     <li data-md="">
@@ -10443,7 +10462,9 @@ property is the <emu-val>String</emu-val> value “forEach”.</p>
    <h4 class="heading settled" data-level="3.6.9" id="es-iterable"><span class="secno">3.6.9. </span><span class="content">Iterable declarations</span><a class="self-link" href="#es-iterable"></a></h4>
    <h5 class="heading settled" data-level="3.6.9.1" id="es-iterable-entries"><span class="secno">3.6.9.1. </span><span class="content">entries</span><a class="self-link" href="#es-iterable-entries"></a></h5>
    <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-113">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-13">iterable declaration</a>,
-then a property named “entries” must exist with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-10">function object</a>.</p>
+then a property named “entries” must exist with attributes
+{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
+and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-10">function object</a>.</p>
    <p>The location of the property is determined as follows:</p>
    <ul>
     <li data-md="">
@@ -10465,7 +10486,9 @@ then the <emu-val>Function</emu-val> object is
 the value of the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> property.</p>
    <h5 class="heading settled" data-level="3.6.9.2" id="es-iterable-keys"><span class="secno">3.6.9.2. </span><span class="content">keys</span><a class="self-link" href="#es-iterable-keys"></a></h5>
    <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-114">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-14">iterable declaration</a>,
-then a property named “keys” must exist with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-11">function object</a>.</p>
+then a property named “keys” must exist with attributes
+{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
+and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-11">function object</a>.</p>
    <p>The location of the property is determined as follows:</p>
    <ul>
     <li data-md="">
@@ -10515,7 +10538,8 @@ then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-thr
    <h5 class="heading settled" data-level="3.6.9.3" id="es-iterable-values"><span class="secno">3.6.9.3. </span><span class="content">values</span><a class="self-link" href="#es-iterable-values"></a></h5>
    <p>If the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-116">interface</a> has an <a data-link-type="dfn" href="#dfn-iterable-declaration" id="ref-for-dfn-iterable-declaration-16">iterable declaration</a>,
 then a property named “values” must exist
-with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-12">function object</a>.</p>
+with attributes { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
+and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-12">function object</a>.</p>
    <p>The location of the property is determined as follows:</p>
    <ul>
     <li data-md="">
@@ -10585,7 +10609,9 @@ its index is set to 0.</p>
 prototype for <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-7">default iterator objects</a> for the interface.</p>
    <p>The internal [[Prototype]] property of an <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-3">iterator prototype object</a> must be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%IteratorPrototype%</a>.</p>
    <div class="algorithm" data-algorithm="to invoke the next property of iterators">
-    <p>An <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-4">iterator prototype object</a> must have a property named “next” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-13">function object</a> that behaves as follows:</p>
+    <p>An <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-4">iterator prototype object</a> must have a property named “next” with attributes
+    { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
+    and whose value is a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-13">function object</a> that behaves as follows:</p>
     <ol>
      <li data-md="">
       <p>Let <var>interface</var> be the <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-123">interface</a> for which the <a data-link-type="dfn" href="#dfn-iterator-prototype-object" id="ref-for-dfn-iterator-prototype-object-5">iterator prototype object</a> exists.</p>
@@ -10717,7 +10743,8 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
    <p>There must exist a property named “size” on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-37">interface prototype object</a> with the following characteristics:</p>
    <ul>
     <li data-md="">
-     <p>The property has attributes <span class="prop-desc">{ [[Get]]: <var>G</var>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>,
+     <p>The property has attributes
+{ [[Get]]: <var>G</var>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> },
 where <var>G</var> is the interface’s <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-map-size-getter">map size getter</dfn>,
 defined below.</p>
     <li data-md="">
@@ -10750,13 +10777,14 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
      <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “size”.</p>
    </ul>
    <h5 class="heading settled" data-level="3.6.10.2" id="es-map-entries"><span class="secno">3.6.10.2. </span><span class="content">entries</span><a class="self-link" href="#es-map-entries"></a></h5>
-   <p>A property named “entries” must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-38">interface prototype object</a> with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-15">function object</a> that is the value of
+   <p>A property named “entries” must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-38">interface prototype object</a> with attributes { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
+and whose value is the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-15">function object</a> that is the value of
 the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> property.</p>
    <h5 class="heading settled" data-level="3.6.10.3" id="es-map-keys-values"><span class="secno">3.6.10.3. </span><span class="content">keys and values</span><a class="self-link" href="#es-map-keys-values"></a></h5>
    <p>For both of “keys” and “values”, there must exist a property with that name on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-39">interface prototype object</a> with the following characteristics:</p>
    <ul>
     <li data-md="">
-     <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
+     <p>The property has attributes { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }.</p>
     <li data-md="">
      <p>The value of the property is a <emu-val>Function</emu-val> object that <a data-link-type="dfn" href="#dfn-forwards-to-the-internal-map-object" id="ref-for-dfn-forwards-to-the-internal-map-object-1">forwards that name to the internal map object</a>.</p>
    </ul>
@@ -10766,7 +10794,8 @@ the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known
    <p>For both of “get” and “has”, there must exist a property with that name on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-40">interface prototype object</a> with the following characteristics:</p>
    <ul>
     <li data-md="">
-     <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
+     <p>The property has attributes
+{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }.</p>
     <li data-md="">
      <div class="algorithm" data-algorithm="to invoke the get and has methods of Maps">
       <p>The value of the property is a <emu-val>Function</emu-val> object
@@ -10814,7 +10843,7 @@ then a property named “clear” and the following characteristics
 must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-41">interface prototype object</a>:</p>
    <ul>
     <li data-md="">
-     <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
+     <p>The property has attributes { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }.</p>
     <li data-md="">
      <p>The value of the property is a <emu-val>Function</emu-val> object that <a data-link-type="dfn" href="#dfn-forwards-to-the-internal-map-object" id="ref-for-dfn-forwards-to-the-internal-map-object-2">forwards “clear” to the internal map object</a>.</p>
    </ul>
@@ -10826,7 +10855,7 @@ then a property named “delete” and the following characteristics
 must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-42">interface prototype object</a>:</p>
    <ul>
     <li data-md="">
-     <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
+     <p>The property has attributes { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }.</p>
     <li data-md="">
      <div class="algorithm" data-algorithm="to invoke the delete method of Maps">
       <p>The value of the property is a <emu-val>Function</emu-val> object that behaves as follows when invoked:</p>
@@ -10872,7 +10901,8 @@ then a property named “set” and the following characteristics
 must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-43">interface prototype object</a>:</p>
    <ul>
     <li data-md="">
-     <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
+     <p>The property has attributes
+{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }.</p>
     <li data-md="">
      <div class="algorithm" data-algorithm="to invoke the set method of Maps">
       <p>The value of the property is a <emu-val>Function</emu-val> object that behaves as follows when invoked:</p>
@@ -10967,7 +10997,7 @@ then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-thr
    <p>There must exist a property named “size” on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-45">interface prototype object</a> with the following characteristics:</p>
    <ul>
     <li data-md="">
-     <p>The property has attributes <span class="prop-desc">{ [[Get]]: <var>G</var>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>,
+     <p>The property has attributes { [[Get]]: <var>G</var>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> },
 where <var>G</var> is the interface’s <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-set-size-getter">set size getter</dfn>,
 defined below.</p>
     <li data-md="">
@@ -11000,13 +11030,15 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
      <p>The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “size”.</p>
    </ul>
    <h5 class="heading settled" data-level="3.6.11.2" id="es-set-values"><span class="secno">3.6.11.2. </span><span class="content">values</span><a class="self-link" href="#es-set-values"></a></h5>
-   <p>A property named “values” must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-46">interface prototype object</a> with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-17">function object</a> that is the value of
+   <p>A property named “values” must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-46">interface prototype object</a> with attributes { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
+and whose value is the <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-17">function object</a> that is the value of
 the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> property.</p>
    <h5 class="heading settled" data-level="3.6.11.3" id="es-set-entries-keys"><span class="secno">3.6.11.3. </span><span class="content">entries and keys</span><a class="self-link" href="#es-set-entries-keys"></a></h5>
    <p>For both of “entries” and “keys”, there must exist a property with that name on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-47">interface prototype object</a> with the following characteristics:</p>
    <ul>
     <li data-md="">
-     <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
+     <p>The property has attributes
+{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }.</p>
     <li data-md="">
      <p>The value of the property is a <emu-val>Function</emu-val> object that <a data-link-type="dfn" href="#dfn-forwards-to-the-internal-set-object" id="ref-for-dfn-forwards-to-the-internal-set-object-1">forwards that name to the internal set object</a>.</p>
    </ul>
@@ -11018,7 +11050,8 @@ the <emu-val>String</emu-val> value “entries” or “keys”, correspondingly
    <p>There must exist a property with named “has” on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-48">interface prototype object</a> with the following characteristics:</p>
    <ul>
     <li data-md="">
-     <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
+     <p>The property has attributes
+{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }.</p>
     <li data-md="">
      <div class="algorithm" data-algorithm="to invoke the has method of Sets">
       <p>The value of the property is a <emu-val>Function</emu-val> object that behaves as follows when invoked:</p>
@@ -11069,7 +11102,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
 must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-49">interface prototype object</a>:</p>
    <ul>
     <li data-md="">
-     <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
+     <p>The property has attributes { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }.</p>
     <li data-md="">
      <div class="algorithm" data-algorithm="to invoke the add and delete methods of Sets">
       <p>The value of the property is a <emu-val>Function</emu-val> object that behaves as follows when invoked:</p>
@@ -11120,7 +11153,7 @@ then a property named “clear” and the following characteristics
 must exist on <var>A</var>’s <a data-link-type="dfn" href="#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object-50">interface prototype object</a>:</p>
    <ul>
     <li data-md="">
-     <p>The property has attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
+     <p>The property has attributes { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }.</p>
     <li data-md="">
      <p>The value of the property is a <emu-val>Function</emu-val> object that <a data-link-type="dfn" href="#dfn-forwards-to-the-internal-set-object" id="ref-for-dfn-forwards-to-the-internal-set-object-2">forwards “clear” to the internal set object</a>.</p>
    </ul>
@@ -11929,9 +11962,9 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
 a corresponding property must exist on the ECMAScript
 environment’s global object. The name of the property is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-91">identifier</a> of the namespace, and its value is an object
 called the <dfn data-dfn-type="dfn" data-export="" id="dfn-namespace-object">namespace object<a class="self-link" href="#dfn-namespace-object"></a></dfn>.</p>
-   <p>The property has the attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>,
-[[Configurable]]: <emu-val>true</emu-val> }</span>. The characteristics of a
-namespace object are described in <a href="#namespace-object">§3.12.1 Namespace object</a>.</p>
+   <p>The property has the attributes
+{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }.
+The characteristics of a namespace object are described in <a href="#namespace-object">§3.12.1 Namespace object</a>.</p>
    <h4 class="heading settled" data-level="3.12.1" id="namespace-object"><span class="secno">3.12.1. </span><span class="content">Namespace object</span><a class="self-link" href="#namespace-object"></a></h4>
    <div class="algorithm" data-algorithm="to create a namespace object">
     <p>The namespace object for a given <a data-link-type="dfn" href="#dfn-namespace" id="ref-for-dfn-namespace-13">namespace</a> <var>namespace</var> and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> <var>realm</var> is created as follows:</p>
@@ -11953,15 +11986,17 @@ namespace object are described in <a href="#namespace-object">§3.12.1 Namespace
 whose name is “DOMException” and value is an object called the <dfn class="dfn-paneled" data-dfn-for="DOMException" data-dfn-type="dfn" data-export="" id="dfn-DOMException-constructor-object">DOMException constructor object</dfn>,
 which provides access to legacy DOMException code constants and allows construction of
 DOMException instances.
-The property has the attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span>.</p>
+The property has the attributes { [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }.</p>
    <h4 class="heading settled" data-level="3.13.1" id="es-DOMException-constructor-object"><span class="secno">3.13.1. </span><span class="content">DOMException constructor object</span><a class="self-link" href="#es-DOMException-constructor-object"></a></h4>
    <p>The DOMException constructor object must be a <a data-link-type="dfn" href="#dfn-function-object" id="ref-for-dfn-function-object-18">function object</a> but with a [[Prototype]] value of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%Error%</a>.</p>
    <p>For every legacy code listed in the <a href="#dfn-error-names-table" id="ref-for-dfn-error-names-table-2">error names table</a>,
 there must be a property on the DOMException constructor object
 whose name and value are as indicated in the table.  The property has
-attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span>.</p>
+attributes { [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }.</p>
    <p>The DOMException constructor object must also have a property named
-“prototype” with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span> whose value is an object called the <dfn class="dfn-paneled" data-dfn-for="DOMException" data-dfn-type="dfn" data-export="" id="dfn-DOMException-prototype-object">DOMException prototype object</dfn>.
+“prototype” with attributes
+{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }
+whose value is an object called the <dfn class="dfn-paneled" data-dfn-for="DOMException" data-dfn-type="dfn" data-export="" id="dfn-DOMException-prototype-object">DOMException prototype object</dfn>.
 This object also provides access to the legacy code values.</p>
    <h5 class="heading settled" data-level="3.13.1.1" id="es-DOMException-call"><span class="secno">3.13.1.1. </span><span class="content">DOMException(message, name)</span><a class="self-link" href="#es-DOMException-call"></a></h5>
    <div class="algorithm" data-algorithm="to create a DOMException">
@@ -11986,13 +12021,13 @@ This object also provides access to the legacy code values.</p>
        <li data-md="">
         <p>Let <var>name</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a>(<var>name</var>).</p>
        <li data-md="">
-        <p>Let <var>status</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow">DefinePropertyOrThrow</a>(<var>O</var>, <code>"name"</code>, PropertyDescriptor<span class="prop-desc">{[[Value]]: <var>name</var>, [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val>}</span>).</p>
+        <p>Let <var>status</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow">DefinePropertyOrThrow</a>(<var>O</var>, <code>"name"</code>, PropertyDescriptor{[[Value]]: <var>name</var>, [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val>}).</p>
        <li data-md="">
         <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>status</var>).</p>
        <li data-md="">
         <p>Let <var>code</var> be the legacy code indicated in the <a data-link-type="dfn" href="#dfn-error-names-table" id="ref-for-dfn-error-names-table-3">error names table</a> for error name <var>name</var>, or <emu-val>0</emu-val> if there is none.</p>
        <li data-md="">
-        <p>Let <var>status</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow">DefinePropertyOrThrow</a>(<var>O</var>, <code>"code"</code>, PropertyDescriptor<span class="prop-desc">{[[Value]]: <var>code</var>, [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val>}</span>).</p>
+        <p>Let <var>status</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow">DefinePropertyOrThrow</a>(<var>O</var>, <code>"code"</code>, PropertyDescriptor{[[Value]]: <var>code</var>, [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val>}).</p>
        <li data-md="">
         <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a>(<var>status</var>).</p>
       </ol>
@@ -12005,11 +12040,13 @@ This object also provides access to the legacy code values.</p>
 have an internal [[Prototype]] property whose value is <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%ErrorPrototype%</a>.</p>
    <p>The <a data-link-type="dfn" href="#dfn-class-string" id="ref-for-dfn-class-string-6">class string</a> of the <a data-link-type="dfn" href="#dfn-DOMException-prototype-object" id="ref-for-dfn-DOMException-prototype-object-2">DOMException prototype object</a> is “DOMExceptionPrototype”.</p>
    <p>There must be a property named “constructor”
-on the DOMException prototype object with attributes <span class="prop-desc">{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }</span> and whose value is the <a data-link-type="dfn" href="#dfn-DOMException-constructor-object" id="ref-for-dfn-DOMException-constructor-object-2">DOMException constructor object</a>.</p>
+on the DOMException prototype object with attributes
+{ [[Writable]]: <emu-val>true</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }
+and whose value is the <a data-link-type="dfn" href="#dfn-DOMException-constructor-object" id="ref-for-dfn-DOMException-constructor-object-2">DOMException constructor object</a>.</p>
    <p>For every legacy code listed in the <a href="#dfn-error-names-table" id="ref-for-dfn-error-names-table-4">error names table</a>,
 there must be a property on the DOMException prototype object
 whose name and value are as indicated in the table.  The property has
-attributes <span class="prop-desc">{ [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }</span>.</p>
+attributes { [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>true</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }.</p>
    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="3.14" data-lt="Exception objects" data-noexport="" id="es-exception-objects"><span class="secno">3.14. </span><span class="content">Exception objects</span></h3>
    <p><a data-link-type="dfn" href="#dfn-simple-exception" id="ref-for-dfn-simple-exception-6">Simple exceptions</a> are represented
 by native ECMAScript objects of the corresponding type.</p>


### PR DESCRIPTION
Closes #168.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
    
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://cdn.rawgit.com/tobie/webidl/23d2c5f/index.html) | [Diff w/ current ED](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fheycam.github.io%2Fwebidl%2F&doc2=https%3A%2F%2Fcdn.rawgit.com%2Ftobie%2Fwebidl%2F23d2c5f%2Findex.html) | [Diff w/ base](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2F68b4d84%2Findex.html&doc2=https%3A%2F%2Fcdn.rawgit.com%2Ftobie%2Fwebidl%2F23d2c5f%2Findex.html)