### PR TITLE
Fix #296: ban dictionary recursion through records.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4184,6 +4184,7 @@ if at least one of the following is true:
     includes |D|
 *   the type is a dictionary, one of whose members or inherited members has
     a type that includes |D|
+*   the type is <code>[=record=]&lt;|K|, |V|></code> where |V| includes |D|
 
 As with interfaces, the IDL for dictionaries can be split into multiple parts
 by using <dfn id="dfn-partial-dictionary" export>partial dictionary</dfn> definitions

--- a/index.html
+++ b/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 6ef2009a74468c39cdee1058d2c325259bdcb4fa" name="generator">
+  <meta content="Bikeshed version 90eb18a0d2a7680cdd94ecc3b342163de5a3fd43" name="generator">
 <style>
         pre.set {
           font-size: 80%;
@@ -1567,7 +1567,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web IDL</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-02">2 February 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-03">3 February 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -4823,6 +4823,8 @@ one of whose <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-d
     <li data-md="">
      <p>the type is a dictionary, one of whose members or inherited members has
 a type that includes <var>D</var></p>
+    <li data-md="">
+     <p>the type is <code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-2">record</a>&lt;<var>K</var>, <var>V</var>></code> where <var>V</var> includes <var>D</var></p>
    </ul>
    <p>As with interfaces, the IDL for dictionaries can be split into multiple parts
 by using <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-partial-dictionary">partial dictionary</dfn> definitions
@@ -7172,13 +7174,13 @@ alert<span class="p">(</span>b<span class="p">[</span><span class="mi">4</span><
 </span></pre>
    </div>
    <h4 class="heading settled" data-level="3.2.19" id="es-record"><span class="secno">3.2.19. </span><span class="content">Records — record&lt;<var>K</var>, <var>V</var>></span><a class="self-link" href="#es-record"></a></h4>
-   <p>IDL <a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-2">record</a>&lt;<var>K</var>, <var>V</var>> values are represented by
+   <p>IDL <a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-3">record</a>&lt;<var>K</var>, <var>V</var>> values are represented by
 ECMAScript <emu-val>Object</emu-val> values.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to record" id="es-to-record">
-    <p>An ECMAScript value <var>O</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-29">converted</a> to an IDL <code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-3">record</a>&lt;<var>K</var>, <var>V</var>></code> value as follows:</p>
+    <p>An ECMAScript value <var>O</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-29">converted</a> to an IDL <code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-4">record</a>&lt;<var>K</var>, <var>V</var>></code> value as follows:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>result</var> be a new empty instance of <code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-4">record</a>&lt;<var>K</var>, <var>V</var>></code>.</p>
+      <p>Let <var>result</var> be a new empty instance of <code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-5">record</a>&lt;<var>K</var>, <var>V</var>></code>.</p>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>O</var>) is Undefined or Null,
 return <var>result</var>.</p>
@@ -7212,7 +7214,7 @@ return <var>result</var>.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="convert a record to an ECMAScript value" id="record-to-es">
-    <p>An IDL <code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-5">record</a>&lt;…></code> value <var>D</var> is <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-28">converted</a> to an ECMAScript value as follows:</p>
+    <p>An IDL <code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-6">record</a>&lt;…></code> value <var>D</var> is <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-28">converted</a> to an ECMAScript value as follows:</p>
     <ol>
      <li data-md="">
       <p>Let <var>result</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-objectcreate">ObjectCreate</a>(<a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a>).</p>
@@ -7234,7 +7236,7 @@ return <var>result</var>.</p>
    </div>
    <div class="example" id="example-es-record">
     <a class="self-link" href="#example-es-record"></a> 
-    <p>Passing the ECMAScript value <code>{b: 3, a: 4}</code> as a <code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-6">record</a>&lt;DOMString, double></code> argument
+    <p>Passing the ECMAScript value <code>{b: 3, a: 4}</code> as a <code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-7">record</a>&lt;DOMString, double></code> argument
     would result in the IDL value « ("b", 3), ("a", 4) ».</p>
     <p>Records only consider <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-own-property">own</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-property-attributes">enumerable</a> properties, so given an IDL operation <code>record&lt;DOMString, double>
     identity(record&lt;DOMString, double> arg)</code> which returns its
@@ -7264,15 +7266,15 @@ console<span class="p">.</span>assert<span class="p">(</span>entries<span class=
      <tbody>
       <tr>
        <td><code>{"😞": 1}</code>
-       <td><code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-7">record</a>&lt;ByteString, double></code>
+       <td><code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-8">record</a>&lt;ByteString, double></code>
        <td><emu-val>TypeError</emu-val>
       <tr>
        <td><code>{"\uD83D": 1}</code>
-       <td><code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-8">record</a>&lt;USVString, double></code>
+       <td><code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-9">record</a>&lt;USVString, double></code>
        <td>« ("\uFFFD", 1) »
       <tr>
        <td><code>{"\uD83D": {hello: "world"}}</code>
-       <td><code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-9">record</a>&lt;DOMString, double></code>
+       <td><code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-10">record</a>&lt;DOMString, double></code>
        <td>« ("\uD83D", 0) »
     </table>
    </div>
@@ -14940,7 +14942,8 @@ language binding.</p>
    <b><a href="#idl-record">#idl-record</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-record-1">2.2.6. Overloading</a>
-    <li><a href="#ref-for-idl-record-2">3.2.19. Records — record&lt;K, V></a> <a href="#ref-for-idl-record-3">(2)</a> <a href="#ref-for-idl-record-4">(3)</a> <a href="#ref-for-idl-record-5">(4)</a> <a href="#ref-for-idl-record-6">(5)</a> <a href="#ref-for-idl-record-7">(6)</a> <a href="#ref-for-idl-record-8">(7)</a> <a href="#ref-for-idl-record-9">(8)</a>
+    <li><a href="#ref-for-idl-record-2">2.4. Dictionaries</a>
+    <li><a href="#ref-for-idl-record-3">3.2.19. Records — record&lt;K, V></a> <a href="#ref-for-idl-record-4">(2)</a> <a href="#ref-for-idl-record-5">(3)</a> <a href="#ref-for-idl-record-6">(4)</a> <a href="#ref-for-idl-record-7">(5)</a> <a href="#ref-for-idl-record-8">(6)</a> <a href="#ref-for-idl-record-9">(7)</a> <a href="#ref-for-idl-record-10">(8)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="record-type">


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
    
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://cdn.rawgit.com/jyasskin/webidl/4253081/index.html) | [Diff w/ current ED](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fheycam.github.io%2Fwebidl%2F&doc2=https%3A%2F%2Fcdn.rawgit.com%2Fjyasskin%2Fwebidl%2F4253081%2Findex.html) | [Diff w/ base](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fcdn.rawgit.com%2Fheycam%2Fwebidl%2Fc1ff4b2%2Findex.html&doc2=https%3A%2F%2Fcdn.rawgit.com%2Fjyasskin%2Fwebidl%2F4253081%2Findex.html)