### PR TITLE
Allow extended attributes to apply to types

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6009,7 +6009,11 @@ For any [=type=], the [=extended attributes associated with=] it must only conta
 
 The [=type name=] of a type associated with [=extended attributes=] is the concatenation of the
 type name of the original type with the set of strings corresponding to the [=identifiers=] of each
-[=extended attribute associated with=] the type, in order.
+[=extended attribute associated with=] the type, sorted in lexicographic order.
+
+<div class="example">
+    The [=type name=] for a type of the form <code>[B, A] long?</code> is "LongOrNullAB".
+</div>
 
 <h4 oldids="dom-Error" id="idl-Error" interface>Error</h4>
 

--- a/index.bs
+++ b/index.bs
@@ -3329,9 +3329,10 @@ the following algorithm returns <i>true</i>.
     [=member type=] of the union type is distinguishable
     with the non-union type,
     or <i>false</i> otherwise.
-1.  If the two types (taking their [=nullable types/inner type=]
-    if they are [=nullable types=]) appear or are in categories appearing
-    in the following table and there is a “●” mark in the corresponding entry
+1.  Consider the two "innermost" types derived by taking each type's [=annotated types/inner type=]
+    if it is an [=annotated type=], and then taking its [=nullable types/inner type=] inner type
+    if the result is a [=nullable type=]. If these two innermost types appear or are in categories
+    appearing in the following table and there is a “●” mark in the corresponding entry
     or there is a letter in the corresponding entry and the designated additional
     requirement below the table is satisfied, then return <i>true</i>.
     Otherwise return <i>false</i>.

--- a/index.bs
+++ b/index.bs
@@ -1454,12 +1454,9 @@ interface will be stringified to the value of the attribute.  See
 
 The following [=extended attributes=]
 are applicable to regular and static attributes:
-[{{Clamp}}],
-[{{EnforceRange}}],
 [{{Exposed}}],
 [{{SameObject}}],
-[{{SecureContext}}],
-[{{TreatNullAs}}].
+[{{SecureContext}}].
 
 The following [=extended attributes=]
 are applicable only to regular attributes:
@@ -1489,7 +1486,7 @@ are applicable only to regular attributes:
 
 <pre class="grammar" id="prod-AttributeRest">
     AttributeRest :
-        "attribute" Type AttributeName ";"
+        "attribute" TypeWithExtendedAttributes AttributeName ";"
 </pre>
 
 <pre class="grammar" id="prod-AttributeName">
@@ -1891,13 +1888,7 @@ The following extended attributes are applicable to operations:
 [{{Exposed}}],
 [{{NewObject}}],
 [{{SecureContext}}],
-[{{TreatNullAs}}],
 [{{Unforgeable}}].
-
-The following extended attributes are applicable to operation arguments:
-[{{Clamp}}],
-[{{EnforceRange}}],
-[{{TreatNullAs}}].
 
 <pre class="grammar" id="prod-DefaultValue">
     DefaultValue :
@@ -1956,13 +1947,8 @@ The following extended attributes are applicable to operation arguments:
 
 <pre class="grammar" id="prod-Argument">
     Argument :
-        ExtendedAttributeList OptionalOrRequiredArgument
-</pre>
-
-<pre class="grammar" id="prod-OptionalOrRequiredArgument">
-    OptionalOrRequiredArgument :
-        "optional" Type ArgumentName Default
-        Type Ellipsis ArgumentName
+        ExtendedAttributeList "optional" TypeWithExtendedAttributes ArgumentName Default
+        ExtendedAttributeList Type Ellipsis ArgumentName
 </pre>
 
 <pre class="grammar" id="prod-ArgumentName">
@@ -3768,12 +3754,12 @@ The following extended attributes are applicable to [=iterable declarations=]:
 
 <pre class="grammar" id="prod-Iterable">
     Iterable :
-        "iterable" "&lt;" Type OptionalType "&gt;" ";"
+        "iterable" "&lt;" TypeWithExtendedAttributes OptionalType "&gt;" ";"
 </pre>
 
 <pre class="grammar" id="prod-OptionalType">
     OptionalType :
-        "," Type
+        "," TypeWithExtendedAttributes
         ε
 </pre>
 
@@ -3857,7 +3843,7 @@ interfaces must not have an
 
 <pre class="grammar" id="prod-MaplikeRest">
     MaplikeRest :
-        "maplike" "&lt;" Type "," Type "&gt;" ";"
+        "maplike" "&lt;" TypeWithExtendedAttributes "," TypeWithExtendedAttributes "&gt;" ";"
 </pre>
 
 No [=extended attributes=]
@@ -3946,7 +3932,7 @@ interfaces must not have an
 
 <pre class="grammar" id="prod-SetlikeRest">
     SetlikeRest :
-        "setlike" "&lt;" Type "&gt;" ";"
+        "setlike" "&lt;" TypeWithExtendedAttributes "&gt;" ";"
 </pre>
 
 No [=extended attributes=]
@@ -4316,10 +4302,6 @@ The following extended attributes are applicable to dictionaries:
 [{{Exposed}}],
 [{{SecureContext}}],
 
-The following extended attributes are applicable to dictionary members:
-[{{Clamp}}],
-[{{EnforceRange}}].
-
 <div data-fill-with="grammar-Partial"></div>
 
 <div data-fill-with="grammar-PartialDefinition"></div>
@@ -4331,19 +4313,14 @@ The following extended attributes are applicable to dictionary members:
 
 <pre class="grammar" id="prod-DictionaryMembers">
     DictionaryMembers :
-        ExtendedAttributeList DictionaryMember DictionaryMembers
+        DictionaryMember DictionaryMembers
         ε
 </pre>
 
 <pre class="grammar" id="prod-DictionaryMember">
     DictionaryMember :
-        Required Type identifier Default ";"
-</pre>
-
-<pre class="grammar" id="prod-Required">
-    Required :
-        "required"
-        ε
+        ExtendedAttributeList "required" TypeWithExtendedAttributes identifier Default ";"
+        ExtendedAttributeList Type identifier Default ";"
 </pre>
 
 <pre class="grammar" id="prod-PartialDictionary">
@@ -4867,7 +4844,7 @@ the type in the IDL.
 <pre highlight="webidl" class="syntax">typedef type identifier;</pre>
 
 The type being given a new name is specified after the <emu-t>typedef</emu-t>
-keyword (matching <emu-nt><a href="#prod-Type">Type</a></emu-nt>), and the
+keyword (matching <emu-nt><a href="#prod-Type">TypeWithExtendedAttributes</a></emu-nt>), and the
 <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> token following the
 type gives the name.
 
@@ -4879,7 +4856,7 @@ defined in this specification are applicable to [=typedefs=].
 
 <pre class="grammar" id="prod-Typedef">
     Typedef :
-        "typedef" Type identifier ";"
+        "typedef" TypeWithExtendedAttributes identifier ";"
 </pre>
 
 <div class="example">
@@ -5192,6 +5169,12 @@ type.
         UnionType Null
 </pre>
 
+<pre class="grammar" id="prod-TypeWithExtendedAttributes">
+    TypeWithExtendedAttributes :
+        ExtendedAttributeList SingleType
+        ExtendedAttributeList UnionType Null
+</pre>
+
 <pre class="grammar" id="prod-SingleType">
     SingleType :
         NonAnyType
@@ -5205,7 +5188,7 @@ type.
 
 <pre class="grammar" id="prod-UnionMemberType">
     UnionMemberType :
-        NonAnyType
+        ExtendedAttributeList NonAnyType
         UnionType Null
 </pre>
 
