### PR TITLE
Merge deprecated DOMException names back into the main table.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -145,9 +145,18 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
           font-style: italic;
         }
 
-        .mute {
-          color: #9D937D
+        .mute,
+        .deprecated,
+        .deprecated a,
+        .deprecated code {
+          color: #9D937D;
         }
+
+        .deprecated a:visited,
+        .deprecated a {
+            border-bottom-color: #9D937D;
+        }
+
 
         emu-val {
             font-weight: bold;
@@ -4460,6 +4469,10 @@ entails in the ECMAScript language binding.
 The <dfn id="dfn-error-names-table" export>error names table</dfn> below lists all the allowed error names
 for {{DOMException|DOMExceptions}}, a description, and legacy code values.
 
+<p class="advisement">
+    The {{DOMException}}s marked as deprecated are kept for legacy purposes but their usage is discouraged.
+</p>
+
 Note: If an error name is not listed here, please file a bug as indicated at the top of this specification and it will be addressed shortly. Thanks!
 
 <table id="error-names" class="vert data">
@@ -4470,102 +4483,132 @@ Note: If an error name is not listed here, please file a bug as indicated at the
         <tr>
             <td>"<dfn id="indexsizeerror" exception export><code>IndexSizeError</code></dfn>"</td>
             <td>The index is not in the allowed range.</td>
-            <td><dfn id="dom-domexception-index_size_err" for="DOMException" const export><code>INDEX_SIZE_ERR</code></dfn> (1)</td>
+            <td><dfn id="dom-domexception-index_size_err" for="DOMException" const export><code>INDEX_SIZE_ERR</code></dfn>&nbsp;(1)</td>
+        </tr>
+        <tr class="deprecated">
+            <td>"<dfn id="domstringsizeerror" exception export><code>DOMStringSizeError</code></dfn>"</td>
+            <td><strong>Deprecated.</strong> Use {{RangeError}} instead.</td>
+            <td><dfn id="dom-domexception-domstring_size_err" for="DOMException" const><code>DOMSTRING_SIZE_ERR</code></dfn>&nbsp;(2)</td>
         </tr>
         <tr>
             <td>"<dfn id="hierarchyrequesterror" exception export><code>HierarchyRequestError</code></dfn>"</td>
             <td>The operation would yield an incorrect <a href="https://dom.spec.whatwg.org/#concept-node-tree" title="concept-node-tree">node tree</a>.</td>
-            <td><dfn id="dom-domexception-hierarchy_request_err" for="DOMException" const export><code>HIERARCHY_REQUEST_ERR</code></dfn> (3)</td>
+            <td><dfn id="dom-domexception-hierarchy_request_err" for="DOMException" const export><code>HIERARCHY_REQUEST_ERR</code></dfn>&nbsp;(3)</td>
         </tr>
         <tr>
             <td>"<dfn id="wrongdocumenterror" exception export><code>WrongDocumentError</code></dfn>"</td>
             <td>The object is in the wrong <a href="https://dom.spec.whatwg.org/#concept-document" title="concept-document">document</a>.</td>
-            <td><dfn id="dom-domexception-wrong_document_err" for="DOMException" const export><code>WRONG_DOCUMENT_ERR</code></dfn> (4)</td>
+            <td><dfn id="dom-domexception-wrong_document_err" for="DOMException" const export><code>WRONG_DOCUMENT_ERR</code></dfn>&nbsp;(4)</td>
         </tr>
         <tr>
             <td>"<dfn id="invalidcharactererror" exception export><code>InvalidCharacterError</code></dfn>"</td>
             <td>The string contains invalid characters.</td>
-            <td><dfn id="dom-domexception-invalid_character_err" for="DOMException" const export><code>INVALID_CHARACTER_ERR</code></dfn> (5)</td>
+            <td><dfn id="dom-domexception-invalid_character_err" for="DOMException" const export><code>INVALID_CHARACTER_ERR</code></dfn>&nbsp;(5)</td>
+        </tr>
+        <tr class="deprecated">
+            <td>"<dfn id="nodataallowederror" exception export><code>NoDataAllowedError</code></dfn>"</td>
+            <td><strong>Deprecated.</strong></td>
+            <td><dfn id="dom-domexception-no_data_allowed_err" for="DOMException" const><code>NO_DATA_ALLOWED_ERR</code></dfn>&nbsp;(6)</td>
         </tr>
         <tr>
             <td>"<dfn id="nomodificationallowederror" exception export><code>NoModificationAllowedError</code></dfn>"</td>
             <td>The object can not be modified.</td>
-            <td><dfn id="dom-domexception-no_modification_allowed_err" for="DOMException" const export><code>NO_MODIFICATION_ALLOWED_ERR</code></dfn> (7)</td>
+            <td><dfn id="dom-domexception-no_modification_allowed_err" for="DOMException" const export><code>NO_MODIFICATION_ALLOWED_ERR</code></dfn>&nbsp;(7)</td>
         </tr>
         <tr>
             <td>"<dfn id="notfounderror" exception export><code>NotFoundError</code></dfn>"</td>
             <td>The object can not be found here.</td>
-            <td><dfn id="dom-domexception-not_found_err" for="DOMException" const export><code>NOT_FOUND_ERR</code></dfn> (8)</td>
+            <td><dfn id="dom-domexception-not_found_err" for="DOMException" const export><code>NOT_FOUND_ERR</code></dfn>&nbsp;(8)</td>
         </tr>
         <tr>
             <td>"<dfn id="notsupportederror" exception export><code>NotSupportedError</code></dfn>"</td>
             <td>The operation is not supported.</td>
-            <td><dfn id="dom-domexception-not_supported_err" for="DOMException" const export><code>NOT_SUPPORTED_ERR</code></dfn> (9)</td>
+            <td><dfn id="dom-domexception-not_supported_err" for="DOMException" const export><code>NOT_SUPPORTED_ERR</code></dfn>&nbsp;(9)</td>
         </tr>
         <tr>
             <td>"<dfn id="inuseattributeerror" exception export><code>InUseAttributeError</code></dfn>"</td>
             <td>The attribute is in use.</td>
-            <td><dfn id="dom-domexception-inuse_attribute_err" for="DOMException" const export><code>INUSE_ATTRIBUTE_ERR</code></dfn> (10)</td>
+            <td><dfn id="dom-domexception-inuse_attribute_err" for="DOMException" const export><code>INUSE_ATTRIBUTE_ERR</code></dfn>&nbsp;(10)</td>
         </tr>
         <tr>
             <td>"<dfn id="invalidstateerror" exception export><code>InvalidStateError</code></dfn>"</td>
             <td>The object is in an invalid state.</td>
-            <td><dfn id="dom-domexception-invalid_state_err" for="DOMException" const export><code>INVALID_STATE_ERR</code></dfn> (11)</td>
+            <td><dfn id="dom-domexception-invalid_state_err" for="DOMException" const export><code>INVALID_STATE_ERR</code></dfn>&nbsp;(11)</td>
         </tr>
         <tr>
             <td>"<dfn id="syntaxerror" exception export><code>SyntaxError</code></dfn>"</td>
             <td>The string did not match the expected pattern.</td>
-            <td><dfn id="dom-domexception-syntax_err" for="DOMException" const export><code>SYNTAX_ERR</code></dfn> (12)</td>
+            <td><dfn id="dom-domexception-syntax_err" for="DOMException" const export><code>SYNTAX_ERR</code></dfn>&nbsp;(12)</td>
         </tr>
         <tr>
             <td>"<dfn id="invalidmodificationerror" exception export><code>InvalidModificationError</code></dfn>"</td>
             <td>The object can not be modified in this way.</td>
-            <td><dfn id="dom-domexception-invalid_modification_err" for="DOMException" const export><code>INVALID_MODIFICATION_ERR</code></dfn> (13)</td>
+            <td><dfn id="dom-domexception-invalid_modification_err" for="DOMException" const export><code>INVALID_MODIFICATION_ERR</code></dfn>&nbsp;(13)</td>
         </tr>
         <tr>
             <td>"<dfn id="namespaceerror" exception export><code>NamespaceError</code></dfn>"</td>
             <td>The operation is not allowed by <cite>Namespaces in XML</cite>. [[XML-NAMES]]</td>
-            <td><dfn id="dom-domexception-namespace_err" for="DOMException" const export><code>NAMESPACE_ERR</code></dfn> (14)</td>
+            <td><dfn id="dom-domexception-namespace_err" for="DOMException" const export><code>NAMESPACE_ERR</code></dfn>&nbsp;(14)</td>
+        </tr>
+        <tr class="deprecated">
+            <td>"<dfn id="invalidaccesserror" exception export><code>InvalidAccessError</code></dfn>"</td>
+            <td>
+                <strong>Deprecated.</strong>
+                Use {{TypeError}} for invalid arguments,
+                "{{NotSupportedError!!exception}}" {{DOMException}} for unsupported operations, and
+                "{{NotAllowedError!!exception}}" {{DOMException}} for denied requests instead.
+            </td>
+            <td><dfn id="dom-domexception-invalid_access_err" for="DOMException" const><code>INVALID_ACCESS_ERR</code></dfn>&nbsp;(15)</td>
+        </tr>
+        <tr class="deprecated">
+            <td>"<dfn id="validationerror" exception export><code>ValidationError</code></dfn>"</td>
+            <td><strong>Deprecated.</strong></td>
+            <td><dfn id="dom-domexception-validation_err" for="DOMException" const><code>VALIDATION_ERR</code></dfn>&nbsp;(16)</td>
+        </tr>
+        <tr class="deprecated">
+            <td>"<dfn id="typemismatcherror" exception export><code>TypeMismatchError</code></dfn>"</td>
+            <td><strong>Deprecated.</strong> Use {{TypeError}} instead.</td>
+            <td><dfn id="dom-domexception-type_mismatch_err" for="DOMException" const><code>TYPE_MISMATCH_ERR</code></dfn>&nbsp;(17)</td>
         </tr>
         <tr>
             <td>"<dfn id="securityerror" exception export><code>SecurityError</code></dfn>"</td>
             <td>The operation is insecure.</td>
-            <td><dfn id="dom-domexception-security_err" for="DOMException" const export><code>SECURITY_ERR</code></dfn> (18)</td>
+            <td><dfn id="dom-domexception-security_err" for="DOMException" const export><code>SECURITY_ERR</code></dfn>&nbsp;(18)</td>
         </tr>
         <tr>
             <td>"<dfn id="networkerror" exception export><code>NetworkError</code></dfn>"</td>
             <td>A network error occurred.</td>
-            <td><dfn id="dom-domexception-network_err" for="DOMException" const export><code>NETWORK_ERR</code></dfn> (19)</td>
+            <td><dfn id="dom-domexception-network_err" for="DOMException" const export><code>NETWORK_ERR</code></dfn>&nbsp;(19)</td>
         </tr>
         <tr>
             <td>"<dfn id="aborterror" exception export><code>AbortError</code></dfn>"</td>
             <td>The operation was aborted.</td>
-            <td><dfn id="dom-domexception-abort_err" for="DOMException" const export><code>ABORT_ERR</code></dfn> (20)</td>
+            <td><dfn id="dom-domexception-abort_err" for="DOMException" const export><code>ABORT_ERR</code></dfn>&nbsp;(20)</td>
         </tr>
         <tr>
             <td>"<dfn id="urlmismatcherror" exception export><code>URLMismatchError</code></dfn>"</td>
             <td>The given URL does not match another URL.</td>
-            <td><dfn id="dom-domexception-url_mismatch_err" for="DOMException" const export><code>URL_MISMATCH_ERR</code></dfn> (21)</td>
+            <td><dfn id="dom-domexception-url_mismatch_err" for="DOMException" const export><code>URL_MISMATCH_ERR</code></dfn>&nbsp;(21)</td>
         </tr>
         <tr>
             <td>"<dfn id="quotaexceedederror" exception export><code>QuotaExceededError</code></dfn>"</td>
             <td>The quota has been exceeded.</td>
-            <td><dfn id="dom-domexception-quota_exceeded_err" for="DOMException" const export><code>QUOTA_EXCEEDED_ERR</code></dfn> (22)</td>
+            <td><dfn id="dom-domexception-quota_exceeded_err" for="DOMException" const export><code>QUOTA_EXCEEDED_ERR</code></dfn>&nbsp;(22)</td>
         </tr>
         <tr>
             <td>"<dfn id="timeouterror" exception export><code>TimeoutError</code></dfn>"</td>
             <td>The operation timed out.</td>
-            <td><dfn id="dom-domexception-timeout_err" for="DOMException" const export><code>TIMEOUT_ERR</code></dfn> (23)</td>
+            <td><dfn id="dom-domexception-timeout_err" for="DOMException" const export><code>TIMEOUT_ERR</code></dfn>&nbsp;(23)</td>
         </tr>
         <tr>
             <td>"<dfn id="invalidnodetypeerror" exception export><code>InvalidNodeTypeError</code></dfn>"</td>
             <td>The supplied node is incorrect or has an incorrect ancestor for this operation.</td>
-            <td><dfn id="dom-domexception-invalid_node_type_err" for="DOMException" const export><code>INVALID_NODE_TYPE_ERR</code></dfn> (24)</td>
+            <td><dfn id="dom-domexception-invalid_node_type_err" for="DOMException" const export><code>INVALID_NODE_TYPE_ERR</code></dfn>&nbsp;(24)</td>
         </tr>
         <tr>
             <td>"<dfn id="datacloneerror" exception export><code>DataCloneError</code></dfn>"</td>
             <td>The object can not be cloned.</td>
-            <td><dfn id="dom-domexception-data_clone_err" for="DOMException" const export><code>DATA_CLONE_ERR</code></dfn> (25)</td>
+            <td><dfn id="dom-domexception-data_clone_err" for="DOMException" const export><code>DATA_CLONE_ERR</code></dfn>&nbsp;(25)</td>
         </tr>
         <tr>
             <td>"<dfn id="encodingerror" exception export><code>EncodingError</code></dfn>"</td>
@@ -4619,60 +4662,6 @@ Note: If an error name is not listed here, please file a bug as indicated at the
         </tr>
     </tbody>
 </table>
-
-<div class=advisement>
-    Additionally, the following {{DOMException|DOMExceptions}} are kept for legacy purposes but their usage is discouraged:
-
-    <table id="legacy-error-names" class="vert data">
-        <thead>
-            <tr>
-                <th>DOMException</th>
-                <th>Alternative</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>
-                    "<dfn id="domstringsizeerror" exception><code>DOMStringSizeError</code></dfn>"<br>
-                    <dfn id="dom-domexception-domstring_size_err" for="DOMException" const><code>DOMSTRING_SIZE_ERR</code></dfn>&nbsp;(2)
-                </td>
-                <td>Use {{RangeError}}.</td>
-            </tr>
-            <tr>
-                <td>
-                    "<dfn id="nodataallowederror" exception><code>NoDataAllowedError</code></dfn>"<br>
-                    <dfn id="dom-domexception-no_data_allowed_err" for="DOMException" const><code>NO_DATA_ALLOWED_ERR</code></dfn>&nbsp;(6)
-                </td>
-                <td>—</td>
-            </tr>
-            <tr>
-                <td>
-                    "<dfn id="invalidaccesserror" exception><code>InvalidAccessError</code></dfn>"<br>
-                    <dfn id="dom-domexception-invalid_access_err" for="DOMException" const><code>INVALID_ACCESS_ERR</code></dfn>&nbsp;(15)
-                </td>
-                <td>
-                    Use {{TypeError}} for invalid arguments,
-                    "{{NotSupportedError!!exception}}" {{DOMException}} for unsupported operations, and
-                    "{{NotAllowedError!!exception}}" {{DOMException}} for denied requests.
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    "<dfn id="validationerror" exception><code>ValidationError</code></dfn>"<br>
-                    <dfn id="dom-domexception-validation_err" for="DOMException" const><code>VALIDATION_ERR</code></dfn>&nbsp;(16)
-                </td>
-                <td>—</td>
-            </tr>
-            <tr>
-                <td>
-                    "<dfn id="typemismatcherror" exception><code>TypeMismatchError</code></dfn>"<br>
-                    <dfn id="dom-domexception-type_mismatch_err" for="DOMException" const><code>TYPE_MISMATCH_ERR</code></dfn>&nbsp;(17)
-                </td>
-                <td>Use {{TypeError}}.</td>
-            </tr>
-        </tbody>
-    </table>
-</div>
 
 
 <h3 id="idl-enums">Enumerations</h3>

--- a/index.html
+++ b/index.html
@@ -1188,9 +1188,18 @@ Possible extra rowspan handling
           font-style: italic;
         }
 
-        .mute {
-          color: #9D937D
+        .mute,
+        .deprecated,
+        .deprecated a,
+        .deprecated code {
+          color: #9D937D;
         }
+
+        .deprecated a:visited,
+        .deprecated a {
+            border-bottom-color: #9D937D;
+        }
+
 
         emu-val {
             font-weight: bold;
@@ -1558,7 +1567,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web IDL</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-24">24 January 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-25">25 January 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -5017,94 +5026,117 @@ entails in the ECMAScript language binding.</p>
    <h4 class="heading settled" data-level="2.5.1" id="idl-DOMException-error-names"><span class="secno">2.5.1. </span><span class="content">Error names</span><a class="self-link" href="#idl-DOMException-error-names"></a></h4>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-error-names-table">error names table</dfn> below lists all the allowed error names
 for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-11">DOMExceptions</a></code>, a description, and legacy code values.</p>
+   <p class="advisement"> The <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-12">DOMException</a></code>s marked as deprecated are kept for legacy purposes but their usage is discouraged. </p>
    <p class="note" role="note">Note: If an error name is not listed here, please file a bug as indicated at the top of this specification and it will be addressed shortly. Thanks!</p>
    <table class="vert data" id="error-names">
     <thead>
      <tr>
       <th>Name
       <th>Description
-      <th>Legacy <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-12">code</a></code> name and value
+      <th>Legacy <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-13">code</a></code> name and value
     <tbody>
      <tr>
       <td>"<dfn class="dfn-paneled idl-code" data-dfn-type="exception" data-export="" id="indexsizeerror"><code>IndexSizeError</code></dfn>"
       <td>The index is not in the allowed range.
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-index_size_err"><code>INDEX_SIZE_ERR</code><a class="self-link" href="#dom-domexception-index_size_err"></a></dfn> (1)
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-index_size_err"><code>INDEX_SIZE_ERR</code><a class="self-link" href="#dom-domexception-index_size_err"></a></dfn> (1)
+     <tr class="deprecated">
+      <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="domstringsizeerror"><code>DOMStringSizeError</code><a class="self-link" href="#domstringsizeerror"></a></dfn>"
+      <td><strong>Deprecated.</strong> Use <code class="idl"><a data-link-type="idl" href="#exceptiondef-rangeerror" id="ref-for-exceptiondef-rangeerror-1">RangeError</a></code> instead.
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-domstring_size_err"><code>DOMSTRING_SIZE_ERR</code><a class="self-link" href="#dom-domexception-domstring_size_err"></a></dfn> (2)
      <tr>
       <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="hierarchyrequesterror"><code>HierarchyRequestError</code><a class="self-link" href="#hierarchyrequesterror"></a></dfn>"
       <td>The operation would yield an incorrect <a href="https://dom.spec.whatwg.org/#concept-node-tree" title="concept-node-tree">node tree</a>.
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-hierarchy_request_err"><code>HIERARCHY_REQUEST_ERR</code><a class="self-link" href="#dom-domexception-hierarchy_request_err"></a></dfn> (3)
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-hierarchy_request_err"><code>HIERARCHY_REQUEST_ERR</code><a class="self-link" href="#dom-domexception-hierarchy_request_err"></a></dfn> (3)
      <tr>
       <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="wrongdocumenterror"><code>WrongDocumentError</code><a class="self-link" href="#wrongdocumenterror"></a></dfn>"
       <td>The object is in the wrong <a href="https://dom.spec.whatwg.org/#concept-document" title="concept-document">document</a>.
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-wrong_document_err"><code>WRONG_DOCUMENT_ERR</code><a class="self-link" href="#dom-domexception-wrong_document_err"></a></dfn> (4)
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-wrong_document_err"><code>WRONG_DOCUMENT_ERR</code><a class="self-link" href="#dom-domexception-wrong_document_err"></a></dfn> (4)
      <tr>
       <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="invalidcharactererror"><code>InvalidCharacterError</code><a class="self-link" href="#invalidcharactererror"></a></dfn>"
       <td>The string contains invalid characters.
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-invalid_character_err"><code>INVALID_CHARACTER_ERR</code><a class="self-link" href="#dom-domexception-invalid_character_err"></a></dfn> (5)
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-invalid_character_err"><code>INVALID_CHARACTER_ERR</code><a class="self-link" href="#dom-domexception-invalid_character_err"></a></dfn> (5)
+     <tr class="deprecated">
+      <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="nodataallowederror"><code>NoDataAllowedError</code><a class="self-link" href="#nodataallowederror"></a></dfn>"
+      <td><strong>Deprecated.</strong>
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-no_data_allowed_err"><code>NO_DATA_ALLOWED_ERR</code><a class="self-link" href="#dom-domexception-no_data_allowed_err"></a></dfn> (6)
      <tr>
       <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="nomodificationallowederror"><code>NoModificationAllowedError</code><a class="self-link" href="#nomodificationallowederror"></a></dfn>"
       <td>The object can not be modified.
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-no_modification_allowed_err"><code>NO_MODIFICATION_ALLOWED_ERR</code><a class="self-link" href="#dom-domexception-no_modification_allowed_err"></a></dfn> (7)
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-no_modification_allowed_err"><code>NO_MODIFICATION_ALLOWED_ERR</code><a class="self-link" href="#dom-domexception-no_modification_allowed_err"></a></dfn> (7)
      <tr>
       <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="notfounderror"><code>NotFoundError</code><a class="self-link" href="#notfounderror"></a></dfn>"
       <td>The object can not be found here.
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-not_found_err"><code>NOT_FOUND_ERR</code><a class="self-link" href="#dom-domexception-not_found_err"></a></dfn> (8)
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-not_found_err"><code>NOT_FOUND_ERR</code><a class="self-link" href="#dom-domexception-not_found_err"></a></dfn> (8)
      <tr>
       <td>"<dfn class="dfn-paneled idl-code" data-dfn-type="exception" data-export="" id="notsupportederror"><code>NotSupportedError</code></dfn>"
       <td>The operation is not supported.
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-not_supported_err"><code>NOT_SUPPORTED_ERR</code><a class="self-link" href="#dom-domexception-not_supported_err"></a></dfn> (9)
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-not_supported_err"><code>NOT_SUPPORTED_ERR</code><a class="self-link" href="#dom-domexception-not_supported_err"></a></dfn> (9)
      <tr>
       <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="inuseattributeerror"><code>InUseAttributeError</code><a class="self-link" href="#inuseattributeerror"></a></dfn>"
       <td>The attribute is in use.
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-inuse_attribute_err"><code>INUSE_ATTRIBUTE_ERR</code><a class="self-link" href="#dom-domexception-inuse_attribute_err"></a></dfn> (10)
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-inuse_attribute_err"><code>INUSE_ATTRIBUTE_ERR</code><a class="self-link" href="#dom-domexception-inuse_attribute_err"></a></dfn> (10)
      <tr>
       <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="invalidstateerror"><code>InvalidStateError</code><a class="self-link" href="#invalidstateerror"></a></dfn>"
       <td>The object is in an invalid state.
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-invalid_state_err"><code>INVALID_STATE_ERR</code><a class="self-link" href="#dom-domexception-invalid_state_err"></a></dfn> (11)
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-invalid_state_err"><code>INVALID_STATE_ERR</code><a class="self-link" href="#dom-domexception-invalid_state_err"></a></dfn> (11)
      <tr>
       <td>"<dfn class="dfn-paneled idl-code" data-dfn-type="exception" data-export="" id="syntaxerror"><code>SyntaxError</code></dfn>"
       <td>The string did not match the expected pattern.
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-syntax_err"><code>SYNTAX_ERR</code><a class="self-link" href="#dom-domexception-syntax_err"></a></dfn> (12)
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-syntax_err"><code>SYNTAX_ERR</code><a class="self-link" href="#dom-domexception-syntax_err"></a></dfn> (12)
      <tr>
       <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="invalidmodificationerror"><code>InvalidModificationError</code><a class="self-link" href="#invalidmodificationerror"></a></dfn>"
       <td>The object can not be modified in this way.
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-invalid_modification_err"><code>INVALID_MODIFICATION_ERR</code><a class="self-link" href="#dom-domexception-invalid_modification_err"></a></dfn> (13)
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-invalid_modification_err"><code>INVALID_MODIFICATION_ERR</code><a class="self-link" href="#dom-domexception-invalid_modification_err"></a></dfn> (13)
      <tr>
       <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="namespaceerror"><code>NamespaceError</code><a class="self-link" href="#namespaceerror"></a></dfn>"
       <td>The operation is not allowed by <cite>Namespaces in XML</cite>. <a data-link-type="biblio" href="#biblio-xml-names">[XML-NAMES]</a>
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-namespace_err"><code>NAMESPACE_ERR</code><a class="self-link" href="#dom-domexception-namespace_err"></a></dfn> (14)
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-namespace_err"><code>NAMESPACE_ERR</code><a class="self-link" href="#dom-domexception-namespace_err"></a></dfn> (14)
+     <tr class="deprecated">
+      <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="invalidaccesserror"><code>InvalidAccessError</code><a class="self-link" href="#invalidaccesserror"></a></dfn>"
+      <td> <strong>Deprecated.</strong> Use <code class="idl"><a data-link-type="idl" href="#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror-3">TypeError</a></code> for invalid arguments,
+                "<code class="idl"><a class="idl-code" data-link-type="exception" href="#notsupportederror" id="ref-for-notsupportederror-1">NotSupportedError</a></code>" <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-14">DOMException</a></code> for unsupported operations, and
+                "<code class="idl"><a class="idl-code" data-link-type="exception" href="#notallowederror" id="ref-for-notallowederror-1">NotAllowedError</a></code>" <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-15">DOMException</a></code> for denied requests instead. 
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-invalid_access_err"><code>INVALID_ACCESS_ERR</code><a class="self-link" href="#dom-domexception-invalid_access_err"></a></dfn> (15)
+     <tr class="deprecated">
+      <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="validationerror"><code>ValidationError</code><a class="self-link" href="#validationerror"></a></dfn>"
+      <td><strong>Deprecated.</strong>
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-validation_err"><code>VALIDATION_ERR</code><a class="self-link" href="#dom-domexception-validation_err"></a></dfn> (16)
+     <tr class="deprecated">
+      <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="typemismatcherror"><code>TypeMismatchError</code><a class="self-link" href="#typemismatcherror"></a></dfn>"
+      <td><strong>Deprecated.</strong> Use <code class="idl"><a data-link-type="idl" href="#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror-4">TypeError</a></code> instead.
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-type_mismatch_err"><code>TYPE_MISMATCH_ERR</code><a class="self-link" href="#dom-domexception-type_mismatch_err"></a></dfn> (17)
      <tr>
       <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="securityerror"><code>SecurityError</code><a class="self-link" href="#securityerror"></a></dfn>"
       <td>The operation is insecure.
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-security_err"><code>SECURITY_ERR</code><a class="self-link" href="#dom-domexception-security_err"></a></dfn> (18)
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-security_err"><code>SECURITY_ERR</code><a class="self-link" href="#dom-domexception-security_err"></a></dfn> (18)
      <tr>
       <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="networkerror"><code>NetworkError</code><a class="self-link" href="#networkerror"></a></dfn>"
       <td>A network error occurred.
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-network_err"><code>NETWORK_ERR</code><a class="self-link" href="#dom-domexception-network_err"></a></dfn> (19)
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-network_err"><code>NETWORK_ERR</code><a class="self-link" href="#dom-domexception-network_err"></a></dfn> (19)
      <tr>
       <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="aborterror"><code>AbortError</code><a class="self-link" href="#aborterror"></a></dfn>"
       <td>The operation was aborted.
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-abort_err"><code>ABORT_ERR</code><a class="self-link" href="#dom-domexception-abort_err"></a></dfn> (20)
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-abort_err"><code>ABORT_ERR</code><a class="self-link" href="#dom-domexception-abort_err"></a></dfn> (20)
      <tr>
       <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="urlmismatcherror"><code>URLMismatchError</code><a class="self-link" href="#urlmismatcherror"></a></dfn>"
       <td>The given URL does not match another URL.
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-url_mismatch_err"><code>URL_MISMATCH_ERR</code><a class="self-link" href="#dom-domexception-url_mismatch_err"></a></dfn> (21)
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-url_mismatch_err"><code>URL_MISMATCH_ERR</code><a class="self-link" href="#dom-domexception-url_mismatch_err"></a></dfn> (21)
      <tr>
       <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="quotaexceedederror"><code>QuotaExceededError</code><a class="self-link" href="#quotaexceedederror"></a></dfn>"
       <td>The quota has been exceeded.
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-quota_exceeded_err"><code>QUOTA_EXCEEDED_ERR</code><a class="self-link" href="#dom-domexception-quota_exceeded_err"></a></dfn> (22)
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-quota_exceeded_err"><code>QUOTA_EXCEEDED_ERR</code><a class="self-link" href="#dom-domexception-quota_exceeded_err"></a></dfn> (22)
      <tr>
       <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="timeouterror"><code>TimeoutError</code><a class="self-link" href="#timeouterror"></a></dfn>"
       <td>The operation timed out.
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-timeout_err"><code>TIMEOUT_ERR</code><a class="self-link" href="#dom-domexception-timeout_err"></a></dfn> (23)
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-timeout_err"><code>TIMEOUT_ERR</code><a class="self-link" href="#dom-domexception-timeout_err"></a></dfn> (23)
      <tr>
       <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="invalidnodetypeerror"><code>InvalidNodeTypeError</code><a class="self-link" href="#invalidnodetypeerror"></a></dfn>"
       <td>The supplied node is incorrect or has an incorrect ancestor for this operation.
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-invalid_node_type_err"><code>INVALID_NODE_TYPE_ERR</code><a class="self-link" href="#dom-domexception-invalid_node_type_err"></a></dfn> (24)
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-invalid_node_type_err"><code>INVALID_NODE_TYPE_ERR</code><a class="self-link" href="#dom-domexception-invalid_node_type_err"></a></dfn> (24)
      <tr>
       <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="datacloneerror"><code>DataCloneError</code><a class="self-link" href="#datacloneerror"></a></dfn>"
       <td>The object can not be cloned.
-      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-data_clone_err"><code>DATA_CLONE_ERR</code><a class="self-link" href="#dom-domexception-data_clone_err"></a></dfn> (25)
+      <td><dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-data_clone_err"><code>DATA_CLONE_ERR</code><a class="self-link" href="#dom-domexception-data_clone_err"></a></dfn> (25)
      <tr>
       <td>"<dfn class="idl-code" data-dfn-type="exception" data-export="" id="encodingerror"><code>EncodingError</code><a class="self-link" href="#encodingerror"></a></dfn>"
       <td>The encoding operation (either encoded or decoding) failed.
@@ -5146,33 +5178,6 @@ for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-f
       <td>The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.
       <td>—
    </table>
-   <div class="advisement">
-     Additionally, the following <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-13">DOMExceptions</a></code> are kept for legacy purposes but their usage is discouraged: 
-    <table class="vert data" id="legacy-error-names">
-     <thead>
-      <tr>
-       <th>DOMException
-       <th>Alternative
-     <tbody>
-      <tr>
-       <td> "<dfn class="idl-code" data-dfn-type="exception" data-export="" id="domstringsizeerror"><code>DOMStringSizeError</code><a class="self-link" href="#domstringsizeerror"></a></dfn>"<br> <dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-domstring_size_err"><code>DOMSTRING_SIZE_ERR</code><a class="self-link" href="#dom-domexception-domstring_size_err"></a></dfn> (2) 
-       <td>Use <code class="idl"><a data-link-type="idl" href="#exceptiondef-rangeerror" id="ref-for-exceptiondef-rangeerror-1">RangeError</a></code>.
-      <tr>
-       <td> "<dfn class="idl-code" data-dfn-type="exception" data-export="" id="nodataallowederror"><code>NoDataAllowedError</code><a class="self-link" href="#nodataallowederror"></a></dfn>"<br> <dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-no_data_allowed_err"><code>NO_DATA_ALLOWED_ERR</code><a class="self-link" href="#dom-domexception-no_data_allowed_err"></a></dfn> (6) 
-       <td>—
-      <tr>
-       <td> "<dfn class="idl-code" data-dfn-type="exception" data-export="" id="invalidaccesserror"><code>InvalidAccessError</code><a class="self-link" href="#invalidaccesserror"></a></dfn>"<br> <dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-invalid_access_err"><code>INVALID_ACCESS_ERR</code><a class="self-link" href="#dom-domexception-invalid_access_err"></a></dfn> (15) 
-       <td> Use <code class="idl"><a data-link-type="idl" href="#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror-3">TypeError</a></code> for invalid arguments,
-                    "<code class="idl"><a class="idl-code" data-link-type="exception" href="#notsupportederror" id="ref-for-notsupportederror-1">NotSupportedError</a></code>" <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-14">DOMException</a></code> for unsupported operations, and
-                    "<code class="idl"><a class="idl-code" data-link-type="exception" href="#notallowederror" id="ref-for-notallowederror-1">NotAllowedError</a></code>" <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-15">DOMException</a></code> for denied requests. 
-      <tr>
-       <td> "<dfn class="idl-code" data-dfn-type="exception" data-export="" id="validationerror"><code>ValidationError</code><a class="self-link" href="#validationerror"></a></dfn>"<br> <dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-validation_err"><code>VALIDATION_ERR</code><a class="self-link" href="#dom-domexception-validation_err"></a></dfn> (16) 
-       <td>—
-      <tr>
-       <td> "<dfn class="idl-code" data-dfn-type="exception" data-export="" id="typemismatcherror"><code>TypeMismatchError</code><a class="self-link" href="#typemismatcherror"></a></dfn>"<br> <dfn class="idl-code" data-dfn-for="DOMException" data-dfn-type="const" data-export="" id="dom-domexception-type_mismatch_err"><code>TYPE_MISMATCH_ERR</code><a class="self-link" href="#dom-domexception-type_mismatch_err"></a></dfn> (17) 
-       <td>Use <code class="idl"><a data-link-type="idl" href="#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror-4">TypeError</a></code>.
-    </table>
-   </div>
    <h3 class="heading settled" data-level="2.6" id="idl-enums"><span class="secno">2.6. </span><span class="content">Enumerations</span><a class="self-link" href="#idl-enums"></a></h3>
    <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-enumeration">enumeration</dfn> is a definition (matching <emu-nt><a href="#prod-Enum">Enum</a></emu-nt>) used to declare a type
 whose valid values are a set of predefined strings.  Enumerations


### PR DESCRIPTION
Introduce light styling for deprecated content.

Closes #284.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
    #idl-DOMException-error-names
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://cdn.rawgit.com/tobie/webidl/ba0187c/index.html#idl-DOMException-error-names) | [Diff w/ current ED](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fheycam.github.io%2Fwebidl%2F&doc2=https%3A%2F%2Fcdn.rawgit.com%2Ftobie%2Fwebidl%2Fba0187c%2Findex.html#idl-DOMException-error-names) | [Diff w/ base](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2F3834774%2Findex.html&doc2=https%3A%2F%2Fcdn.rawgit.com%2Ftobie%2Fwebidl%2Fba0187c%2Findex.html#idl-DOMException-error-names)