### PR TITLE
Editorial: use recently added ids to ES math equations.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -48,13 +48,13 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         url: sec-ecmascript-data-types-and-values
             text: Type
             text: Type(x)
+        text: sign; url: eqn-sign
+        text: floor; url: eqn-floor
+        text: min; url: eqn-min
+        text: max; url: eqn-max
+        text: abs; url: eqn-abs
+        text: modulo; url: eqn-modulo
         url: sec-algorithm-conventions
-            text: sign
-            text: floor
-            text: min
-            text: max
-            text: abs
-            text: modulo
             text: !
             text: ?
             text: ECMA-262 section 5.2

--- a/index.html
+++ b/index.html
@@ -6555,7 +6555,7 @@ ECMAScript <emu-val>Boolean</emu-val> value <var>x</var>.</p>
     <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" data-lt="IntegerPart" id="abstract-opdef-integerpart">IntegerPart(<var>n</var>)</dfn>:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>r</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">floor</a>(<a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">abs</a>(<var>n</var>)).</p>
+      <p>Let <var>r</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#eqn-floor">floor</a>(<a data-link-type="dfn" href="https://tc39.github.io/ecma262/#eqn-abs">abs</a>(<var>n</var>)).</p>
      <li data-md="">
       <p>If <var>n</var> &lt; 0, then return -1 × <var>r</var>.</p>
      <li data-md="">
@@ -6631,7 +6631,7 @@ then <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-thr
       <p>then:</p>
       <ol>
        <li data-md="">
-        <p>Set <var>x</var> to <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">min</a>(<a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">max</a>(<var>x</var>, <var>lowerBound</var>), <var>upperBound</var>).</p>
+        <p>Set <var>x</var> to <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#eqn-min">min</a>(<a data-link-type="dfn" href="https://tc39.github.io/ecma262/#eqn-max">max</a>(<var>x</var>, <var>lowerBound</var>), <var>upperBound</var>).</p>
        <li data-md="">
         <p>Round <var>x</var> to the nearest integer, choosing the even integer if it lies halfway between two,
 and choosing +0 rather than −0.</p>
@@ -6644,7 +6644,7 @@ then return 0.</p>
      <li data-md="">
       <p>Set <var>x</var> to <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="abstract-op" href="#abstract-opdef-integerpart" id="ref-for-abstract-opdef-integerpart-2">IntegerPart</a>(<var>x</var>).</p>
      <li data-md="">
-      <p>Set <var>x</var> to <var>x</var> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">modulo</a> 2<sup><var>bitLength</var></sup>.</p>
+      <p>Set <var>x</var> to <var>x</var> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#eqn-modulo">modulo</a> 2<sup><var>bitLength</var></sup>.</p>
      <li data-md="">
       <p>If <var>signedness</var> is "signed" and <var>x</var> ≥ 2<sup><var>bitLength</var> − 1</sup>,
 then return <var>x</var> − 2<sup><var>bitLength</var></sup>.</p>
@@ -13059,7 +13059,7 @@ language binding.</p>
      <li><a href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@iterator</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@tostringtag</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-well-known-symbols">@@unscopables</a>
-     <li><a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">abs</a>
+     <li><a href="https://tc39.github.io/ecma262/#eqn-abs">abs</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-array-iterator-objects">array iterator objects</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-array-prototype-object">array methods</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-arraycreate">arraycreate</a>
@@ -13084,7 +13084,7 @@ language binding.</p>
      <li><a href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type">element</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-property-attributes">enumerable</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">equally close values</a>
-     <li><a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">floor</a>
+     <li><a href="https://tc39.github.io/ecma262/#eqn-floor">floor</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-get-o-p">get</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-getiterator">getiterator</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-getmethod">getmethod</a>
@@ -13098,9 +13098,9 @@ language binding.</p>
      <li><a href="https://tc39.github.io/ecma262/#sec-iteratorstep">iteratorstep</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-iteratorvalue">iteratorvalue</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">list</a>
-     <li><a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">max</a>
-     <li><a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">min</a>
-     <li><a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">modulo</a>
+     <li><a href="https://tc39.github.io/ecma262/#eqn-max">max</a>
+     <li><a href="https://tc39.github.io/ecma262/#eqn-min">min</a>
+     <li><a href="https://tc39.github.io/ecma262/#eqn-modulo">modulo</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-built-in-function-objects">newtarget</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-normalcompletion">normalcompletion</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">number type</a>


### PR DESCRIPTION
See: https://github.com/tc39/ecma262/commit/390234dd4260504fc6e9f40c79fa50cc5256be95.

Fixes #288.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
    
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://cdn.rawgit.com/tobie/webidl/5b30416/index.html) | [Diff w/ current ED](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fheycam.github.io%2Fwebidl%2F&doc2=https%3A%2F%2Fcdn.rawgit.com%2Ftobie%2Fwebidl%2F5b30416%2Findex.html) | [Diff w/ base](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2Fe5d04d0%2Findex.html&doc2=https%3A%2F%2Fcdn.rawgit.com%2Ftobie%2Fwebidl%2F5b30416%2Findex.html)