@@ -5221,12 +5204,12 @@ type.
         PrimitiveType Null
         StringType Null
         identifier Null
-        "sequence" "&lt;" Type "&gt;" Null
+        "sequence" "&lt;" TypeWithExtendedAttributes "&gt;" Null
         "object" Null
         "Error" Null
         "DOMException" Null
         BufferRelatedType Null
-        "FrozenArray" "&lt;" Type "&gt;" Null
+        "FrozenArray" "&lt;" TypeWithExtendedAttributes "&gt;" Null
         RecordType Null
 </pre>
 
@@ -5285,7 +5268,7 @@ type.
 
 <pre class="grammar" id="prod-RecordType">
     RecordType :
-        "record" "&lt;" StringType "," Type "&gt;"
+        "record" "&lt;" StringType "," TypeWithExtendedAttributes "&gt;"
 </pre>
 
 <pre class="grammar" id="prod-Null">
@@ -5293,7 +5276,6 @@ type.
         "?"
         ε
 </pre>
-
 
 <h4 oldids="dom-any" id="idl-any" interface>any</h4>
 
@@ -5974,6 +5956,54 @@ and joining them with the string “Or”.
 <div data-fill-with="grammar-NonAnyType"></div>
 
 
+<h4 id="idl-types-with-extended-attributes">Types with extended attributes</h4>
+
+Additional types can be created from existing ones by specifying certain [=extended attributes=] on
+the existing types. For example, <code>[Clamp] long</code> defines a new type whose behavior is
+based on that of the {{long}} type, but modified as specified by the [{{Clamp}}] extended attribute.
+
+<p id="extended-attributes-applicable-to-types">
+    The following extended attributes are applicable to types:
+    [{{Clamp}}],
+    [{{EnforceRange}}], and
+    [{{LegacyTreatNullAsEmptyString}}].
+</p>
+
+<div algorithm>
+    The <dfn for="IDL type" lt="extended attribute associated with|extended attributes associated with">extended attributes associated with</dfn>
+    a [=type=] |type| are determined as follows:
+
+    1.  Let |extended attributes| be the empty set.
+    1.  If |type| appears as part of a
+        <emu-nt><a href="#prod-TypeWithExtendedAttributes">TypeWithExtendedAttributes</a></emu-nt>
+        production, add the [=extended attributes=] present in the production's
+        <emu-nt><a href="#prod-ExtendedAttributeList">ExtendedAttributeList</a></emu-nt> to
+        |extended attributes|.
+    1.  If |type| is a [=member type=] of a [=union type=] |U|, add the
+        [=extended attributes associated with=] |U| to |extended attributes|.
+    1.  If |type| appears as part of a <emu-nt><a href="#prod-Type">Type</a></emu-nt> production
+        within an <emu-nt><a href="#prod-Argument">Argument</a></emu-nt> production, add to
+        |extended attributes| all of the [=extended attributes=] present in the production's
+        <emu-nt><a href="#prod-ExtendedAttributeList">ExtendedAttributeList</a></emu-nt> that are
+        <a href="#extended-attributes-applicable-to-types">applicable to types</a>.
+    1.  If |type| appears as part of a <emu-nt><a href="#prod-Type">Type</a></emu-nt> production
+        within an <emu-nt><a href="#prod-DictionaryMember">DictionaryMember</a></emu-nt> production,
+        add to |extended attributes| all of the [=extended attributes=] present in the production's
+        <emu-nt><a href="#prod-ExtendedAttributeList">ExtendedAttributeList</a></emu-nt> that are
+        <a href="#extended-attributes-applicable-to-types">applicable to types</a>.
+    1.  If |type| is a [=typedef=], add the [=extended attributes associated with=] the type being
+        given a new name to |extended attributes|.
+    1. Return |extended attributes|.
+</div>
+
+For any [=type=], the [=extended attributes associated with=] it must only contain
+[=extended attributes=] that are
+<a href="#extended-attributes-applicable-to-types">applicable to types</a>.
+
+The [=type name=] of a type associated with [=extended attributes=] is the concatenation of the
+type name of the original type with the set of strings corresponding to the [=identifiers=] of each
+[=extended attribute associated with=] the type.
+
 <h4 oldids="dom-Error" id="idl-Error" interface>Error</h4>
 
 The {{Error!!interface}} type corresponds to the
@@ -6119,6 +6149,7 @@ type is the concatenation of the type name for |T| and the string
 An <dfn id="dfn-extended-attribute" export>extended attribute</dfn> is an annotation
 that can appear on
 definitions,
+[=types=],
 [=interface members=],
 [=namespace members=],
 [=dictionary members=],
@@ -6525,6 +6556,9 @@ when passed to a [=platform object=] expecting that type, and how IDL values
 of that type are <dfn id="dfn-convert-idl-to-ecmascript-value" export lt="converted to an ECMAScript value|converted to ECMAScript values">converted to ECMAScript values</dfn>
 when returned from a platform object.
 
+Note that the sub-sections and algorithms below also apply to the related types created by applying
+extended attributes to the types named in their headers.
+
 
 <h4 id="es-any">any</h4>
 
@@ -6808,9 +6842,10 @@ In effect, where <var ignore>x</var> is a <emu-val>Number</emu-val> value,
         1.  If |signedness| is "unsigned", then let |lowerBound| be 0.
         1.  Otherwise let |lowerBound| be −2<sup>53</sup> + 1.
 
-            Note: this ensures {{long long}} types annotated with
-            [{{EnforceRange}}] or [{{Clamp}}] [=extended attributes=]
-            are representable in ECMAScript's [=Number type=] as unambiguous integers.
+            Note: this ensures {{long long}} types
+            [=extended attribute associated with|associated with=] [{{EnforceRange}}] or
+            [{{Clamp}}] [=extended attributes=] are representable in ECMAScript's [=Number type=]
+            as unambiguous integers.
 
     1.  Otherwise, if |signedness| is "unsigned", then:
         1.  Let |lowerBound| be 0.
@@ -6820,27 +6855,17 @@ In effect, where <var ignore>x</var> is a <emu-val>Number</emu-val> value,
         1.  Let |upperBound| be 2<sup>|bitLength| − 1</sup> − 1.
     1.  Let |x| be [=?=] [=ToNumber=](|V|).
     1.  If |x| is −0, then set |x| to +0.
-    1.  If the conversion to an IDL value is being performed due to any of the following:
-        *   |V| is being assigned to an [=attribute=] annotated with the [{{EnforceRange}}] [=extended attribute=],
-        *   |V| is being passed as an [=operation=] argument annotated with the [{{EnforceRange}}] extended attribute, or
-        *   |V| is being used as the value of a [=dictionary member=] annotated with the [{{EnforceRange}}] extended attribute,
-
-        then:
-
+    1.  If the conversion is to an IDL type [=extended attribute associated with|associated with=]
+        the [{{EnforceRange}}] [=extended attribute=], then:
         1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
             then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
         1.  Set |x| to [=!=] <a abstract-op>IntegerPart</a>(|x|).
         1.  If |x| &lt; |lowerBound| or |x| &gt; |upperBound|,
             then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
         1.  Return |x|.
-
-    1.  If |x| is not <emu-val>NaN</emu-val> and the conversion to an IDL value is being performed due to any of the following:
-        *   |V| is being assigned to an [=attribute=] annotated with the [{{Clamp}}] [=extended attribute=],
-        *   |V| is being passed as an [=operation=] argument annotated with the [{{Clamp}}] extended attribute, or
-        *   |V| is being used as the value of a [=dictionary member=] annotated with the [{{Clamp}}] extended attribute,
-
+    1.  If |x| is not <emu-val>NaN</emu-val> and the conversion is to an IDL type
+        [=extended attribute associated with|associated with=] the [{{Clamp}}] extended attribute,
         then:
