### PR TITLE
Adjust wording in the legacy callers section.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2146,7 +2146,7 @@ is used to determine which legacy caller is invoked when the object is called
 as if it were a function.
 
 [=Legacy callers=] can only be defined on interfaces that also
-[=support indexed properties|supports indexed=] or
+[=support indexed properties|support indexed=] or
 [=support named properties|named properties=].
 
 Note: This artificial restriction allows bundling all interfaces with exotic object behavior


### PR DESCRIPTION
Say "interfaces that also support", not "interfaces that also supports".