### PR TITLE
Interfaces with indexed properties must have a length attribute

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2764,6 +2764,9 @@ then the interface definition must be accompanied by
 a description of what indices the object can be indexed with at
 any given time. These indices are called the <dfn id="dfn-supported-property-indices" export>supported property indices</dfn>.
 
+Interfaces that [=support indexed properties=] must define
+an [=integer types|integer-typed=] [=attribute=] named “length”.
+
 Indexed property getters must
 be declared to take a single {{unsigned long}} argument.
 Indexed property setters must
@@ -3605,9 +3608,7 @@ value associated with the key.
 
 A [=value iterator=]
 must only be declared on an interface
-that [=support indexed properties|supports indexed properties=]
-and has an [=integer types|integer-typed=]
-[=attribute=] named “length”.
+that [=support indexed properties|supports indexed properties=].
 The value-type of the [=value iterator=]
 must be the same as the type returned by
 the [=indexed property getter=].

--- a/index.html
+++ b/index.html
@@ -1558,7 +1558,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web IDL</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-23">23 January 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-24">24 January 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -3768,6 +3768,8 @@ it implements an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-i
 then the interface definition must be accompanied by
 a description of what indices the object can be indexed with at
 any given time. These indices are called the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-supported-property-indices">supported property indices</dfn>.</p>
+   <p>Interfaces that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-5">support indexed properties</a> must define
+an <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-2">integer-typed</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-11">attribute</a> named “length”.</p>
    <p>Indexed property getters must
 be declared to take a single <code class="idl"><a data-link-type="idl" href="#idl-unsigned-long" id="ref-for-idl-unsigned-long-3">unsigned long</a></code> argument.
 Indexed property setters must
@@ -4476,26 +4478,26 @@ If two type parameters are given, then the interface has a <dfn class="dfn-panel
 value pairs, where the first value is a key and the second is the
 value associated with the key.</p>
    <p>A <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-1">value iterator</a> must only be declared on an interface
-that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-5">supports indexed properties</a> and has an <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-2">integer-typed</a> <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-11">attribute</a> named “length”.
+that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-6">supports indexed properties</a>.
 The value-type of the <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-2">value iterator</a> must be the same as the type returned by
 the <a data-link-type="dfn" href="#dfn-indexed-property-getter" id="ref-for-dfn-indexed-property-getter-4">indexed property getter</a>.
 A <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-3">value iterator</a> is implicitly
 defined to iterate over the object’s indexed properties.</p>
    <p>A <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-1">pair iterator</a> must not be declared on an interface
-that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-6">supports indexed properties</a>.
+that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-7">supports indexed properties</a>.
 Prose accompanying an interface with a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-2">pair iterator</a> must define what the list of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-value-pairs-to-iterate-over">value pairs to iterate over</dfn> is.</p>
    <div class="note" role="note">
     <p>The ECMAScript forEach method that is generated for a <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-4">value iterator</a> invokes its callback like Array.prototype.forEach does, and the forEach
     method for a <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-3">pair iterator</a> invokes its callback like Map.prototype.forEach does.</p>
-    <p>Since <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-5">value iterators</a> are currently allowed only on interfaces that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-7">support indexed properties</a>,
+    <p>Since <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-5">value iterators</a> are currently allowed only on interfaces that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-8">support indexed properties</a>,
     it makes sense to use an Array-like forEach method.
-    There may be a need for <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-6">value iterators</a> (a) on interfaces that do not <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-8">support indexed properties</a>,
+    There may be a need for <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-6">value iterators</a> (a) on interfaces that do not <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-9">support indexed properties</a>,
     or (b) with a forEach method that instead invokes its callback like
     Set.protoype.forEach (where the key is the same as the value).
     If you’re creating an API that needs such a forEach method, please send a request to <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>.</p>
    </div>
    <p class="note" role="note">Note: This is how <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-iterator-objects">array iterator objects</a> work.