-
         1.  Set |x| to [=min=]([=max=](|x|, |lowerBound|), |upperBound|).
         1.  Round |x| to the nearest integer, choosing the even integer if it lies halfway between two,
             and choosing +0 rather than −0.
@@ -6991,20 +7016,9 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL {{DOMString}} value by running the following algorithm:
 
-    1.  If |V| is <emu-val>null</emu-val>
-        and the conversion to an IDL value is being performed due
-        to any of the following:
-        *   |V| is being passed as an [=operation=]
-            argument that is annotated with [{{TreatNullAs}}],
-        *   |V| is being assigned to an [=attribute=]
-            annotated with [{{TreatNullAs}}],
-        *   |V| is being returned from a [=user object=] implementation of an
-            operation annotated with [{{TreatNullAs}}], or
-        *   |V| is being returned from a [=user object=] implementation of an
-            attribute annotated with [{{TreatNullAs}}],
-
-        then return the {{DOMString}}
-        value that represents the empty string.
+    1.  If |V| is <emu-val>null</emu-val> and the conversion is to an IDL type
+        [=extended attribute associated with|associated with=] the [{{LegacyTreatNullAsEmptyString}}] extended
+        attribute, then return the {{DOMString}} value that represents the empty string.
     1.  Let |x| be [=ToString=](|V|).
     1.  Return the IDL {{DOMString}} value that represents the same sequence of code units as the one the ECMAScript <emu-val>String</emu-val> value |x| represents.
 </div>
@@ -7920,27 +7934,19 @@ whose presence affects only the ECMAScript binding.
 
 <h4 id="Clamp" extended-attribute lt="Clamp">[Clamp]</h4>
 
-If the [{{Clamp}}]
-[=extended attribute=]
-appears on an [=operation=] argument,
-writable [=attribute=] or
-[=dictionary member=]
-whose type is one of the [=integer types=],
-it indicates that when an ECMAScript <emu-val>Number</emu-val> is
-converted to the IDL type, out of range values will be clamped to the range
-of valid values, rather than using the operators that use a modulo operation
-([=ToInt32=], [=ToUint32=], etc.).
+If the [{{Clamp}}] [=extended attribute=] appears on one of the [=integer types=], it creates a new
+IDL type such that that when an ECMAScript <emu-val>Number</emu-val> is converted to the IDL type,
+out-of-range values will be clamped to the range of valid values, rather than using the operators
+that use a modulo operation ([=ToInt32=], [=ToUint32=], etc.).
 
 The [{{Clamp}}]
 extended attribute must
 [=takes no arguments|take no arguments=].
 
-The [{{Clamp}}] extended attribute
-must not appear on a [=read only=]
-attribute, or an attribute, operation argument or dictionary member
-that is not of an integer type.  It also must not
-be used in conjunction with the [{{EnforceRange}}]
-extended attribute.
+A [=type=] annotated with the [{{Clamp}}] extended attribute must not appear in a [=read only=]
+attribute. A type must not be [=extended attributes associated with|associated with=] both the
+[{{Clamp}}] and [{{EnforceRange}}] extended attributes. A type that is not an [=integer type=] must
+not be [=extended attributes associated with|associated with=] the [{{Clamp}}] extended attribute.
 
 See the rules for converting ECMAScript values to the various IDL integer
 types in [[#es-type-mapping]]
@@ -8064,29 +8070,21 @@ for an interface is to be implemented.
 
 <h4 id="EnforceRange" extended-attribute lt="EnforceRange">[EnforceRange]</h4>
 
-If the [{{EnforceRange}}]
-[=extended attribute=]
-appears on an [=operation=] argument,
-writable [=regular attribute=] or
-[=dictionary member=]
-whose type is one of the [=integer types=],
-it indicates that when an ECMAScript <emu-val>Number</emu-val> is
-converted to the IDL type, out of range values will cause an exception to
-be thrown, rather than converted to being a valid value using the operators that use a modulo operation
-([=ToInt32=], [=ToUint32=], etc.).  The <emu-val>Number</emu-val>
-will be rounded towards zero before being checked against its range.
+If the [{{EnforceRange}}] [=extended attribute=] appears on one of the [=integer types=], it creates
+a new IDL type such that that when an ECMAScript <emu-val>Number</emu-val> is converted to the IDL
+type, out-of-range values will cause an exception to be thrown, rather than being converted to a
+valid value using using the operators that use a modulo operation ([=ToInt32=], [=ToUint32=], etc.).
+The <emu-val>Number</emu-val> will be rounded toward zero before being checked against its range.
 
 The [{{EnforceRange}}]
 extended attribute must
 [=takes no arguments|take no arguments=].
 
-The [{{EnforceRange}}] extended attribute
-must not appear on a [=read only=]
-attribute, a [=static attribute=],
-or an attribute, operation argument or dictionary member
-that is not of an integer type.  It also must not
-be used in conjunction with the [{{Clamp}}]
-extended attribute.
+A [=type=] annotated with the [{{EnforceRange}}] extended attribute must not appear in a
+[=read only=] attribute. A type must not be [=extended attributes associated with|associated with=]
+both the [{{Clamp}}] and [{{EnforceRange}}] extended attributes. A type that is not an
+[=integer type=] must not be [=extended attributes associated with|associated with=] the
+[{{Clamp}}] extended attribute.
 
 See the rules for converting ECMAScript values to the various IDL integer
 types in [[#es-type-mapping]]
@@ -8582,6 +8580,66 @@ entails.
     succeed on objects implementing <code class="idl">ImmutableItemList</code>.
     The exact behavior depends on the definition of the [=Array methods=] themselves.
 
+</div>
+
+
+<h4 id="LegacyTreatNullAsEmptyString" extended-attribute lt="LegacyTreatNullAsEmptyString" oldids="TreatNullAs">[LegacyTreatNullAsEmptyString]</h4>
+
+If the [{{LegacyTreatNullAsEmptyString}}] [=extended attribute=] appears on the {{DOMString}} type,
+it creates a new IDL type such that that when an ECMAScript <emu-val>null</emu-val> is converted to
+the IDL type, it will be handled differently from its default handling. Instead of being stringified
+to <code>"null"</code>, which is the default, it will be converted to the empty string.
+
+The [{{LegacyTreatNullAsEmptyString}}] extended attribute must
+[=takes no arguments|take no arguments=].
+
+The [{{LegacyTreatNullAsEmptyString}}] extended attribute must not be
+[=extended attribute associated with|associated with=] a [=type=] that is not {{DOMString}}.
+
+Note: This means that even <code class="idl">DOMString?</code> must not use
+[{{LegacyTreatNullAsEmptyString}}], since <emu-val>null</emu-val> is a valid value of that type.
+
+See [[#es-DOMString]] for the specific requirements that the use of
+[{{LegacyTreatNullAsEmptyString}}] entails.
+
+<p class="advisement">
+    As indicated by its name, [{{LegacyTreatNullAsEmptyString}}] exists only so that legacy Web
+    platform features can be specified. It produces unintuitive behavior that is not uniform with
+    the treatment of strings on the rest of the platform. As such, it should not be used by new
+    specifications.
+</p>
+
+<div class="example">
+    The following [=IDL fragment=] defines an interface that has one attribute whose type has the
+    extended attribute, and one operation whose argument's type has the extended attribute:
+
+    <pre highlight="webidl">
+        interface Dog {
+          attribute DOMString name;
+          [LegacyTreatNullAsEmptyString] attribute DOMString owner;
+
+          boolean isMemberOfBreed([LegacyTreatNullAsEmptyString] DOMString breedName);
+        };
+    </pre>
+
+    An ECMAScript implementation implementing the <code class="idl">Dog</code>
+    interface would convert a <emu-val>null</emu-val> value
+    assigned to the <code>owner</code> property or passed as the
+    argument to the <code>isMemberOfBreed</code> function
+    to the empty string rather than <code>"null"</code>:
+
+    <pre highlight="js">
+        var d = getDog();         // Assume d is a platform object implementing the Dog
+                                  // interface.
+
+        d.name = null;            // This assigns the string "null" to the .name
+                                  // property.
+
+        d.owner = null;           // This assigns the string "" to the .owner property.
+
+        d.isMemberOfBreed(null);  // This passes the string "" to the isMemberOfBreed
+                                  // function.
+    </pre>
 </div>
 
 
@@ -9441,82 +9499,6 @@ for the specific requirements that the use of
 
         manager.handler2 = 123;
         manager.handler2;            // Evaluates to null.
-    </pre>
-</div>
-
-
-<h4 id="TreatNullAs" extended-attribute lt="TreatNullAs">[TreatNullAs]</h4>
-
-If the [{{TreatNullAs}}]
-[=extended attribute=]
-appears on an [=attribute=]
-or [=operation=] argument whose type is
-{{DOMString}},
-it indicates that a <emu-val>null</emu-val> value
-assigned to the attribute or passed as the operation argument will be
-handled differently from its default handling.  Instead of being stringified
-to “null”, which is the default,
-it will be converted to the empty string “”.
-
-If [{{TreatNullAs}}] is specified on
-an operation itself, and that operation is on a [=callback interface=],
-then it indicates that a <a href="#es-user-objects">user object implementing the interface</a> will have the return
-value of the function that implements the operation handled in the same way as for operation arguments
-and attributes, as above.
-
-The [{{TreatNullAs}}]
-extended attribute must [=takes an identifier|take the identifier=]
-<code>EmptyString</code>.
-
-The [{{TreatNullAs}}] extended attribute
-must not be specified on an operation argument,
-attribute or operation return value whose type is not {{DOMString}}.
-
-Note: This means that even an attribute of type <code class="idl">DOMString?</code> must not
-use [{{TreatNullAs}}], since <emu-val>null</emu-val>
-is a valid value of that type.
-
-The [{{TreatNullAs}}] extended attribute
-also must not be specified on an operation on
-a non-callback interface.
-
-See [[#es-DOMString]]
-for the specific requirements that the use of
-[{{TreatNullAs}}] entails.
-
-<div class="example">
-
-    The following [=IDL fragment=] defines an interface that has one
-    attribute with the [{{TreatNullAs}}]
-    extended attribute, and one operation with an argument that has
-    the extended attribute:
-
-    <pre highlight="webidl">
-        interface Dog {
-          attribute DOMString name;
-          [TreatNullAs=EmptyString] attribute DOMString owner;
-
-          boolean isMemberOfBreed([TreatNullAs=EmptyString] DOMString breedName);
-        };
-    </pre>
-
-    An ECMAScript implementation implementing the <code class="idl">Dog</code>
-    interface would convert a <emu-val>null</emu-val> value
-    assigned to the “owner” property or passed as the
-    argument to the <code>isMemberOfBreed</code> function
-    to the empty string rather than <code>"null"</code>:
-
-    <pre highlight="js">
-        var d = getDog();         // Assume d is a platform object implementing the Dog
-                                  // interface.
-
-        d.name = null;            // This assigns the string "null" to the .name
-                                  // property.
-
-        d.owner = null;           // This assigns the string "" to the .owner property.
-
-        d.isMemberOfBreed(null);  // This passes the string "" to the isMemberOfBreed
-                                  // function.
     </pre>
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -5962,12 +5962,10 @@ Additional types can be created from existing ones by specifying certain [=exten
 the existing types. For example, <code>[Clamp] long</code> defines a new type whose behavior is
 based on that of the {{long}} type, but modified as specified by the [{{Clamp}}] extended attribute.
 
-<p id="extended-attributes-applicable-to-types">
-    The following extended attributes are applicable to types:
-    [{{Clamp}}],
-    [{{EnforceRange}}], and
-    [{{LegacyTreatNullAsEmptyString}}].
-</p>
+The following extended attributes are <dfn for="extended attributes">applicable to types</dfn>:
+[{{Clamp}}],
+[{{EnforceRange}}], and
+[{{LegacyTreatNullAsEmptyString}}].
 
 <div algorithm>
     The <dfn for="IDL type" lt="extended attribute associated with|extended attributes associated with">extended attributes associated with</dfn>
@@ -5985,21 +5983,20 @@ based on that of the {{long}} type, but modified as specified by the [{{Clamp}}]
         within an <emu-nt><a href="#prod-Argument">Argument</a></emu-nt> production, [=set/append=]
         to |extended attributes| all of the [=extended attributes=] present in the production's
         <emu-nt><a href="#prod-ExtendedAttributeList">ExtendedAttributeList</a></emu-nt> that are
-        <a href="#extended-attributes-applicable-to-types">applicable to types</a>.
+        [=applicable to types=].
     1.  If |type| appears as part of a <emu-nt><a href="#prod-Type">Type</a></emu-nt> production
         within an <emu-nt><a href="#prod-DictionaryMember">DictionaryMember</a></emu-nt> production,
         [=set/append=] to |extended attributes| all of the [=extended attributes=] present in the
         production's
         <emu-nt><a href="#prod-ExtendedAttributeList">ExtendedAttributeList</a></emu-nt> that are
-        <a href="#extended-attributes-applicable-to-types">applicable to types</a>.
+        [=applicable to types=].
     1.  If |type| is a [=typedef=], [=set/append=] the [=extended attributes associated with=] the
         type being given a new name to |extended attributes|.
     1. Return |extended attributes|.
 </div>
 
 For any [=type=], the [=extended attributes associated with=] it must only contain
-[=extended attributes=] that are
-<a href="#extended-attributes-applicable-to-types">applicable to types</a>.
+[=extended attributes=] that are [=applicable to types=].
 
 The [=type name=] of a type associated with [=extended attributes=] is the concatenation of the
 type name of the original type with the set of strings corresponding to the [=identifiers=] of each

--- a/index.bs
+++ b/index.bs
@@ -1244,7 +1244,7 @@ If |VT| is the type of the value assigned to a constant, and |DT|
 is the type of the constant, dictionary member or optional argument itself, then these types must
 be compatible, which is the case if |DT| and |VT| are identical,
 or |DT| is a [=nullable type=]
-whose [=inner type=] is |VT|.
+whose [=nullable types/inner type=] is |VT|.
 
 [=Constants=] are not associated with
 particular instances of the [=interface=]
@@ -1638,7 +1638,7 @@ identify any one of those definitions or a [=dictionary=].
 
 If the operation argument type, after resolving typedefs,
 is a [=nullable type=],
-its [=inner type=] must not be a [=dictionary type=].
+its [=nullable types/inner type=] must not be a [=dictionary type=].
 
 <pre highlight="webidl" class="syntax">
     interface interface_identifier {
@@ -1840,7 +1840,7 @@ Optional argument default values can also be specified using the
 two token value <code>[]</code>, which represents an empty sequence
 value.  The type of this value is the same as the type of the optional
 argument it is being used as the default value of.  That type
-must be a [=sequence type=], a [=nullable type=] whose [=inner type=] is a
+must be a [=sequence type=], a [=nullable type=] whose [=nullable types/inner type=] is a
 [=sequence type=] or a [=union type=] or [=nullable type|nullable=] union type
 that has a [=sequence type=] in its [=flattened member types=].
 
@@ -2587,7 +2587,7 @@ The list of <dfn id="dfn-serializable-type" export lt="serializable type">serial
      :: the equivalent {{DOMString}} value where each code unit has the same value as the corresponding byte value
      :  a [=nullable type|nullable=] serializable type
      :: converted to <emu-val>null</emu-val> if that is its value,
-        otherwise converted as per its [=inner type=]
+        otherwise converted as per its [=nullable types/inner type=]
      :  a [=union type=] where all of its [=member types=] are serializable types
      :: converted as per its [=specific type=]
      :  a [=sequence type=] that has a serializable type as its element type
@@ -3329,7 +3329,7 @@ the following algorithm returns <i>true</i>.
     [=member type=] of the union type is distinguishable
     with the non-union type,
     or <i>false</i> otherwise.
-1.  If the two types (taking their [=inner types=]
+1.  If the two types (taking their [=nullable types/inner type=]
     if they are [=nullable types=]) appear or are in categories appearing
     in the following table and there is a “●” mark in the corresponding entry
     or there is a letter in the corresponding entry and the designated additional
@@ -4133,7 +4133,7 @@ identify any one of those definitions or a [=dictionary=].
 
 If the type of the [=dictionary member=], after resolving typedefs,
 is a [=nullable type=],
-its [=inner type=] must not be a [=dictionary type=].
+its [=nullable types/inner type=] must not be a [=dictionary type=].
 
 <pre highlight="webidl" class="syntax">
     dictionary identifier {
@@ -4187,7 +4187,7 @@ if at least one of the following is true:
 *   the type is |D|
 *   the type is a dictionary that [=interface/inherits=] from |D|
 *   the type is a [=nullable type=]
-    whose [=inner type=] includes |D|
+    whose [=nullable types/inner type=] includes |D|
 *   the type is a [=sequence type=] or [=frozen array type|frozen array=]
     whose element type includes |D|
 *   the type is a [=union type=],
@@ -5710,12 +5710,12 @@ is the [=identifier=] of the callback function.
 <h4 id="idl-nullable-type">Nullable types — |T|?</h4>
 
 A <dfn id="dfn-nullable-type" export>nullable type</dfn> is an IDL type constructed
-from an existing type (called the <dfn id="dfn-inner-type" export>inner type</dfn>),
+from an existing type (called the <dfn id="dfn-inner-type" export for="nullable types">inner type</dfn>),
 which just allows the additional value <emu-val>null</emu-val>
 to be a member of its set of values.  [=Nullable types=]
 are represented in IDL by placing a <span class="char">U+003F QUESTION MARK ("?")</span>
 character after an existing type.
-The inner type must not be:
+The [=nullable types/inner type=] must not be:
 
 *   {{any}},
 *   a [=Promise type=],
@@ -5727,11 +5727,11 @@ Note: Although dictionary types can in general be nullable,
 they cannot when used as the type of an operation argument or a dictionary member.
 
 Nullable type constant values in IDL are represented in the same way that
-constant values of their [=inner type=]
+constant values of their [=nullable types/inner type=]
 would be represented, or with the <emu-t>null</emu-t> token.
 
 The [=type name=] of a nullable type
-is the concatenation of the type name of the inner type |T| and
+is the concatenation of the type name of the [=nullable types/inner type=] |T| and
 the string “OrNull”.
 
 <div class="example">
@@ -5885,7 +5885,7 @@ that matches the value.
     1.  Initialize |S| to ∅.
     1.  For each [=member type=] |U| of |T|:
         1.  If |U| is a [=nullable type=], then
-            set |U| to be the [=inner type=] of |U|.
+            set |U| to be the [=nullable types/inner type=] of |U|.
         1.  If |U| is a [=union type=], then
             add to |S| the [=flattened member types=]
             of |U|.
@@ -5913,7 +5913,7 @@ are the six types <code>Node</code>, <code>sequence&lt;long&gt;</code>, <code>Ev
     1.  For each [=member type=] |U| of |T|:
         1.  If |U| is a [=nullable type=], then:
             1.  Set |n| to |n| + 1.
-            1.  Set |U| to be the [=inner type=] of |U|.
+            1.  Set |U| to be the [=nullable types/inner type=] of |U|.
         1.  If |U| is a [=union type=], then:
             1.  Let |m| be the [=number of nullable member types=] of |U|.
             1.  Set |n| to |n| + |m|.
@@ -5956,11 +5956,17 @@ and joining them with the string “Or”.
 <div data-fill-with="grammar-NonAnyType"></div>
 
 
-<h4 id="idl-types-with-extended-attributes">Types with extended attributes</h4>
+<h4 id="idl-annotated-types">Annotated types</h4>
 
 Additional types can be created from existing ones by specifying certain [=extended attributes=] on
-the existing types. For example, <code>[Clamp] long</code> defines a new type whose behavior is
-based on that of the {{long}} type, but modified as specified by the [{{Clamp}}] extended attribute.
+the existing types. Such types are called <dfn export>annotated types</dfn>, and the types they
+annotate are called <dfn export for="annotated types" lt="inner type">inner types</dfn>.
+
+<div class="example">
+    <code>[Clamp] long</code> defines a new [=annotated type=], whose behavior is based on that of
+    the [=annotated types/inner type=] {{long}}, but modified as specified by the [{{Clamp}}]
+    extended attribute.
+</div>
 
 The following extended attributes are <dfn for="extended attributes">applicable to types</dfn>:
 [{{Clamp}}],
@@ -6554,7 +6560,7 @@ when passed to a [=platform object=] expecting that type, and how IDL values
 of that type are <dfn id="dfn-convert-idl-to-ecmascript-value" export lt="converted to an ECMAScript value|converted to ECMAScript values">converted to ECMAScript values</dfn>
 when returned from a platform object.
 
-Note that the sub-sections and algorithms below also apply to the related types created by applying
+Note that the sub-sections and algorithms below also apply to [=annotated types=] created by applying
 extended attributes to the types named in their headers.
 
 
@@ -7254,14 +7260,14 @@ when they can be any object.
 <h4 id="es-nullable-type">Nullable types — |T|?</h4>
 
 IDL [=nullable type=] values are represented
-by values of either the ECMAScript type corresponding to the [=inner type|inner IDL type=], or
+by values of either the ECMAScript type corresponding to the [=nullable types/inner type|inner IDL type=], or
 the ECMAScript <emu-val>null</emu-val> value.
 
 <div id="es-to-nullable" algorithm="convert an ECMAScript value to nullable">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL [=nullable type=] <code class="idl">|T|?</code>
-    value (where |T| is the [=inner type=]) as follows:
+    value (where |T| is the [=nullable types/inner type=]) as follows:
 
     1.  If [=Type=](|V|) is not Object, and
         the conversion to an IDL value is being performed due
@@ -7277,7 +7283,7 @@ the ECMAScript <emu-val>null</emu-val> value.
         value <emu-val>null</emu-val>.
     1.  Otherwise, return the result of
         [=converted to an IDL value|converting=] |V|
-        using the rules for the [=inner type|inner IDL type=] <code class="idl">T</code>.
+        using the rules for the [=nullable types/inner type|inner IDL type=] <code class="idl">T</code>.
 </div>
 
 <div id="nullable-to-es" algorithm="convert a nullable to an ECMAScript value">
@@ -7291,7 +7297,7 @@ the ECMAScript <emu-val>null</emu-val> value.
     1.  Otherwise, the ECMAScript value is the result of
         [=converted to an ECMAScript value|converting=]
         the IDL [=nullable type=] value
-        to the [=inner type|inner IDL type=] <code class="idl">|T|</code>.
+        to the [=nullable types/inner type|inner IDL type=] <code class="idl">|T|</code>.
 </div>
 
 <h4 id="es-sequence">Sequences — sequence&lt;|T|&gt;</h4>

--- a/index.bs
+++ b/index.bs
@@ -4843,7 +4843,7 @@ the type in the IDL.
 
 <pre highlight="webidl" class="syntax">typedef type identifier;</pre>
 
-The type being given a new name is specified after the <emu-t>typedef</emu-t>
+The <dfn>type being given a new name</dfn> is specified after the <emu-t>typedef</emu-t>
 keyword (matching <emu-nt><a href="#prod-Type">TypeWithExtendedAttributes</a></emu-nt>), and the
 <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> token following the
 type gives the name.
@@ -5991,7 +5991,7 @@ The following extended attributes are <dfn for="extended attributes">applicable 
         <emu-nt><a href="#prod-ExtendedAttributeList">ExtendedAttributeList</a></emu-nt> that are
         [=applicable to types=].
     1.  If |type| is a [=typedef=], [=set/append=] the [=extended attributes associated with=] the
-        type being given a new name to |extended attributes|.
+        [=type being given a new name=] to |extended attributes|.
     1. Return |extended attributes|.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -5879,13 +5879,16 @@ that matches the value.
 <div algorithm>
 
     The <dfn id="dfn-flattened-union-member-types" for="union" export>flattened member types</dfn>
-    of a [=union type=] is a set of types determined as follows:
+    of a [=union type=], possibly [=annotated type|annotated=], is a set of types determined as
+    follows:
 
     1.  Let |T| be the [=union type=].
     1.  Initialize |S| to ∅.
     1.  For each [=member type=] |U| of |T|:
         1.  If |U| is a [=nullable type=], then
             set |U| to be the [=nullable types/inner type=] of |U|.
+        1.  If |U| is an [=annotated type=], then
+            set |U| to be the [=annotated types/inner type=] of |U|.
         1.  If |U| is a [=union type=], then
             add to |S| the [=flattened member types=]
             of |U|.
@@ -9736,8 +9739,9 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
             and there is an entry in |S| that has one of the following types at position |i| of its type list,
             *   a [=nullable type=]
             *   a [=dictionary type=]
-            *   a [=union type=] that [=includes a nullable type=] or that has a [=dictionary type=] in
-                its [=flattened member types|flattened members=]
+            *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
+            *   a [=union type=] or [=annotated type|annotated=] union type that [=includes a nullable type=] or that
+                has a [=dictionary type=] in its [=flattened member types|flattened members=]
 
             then remove from |S| all other entries.
 
@@ -9746,7 +9750,8 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
             *   an [=interface type=] that |V| implements
             *   {{object}}
             *   a [=nullable type|nullable=] version of any of the above types
-            *   a [=union type=] or a [=nullable type|nullable=] union type
+            *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
+            *   a [=union type=], [=nullable type|nullable=] union type, or [=annotated type|annotated=] union type
                 that has one of the above types in its [=flattened member types=]
 
             then remove from |S| all other entries.
@@ -9757,7 +9762,8 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
             *   {{Error!!interface}}
             *   {{object}}
             *   a [=nullable type|nullable=] version of either of the above types
-            *   a [=union type=] or [=nullable type|nullable=] union type
+            *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
+            *   a [=union type=], [=nullable type|nullable=] union type, or [=annotated type|annotated=] union type
                 that has one of the above types in its [=flattened member types=]
 
             then remove from |S| all other entries.
@@ -9767,7 +9773,8 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
             *   {{Error!!interface}}
             *   {{object}}
             *   a [=nullable type|nullable=] version of either of the above types
-            *   a [=union type=] or [=nullable type|nullable=] union type
+            *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
+            *   a [=union type=], [=nullable type|nullable=] union type, or [=annotated type|annotated=] union type
                 that has one of the above types in its [=flattened member types=]
 
             then remove from |S| all other entries.
@@ -9777,7 +9784,8 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
             *   {{ArrayBuffer}}
             *   {{object}}
             *   a [=nullable type|nullable=] version of either of the above types
-            *   a [=union type=] or [=nullable type|nullable=] union type
+            *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
+            *   a [=union type=], [=nullable type|nullable=] union type, or [=annotated type|annotated=] union type
                 that has one of the above types in its [=flattened member types=]
 
             then remove from |S| all other entries.
@@ -9787,7 +9795,8 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
             *   {{DataView}}
             *   {{object}}
             *   a [=nullable type|nullable=] version of either of the above types
-            *   a [=union type=] or [=nullable type|nullable=] union type
+            *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
+            *   a [=union type=], [=nullable type|nullable=] union type, or [=annotated type|annotated=] union type
                 that has one of the above types in its [=flattened member types=]
 
             then remove from |S| all other entries.
@@ -9798,7 +9807,8 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
                 is equal to the value of |V|’s \[[TypedArrayName]] [=internal slot=]
             *   {{object}}
             *   a [=nullable type|nullable=] version of either of the above types
-            *   a [=union type=] or [=nullable type|nullable=] union type
+            *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
+            *   a [=union type=], [=nullable type|nullable=] union type, or [=annotated type|annotated=] union type
                 that has one of the above types in its [=flattened member types=]
 
             then remove from |S| all other entries.
@@ -9808,7 +9818,8 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
             *   a [=callback function=] type
             *   {{object}}
             *   a [=nullable type|nullable=] version of any of the above types
-            *   a [=union type=] or [=nullable type|nullable=] union type
+            *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
+            *   a [=union type=], [=nullable type|nullable=] union type, or [=annotated type|annotated=] union type
                 that has one of the above types in its [=flattened member types=]
 
             then remove from |S| all other entries.
@@ -9819,7 +9830,8 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
             *   a [=sequence type=]
             *   a [=frozen array type=]
             *   a [=nullable type|nullable=] version of any of the above types
-            *   a [=union type=] or [=nullable type|nullable=] union type
+            *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
+            *   a [=union type=], [=nullable type|nullable=] union type, or [=annotated type|annotated=] union type
                 that has one of the above types in its [=flattened member types=]
 
             and after performing the following steps,
@@ -9838,7 +9850,8 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
             *   a [=record type=]
             *   {{object}}
             *   a [=nullable type|nullable=] version of any of the above types
-            *   a [=union type=] or [=nullable type|nullable=] union type
+            *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
+            *   a [=union type=], [=nullable type|nullable=] union type, or [=annotated type|annotated=] union type
                 that has one of the above types in its [=flattened member types=]
 
             then remove from |S| all other entries.
@@ -9847,7 +9860,8 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
             and there is an entry in |S| that has one of the following types at position |i| of its type list,
             *   {{boolean}}
             *   a [=nullable type|nullable=] {{boolean}}
-            *   a [=union type=] or [=nullable type|nullable=] union type
+            *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
+            *   a [=union type=], [=nullable type|nullable=] union type, or [=annotated type|annotated=] union type
                 that has one of the above types in its [=flattened member types=]
 
             then remove from |S| all other entries.
@@ -9856,7 +9870,8 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
             and there is an entry in |S| that has one of the following types at position |i| of its type list,
             *   a [=numeric type=]
             *   a [=nullable type|nullable=] [=numeric type=]
-            *   a [=union type=] or [=nullable type|nullable=] union type
+            *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
+            *   a [=union type=], [=nullable type|nullable=] union type, or [=annotated type|annotated=] union type
                 that has one of the above types in its [=flattened member types=]
 
             then remove from |S| all other entries.
@@ -9864,7 +9879,8 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
         1.  Otherwise: if there is an entry in |S| that has one of the following types at position |i| of its type list,
             *   a [=string type=]
             *   a [=nullable type|nullable=] version of any of the above types
-            *   a [=union type=] or [=nullable type|nullable=] union type
+            *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
+            *   a [=union type=], [=nullable type|nullable=] union type, or [=annotated type|annotated=] union type
                 that has one of the above types in its [=flattened member types=]
 
             then remove from |S| all other entries.
@@ -9872,7 +9888,8 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
         1.  Otherwise: if there is an entry in |S| that has one of the following types at position |i| of its type list,
             *   a [=numeric type=]
             *   a [=nullable type|nullable=] [=numeric type=]
-            *   a [=union type=] or [=nullable type|nullable=] union type
+            *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
+            *   a [=union type=], [=nullable type|nullable=] union type, or [=annotated type|annotated=] union type
                 that has one of the above types in its [=flattened member types=]
 
             then remove from |S| all other entries.
@@ -9880,7 +9897,8 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
         1.  Otherwise: if there is an entry in |S| that has one of the following types at position |i| of its type list,
             *   {{boolean}}
             *   a [=nullable type|nullable=] {{boolean}}
-            *   a [=union type=] or [=nullable type|nullable=] union type
+            *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
+            *   a [=union type=], [=nullable type|nullable=] union type, or [=annotated type|annotated=] union type
                 that has one of the above types in its [=flattened member types=]
 
             then remove from |S| all other entries.

--- a/index.bs
+++ b/index.bs
@@ -5973,26 +5973,27 @@ based on that of the {{long}} type, but modified as specified by the [{{Clamp}}]
     The <dfn for="IDL type" lt="extended attribute associated with|extended attributes associated with">extended attributes associated with</dfn>
     a [=type=] |type| are determined as follows:
 
-    1.  Let |extended attributes| be the empty set.
+    1.  Let |extended attributes| be a new empty [=set=].
     1.  If |type| appears as part of a
         <emu-nt><a href="#prod-TypeWithExtendedAttributes">TypeWithExtendedAttributes</a></emu-nt>
-        production, add the [=extended attributes=] present in the production's
+        production, [=set/append=] each of the [=extended attributes=] present in the production's
         <emu-nt><a href="#prod-ExtendedAttributeList">ExtendedAttributeList</a></emu-nt> to
         |extended attributes|.
-    1.  If |type| is a [=member type=] of a [=union type=] |U|, add the
+    1.  If |type| is a [=member type=] of a [=union type=] |U|, [=set/append=] each of the
         [=extended attributes associated with=] |U| to |extended attributes|.
     1.  If |type| appears as part of a <emu-nt><a href="#prod-Type">Type</a></emu-nt> production
-        within an <emu-nt><a href="#prod-Argument">Argument</a></emu-nt> production, add to
-        |extended attributes| all of the [=extended attributes=] present in the production's
+        within an <emu-nt><a href="#prod-Argument">Argument</a></emu-nt> production, [=set/append=]
+        to |extended attributes| all of the [=extended attributes=] present in the production's
         <emu-nt><a href="#prod-ExtendedAttributeList">ExtendedAttributeList</a></emu-nt> that are
         <a href="#extended-attributes-applicable-to-types">applicable to types</a>.
     1.  If |type| appears as part of a <emu-nt><a href="#prod-Type">Type</a></emu-nt> production
         within an <emu-nt><a href="#prod-DictionaryMember">DictionaryMember</a></emu-nt> production,
-        add to |extended attributes| all of the [=extended attributes=] present in the production's
+        [=set/append=] to |extended attributes| all of the [=extended attributes=] present in the
+        production's
         <emu-nt><a href="#prod-ExtendedAttributeList">ExtendedAttributeList</a></emu-nt> that are
         <a href="#extended-attributes-applicable-to-types">applicable to types</a>.
-    1.  If |type| is a [=typedef=], add the [=extended attributes associated with=] the type being
-        given a new name to |extended attributes|.
+    1.  If |type| is a [=typedef=], [=set/append=] the [=extended attributes associated with=] the
+        type being given a new name to |extended attributes|.
     1. Return |extended attributes|.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -6000,7 +6000,7 @@ For any [=type=], the [=extended attributes associated with=] it must only conta
 
 The [=type name=] of a type associated with [=extended attributes=] is the concatenation of the
 type name of the original type with the set of strings corresponding to the [=identifiers=] of each
-[=extended attribute associated with=] the type.
+[=extended attribute associated with=] the type, in order.
 
 <h4 oldids="dom-Error" id="idl-Error" interface>Error</h4>
 

--- a/index.bs
+++ b/index.bs
@@ -5980,7 +5980,7 @@ The following extended attributes are <dfn for="extended attributes">applicable 
     The <dfn for="IDL type" lt="extended attribute associated with|extended attributes associated with">extended attributes associated with</dfn>
     a [=type=] |type| are determined as follows:
 
-    1.  Let |extended attributes| be a new empty [=set=].
+    1.  Let |extended attributes| be a new empty [=ordered set|set=].
     1.  If |type| appears as part of a
         <emu-nt><a href="#prod-TypeWithExtendedAttributes">TypeWithExtendedAttributes</a></emu-nt>
         production, [=set/append=] each of the [=extended attributes=] present in the production's

--- a/index.bs
+++ b/index.bs
@@ -5965,7 +5965,7 @@ based on that of the {{long}} type, but modified as specified by the [{{Clamp}}]
 The following extended attributes are <dfn for="extended attributes">applicable to types</dfn>:
 [{{Clamp}}],
 [{{EnforceRange}}], and
-[{{LegacyTreatNullAsEmptyString}}].
+[{{TreatNullAs}}].
 
 <div algorithm>
     The <dfn for="IDL type" lt="extended attribute associated with|extended attributes associated with">extended attributes associated with</dfn>
@@ -7015,7 +7015,7 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
     to an IDL {{DOMString}} value by running the following algorithm:
 
     1.  If |V| is <emu-val>null</emu-val> and the conversion is to an IDL type
-        [=extended attribute associated with|associated with=] the [{{LegacyTreatNullAsEmptyString}}] extended
+        [=extended attribute associated with|associated with=] the [{{TreatNullAs}}] extended
         attribute, then return the {{DOMString}} value that represents the empty string.
     1.  Let |x| be [=ToString=](|V|).
     1.  Return the IDL {{DOMString}} value that represents the same sequence of code units as the one the ECMAScript <emu-val>String</emu-val> value |x| represents.
@@ -8581,66 +8581,6 @@ entails.
 </div>
 
 
-<h4 id="LegacyTreatNullAsEmptyString" extended-attribute lt="LegacyTreatNullAsEmptyString" oldids="TreatNullAs">[LegacyTreatNullAsEmptyString]</h4>
-
-If the [{{LegacyTreatNullAsEmptyString}}] [=extended attribute=] appears on the {{DOMString}} type,
-it creates a new IDL type such that that when an ECMAScript <emu-val>null</emu-val> is converted to
-the IDL type, it will be handled differently from its default handling. Instead of being stringified
-to <code>"null"</code>, which is the default, it will be converted to the empty string.
-
-The [{{LegacyTreatNullAsEmptyString}}] extended attribute must
-[=takes no arguments|take no arguments=].
-
-The [{{LegacyTreatNullAsEmptyString}}] extended attribute must not be
-[=extended attribute associated with|associated with=] a [=type=] that is not {{DOMString}}.
-
-Note: This means that even <code class="idl">DOMString?</code> must not use
-[{{LegacyTreatNullAsEmptyString}}], since <emu-val>null</emu-val> is a valid value of that type.
-
-See [[#es-DOMString]] for the specific requirements that the use of
-[{{LegacyTreatNullAsEmptyString}}] entails.
-
-<p class="advisement">
-    As indicated by its name, [{{LegacyTreatNullAsEmptyString}}] exists only so that legacy Web
-    platform features can be specified. It produces unintuitive behavior that is not uniform with
-    the treatment of strings on the rest of the platform. As such, it should not be used by new
-    specifications.
-</p>
-
-<div class="example">
-    The following [=IDL fragment=] defines an interface that has one attribute whose type has the
-    extended attribute, and one operation whose argument's type has the extended attribute:
-
-    <pre highlight="webidl">
-        interface Dog {
-          attribute DOMString name;
-          [LegacyTreatNullAsEmptyString] attribute DOMString owner;
-
-          boolean isMemberOfBreed([LegacyTreatNullAsEmptyString] DOMString breedName);
-        };
-    </pre>
-
-    An ECMAScript implementation implementing the <code class="idl">Dog</code>
-    interface would convert a <emu-val>null</emu-val> value
-    assigned to the <code>owner</code> property or passed as the
-    argument to the <code>isMemberOfBreed</code> function
-    to the empty string rather than <code>"null"</code>:
-
-    <pre highlight="js">
-        var d = getDog();         // Assume d is a platform object implementing the Dog
-                                  // interface.
-
-        d.name = null;            // This assigns the string "null" to the .name
-                                  // property.
-
-        d.owner = null;           // This assigns the string "" to the .owner property.
-
-        d.isMemberOfBreed(null);  // This passes the string "" to the isMemberOfBreed
-                                  // function.
-    </pre>
-</div>
-
-
 <h4 id="LegacyUnenumerableNamedProperties" extended-attribute lt="LegacyUnenumerableNamedProperties">[LegacyUnenumerableNamedProperties]</h4>
 
 If the [{{LegacyUnenumerableNamedProperties}}]
@@ -9497,6 +9437,58 @@ for the specific requirements that the use of
 
         manager.handler2 = 123;
         manager.handler2;            // Evaluates to null.
+    </pre>
+</div>
+
+
+<h4 id="TreatNullAs" extended-attribute lt="TreatNullAs">[TreatNullAs]</h4>
+
+If the [{{TreatNullAs}}] [=extended attribute=] appears on the {{DOMString}} type, it creates a new
+IDL type such that that when an ECMAScript <emu-val>null</emu-val> is converted to the IDL type, it
+will be handled differently from its default handling. Instead of being stringified to
+<code>"null"</code>, which is the default, it will be converted to the empty string.
+
+The [{{TreatNullAs}}] extended attribute must [=takes an identifier|take the identifier=]
+<code>EmptyString</code>.
+
+The [{{TreatNullAs}}] extended attribute must not be
+[=extended attribute associated with|associated with=] a [=type=] that is not {{DOMString}}.
+
+Note: This means that even <code class="idl">DOMString?</code> must not use [{{TreatNullAs}}], since
+<emu-val>null</emu-val> is a valid value of that type.
+
+See [[#es-DOMString]] for the specific requirements that the use of [{{TreatNullAs}}] entails.
+
+<div class="example">
+    The following [=IDL fragment=] defines an interface that has one attribute whose type has the
+    extended attribute, and one operation whose argument's type has the extended attribute:
+
+    <pre highlight="webidl">
+        interface Dog {
+          attribute DOMString name;
+          [TreatNullAs=EmptyString] attribute DOMString owner;
+
+          boolean isMemberOfBreed([TreatNullAs=EmptyString] DOMString breedName);
+        };
+    </pre>
+
+    An ECMAScript implementation implementing the <code class="idl">Dog</code>
+    interface would convert a <emu-val>null</emu-val> value
+    assigned to the <code>owner</code> property or passed as the
+    argument to the <code>isMemberOfBreed</code> function
+    to the empty string rather than <code>"null"</code>:
+
+    <pre highlight="js">
+        var d = getDog();         // Assume d is a platform object implementing the Dog
+                                  // interface.
+
+        d.name = null;            // This assigns the string "null" to the .name
+                                  // property.
+
+        d.owner = null;           // This assigns the string "" to the .owner property.
+
+        d.isMemberOfBreed(null);  // This passes the string "" to the isMemberOfBreed
+                                  // function.
     </pre>
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -5934,6 +5934,7 @@ a [=dictionary type=] in its [=flattened member types=].
 A type <dfn id="dfn-includes-a-nullable-type" export>includes a nullable type</dfn> if:
 
 *   the type is a [=nullable type=], or
+*   the type is an [=annotated type=] and its [=annotated types/inner type=] is a nullable type, or
 *   the type is a [=union type=] and its
     [=number of nullable member types=] is 1.
 

--- a/index.bs
+++ b/index.bs
@@ -5885,10 +5885,10 @@ that matches the value.
     1.  Let |T| be the [=union type=].
     1.  Initialize |S| to ∅.
     1.  For each [=member type=] |U| of |T|:
-        1.  If |U| is a [=nullable type=], then
-            set |U| to be the [=nullable types/inner type=] of |U|.
         1.  If |U| is an [=annotated type=], then
             set |U| to be the [=annotated types/inner type=] of |U|.
+        1.  If |U| is a [=nullable type=], then
+            set |U| to be the [=nullable types/inner type=] of |U|.
         1.  If |U| is a [=union type=], then
             add to |S| the [=flattened member types=]
             of |U|.


### PR DESCRIPTION
This implements the plan discussed in https://lists.w3.org/Archives/Public/public-script-coord/2017JanMar/0003.html and sets the stage for using extended attributes for SharedArrayBuffer-related purposes.

@bzbarsky, I could use some close review on this. Some points for discussion:

- Is `[Clamp] long` being a distinct type from `long` a good way of doing this? I based that on how `long?` is different from `long`, and it seems like a good mental model.
- Is it sufficiently clear that extended attributes propagate through typedefs? (A point you called out specifically in your email.) If not, any suggestions on how to make this clear?
- We have separate TypeWithAttributes and Type mainly so that ReturnType does not get attributes. Does that seem good?
- I didn't allow (gramatically) specifying an extended attribute over an entire union. I forget why, but an hour ago it seemed like a bad idea... if you have any thoughts to help guide me one way or another on this that would be appreciated.
- This will invalidate a lot of existing IDL which will need to get updated. E.g. `[TreatNullAs=EmptyString] attribute DOMString data;` must become `attribute [TreatNullAs=EmptyString] DOMString data;`. I think this is the right way to go, as it's clearer how things work and doesn't require any propagation of extended attributes from attribute/argument declarations into their types, which sounds annoying to spec and would cause inconsistency as sometimes people would do that and sometimes not. I also think this would be a good test case for future more-disruptive changes.
- TreatNullAs questions:
  - [Searching Chromium](https://cs.chromium.org/search/?q=TreatNullAs%3DEmptyString+file:.idl&sq=package:chromium&type=cs) I find no instances of this being used on callback interfaces. Can we nuke that part of the spec?
  - While we're here, since this is going to invalidate existing IDL anyway, can we just get rid of the silly identifier argument and make this `[TreatNullAsEmptyString]`?

I hope I didn't miss anything major; this seemed almost too easy...


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/heycam/webidl/extended-attrs-on-types.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/83d33a6...77cbdcb.html)