-For interfaces that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-9">support indexed properties</a>,
+For interfaces that <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-10">support indexed properties</a>,
 the iterator objects returned by “entries”, “keys”, “values” and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a> are
 actual <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-iterator-objects">array iterator objects</a>.</p>
    <p>Interfaces with iterable declarations must not
@@ -5427,7 +5429,7 @@ object that are considered to be platform objects:</p>
      <p>objects representing IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-16">DOMExceptions</a></code>.</p>
    </ul>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-legacy-platform-object">Legacy platform objects</dfn> are <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-9">platform objects</a> that implement an <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-51">interface</a> which
-does not have a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-5">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-6">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-22">extended attribute</a>, <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-10">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-5">named properties</a>,
+does not have a [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-5">Global</a></code>] or [<code class="idl"><a data-link-type="idl" href="#Global" id="ref-for-Global-6">PrimaryGlobal</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-22">extended attribute</a>, <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-11">supports indexed</a> or <a data-link-type="dfn" href="#dfn-support-named-properties" id="ref-for-dfn-support-named-properties-5">named properties</a>,
 and may have one or multiple <a data-link-type="dfn" href="#idl-legacy-callers" id="ref-for-idl-legacy-callers-10">legacy callers</a>.</p>
    <p>In a browser, for example,
 the browser-implemented DOM objects (implementing interfaces such as <code class="idl">Node</code> and <code class="idl">Document</code>) that provide access to a web page’s contents
@@ -8104,7 +8106,7 @@ It must not be used on an interface that
 has any <a data-link-type="dfn" href="#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces-14">inherited interfaces</a>.</p>
    <p class="note" role="note">Note: Interfaces using [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-5">LegacyArrayClass</a></code>] will
 need to define a “length” <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-32">attribute</a> of type <code class="idl"><a data-link-type="idl" href="#idl-unsigned-long" id="ref-for-idl-unsigned-long-13">unsigned long</a></code> that exposes the length
-of the array-like object, in order for the inherited <emu-val>Array</emu-val> methods to operate correctly.  Such interfaces would typically also <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-11">support indexed properties</a>,
+of the array-like object, in order for the inherited <emu-val>Array</emu-val> methods to operate correctly.  Such interfaces would typically also <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-12">support indexed properties</a>,
 which would provide access to the array elements.</p>
    <p>See <a href="#interface-prototype-object">§3.6.3 Interface prototype object</a> for the
 specific requirements that the use of [<code class="idl"><a data-link-type="idl" href="#LegacyArrayClass" id="ref-for-LegacyArrayClass-6">LegacyArrayClass</a></code>]
@@ -10560,7 +10562,7 @@ is an object whose internal [[Prototype]] property is the <a data-link-type="dfn
      <p>its <em>index</em>, which is the current index into the values value to be iterated.</p>
    </ol>
    <p class="note" role="note">Note: Default iterator objects are only used for <a data-link-type="dfn" href="#dfn-pair-iterator" id="ref-for-dfn-pair-iterator-10">pair iterators</a>; <a data-link-type="dfn" href="#dfn-value-iterator" id="ref-for-dfn-value-iterator-10">value iterators</a>, as they are currently
-restricted to iterating over an object’s <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-12">supported indexed properties</a>,
+restricted to iterating over an object’s <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-13">supported indexed properties</a>,
 use standard ECMAScript Array iterator objects.</p>
    <p>When a <a data-link-type="dfn" href="#dfn-default-iterator-object" id="ref-for-dfn-default-iterator-object-5">default iterator object</a> is first created,
 its index is set to 0.</p>
@@ -11212,7 +11214,7 @@ and for <a data-link-type="dfn" href="#dfn-setter" id="ref-for-dfn-setter-1">set
       <p>If <var>O</var> and <var>Receiver</var> are the same object, then:</p>
       <ol>
        <li data-md="">
-        <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-13">supports indexed properties</a>, <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-1">array index property name</a>, and <var>O</var> implements an interface with an <a data-link-type="dfn" href="#dfn-indexed-property-setter" id="ref-for-dfn-indexed-property-setter-6">indexed property setter</a>, then:</p>
+        <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-14">supports indexed properties</a>, <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-1">array index property name</a>, and <var>O</var> implements an interface with an <a data-link-type="dfn" href="#dfn-indexed-property-setter" id="ref-for-dfn-indexed-property-setter-6">indexed property setter</a>, then:</p>
         <ol>
          <li data-md="">
           <p><a data-link-type="dfn" href="#invoke-indexed-setter" id="ref-for-invoke-indexed-setter-1">Invoke the indexed property setter</a> with <var>P</var> and <var>V</var>.</p>
@@ -11241,7 +11243,7 @@ and <var>O</var> implements an interface with a <a data-link-type="dfn" href="#d
     the following steps must be taken:</p>
     <ol>
      <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-14">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-3">array index property name</a>, then:</p>
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-15">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-3">array index property name</a>, then:</p>
       <ol>
        <li data-md="">
         <p>If the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-isdatadescriptor">IsDataDescriptor</a>(<var>Desc</var>) is <emu-val>false</emu-val>, then return <emu-val>false</emu-val>.</p>
@@ -11290,7 +11292,7 @@ interface with a <a data-link-type="dfn" href="#dfn-named-property-setter" id="r
     <p>The internal [[Delete]] method of every <a data-link-type="dfn" href="#dfn-legacy-platform-object" id="ref-for-dfn-legacy-platform-object-8">legacy platform object</a> <var>O</var> must behave as follows when called with property name <var>P</var>.</p>
     <ol>
      <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-15">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-4">array index property name</a>, then:</p>
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-16">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-4">array index property name</a>, then:</p>
       <ol>
        <li data-md="">
         <p>Let <var>index</var> be the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-touint32">ToUint32</a>(<var>P</var>).</p>
@@ -11375,7 +11377,7 @@ properties on the object must be
 enumerated in the following order:</p>
    <ol>
     <li data-md="">
-     <p>If the object <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-16">supports indexed properties</a>, then
+     <p>If the object <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-17">supports indexed properties</a>, then
 the object’s <a data-link-type="dfn" href="#dfn-supported-property-indices" id="ref-for-dfn-supported-property-indices-6">supported property indices</a> are
 enumerated first, in numerical order.</p>
     <li data-md="">
@@ -11514,7 +11516,7 @@ and false otherwise.</p>
     an object <var>O</var>, a property name <var>P</var>, and a boolean <var>ignoreNamedProps</var> value:</p>
     <ol>
      <li data-md="">
-      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-17">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-5">array index property name</a>, then:</p>
+      <p>If <var>O</var> <a data-link-type="dfn" href="#dfn-support-indexed-properties" id="ref-for-dfn-support-indexed-properties-18">supports indexed properties</a> and <var>P</var> is an <a data-link-type="dfn" href="#dfn-array-index-property-name" id="ref-for-dfn-array-index-property-name-5">array index property name</a>, then:</p>
       <ol>
        <li data-md="">
         <p>Let <var>index</var> be the result of calling <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-touint32">ToUint32</a>(<var>P</var>).</p>
@@ -13487,7 +13489,7 @@ language binding.</p>
     <li><a href="#ref-for-dfn-attribute-6">2.2.2. Attributes</a> <a href="#ref-for-dfn-attribute-7">(2)</a> <a href="#ref-for-dfn-attribute-8">(3)</a>
     <li><a href="#ref-for-dfn-attribute-9">2.2.3. Operations</a>
     <li><a href="#ref-for-dfn-attribute-10">2.2.4.2. Stringifiers</a>
-    <li><a href="#ref-for-dfn-attribute-11">2.2.7. Iterable declarations</a>
+    <li><a href="#ref-for-dfn-attribute-11">2.2.4.4. Indexed properties</a>
     <li><a href="#ref-for-dfn-attribute-12">2.2.8. Maplike declarations</a>
     <li><a href="#ref-for-dfn-attribute-13">2.2.9. Setlike declarations</a>
     <li><a href="#ref-for-dfn-attribute-14">2.4. Dictionaries</a>
@@ -13834,16 +13836,16 @@ language binding.</p>
    <b><a href="#dfn-support-indexed-properties">#dfn-support-indexed-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-support-indexed-properties-1">2.2.4.1. Legacy callers</a> <a href="#ref-for-dfn-support-indexed-properties-2">(2)</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-3">2.2.4.4. Indexed properties</a> <a href="#ref-for-dfn-support-indexed-properties-4">(2)</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-5">2.2.7. Iterable declarations</a> <a href="#ref-for-dfn-support-indexed-properties-6">(2)</a> <a href="#ref-for-dfn-support-indexed-properties-7">(3)</a> <a href="#ref-for-dfn-support-indexed-properties-8">(4)</a> <a href="#ref-for-dfn-support-indexed-properties-9">(5)</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-10">2.10. Objects implementing interfaces</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-11">3.3.6. [LegacyArrayClass]</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-12">3.6.9.4. Default iterator objects</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-13">3.9.2. [[Set]]</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-14">3.9.3. [[DefineOwnProperty]]</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-15">3.9.4. [[Delete]]</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-16">3.9.7. Property enumeration</a>
-    <li><a href="#ref-for-dfn-support-indexed-properties-17">3.9.8. Abstract operations</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-3">2.2.4.4. Indexed properties</a> <a href="#ref-for-dfn-support-indexed-properties-4">(2)</a> <a href="#ref-for-dfn-support-indexed-properties-5">(3)</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-6">2.2.7. Iterable declarations</a> <a href="#ref-for-dfn-support-indexed-properties-7">(2)</a> <a href="#ref-for-dfn-support-indexed-properties-8">(3)</a> <a href="#ref-for-dfn-support-indexed-properties-9">(4)</a> <a href="#ref-for-dfn-support-indexed-properties-10">(5)</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-11">2.10. Objects implementing interfaces</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-12">3.3.6. [LegacyArrayClass]</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-13">3.6.9.4. Default iterator objects</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-14">3.9.2. [[Set]]</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-15">3.9.3. [[DefineOwnProperty]]</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-16">3.9.4. [[Delete]]</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-17">3.9.7. Property enumeration</a>
+    <li><a href="#ref-for-dfn-support-indexed-properties-18">3.9.8. Abstract operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-supported-property-indices">
@@ -14500,7 +14502,7 @@ language binding.</p>
    <b><a href="#dfn-integer-type">#dfn-integer-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-integer-type-1">2.2.4.3. Serializers</a>
-    <li><a href="#ref-for-dfn-integer-type-2">2.2.7. Iterable declarations</a>
+    <li><a href="#ref-for-dfn-integer-type-2">2.2.4.4. Indexed properties</a>
     <li><a href="#ref-for-dfn-integer-type-3">2.11. Types</a>
     <li><a href="#ref-for-dfn-integer-type-4">3.3.1. [Clamp]</a>
     <li><a href="#ref-for-dfn-integer-type-5">3.3.3. [EnforceRange]</a>


### PR DESCRIPTION
Closes #80.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
    
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://cdn.rawgit.com/tobie/webidl/2df687b/index.html) | [Diff w/ current ED](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fheycam.github.io%2Fwebidl%2F&doc2=https%3A%2F%2Fcdn.rawgit.com%2Ftobie%2Fwebidl%2F2df687b%2Findex.html) | [Diff w/ base](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2Fca94c43%2Findex.html&doc2=https%3A%2F%2Fcdn.rawgit.com%2Ftobie%2Fwebidl%2F2df687b%2Findex.html)