### PR TITLE
Allow records to be nullable in all cases and omitted as optional operation arguments.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1633,7 +1633,7 @@ identify any one of those definitions or a [=dictionary=].
 
 If the operation argument type, after resolving typedefs,
 is a [=nullable type=],
-its [=inner type=] must not be a [=record type=] or [=dictionary type=].
+its [=inner type=] must not be a [=dictionary type=].
 
 <pre highlight="webidl" class="syntax">
     interface interface_identifier {
@@ -1772,16 +1772,12 @@ corresponding argument omitted.
     conversion of <emu-val>undefined</emu-val> to be used (i.e., <emu-val>false</emu-val>).
 </p>
 
-If the type of an argument is a [=dictionary type=] or [=record type=]
-or a [=union type=] that has a
-dictionary or record type as one of its [=flattened member types=],
-and that dictionary type and its ancestors have no [=required dictionary member|required members=],
-and the argument is either the final argument or is followed only by
-[=optional arguments=], then
-the argument must be specified as optional.
-Such arguments are always considered to have a
-[=optional argument/default value=] of an empty dictionary or record, as appropriate,
-unless otherwise specified.
+If the type of an argument is a [=dictionary type=] or a [=union type=] that has a dictionary as one
+of its [=flattened member types=], and that dictionary type and its ancestors have no
+[=required dictionary member|required members=], and the argument is either the final argument or is
+followed only by [=optional arguments=], then the argument must be specified as optional. Such
+arguments are always considered to have a [=optional argument/default value=] of an empty
+dictionary, unless otherwise specified.
 
 <div class="note">
 
@@ -3296,15 +3292,15 @@ the following algorithm returns <i>true</i>.
     and the other type either
     [=includes a nullable type=],
     is a [=union type=] with [=flattened member types=]
-    including a [=dictionary type=] or [=record type=], or
-    is a [=dictionary type=] or [=record type=],
+    including a [=dictionary type=], or
+    is a [=dictionary type=],
     return <i>false</i>.
     <div class="example" id="example-distinguishability-nullable">
         None of the following pairs are distinguishable:
         <ul>
             <li>
                 <code>{{double}}?</code> and
-                <code>[=record=]&lt;{{DOMString}}, {{DOMString}}></code>
+                <code>Dictionary1</code>
             </li>
             <li>
                 <code>(Interface1 or {{long}})?</code> and
@@ -4131,7 +4127,7 @@ identify any one of those definitions or a [=dictionary=].
 
 If the type of the [=dictionary member=], after resolving typedefs,
 is a [=nullable type=],
-its [=inner type=] must not be a [=record type=] or [=dictionary type=].
+its [=inner type=] must not be a [=dictionary type=].
 
 <pre highlight="webidl" class="syntax">
     dictionary identifier {
@@ -5720,9 +5716,9 @@ The inner type must not be:
 *   a [=Promise type=],
 *   another nullable type, or
 *   a [=union type=] that itself has [=includes a nullable type=]
-    or has a dictionary or record type as one of its [=flattened member types=].
+    or has a dictionary type as one of its [=flattened member types=].
 
-Note: Although dictionary and record types can in general be nullable,
+Note: Although dictionary types can in general be nullable,
 they cannot when used as the type of an operation argument or a dictionary member.
 
 Nullable type constant values in IDL are represented in the same way that
@@ -5922,8 +5918,7 @@ be used as a [=member types|union member type=].
 The [=number of nullable member types=]
 of a [=union type=] must
 be 0 or 1, and if it is 1 then the union type must also not have
-a [=dictionary type=] or [=record type=] in its
-[=flattened member types=].
+a [=dictionary type=] in its [=flattened member types=].
 
 A type <dfn id="dfn-includes-a-nullable-type" export>includes a nullable type</dfn> if:
 
@@ -7410,11 +7405,9 @@ ECMAScript <emu-val>Object</emu-val> values.
     An ECMAScript value |O| is [=converted to an IDL value|converted=]
     to an IDL <code>[=record=]&lt;|K|, |V|></code> value as follows:
 
-    1.  Let |result| be a new empty instance of <code>[=record=]&lt;|K|, |V|></code>.
-    1.  If [=Type=](|O|) is Undefined or Null,
-        return |result|.
     1.  If [=Type=](|O|) is not Object,
         [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+    1.  Let |result| be a new empty instance of <code>[=record=]&lt;|K|, |V|></code>.
     1.  Let |keys| be [=?=] |O|.\[[OwnPropertyKeys]]().
     1.  Repeat, for each element |key| of |keys| in [=List=] order:
         1.  Let |desc| be [=?=] |O|.\[[GetOwnProperty]](|key|).
@@ -7584,8 +7577,6 @@ that correspond to the union’s [=member types=].
     1.  If |V| is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, then:
         1.  If |types| includes a [=dictionary type=], then return the
             result of [=converted to an IDL value|converting=] |V| to that dictionary type.
-        1.  If |types| includes a [=record type=], then return the
-            result of [=converted to an IDL value|converting=] |V| to that record type.
     1.  If |V| is a [=platform object=], then:
         1.  If |types| includes an [=interface type=] that |V|
             implements, then return the IDL value that is a reference to the object |V|.
@@ -9723,10 +9714,8 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
             and there is an entry in |S| that has one of the following types at position |i| of its type list,
             *   a [=nullable type=]
             *   a [=dictionary type=]
-            *   a [=record type=]
-            *   a [=union type=] that
-                [=includes a nullable type=] or that
-                has a [=dictionary type=] or a [=record type=] in its [=flattened member types|flattened members=]
+            *   a [=union type=] that [=includes a nullable type=] or that has a [=dictionary type=] in
+                its [=flattened member types|flattened members=]
 
             then remove from |S| all other entries.
 

--- a/index.html
+++ b/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 2de6f41e63a9bd84932e1a28745f8d452d3b0e46" name="generator">
+  <meta content="Bikeshed version 862f905dcd28738c926b57b7cfebee04d3d6e31e" name="generator">
 <style>
         pre.set {
           font-size: 80%;
@@ -1567,7 +1567,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web IDL</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-07">7 February 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-11">11 February 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2880,7 +2880,7 @@ If the operation argument type is an <a data-link-type="dfn" href="#dfn-identifi
 identify any one of those definitions or a <a data-link-type="dfn" href="#dfn-dictionary" id="ref-for-dfn-dictionary-6">dictionary</a>.</p>
    <p>If the operation argument type, after resolving typedefs,
 is a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-5">nullable type</a>,
-its <a data-link-type="dfn" href="#dfn-inner-type" id="ref-for-dfn-inner-type-2">inner type</a> must not be a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-2">record type</a> or <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-2">dictionary type</a>.</p>
+its <a data-link-type="dfn" href="#dfn-inner-type" id="ref-for-dfn-inner-type-2">inner type</a> must not be a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-2">dictionary type</a>.</p>
 <pre class="syntax highlight"><span class="kt">interface</span> <span class="nv">interface_identifier</span> {
   <span class="n">return_type</span> <span class="nv">identifier</span>(<span class="n">type</span> <span class="nv">identifier</span>, <span class="n">type</span> <span class="nv">identifier</span> /* , ... */);
 };
@@ -2974,13 +2974,11 @@ corresponding argument omitted.</p>
    <p class="advisement"> It is strongly suggested not to use <a data-link-type="dfn" href="#dfn-optional-argument-default-value" id="ref-for-dfn-optional-argument-default-value-3">default value</a> of <emu-val>true</emu-val> for <code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref-for-idl-boolean-2">boolean</a></code>-typed arguments,
     as this can be confusing for authors who might otherwise expect the default
     conversion of <emu-val>undefined</emu-val> to be used (i.e., <emu-val>false</emu-val>). </p>
-   <p>If the type of an argument is a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-3">dictionary type</a> or <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-3">record type</a> or a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-2">union type</a> that has a
-dictionary or record type as one of its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-2">flattened member types</a>,
-and that dictionary type and its ancestors have no <a data-link-type="dfn" href="#required-dictionary-member" id="ref-for-required-dictionary-member-1">required members</a>,
-and the argument is either the final argument or is followed only by <a data-link-type="dfn" href="#dfn-optional-argument" id="ref-for-dfn-optional-argument-1">optional arguments</a>, then
-the argument must be specified as optional.
-Such arguments are always considered to have a <a data-link-type="dfn" href="#dfn-optional-argument-default-value" id="ref-for-dfn-optional-argument-default-value-4">default value</a> of an empty dictionary or record, as appropriate,
-unless otherwise specified.</p>
+   <p>If the type of an argument is a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-3">dictionary type</a> or a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-2">union type</a> that has a dictionary as one
+of its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-2">flattened member types</a>, and that dictionary type and its ancestors have no <a data-link-type="dfn" href="#required-dictionary-member" id="ref-for-required-dictionary-member-1">required members</a>, and the argument is either the final argument or is
+followed only by <a data-link-type="dfn" href="#dfn-optional-argument" id="ref-for-dfn-optional-argument-1">optional arguments</a>, then the argument must be specified as optional. Such
+arguments are always considered to have a <a data-link-type="dfn" href="#dfn-optional-argument-default-value" id="ref-for-dfn-optional-argument-default-value-4">default value</a> of an empty
+dictionary, unless otherwise specified.</p>
    <div class="note" role="note">
     <p>This is to encourage API designs that do not require authors to pass an
     empty dictionary value when they wish only to use the dictionary’s
@@ -4242,18 +4240,18 @@ the following algorithm returns <i>true</i>.</p>
    <ol class="algorithm">
     <li data-md="">
      <p>If one type <a data-link-type="dfn" href="#dfn-includes-a-nullable-type" id="ref-for-dfn-includes-a-nullable-type-1">includes a nullable type</a> and the other type either <a data-link-type="dfn" href="#dfn-includes-a-nullable-type" id="ref-for-dfn-includes-a-nullable-type-2">includes a nullable type</a>,
-is a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-5">union type</a> with <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-4">flattened member types</a> including a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-4">dictionary type</a> or <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-4">record type</a>, or
-is a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-5">dictionary type</a> or <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-5">record type</a>,
+is a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-5">union type</a> with <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-4">flattened member types</a> including a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-4">dictionary type</a>, or
+is a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-5">dictionary type</a>,
 return <i>false</i>.</p>
      <div class="example" id="example-distinguishability-nullable">
       <a class="self-link" href="#example-distinguishability-nullable"></a> None of the following pairs are distinguishable: 
       <ul>
-       <li> <code><code class="idl"><a data-link-type="idl" href="#idl-double" id="ref-for-idl-double-7">double</a></code>?</code> and <code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-1">record</a>&lt;<code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-14">DOMString</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-15">DOMString</a></code>></code> 
-       <li> <code>(Interface1 or <code class="idl"><a data-link-type="idl" href="#idl-long" id="ref-for-idl-long-1">long</a></code>)?</code> and <code>(Interface2 or <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-16">DOMString</a></code>)?</code> 
-       <li> <code>(Interface1 or <code class="idl"><a data-link-type="idl" href="#idl-long" id="ref-for-idl-long-2">long</a></code>?)</code> and <code>(Interface2 or <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-17">DOMString</a></code>)?</code> 
-       <li> <code>(Interface1 or <code class="idl"><a data-link-type="idl" href="#idl-long" id="ref-for-idl-long-3">long</a></code>?)</code> and <code>(Interface2 or <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-18">DOMString</a></code>?)</code> 
-       <li> <code>(Dictionary1 or <code class="idl"><a data-link-type="idl" href="#idl-long" id="ref-for-idl-long-4">long</a></code>)</code> and <code>(Interface2 or <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-19">DOMString</a></code>)?</code> 
-       <li> <code>(Dictionary1 or <code class="idl"><a data-link-type="idl" href="#idl-long" id="ref-for-idl-long-5">long</a></code>)</code> and <code>(Interface2 or <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-20">DOMString</a></code>?)</code> 
+       <li> <code><code class="idl"><a data-link-type="idl" href="#idl-double" id="ref-for-idl-double-7">double</a></code>?</code> and <code>Dictionary1</code> 
+       <li> <code>(Interface1 or <code class="idl"><a data-link-type="idl" href="#idl-long" id="ref-for-idl-long-1">long</a></code>)?</code> and <code>(Interface2 or <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-14">DOMString</a></code>)?</code> 
+       <li> <code>(Interface1 or <code class="idl"><a data-link-type="idl" href="#idl-long" id="ref-for-idl-long-2">long</a></code>?)</code> and <code>(Interface2 or <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-15">DOMString</a></code>)?</code> 
+       <li> <code>(Interface1 or <code class="idl"><a data-link-type="idl" href="#idl-long" id="ref-for-idl-long-3">long</a></code>?)</code> and <code>(Interface2 or <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-16">DOMString</a></code>?)</code> 
+       <li> <code>(Dictionary1 or <code class="idl"><a data-link-type="idl" href="#idl-long" id="ref-for-idl-long-4">long</a></code>)</code> and <code>(Interface2 or <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-17">DOMString</a></code>)?</code> 
+       <li> <code>(Dictionary1 or <code class="idl"><a data-link-type="idl" href="#idl-long" id="ref-for-idl-long-5">long</a></code>)</code> and <code>(Interface2 or <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-18">DOMString</a></code>?)</code> 
       </ul>
      </div>
     <li data-md="">
@@ -4290,7 +4288,7 @@ Otherwise return <i>false</i>.</p>
         <li data-md="">
          <p><a data-link-type="dfn" href="#dfn-dictionary" id="ref-for-dfn-dictionary-9">dictionaries</a></p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#record-type" id="ref-for-record-type-6">record types</a></p>
+         <p><a data-link-type="dfn" href="#record-type" id="ref-for-record-type-2">record types</a></p>
         <li data-md="">
          <p><a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-10">callback interfaces</a></p>
        </ul>
@@ -4410,7 +4408,7 @@ Otherwise return <i>false</i>.</p>
 not the same, and no single <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-6">platform object</a> implements both
 interface-like types.</p>
      </ol>
-     <div class="example" id="example-distinguishability-diff-types"><a class="self-link" href="#example-distinguishability-diff-types"></a> <code class="idl"><a data-link-type="idl" href="#idl-double" id="ref-for-idl-double-8">double</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-21">DOMString</a></code> are distinguishable because
+     <div class="example" id="example-distinguishability-diff-types"><a class="self-link" href="#example-distinguishability-diff-types"></a> <code class="idl"><a data-link-type="idl" href="#idl-double" id="ref-for-idl-double-8">double</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-19">DOMString</a></code> are distinguishable because
     there is a ● at the intersection of <a data-link-type="dfn" href="#dfn-numeric-type" id="ref-for-dfn-numeric-type-1">numeric types</a> with <a data-link-type="dfn" href="#dfn-string-type" id="ref-for-dfn-string-type-2">string types</a>. </div>
      <div class="example" id="example-distinguishability-same-category"><a class="self-link" href="#example-distinguishability-same-category"></a> <code class="idl"><a data-link-type="idl" href="#idl-double" id="ref-for-idl-double-9">double</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-long" id="ref-for-idl-long-6">long</a></code> are not distinguishable because they are both <a data-link-type="dfn" href="#dfn-numeric-type" id="ref-for-dfn-numeric-type-2">numeric types</a>,
     and there is no ● or letter at the intersection of <a data-link-type="dfn" href="#dfn-numeric-type" id="ref-for-dfn-numeric-type-3">numeric types</a> with <a data-link-type="dfn" href="#dfn-numeric-type" id="ref-for-dfn-numeric-type-4">numeric types</a>. </div>
@@ -4449,7 +4447,7 @@ The lowest such index is termed the <dfn class="dfn-paneled" data-dfn-type="dfn"
   <span class="kt">void</span> <span class="nv">f</span>(<span class="kt">double</span> <span class="nv">x</span>);
 };
 </pre>
-    <p>since <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-22">DOMString</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-double" id="ref-for-idl-double-10">double</a></code> are not distinguishable.</p>
+    <p>since <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-20">DOMString</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-double" id="ref-for-idl-double-10">double</a></code> are not distinguishable.</p>
    </div>
    <p>In addition, for each index <var>j</var>, where <var>j</var> is less than the <a data-link-type="dfn" href="#dfn-distinguishing-argument-index" id="ref-for-dfn-distinguishing-argument-index-2">distinguishing argument index</a> for a given type list length, the types at index <var>j</var> in
 all of the entries’ type lists must be the same
@@ -4469,7 +4467,7 @@ be the same.</p>
   &lt;f2, (long, double, Node, Node), (required, required, required, required)>,
   &lt;f3, (double, double, DOMString, Node), (required, required, required, required)> }
 </pre>
-    <p>Looking at entries with type list length 4, the <a data-link-type="dfn" href="#dfn-distinguishing-argument-index" id="ref-for-dfn-distinguishing-argument-index-3">distinguishing argument index</a> is 2, since <code class="idl">Node</code> and <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-23">DOMString</a></code> are <a data-link-type="dfn" href="#dfn-distinguishable" id="ref-for-dfn-distinguishable-3">distinguishable</a>.
+    <p>Looking at entries with type list length 4, the <a data-link-type="dfn" href="#dfn-distinguishing-argument-index" id="ref-for-dfn-distinguishing-argument-index-3">distinguishing argument index</a> is 2, since <code class="idl">Node</code> and <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-21">DOMString</a></code> are <a data-link-type="dfn" href="#dfn-distinguishable" id="ref-for-dfn-distinguishable-3">distinguishable</a>.
     However, since the arguments in these two overloads at index 0 are different,
     the overloading is invalid.</p>
    </div>
@@ -4787,7 +4785,7 @@ not followed by <emu-t>?</emu-t>, then the identifier must
 identify any one of those definitions or a <a data-link-type="dfn" href="#dfn-dictionary" id="ref-for-dfn-dictionary-10">dictionary</a>.</p>
    <p>If the type of the <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-6">dictionary member</a>, after resolving typedefs,
 is a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-9">nullable type</a>,
-its <a data-link-type="dfn" href="#dfn-inner-type" id="ref-for-dfn-inner-type-5">inner type</a> must not be a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-7">record type</a> or <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-6">dictionary type</a>.</p>
+its <a data-link-type="dfn" href="#dfn-inner-type" id="ref-for-dfn-inner-type-5">inner type</a> must not be a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-6">dictionary type</a>.</p>
 <pre class="syntax highlight"><span class="kt">dictionary</span> <span class="nv">identifier</span> {
   <span class="n">type</span> <span class="nv">identifier</span>;
 };
@@ -4830,7 +4828,7 @@ one of whose <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-d
      <p>the type is a dictionary, one of whose members or inherited members has
 a type that includes <var>D</var></p>
     <li data-md="">
-     <p>the type is <code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-2">record</a>&lt;<var>K</var>, <var>V</var>></code> where <var>V</var> includes <var>D</var></p>
+     <p>the type is <code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-1">record</a>&lt;<var>K</var>, <var>V</var>></code> where <var>V</var> includes <var>D</var></p>
    </ul>
    <p>As with interfaces, the IDL for dictionaries can be split into multiple parts
 by using <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-partial-dictionary">partial dictionary</dfn> definitions
@@ -4980,7 +4978,7 @@ class value by implementations.  Web IDL does not allow exceptions
 to be defined, but instead has a number of pre-defined exceptions
 that specifications can reference and throw in their definition of
 operations, attributes, and so on.  Exceptions have an <dfn class="dfn-paneled" data-dfn-for="exception" data-dfn-type="dfn" data-export="" id="dfn-exception-error-name">error name</dfn>,
-a <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-24">DOMString</a></code>,
+a <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-22">DOMString</a></code>,
 which is the type of error the exception represents, and a <dfn data-dfn-for="exception" data-dfn-type="dfn" data-export="" id="dfn-exception-message">message<a class="self-link" href="#dfn-exception-message"></a></dfn>, which is an optional,
 user agent-defined value that provides human readable details of the error.</p>
    <p>There are two kinds of exceptions available to be thrown from specifications.
@@ -5189,7 +5187,7 @@ for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-f
    <h3 class="heading settled" data-level="2.6" id="idl-enums"><span class="secno">2.6. </span><span class="content">Enumerations</span><a class="self-link" href="#idl-enums"></a></h3>
    <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-enumeration">enumeration</dfn> is a definition (matching <emu-nt><a href="#prod-Enum">Enum</a></emu-nt>) used to declare a type
 whose valid values are a set of predefined strings.  Enumerations
-can be used to restrict the possible <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-25">DOMString</a></code> values that can be assigned to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-16">attribute</a> or passed to an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-23">operation</a>.</p>
+can be used to restrict the possible <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-23">DOMString</a></code> values that can be assigned to an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-16">attribute</a> or passed to an <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-23">operation</a>.</p>
 <pre class="syntax highlight"><span class="kt">enum</span> <span class="nv">identifier</span> { <span class="s">"enum"</span>, <span class="s">"values"</span> /* , ... */ };</pre>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="enumeration value" id="dfn-enumeration-value">enumeration values</dfn> are specified
 as a comma-separated list of <emu-t class="regex"><a href="#prod-string">string</a></emu-t> literals.
@@ -5472,7 +5470,7 @@ corresponding to each type, and how <a data-link-type="dfn" href="#dfn-constant"
    <p>The following types are known as <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-numeric-type">numeric types</dfn>:
 the <a data-link-type="dfn" href="#dfn-integer-type" id="ref-for-dfn-integer-type-3">integer types</a>, <code class="idl"><a data-link-type="idl" href="#idl-float" id="ref-for-idl-float-4">float</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-unrestricted-float" id="ref-for-idl-unrestricted-float-5">unrestricted float</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-double" id="ref-for-idl-double-11">double</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-unrestricted-double" id="ref-for-idl-unrestricted-double-6">unrestricted double</a></code>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-primitive-type">primitive types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref-for-idl-boolean-6">boolean</a></code> and the <a data-link-type="dfn" href="#dfn-numeric-type" id="ref-for-dfn-numeric-type-5">numeric types</a>.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-string-type">string types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-26">DOMString</a></code>, all <a data-link-type="dfn" href="#idl-enumeration" id="ref-for-idl-enumeration-1">enumeration types</a>, <code class="idl"><a data-link-type="idl" href="#idl-ByteString" id="ref-for-idl-ByteString-3">ByteString</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-USVString" id="ref-for-idl-USVString-4">USVString</a></code>.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-string-type">string types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-24">DOMString</a></code>, all <a data-link-type="dfn" href="#idl-enumeration" id="ref-for-idl-enumeration-1">enumeration types</a>, <code class="idl"><a data-link-type="idl" href="#idl-ByteString" id="ref-for-idl-ByteString-3">ByteString</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-USVString" id="ref-for-idl-USVString-4">USVString</a></code>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-exception-type">exception types</dfn> are <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-3">Error</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-17">DOMException</a></code>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-typed-array-type">typed array types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-Int8Array" id="ref-for-idl-Int8Array-1">Int8Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Int16Array" id="ref-for-idl-Int16Array-1">Int16Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Int32Array" id="ref-for-idl-Int32Array-1">Int32Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint8Array" id="ref-for-idl-Uint8Array-1">Uint8Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint16Array" id="ref-for-idl-Uint16Array-1">Uint16Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint32Array" id="ref-for-idl-Uint32Array-1">Uint32Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint8ClampedArray" id="ref-for-idl-Uint8ClampedArray-1">Uint8ClampedArray</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Float32Array" id="ref-for-idl-Float32Array-1">Float32Array</a></code> and <code class="idl"><a data-link-type="idl" href="#idl-Float64Array" id="ref-for-idl-Float64Array-1">Float64Array</a></code>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-buffer-source-type">buffer source types</dfn> are <code class="idl"><a data-link-type="idl" href="#idl-ArrayBuffer" id="ref-for-idl-ArrayBuffer-1">ArrayBuffer</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-DataView" id="ref-for-idl-DataView-1">DataView</a></code>,
@@ -5666,25 +5664,25 @@ IEEE 754 floating point numbers, finite and non-finite. <a data-link-type="bibli
 represented with <emu-t class="regex"><a href="#prod-float">float</a></emu-t> tokens.</p>
    <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-14">type name</a> of the <code class="idl"><a data-link-type="idl" href="#idl-unrestricted-double" id="ref-for-idl-unrestricted-double-9">unrestricted double</a></code> type is “UnrestrictedDouble”.</p>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-level="2.11.15" data-lt="DOMString" id="idl-DOMString"><span class="secno">2.11.15. </span><span class="content">DOMString</span><span id="dom-DOMString"></span></h4>
-   <p>The <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-27">DOMString</a></code> type corresponds to
+   <p>The <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-25">DOMString</a></code> type corresponds to
 the set of all possible sequences of <a data-link-type="dfn" href="#dfn-code-unit" id="ref-for-dfn-code-unit-1">code units</a>.
 Such sequences are commonly interpreted as UTF-16 encoded strings <a data-link-type="biblio" href="#biblio-rfc2781">[RFC2781]</a> although this is not required.
-While <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-28">DOMString</a></code> is defined to be
+While <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-26">DOMString</a></code> is defined to be
 an OMG IDL boxed <a data-link-type="dfn" href="#sequence-type" id="ref-for-sequence-type-6">sequence</a>&lt;<code class="idl"><a data-link-type="idl" href="#idl-unsigned-short" id="ref-for-idl-unsigned-short-5">unsigned short</a></code>> valuetype
 in <a href="https://www.w3.org/TR/DOM-Level-3-Core//core#ID-C74D1578">DOM Level 3 Core §The DOMString Type</a>,
-this document defines <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-29">DOMString</a></code> to be an intrinsic type
+this document defines <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-27">DOMString</a></code> to be an intrinsic type
 so as to avoidspecial casing that sequence type
 in various situations where a string is required.</p>
-   <p class="note" role="note"><span>Note:</span> Note also that <emu-val>null</emu-val> is not a value of type <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-30">DOMString</a></code>.
-To allow <emu-val>null</emu-val>, a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-11">nullable</a> <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-31">DOMString</a></code>,
+   <p class="note" role="note"><span>Note:</span> Note also that <emu-val>null</emu-val> is not a value of type <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-28">DOMString</a></code>.
+To allow <emu-val>null</emu-val>, a <a data-link-type="dfn" href="#dfn-nullable-type" id="ref-for-dfn-nullable-type-11">nullable</a> <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-29">DOMString</a></code>,
 written as <code>DOMString?</code> in IDL, needs to be used.</p>
-   <p>Nothing in this specification requires a <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-32">DOMString</a></code> value to be a valid UTF-16 string.  For example, a <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-33">DOMString</a></code> value might include unmatched surrogate pair characters.  However, authors
+   <p>Nothing in this specification requires a <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-30">DOMString</a></code> value to be a valid UTF-16 string.  For example, a <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-31">DOMString</a></code> value might include unmatched surrogate pair characters.  However, authors
 of specifications using Web IDL might want to obtain a sequence of <a data-link-type="dfn" href="http://www.unicode.org/glossary/#unicode_scalar_value">Unicode scalar values</a> given a particular sequence of <a data-link-type="dfn" href="#dfn-code-unit" id="ref-for-dfn-code-unit-2">code units</a>.</p>
    <div class="algorithm" data-algorithm="convert a DOMString to a sequence of Unicode scalar values">
     <p>The following algorithm defines a way to <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="obtain Unicode|convert to a sequence of Unicode scalar values" id="dfn-obtain-unicode">convert a DOMString to a sequence of Unicode scalar values</dfn>:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>S</var> be the <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-34">DOMString</a></code> value.</p>
+      <p>Let <var>S</var> be the <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-32">DOMString</a></code> value.</p>
      <li data-md="">
       <p>Let <var>n</var> be the length of <var>S</var>.</p>
      <li data-md="">
@@ -5744,9 +5742,9 @@ Append to <var>U</var> a <span class="char">U+FFFD REPLACEMENT CHARACTER</span>.
       <p>Return <var>U</var>.</p>
     </ol>
    </div>
-   <p>There is no way to represent a constant <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-35">DOMString</a></code> value in IDL, although <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-36">DOMString</a></code> <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-10">dictionary member</a> and <a data-link-type="dfn" href="#dfn-optional-argument" id="ref-for-dfn-optional-argument-8">operation optional argument</a> default values
+   <p>There is no way to represent a constant <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-33">DOMString</a></code> value in IDL, although <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-34">DOMString</a></code> <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-10">dictionary member</a> and <a data-link-type="dfn" href="#dfn-optional-argument" id="ref-for-dfn-optional-argument-8">operation optional argument</a> default values
 can be specified using a <emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.</p>
-   <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-15">type name</a> of the <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-37">DOMString</a></code> type is “String”.</p>
+   <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-15">type name</a> of the <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-35">DOMString</a></code> type is “String”.</p>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-level="2.11.16" data-lt="ByteString" id="idl-ByteString"><span class="secno">2.11.16. </span><span class="content">ByteString</span><span id="dom-ByteString"></span></h4>
    <p>The <code class="idl"><a data-link-type="idl" href="#idl-ByteString" id="ref-for-idl-ByteString-4">ByteString</a></code> type
 corresponds to the set of all possible sequences of bytes.
@@ -5756,7 +5754,7 @@ can be specified using a <emu-t class="regex"><a href="#prod-string">string</a><
    <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-16">type name</a> of the <code class="idl"><a data-link-type="idl" href="#idl-ByteString" id="ref-for-idl-ByteString-7">ByteString</a></code> type is “ByteString”.</p>
    <p class="advisement"> Specifications should only use <code class="idl"><a data-link-type="idl" href="#idl-ByteString" id="ref-for-idl-ByteString-8">ByteString</a></code> for interfacing with protocols
     that use bytes and strings interchangably, such as HTTP.  In general,
-    strings should be represented with <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-38">DOMString</a></code> values, even if it is expected
+    strings should be represented with <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-36">DOMString</a></code> values, even if it is expected
     that values of the string will always be in ASCII or some
     8 bit character encoding. <a data-link-type="dfn" href="#sequence-type" id="ref-for-sequence-type-7">Sequences</a>, <a data-link-type="dfn" href="#dfn-frozen-array-type" id="ref-for-dfn-frozen-array-type-2">frozen arrays</a> or <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-typedarray-objects">Typed Arrays</a> with <code class="idl"><a data-link-type="idl" href="#idl-octet" id="ref-for-idl-octet-5">octet</a></code> or <code class="idl"><a data-link-type="idl" href="#idl-byte" id="ref-for-idl-byte-5">byte</a></code> elements should be used for holding
     8 bit data rather than <code class="idl"><a data-link-type="idl" href="#idl-ByteString" id="ref-for-idl-ByteString-9">ByteString</a></code>. </p>
@@ -5771,8 +5769,8 @@ can be specified using a <emu-t class="regex"><a href="#prod-string">string</a><
    <p class="advisement"> Specifications should only use <code class="idl"><a data-link-type="idl" href="#idl-USVString" id="ref-for-idl-USVString-9">USVString</a></code> for APIs that perform
     text processing and need a string of Unicode
     scalar values to operate on.  Most APIs that use strings
-    should instead be using <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-39">DOMString</a></code>,
-    which does not make any interpretations of the <a data-link-type="dfn" href="#dfn-code-unit" id="ref-for-dfn-code-unit-4">code units</a> in the string.  When in doubt, use <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-40">DOMString</a></code>. </p>
+    should instead be using <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-37">DOMString</a></code>,
+    which does not make any interpretations of the <a data-link-type="dfn" href="#dfn-code-unit" id="ref-for-dfn-code-unit-4">code units</a> in the string.  When in doubt, use <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-38">DOMString</a></code>. </p>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-level="2.11.18" data-lt="object" id="idl-object"><span class="secno">2.11.18. </span><span class="content">object</span><span id="dom-object"></span></h4>
    <p>The <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-2">object</a></code> type corresponds to the set of
 all possible non-null object references.</p>
@@ -5810,8 +5808,8 @@ is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier
    <h4 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="2.11.21" data-lt="Enumeration types" id="idl-enumeration"><span class="secno">2.11.21. </span><span class="content">Enumeration types</span></h4>
    <p>An <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-45">identifier</a> that
 identifies an <a data-link-type="dfn" href="#dfn-enumeration" id="ref-for-dfn-enumeration-15">enumeration</a> is used to
-refer to a type whose values are the set of strings (sequences of <a data-link-type="dfn" href="#dfn-code-unit" id="ref-for-dfn-code-unit-5">code units</a>, as with <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-41">DOMString</a></code>) that are the <a data-link-type="dfn" href="#dfn-enumeration-value" id="ref-for-dfn-enumeration-value-4">enumeration’s values</a>.</p>
-   <p>Like <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-42">DOMString</a></code>, there is no way to represent a constant <a data-link-type="dfn" href="#dfn-enumeration" id="ref-for-dfn-enumeration-16">enumeration</a> value in IDL, although enumeration-typed <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-13">dictionary member</a> <a data-link-type="dfn" href="#dfn-dictionary-member-default-value" id="ref-for-dfn-dictionary-member-default-value-7">default values</a> can be specified using a <emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.</p>
+refer to a type whose values are the set of strings (sequences of <a data-link-type="dfn" href="#dfn-code-unit" id="ref-for-dfn-code-unit-5">code units</a>, as with <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-39">DOMString</a></code>) that are the <a data-link-type="dfn" href="#dfn-enumeration-value" id="ref-for-dfn-enumeration-value-4">enumeration’s values</a>.</p>
+   <p>Like <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-40">DOMString</a></code>, there is no way to represent a constant <a data-link-type="dfn" href="#dfn-enumeration" id="ref-for-dfn-enumeration-16">enumeration</a> value in IDL, although enumeration-typed <a data-link-type="dfn" href="#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-13">dictionary member</a> <a data-link-type="dfn" href="#dfn-dictionary-member-default-value" id="ref-for-dfn-dictionary-member-default-value-7">default values</a> can be specified using a <emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.</p>
    <p>The <a data-link-type="dfn" href="#dfn-type-name" id="ref-for-dfn-type-name-21">type name</a> of an enumeration type
 is the <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-46">identifier</a> of the enumeration.</p>
    <h4 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="2.11.22" data-lt="Callback function types" data-noexport="" id="idl-callback-function"><span class="secno">2.11.22. </span><span class="content">Callback function types</span></h4>
@@ -5840,9 +5838,9 @@ The inner type must not be:</p>
     <li data-md="">
      <p>another nullable type, or</p>
     <li data-md="">
-     <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-11">union type</a> that itself has <a data-link-type="dfn" href="#dfn-includes-a-nullable-type" id="ref-for-dfn-includes-a-nullable-type-3">includes a nullable type</a> or has a dictionary or record type as one of its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-5">flattened member types</a>.</p>
+     <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-11">union type</a> that itself has <a data-link-type="dfn" href="#dfn-includes-a-nullable-type" id="ref-for-dfn-includes-a-nullable-type-3">includes a nullable type</a> or has a dictionary type as one of its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-5">flattened member types</a>.</p>
    </ul>
-   <p class="note" role="note"><span>Note:</span> Although dictionary and record types can in general be nullable,
+   <p class="note" role="note"><span>Note:</span> Although dictionary types can in general be nullable,
 they cannot when used as the type of an operation argument or a dictionary member.</p>
    <p>Nullable type constant values in IDL are represented in the same way that
 constant values of their <a data-link-type="dfn" href="#dfn-inner-type" id="ref-for-dfn-inner-type-7">inner type</a> would be represented, or with the <emu-t>null</emu-t> token.</p>
@@ -5857,7 +5855,7 @@ the string “OrNull”.</p>
 };
 </pre>
     <p>The following <a data-link-type="dfn" href="#dfn-interface" id="ref-for-dfn-interface-53">interface</a> has two <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-21">attributes</a>: one whose value can
-    be a <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-43">DOMString</a></code> or the <emu-val>null</emu-val> value, and another whose value can be a reference to a <code class="idl">Node</code> object or the <emu-val>null</emu-val> value:</p>
+    be a <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-41">DOMString</a></code> or the <emu-val>null</emu-val> value, and another whose value can be a reference to a <code class="idl">Node</code> object or the <emu-val>null</emu-val> value:</p>
 <pre class="highlight"><span class="kt">interface</span> <span class="nv">Node</span> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span>? <span class="nv">namespaceURI</span>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="n">Node</span>? <span class="nv">parentNode</span>;
@@ -5892,7 +5890,7 @@ The order of a record’s mappings is determined when the record value is create
 In a specification, a record’s value can be written:</p>
    <blockquote> « (key1, value1), (key2, value2), … » </blockquote>
    <p>However, there is no way to represent a constant record value in IDL.</p>
-   <p><var>K</var> must be one of <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-44">DOMString</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-USVString" id="ref-for-idl-USVString-10">USVString</a></code>, or <code class="idl"><a data-link-type="idl" href="#idl-ByteString" id="ref-for-idl-ByteString-10">ByteString</a></code>.</p>
+   <p><var>K</var> must be one of <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-42">DOMString</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-USVString" id="ref-for-idl-USVString-10">USVString</a></code>, or <code class="idl"><a data-link-type="idl" href="#idl-ByteString" id="ref-for-idl-ByteString-10">ByteString</a></code>.</p>
    <p>Records are always passed by value. In language bindings where a record
 is represented by an object of some kind, passing a record
 to a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-11">platform object</a> will not result in a reference to the record
@@ -5990,7 +5988,7 @@ Add <var>U</var> to <var>S</var>.</p>
 be used as a <a data-link-type="dfn" href="#dfn-union-member-type" id="ref-for-dfn-union-member-type-8">union member type</a>.</p>
    <p>The <a data-link-type="dfn" href="#dfn-number-of-nullable-member-types" id="ref-for-dfn-number-of-nullable-member-types-2">number of nullable member types</a> of a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-21">union type</a> must
 be 0 or 1, and if it is 1 then the union type must also not have
-a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-7">dictionary type</a> or <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-8">record type</a> in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-8">flattened member types</a>.</p>
+a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-7">dictionary type</a> in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-8">flattened member types</a>.</p>
    <p>A type <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-includes-a-nullable-type">includes a nullable type</dfn> if:</p>
    <ul>
     <li data-md="">
@@ -6409,7 +6407,7 @@ return the <code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref
 return the result of <a href="#es-to-unrestricted-double">converting</a> <var>V</var> to an <code class="idl"><a data-link-type="idl" href="#idl-unrestricted-double" id="ref-for-idl-unrestricted-double-10">unrestricted double</a></code>.</p>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is String, then
-return the result of <a href="#es-DOMString">converting</a> <var>V</var> to a <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-45">DOMString</a></code>.</p>
+return the result of <a href="#es-DOMString">converting</a> <var>V</var> to a <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-43">DOMString</a></code>.</p>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is Object, then
 return an IDL <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-7">object</a></code> value that references <var>V</var>.</p>
@@ -6779,7 +6777,7 @@ the one that represents the same numeric value as the IDL <code class="idl"><a d
    </div>
    <h4 class="heading settled" data-level="3.2.9" id="es-DOMString"><span class="secno">3.2.9. </span><span class="content">DOMString</span><a class="self-link" href="#es-DOMString"></a></h4>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to DOMString" id="es-to-DOMString">
-    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-15">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-46">DOMString</a></code> value by running the following algorithm:</p>
+    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-15">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-44">DOMString</a></code> value by running the following algorithm:</p>
     <ol>
      <li data-md="">
       <p>If <var>V</var> is <emu-val>null</emu-val> and the conversion to an IDL value is being performed due
@@ -6796,16 +6794,16 @@ operation annotated with [<code class="idl"><a data-link-type="idl" href="#Treat
         <p><var>V</var> is being returned from a <a data-link-type="dfn" href="#dfn-user-object" id="ref-for-dfn-user-object-7">user object</a> implementation of an
 attribute annotated with [<code class="idl"><a data-link-type="idl" href="#TreatNullAs" id="ref-for-TreatNullAs-7">TreatNullAs</a></code>],</p>
       </ul>
-      <p>then return the <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-47">DOMString</a></code> value that represents the empty string.</p>
+      <p>then return the <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-45">DOMString</a></code> value that represents the empty string.</p>
      <li data-md="">
       <p>Let <var>x</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a>(<var>V</var>).</p>
      <li data-md="">
-      <p>Return the IDL <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-48">DOMString</a></code> value that represents the same sequence of code units as the one the ECMAScript <emu-val>String</emu-val> value <var>x</var> represents.</p>
+      <p>Return the IDL <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-46">DOMString</a></code> value that represents the same sequence of code units as the one the ECMAScript <emu-val>String</emu-val> value <var>x</var> represents.</p>
     </ol>
    </div>
-   <p id="DOMString-to-es"> The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-15">converting</a> an IDL <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-49">DOMString</a></code> value to an ECMAScript
+   <p id="DOMString-to-es"> The result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-15">converting</a> an IDL <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-47">DOMString</a></code> value to an ECMAScript
     value is the <emu-val>String</emu-val> value that represents the same sequence of <a data-link-type="dfn" href="#dfn-code-unit" id="ref-for-dfn-code-unit-6">code units</a> that the
-    IDL <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-50">DOMString</a></code> represents. </p>
+    IDL <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-48">DOMString</a></code> represents. </p>
    <h4 class="heading settled" data-level="3.2.10" id="es-ByteString"><span class="secno">3.2.10. </span><span class="content">ByteString</span><a class="self-link" href="#es-ByteString"></a></h4>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to ByteString" id="es-to-ByteString">
     <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-16">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#idl-ByteString" id="ref-for-idl-ByteString-11">ByteString</a></code> value by running the following algorithm:</p>
@@ -6829,7 +6827,7 @@ the value of the corresponding element of <var>x</var>.</p>
     <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-17">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#idl-USVString" id="ref-for-idl-USVString-11">USVString</a></code> value by running the following algorithm:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>string</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-18">converting</a> <var>V</var> to a <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-51">DOMString</a></code>.</p>
+      <p>Let <var>string</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-18">converting</a> <var>V</var> to a <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-49">DOMString</a></code>.</p>
      <li data-md="">
       <p>Return an IDL <code class="idl"><a data-link-type="idl" href="#idl-USVString" id="ref-for-idl-USVString-12">USVString</a></code> value that is the result of <a data-link-type="dfn" href="#dfn-obtain-unicode" id="ref-for-dfn-obtain-unicode-1">converting</a> <var>string</var> to a sequence of <a data-link-type="dfn" href="http://www.unicode.org/glossary/#unicode_scalar_value">Unicode scalar values</a>.</p>
     </ol>
@@ -7180,18 +7178,15 @@ alert<span class="p">(</span>b<span class="p">[</span><span class="mi">4</span><
 </span></pre>
    </div>
    <h4 class="heading settled" data-level="3.2.19" id="es-record"><span class="secno">3.2.19. </span><span class="content">Records — record&lt;<var>K</var>, <var>V</var>></span><a class="self-link" href="#es-record"></a></h4>
-   <p>IDL <a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-3">record</a>&lt;<var>K</var>, <var>V</var>> values are represented by
+   <p>IDL <a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-2">record</a>&lt;<var>K</var>, <var>V</var>> values are represented by
 ECMAScript <emu-val>Object</emu-val> values.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to record" id="es-to-record">
-    <p>An ECMAScript value <var>O</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-29">converted</a> to an IDL <code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-4">record</a>&lt;<var>K</var>, <var>V</var>></code> value as follows:</p>
+    <p>An ECMAScript value <var>O</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-29">converted</a> to an IDL <code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-3">record</a>&lt;<var>K</var>, <var>V</var>></code> value as follows:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>result</var> be a new empty instance of <code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-5">record</a>&lt;<var>K</var>, <var>V</var>></code>.</p>
-     <li data-md="">
-      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>O</var>) is Undefined or Null,
-return <var>result</var>.</p>
-     <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>O</var>) is not Object, <a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-15">throw</a> a <emu-val>TypeError</emu-val>.</p>
+     <li data-md="">
+      <p>Let <var>result</var> be a new empty instance of <code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-4">record</a>&lt;<var>K</var>, <var>V</var>></code>.</p>
      <li data-md="">
       <p>Let <var>keys</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a> <var>O</var>.[[OwnPropertyKeys]]().</p>
      <li data-md="">
@@ -7220,7 +7215,7 @@ return <var>result</var>.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="convert a record to an ECMAScript value" id="record-to-es">
-    <p>An IDL <code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-6">record</a>&lt;…></code> value <var>D</var> is <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-28">converted</a> to an ECMAScript value as follows:</p>
+    <p>An IDL <code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-5">record</a>&lt;…></code> value <var>D</var> is <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-28">converted</a> to an ECMAScript value as follows:</p>
     <ol>
      <li data-md="">
       <p>Let <var>result</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-objectcreate">ObjectCreate</a>(<a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a>).</p>
@@ -7242,7 +7237,7 @@ return <var>result</var>.</p>
    </div>
    <div class="example" id="example-es-record">
     <a class="self-link" href="#example-es-record"></a> 
-    <p>Passing the ECMAScript value <code>{b: 3, a: 4}</code> as a <code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-7">record</a>&lt;DOMString, double></code> argument
+    <p>Passing the ECMAScript value <code>{b: 3, a: 4}</code> as a <code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-6">record</a>&lt;DOMString, double></code> argument
     would result in the IDL value « ("b", 3), ("a", 4) ».</p>
     <p>Records only consider <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-own-property">own</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-property-attributes">enumerable</a> properties, so given an IDL operation <code>record&lt;DOMString, double>
     identity(record&lt;DOMString, double> arg)</code> which returns its
@@ -7272,15 +7267,15 @@ console<span class="p">.</span>assert<span class="p">(</span>entries<span class=
      <tbody>
       <tr>
        <td><code>{"😞": 1}</code>
-       <td><code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-8">record</a>&lt;ByteString, double></code>
+       <td><code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-7">record</a>&lt;ByteString, double></code>
        <td><emu-val>TypeError</emu-val>
       <tr>
        <td><code>{"\uD83D": 1}</code>
-       <td><code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-9">record</a>&lt;USVString, double></code>
+       <td><code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-8">record</a>&lt;USVString, double></code>
        <td>« ("\uFFFD", 1) »
       <tr>
        <td><code>{"\uD83D": {hello: "world"}}</code>
-       <td><code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-10">record</a>&lt;DOMString, double></code>
+       <td><code><a data-link-type="dfn" href="#idl-record" id="ref-for-idl-record-9">record</a>&lt;DOMString, double></code>
        <td>« ("\uD83D", 0) »
     </table>
    </div>
@@ -7378,9 +7373,6 @@ then return the IDL value <emu-val>null</emu-val>.</p>
        <li data-md="">
         <p>If <var>types</var> includes a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-11">dictionary type</a>, then return the
 result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-36">converting</a> <var>V</var> to that dictionary type.</p>
-       <li data-md="">
-        <p>If <var>types</var> includes a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-9">record type</a>, then return the
-result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-37">converting</a> <var>V</var> to that record type.</p>
       </ol>
      <li data-md="">
       <p>If <var>V</var> is a <a data-link-type="dfn" href="#dfn-platform-object" id="ref-for-dfn-platform-object-17">platform object</a>, then:</p>
@@ -7396,7 +7388,7 @@ that is a reference to the object <var>V</var>.</p>
       <ol>
        <li data-md="">
         <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-24">DOMException</a></code> or <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-7">Error</a></code>, then return the
-result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-38">converting</a> <var>V</var> to that type.</p>
+result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-37">converting</a> <var>V</var> to that type.</p>
        <li data-md="">
         <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-15">object</a></code>, then return the IDL value
 that is a reference to the object <var>V</var>.</p>
@@ -7406,7 +7398,7 @@ that is a reference to the object <var>V</var>.</p>
       <ol>
        <li data-md="">
         <p>If <var>types</var> includes <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-8">Error</a></code>, then return the
-result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-39">converting</a> <var>V</var> to <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-9">Error</a></code>.</p>
+result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-38">converting</a> <var>V</var> to <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-9">Error</a></code>.</p>
        <li data-md="">
         <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-16">object</a></code>, then return the IDL value
 that is a reference to the object <var>V</var>.</p>
@@ -7416,7 +7408,7 @@ that is a reference to the object <var>V</var>.</p>
       <ol>
        <li data-md="">
         <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#idl-ArrayBuffer" id="ref-for-idl-ArrayBuffer-10">ArrayBuffer</a></code>, then return the
-result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-40">converting</a> <var>V</var> to <code class="idl"><a data-link-type="idl" href="#idl-ArrayBuffer" id="ref-for-idl-ArrayBuffer-11">ArrayBuffer</a></code>.</p>
+result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-39">converting</a> <var>V</var> to <code class="idl"><a data-link-type="idl" href="#idl-ArrayBuffer" id="ref-for-idl-ArrayBuffer-11">ArrayBuffer</a></code>.</p>
        <li data-md="">
         <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-17">object</a></code>, then return the IDL value
 that is a reference to the object <var>V</var>.</p>
@@ -7426,7 +7418,7 @@ that is a reference to the object <var>V</var>.</p>
       <ol>
        <li data-md="">
         <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#idl-DataView" id="ref-for-idl-DataView-2">DataView</a></code>, then return the
-result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-41">converting</a> <var>V</var> to <code class="idl"><a data-link-type="idl" href="#idl-DataView" id="ref-for-idl-DataView-3">DataView</a></code>.</p>
+result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-40">converting</a> <var>V</var> to <code class="idl"><a data-link-type="idl" href="#idl-DataView" id="ref-for-idl-DataView-3">DataView</a></code>.</p>
        <li data-md="">
         <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-18">object</a></code>, then return the IDL value
 that is a reference to the object <var>V</var>.</p>
@@ -7436,7 +7428,7 @@ that is a reference to the object <var>V</var>.</p>
       <ol>
        <li data-md="">
         <p>If <var>types</var> includes a <a data-link-type="dfn" href="#dfn-typed-array-type" id="ref-for-dfn-typed-array-type-2">typed array type</a> whose name is the value of <var>V</var>’s [[TypedArrayName]] <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">internal slot</a>, then return the
-result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-42">converting</a> <var>V</var> to that type.</p>
+result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-41">converting</a> <var>V</var> to that type.</p>
        <li data-md="">
         <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-19">object</a></code>, then return the IDL value
 that is a reference to the object <var>V</var>.</p>
@@ -7445,7 +7437,7 @@ that is a reference to the object <var>V</var>.</p>
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>V</var>) is true, then:</p>
       <ol>
        <li data-md="">
-        <p>If <var>types</var> includes a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-21">callback function</a> type, then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-43">converting</a> <var>V</var> to that callback function type.</p>
+        <p>If <var>types</var> includes a <a data-link-type="dfn" href="#dfn-callback-function" id="ref-for-dfn-callback-function-21">callback function</a> type, then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-42">converting</a> <var>V</var> to that callback function type.</p>
        <li data-md="">
         <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-20">object</a></code>, then return the IDL value
 that is a reference to the object <var>V</var>.</p>
@@ -7477,12 +7469,12 @@ return the result of <a data-link-type="dfn" href="#create-frozen-array-from-ite
         </ol>
        <li data-md="">
         <p>If <var>types</var> includes a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-12">dictionary type</a>, then return the
-result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-44">converting</a> <var>V</var> to that dictionary type.</p>
+result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-43">converting</a> <var>V</var> to that dictionary type.</p>
        <li data-md="">
-        <p>If <var>types</var> includes a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-10">record type</a>, then return the
-result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-45">converting</a> <var>V</var> to that record type.</p>
+        <p>If <var>types</var> includes a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-3">record type</a>, then return the
+result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-44">converting</a> <var>V</var> to that record type.</p>
        <li data-md="">
-        <p>If <var>types</var> includes a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-17">callback interface</a> type, then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-46">converting</a> <var>V</var> to that interface type.</p>
+        <p>If <var>types</var> includes a <a data-link-type="dfn" href="#dfn-callback-interface" id="ref-for-dfn-callback-interface-17">callback interface</a> type, then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-45">converting</a> <var>V</var> to that interface type.</p>
        <li data-md="">
         <p>If <var>types</var> includes <code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-21">object</a></code>, then return the IDL value
 that is a reference to the object <var>V</var>.</p>
@@ -7492,24 +7484,24 @@ that is a reference to the object <var>V</var>.</p>
       <ol>
        <li data-md="">
         <p>If <var>types</var> includes a <code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref-for-idl-boolean-15">boolean</a></code>,
-then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-47">converting</a> <var>V</var> to <code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref-for-idl-boolean-16">boolean</a></code>.</p>
+then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-46">converting</a> <var>V</var> to <code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref-for-idl-boolean-16">boolean</a></code>.</p>
       </ol>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is Number, then:</p>
       <ol>
        <li data-md="">
         <p>If <var>types</var> includes a <a data-link-type="dfn" href="#dfn-numeric-type" id="ref-for-dfn-numeric-type-6">numeric type</a>,
-then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-48">converting</a> <var>V</var> to that <a data-link-type="dfn" href="#dfn-numeric-type" id="ref-for-dfn-numeric-type-7">numeric type</a>.</p>
+then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-47">converting</a> <var>V</var> to that <a data-link-type="dfn" href="#dfn-numeric-type" id="ref-for-dfn-numeric-type-7">numeric type</a>.</p>
       </ol>
      <li data-md="">
       <p>If <var>types</var> includes a <a data-link-type="dfn" href="#dfn-string-type" id="ref-for-dfn-string-type-3">string type</a>,
-then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-49">converting</a> <var>V</var> to that type.</p>
+then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-48">converting</a> <var>V</var> to that type.</p>
      <li data-md="">
       <p>If <var>types</var> includes a <a data-link-type="dfn" href="#dfn-numeric-type" id="ref-for-dfn-numeric-type-8">numeric type</a>,
-then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-50">converting</a> <var>V</var> to that <a data-link-type="dfn" href="#dfn-numeric-type" id="ref-for-dfn-numeric-type-9">numeric type</a>.</p>
+then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-49">converting</a> <var>V</var> to that <a data-link-type="dfn" href="#dfn-numeric-type" id="ref-for-dfn-numeric-type-9">numeric type</a>.</p>
      <li data-md="">
       <p>If <var>types</var> includes a <code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref-for-idl-boolean-17">boolean</a></code>,
-then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-51">converting</a> <var>V</var> to <code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref-for-idl-boolean-18">boolean</a></code>.</p>
+then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-50">converting</a> <var>V</var> to <code class="idl"><a data-link-type="idl" href="#idl-boolean" id="ref-for-idl-boolean-18">boolean</a></code>.</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="#ecmascript-throw" id="ref-for-ecmascript-throw-17">Throw</a> a <emu-val>TypeError</emu-val>.</p>
     </ol>
@@ -7521,7 +7513,7 @@ then return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-
 by native ECMAScript <emu-val>Error</emu-val> objects and
 platform objects for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-25">DOMExceptions</a></code>.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to Error" id="es-to-Error">
-    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-52">converted</a> to an IDL <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-11">Error</a></code> value by running the following algorithm:</p>
+    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-51">converted</a> to an IDL <code class="idl"><a class="idl-code" data-link-type="interface" href="#idl-Error" id="ref-for-idl-Error-11">Error</a></code> value by running the following algorithm:</p>
     <ol>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
@@ -7539,7 +7531,7 @@ to the same object as <var>V</var>.</p>
    <p>IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-26">DOMException</a></code> values are represented
 by platform objects for <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-27">DOMExceptions</a></code>.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to DOMException" id="es-to-DOMException">
-    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-53">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-28">DOMException</a></code> value by running the following algorithm:</p>
+    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-52">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#dfn-DOMException" id="ref-for-dfn-DOMException-28">DOMException</a></code> value by running the following algorithm:</p>
     <ol>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
@@ -7556,7 +7548,7 @@ to the same object as <var>V</var>.</p>
    <h4 class="heading settled" data-level="3.2.24" id="es-buffer-source-types"><span class="secno">3.2.24. </span><span class="content">Buffer source types</span><a class="self-link" href="#es-buffer-source-types"></a></h4>
    <p>Values of the IDL <a data-link-type="dfn" href="#dfn-buffer-source-type" id="ref-for-dfn-buffer-source-type-3">buffer source types</a> are represented by objects of the corresponding ECMAScript class.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to buffer source" id="es-to-buffer-source">
-    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-54">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#idl-ArrayBuffer" id="ref-for-idl-ArrayBuffer-12">ArrayBuffer</a></code> value by running the following algorithm:</p>
+    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-53">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#idl-ArrayBuffer" id="ref-for-idl-ArrayBuffer-12">ArrayBuffer</a></code> value by running the following algorithm:</p>
     <ol>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
@@ -7569,7 +7561,7 @@ to the same object as <var>V</var>.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="convert a buffer source to an ECMAScript value" id="buffer-source-to-es">
-    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-55">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#idl-DataView" id="ref-for-idl-DataView-4">DataView</a></code> value by running the following algorithm:</p>
+    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-54">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#idl-DataView" id="ref-for-idl-DataView-4">DataView</a></code> value by running the following algorithm:</p>
     <ol>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>V</var>) is not Object,
@@ -7581,7 +7573,7 @@ to the same object as <var>V</var>.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to buffer source type">
-    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-56">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#idl-Int8Array" id="ref-for-idl-Int8Array-2">Int8Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Int16Array" id="ref-for-idl-Int16Array-2">Int16Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Int32Array" id="ref-for-idl-Int32Array-2">Int32Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint8Array" id="ref-for-idl-Uint8Array-3">Uint8Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint16Array" id="ref-for-idl-Uint16Array-2">Uint16Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint32Array" id="ref-for-idl-Uint32Array-2">Uint32Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint8ClampedArray" id="ref-for-idl-Uint8ClampedArray-2">Uint8ClampedArray</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Float32Array" id="ref-for-idl-Float32Array-2">Float32Array</a></code> or <code class="idl"><a data-link-type="idl" href="#idl-Float64Array" id="ref-for-idl-Float64Array-2">Float64Array</a></code> value
+    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-55">converted</a> to an IDL <code class="idl"><a data-link-type="idl" href="#idl-Int8Array" id="ref-for-idl-Int8Array-2">Int8Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Int16Array" id="ref-for-idl-Int16Array-2">Int16Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Int32Array" id="ref-for-idl-Int32Array-2">Int32Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint8Array" id="ref-for-idl-Uint8Array-3">Uint8Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint16Array" id="ref-for-idl-Uint16Array-2">Uint16Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint32Array" id="ref-for-idl-Uint32Array-2">Uint32Array</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Uint8ClampedArray" id="ref-for-idl-Uint8ClampedArray-2">Uint8ClampedArray</a></code>, <code class="idl"><a data-link-type="idl" href="#idl-Float32Array" id="ref-for-idl-Float32Array-2">Float32Array</a></code> or <code class="idl"><a data-link-type="idl" href="#idl-Float64Array" id="ref-for-idl-Float64Array-2">Float64Array</a></code> value
     by running the following algorithm:</p>
     <ol>
      <li data-md="">
@@ -7641,11 +7633,11 @@ a reference to the same object that the IDL value represents.</p>
    <h4 class="heading settled" data-level="3.2.25" id="es-frozen-array"><span class="secno">3.2.25. </span><span class="content">Frozen arrays — FrozenArray&lt;<var>T</var>></span><a class="self-link" href="#es-frozen-array"></a></h4>
    <p>Values of frozen array types are represented by frozen ECMAScript <emu-val>Array</emu-val> object references.</p>
    <div class="algorithm" data-algorithm="convert an ECMAScript value to frozen array">
-    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-57">converted</a> to an IDL <a class="idl-code" data-link-type="interface" href="#idl-frozen-array" id="ref-for-idl-frozen-array-3">FrozenArray&lt;<var>T</var>></a> value
+    <p>An ECMAScript value <var>V</var> is <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-56">converted</a> to an IDL <a class="idl-code" data-link-type="interface" href="#idl-frozen-array" id="ref-for-idl-frozen-array-3">FrozenArray&lt;<var>T</var>></a> value
     by running the following algorithm:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>values</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-58">converting</a> <var>V</var> to IDL type <a data-link-type="dfn" href="#sequence-type" id="ref-for-sequence-type-16">sequence&lt;<var>T</var>></a>.</p>
+      <p>Let <var>values</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-57">converting</a> <var>V</var> to IDL type <a data-link-type="dfn" href="#sequence-type" id="ref-for-sequence-type-16">sequence&lt;<var>T</var>></a>.</p>
      <li data-md="">
       <p>Return the result of <a data-link-type="dfn" href="#dfn-create-frozen-array" id="ref-for-dfn-create-frozen-array-1">creating a frozen array</a> from <var>values</var>.</p>
     </ol>
@@ -8726,7 +8718,7 @@ manager<span class="p">.</span>handler2<span class="p">;</span>            <span
 </span></pre>
    </div>
    <h4 class="heading settled dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export="" data-level="3.3.19" data-lt="TreatNullAs" id="TreatNullAs"><span class="secno">3.3.19. </span><span class="content">[TreatNullAs]</span></h4>
-   <p>If the [<code class="idl"><a data-link-type="idl" href="#TreatNullAs" id="ref-for-TreatNullAs-8">TreatNullAs</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-64">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-44">attribute</a> or <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-45">operation</a> argument whose type is <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-52">DOMString</a></code>,
+   <p>If the [<code class="idl"><a data-link-type="idl" href="#TreatNullAs" id="ref-for-TreatNullAs-8">TreatNullAs</a></code>] <a data-link-type="dfn" href="#dfn-extended-attribute" id="ref-for-dfn-extended-attribute-64">extended attribute</a> appears on an <a data-link-type="dfn" href="#dfn-attribute" id="ref-for-dfn-attribute-44">attribute</a> or <a data-link-type="dfn" href="#dfn-operation" id="ref-for-dfn-operation-45">operation</a> argument whose type is <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-50">DOMString</a></code>,
 it indicates that a <emu-val>null</emu-val> value
 assigned to the attribute or passed as the operation argument will be
 handled differently from its default handling.  Instead of being stringified
@@ -8741,7 +8733,7 @@ and attributes, as above.</p>
 extended attribute must <a data-link-type="dfn" href="#dfn-xattr-identifier" id="ref-for-dfn-xattr-identifier-4">take the identifier</a> <code>EmptyString</code>.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#TreatNullAs" id="ref-for-TreatNullAs-11">TreatNullAs</a></code>] extended attribute
 must not be specified on an operation argument,
-attribute or operation return value whose type is not <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-53">DOMString</a></code>.</p>
+attribute or operation return value whose type is not <code class="idl"><a data-link-type="idl" href="#idl-DOMString" id="ref-for-idl-DOMString-51">DOMString</a></code>.</p>
    <p class="note" role="note"><span>Note:</span> This means that even an attribute of type <code class="idl">DOMString?</code> must not
 use [<code class="idl"><a data-link-type="idl" href="#TreatNullAs" id="ref-for-TreatNullAs-12">TreatNullAs</a></code>], since <emu-val>null</emu-val> is a valid value of that type.</p>
    <p>The [<code class="idl"><a data-link-type="idl" href="#TreatNullAs" id="ref-for-TreatNullAs-13">TreatNullAs</a></code>] extended attribute
@@ -8943,7 +8935,7 @@ then append to <var>values</var> that default value.</p>
           <p>Otherwise, append to <var>values</var> the special value “missing”.</p>
         </ol>
        <li data-md="">
-        <p>Otherwise, append to <var>values</var> the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-59">converting</a> <var>V</var> to IDL type <var>type</var>.</p>
+        <p>Otherwise, append to <var>values</var> the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-58">converting</a> <var>V</var> to IDL type <var>type</var>.</p>
        <li data-md="">
         <p>Set <var>i</var> to <var>i</var> + 1.</p>
       </ol>
@@ -8965,10 +8957,8 @@ and there is an entry in <var>S</var> that has one of the following types at pos
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-13">dictionary type</a></p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-11">record type</a></p>
-         <li data-md="">
-          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-29">union type</a> that <a data-link-type="dfn" href="#dfn-includes-a-nullable-type" id="ref-for-dfn-includes-a-nullable-type-5">includes a nullable type</a> or that
-has a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-14">dictionary type</a> or a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-12">record type</a> in its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-11">flattened members</a></p>
+          <p>a <a data-link-type="dfn" href="#dfn-union-type" id="ref-for-dfn-union-type-29">union type</a> that <a data-link-type="dfn" href="#dfn-includes-a-nullable-type" id="ref-for-dfn-includes-a-nullable-type-5">includes a nullable type</a> or that has a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-14">dictionary type</a> in
+its <a data-link-type="dfn" href="#dfn-flattened-union-member-types" id="ref-for-dfn-flattened-union-member-types-11">flattened members</a></p>
         </ul>
         <p>then remove from <var>S</var> all other entries.</p>
        <li data-md="">
@@ -9112,7 +9102,7 @@ there is an entry in <var>S</var> that has one of the following types at positio
          <li data-md="">
           <p>a <a data-link-type="dfn" href="#idl-dictionary" id="ref-for-idl-dictionary-15">dictionary type</a></p>
          <li data-md="">
-          <p>a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-13">record type</a></p>
+          <p>a <a data-link-type="dfn" href="#record-type" id="ref-for-record-type-4">record type</a></p>
          <li data-md="">
           <p><code class="idl"><a data-link-type="idl" href="#idl-object" id="ref-for-idl-object-31">object</a></code></p>
          <li data-md="">
@@ -9227,7 +9217,7 @@ then append to <var>values</var> that default value.</p>
           <p>Otherwise, append to <var>values</var> the special value “missing”.</p>
         </ol>
        <li data-md="">
-        <p>Otherwise, append to <var>values</var> the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-60">converting</a> <var>V</var> to IDL type <var>type</var>.</p>
+        <p>Otherwise, append to <var>values</var> the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-59">converting</a> <var>V</var> to IDL type <var>type</var>.</p>
        <li data-md="">
         <p>Set <var>i</var> to <var>i</var> + 1.</p>
       </ol>
@@ -9872,7 +9862,7 @@ return <emu-val>undefined</emu-val>.</p>
             <p>Otherwise, <var>idlValue</var> is the enumeration value equal to <var>S</var>.</p>
           </ol>
          <dt>Otherwise
-         <dd> <var>idlValue</var> is the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-61">converting</a> <var>V</var> to an
+         <dd> <var>idlValue</var> is the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-60">converting</a> <var>V</var> to an
         IDL value of <var>attribute</var>’s type. 
         </dl>
        <li data-md="">
@@ -10803,7 +10793,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
        <li data-md="">
         <p>Let <var>keyArg</var> be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.</p>
        <li data-md="">
-        <p>Let <var>keyIDL</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-62">converting</a> <var>keyArg</var> to an IDL value of type <var>keyType</var>.</p>
+        <p>Let <var>keyIDL</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-61">converting</a> <var>keyArg</var> to an IDL value of type <var>keyType</var>.</p>
        <li data-md="">
         <p>Let <var>key</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-50">converting</a> <var>keyIDL</var> to an ECMAScript value.</p>
        <li data-md="">
@@ -10860,7 +10850,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
        <li data-md="">
         <p>Let <var>keyArg</var> be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.</p>
        <li data-md="">
-        <p>Let <var>keyIDL</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-63">converting</a> <var>keyArg</var> to an IDL value of type <var>keyType</var>.</p>
+        <p>Let <var>keyIDL</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-62">converting</a> <var>keyArg</var> to an IDL value of type <var>keyType</var>.</p>
        <li data-md="">
         <p>Let <var>key</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-51">converting</a> <var>keyIDL</var> to an ECMAScript value.</p>
        <li data-md="">
@@ -10909,9 +10899,9 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
        <li data-md="">
         <p>Let <var>valueArg</var> be the second argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.</p>
        <li data-md="">
-        <p>Let <var>keyIDL</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-64">converting</a> <var>keyArg</var> to an IDL value of type <var>keyType</var>.</p>
+        <p>Let <var>keyIDL</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-63">converting</a> <var>keyArg</var> to an IDL value of type <var>keyType</var>.</p>
        <li data-md="">
-        <p>Let <var>valueIDL</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-65">converting</a> <var>valueArg</var> to an IDL value of type <var>valueType</var>.</p>
+        <p>Let <var>valueIDL</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-64">converting</a> <var>valueArg</var> to an IDL value of type <var>valueType</var>.</p>
        <li data-md="">
         <p>Let <var>key</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-52">converting</a> <var>keyIDL</var> to an ECMAScript value.</p>
        <li data-md="">
@@ -11056,7 +11046,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
        <li data-md="">
         <p>Let <var>arg</var> be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.</p>
        <li data-md="">
-        <p>Let <var>idlValue</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-66">converting</a> <var>arg</var> to an IDL value of type <var>type</var>.</p>
+        <p>Let <var>idlValue</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-65">converting</a> <var>arg</var> to an IDL value of type <var>type</var>.</p>
        <li data-md="">
         <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-54">converting</a> <var>idlValue</var> to an ECMAScript value.</p>
        <li data-md="">
@@ -11109,7 +11099,7 @@ then <a data-link-type="dfn" href="#dfn-perform-a-security-check" id="ref-for-df
        <li data-md="">
         <p>Let <var>arg</var> be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.</p>
        <li data-md="">
-        <p>Let <var>idlValue</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-67">converting</a> <var>arg</var> to an IDL value of type <var>type</var>.</p>
+        <p>Let <var>idlValue</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-66">converting</a> <var>arg</var> to an IDL value of type <var>type</var>.</p>
        <li data-md="">
         <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-idl-to-ecmascript-value" id="ref-for-dfn-convert-idl-to-ecmascript-value-55">converting</a> <var>idlValue</var> to an ECMAScript value.</p>
        <li data-md="">
@@ -11488,7 +11478,7 @@ and false otherwise.</p>
      <li data-md="">
       <p>Let <var>T</var> be the type of the second argument of <var>operation</var>.</p>
      <li data-md="">
-      <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-68">converting</a> <var>V</var> to an IDL value of type <var>T</var>.</p>
+      <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-67">converting</a> <var>V</var> to an IDL value of type <var>T</var>.</p>
      <li data-md="">
       <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-84">identifier</a>, then:</p>
       <ol>
@@ -11511,7 +11501,7 @@ and false otherwise.</p>
      <li data-md="">
       <p>Let <var>T</var> be the type of the second argument of <var>operation</var>.</p>
      <li data-md="">
-      <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-69">converting</a> <var>V</var> to an IDL value of type <var>T</var>.</p>
+      <p>Let <var>value</var> be the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-68">converting</a> <var>V</var> to an IDL value of type <var>T</var>.</p>
      <li data-md="">
       <p>If <var>operation</var> was defined without an <a data-link-type="dfn" href="#dfn-identifier" id="ref-for-dfn-identifier-85">identifier</a>, then:</p>
       <ol>
@@ -11723,7 +11713,7 @@ append <emu-val>undefined</emu-val> to <var>esArgs</var>.</p>
      <li data-md="">
       <p>If <var>callResult</var> is an abrupt completion, set <var>completion</var> to <var>callResult</var> and jump to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.</p>
      <li data-md="">
-      <p>Set <var>completion</var> to the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-70">converting</a> <var>callResult</var>.[[Value]] to an IDL value of the same type as the operation’s
+      <p>Set <var>completion</var> to the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-69">converting</a> <var>callResult</var>.[[Value]] to an IDL value of the same type as the operation’s
 return type.</p>
      <li data-md="">
       <p><i id="call-user-object-operation-return">Return:</i> at this
@@ -11742,7 +11732,7 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
        <li data-md="">
         <p>Let <var>rejectedPromise</var> be the result of calling <var>reject</var> with <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a> as the <emu-val>this</emu-val> value and <var>completion</var>.[[Value]] as the single argument value.</p>
        <li data-md="">
-        <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-71">converting</a> <var>rejectedPromise</var> to the operation’s return type.</p>
+        <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-70">converting</a> <var>rejectedPromise</var> to the operation’s return type.</p>
       </ol>
     </ol>
    </div>
@@ -11771,7 +11761,7 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
      <li data-md="">
       <p>If <var>getResult</var> is an abrupt completion, set <var>completion</var> to <var>getResult</var> and jump to the step labeled <a href="#get-user-object-attribute-return"><i>return</i></a>.</p>
      <li data-md="">
-      <p>Set <var>completion</var> to the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-72">converting</a> <var>getResult</var>.[[Value]] to
+      <p>Set <var>completion</var> to the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-71">converting</a> <var>getResult</var>.[[Value]] to
 an IDL value of the same type as the attribute’s type.</p>
      <li data-md="">
       <p><i id="get-user-object-attribute-return">Return:</i> at this
@@ -11790,7 +11780,7 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
        <li data-md="">
         <p>Let <var>rejectedPromise</var> be the result of calling <var>reject</var> with <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a> as the <emu-val>this</emu-val> value and <var>completion</var>.[[Value]] as the single argument value.</p>
        <li data-md="">
-        <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-73">converting</a> <var>rejectedPromise</var> to the attribute’s type.</p>
+        <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-72">converting</a> <var>rejectedPromise</var> to the attribute’s type.</p>
       </ol>
     </ol>
    </div>
@@ -11864,7 +11854,7 @@ described in the previous section).</p>
         <p class="note" role="note"><span>Note:</span> This is only possible when the callback function came from an attribute
 marked with [<code class="idl"><a data-link-type="idl" href="#TreatNonObjectAsNull" id="ref-for-TreatNonObjectAsNull-10">TreatNonObjectAsNull</a></code>].</p>
        <li data-md="">
-        <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-74">converting</a> <emu-val>undefined</emu-val> to the callback function’s return type.</p>
+        <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-73">converting</a> <emu-val>undefined</emu-val> to the callback function’s return type.</p>
       </ol>
      <li data-md="">
       <p>Let <var>realm</var> be <var>F</var>’s <a data-link-type="dfn" href="#dfn-associated-realm" id="ref-for-dfn-associated-realm-4">associated Realm</a>.</p>
@@ -11910,7 +11900,7 @@ append <emu-val>undefined</emu-val> to <var>esArgs</var>.</p>
      <li data-md="">
       <p>If <var>callResult</var> is an abrupt completion, set <var>completion</var> to <var>callResult</var> and jump to the step labeled <a href="#invoke-return"><i>return</i></a>.</p>
      <li data-md="">
-      <p>Set <var>completion</var> to the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-75">converting</a> <var>callResult</var>.[[Value]] to an IDL value of the same type as the operation’s
+      <p>Set <var>completion</var> to the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-74">converting</a> <var>callResult</var>.[[Value]] to an IDL value of the same type as the operation’s
 return type.</p>
      <li data-md="">
       <p><i id="invoke-return">Return:</i> at this
@@ -11929,7 +11919,7 @@ point <var>completion</var> will be set to an ECMAScript completion value.</p>
        <li data-md="">
         <p>Let <var>rejectedPromise</var> be the result of calling <var>reject</var> with <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a> as the <emu-val>this</emu-val> value and <var>completion</var>.[[Value]] as the single argument value.</p>
        <li data-md="">
-        <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-76">converting</a> <var>rejectedPromise</var> to the callback function’s return type.</p>
+        <p>Return the result of <a data-link-type="dfn" href="#dfn-convert-ecmascript-to-idl-value" id="ref-for-dfn-convert-ecmascript-to-idl-value-75">converting</a> <var>rejectedPromise</var> to the callback function’s return type.</p>
       </ol>
     </ol>
    </div>
@@ -14719,20 +14709,20 @@ language binding.</p>
     <li><a href="#ref-for-idl-DOMString-4">2.2.4.2. Stringifiers</a> <a href="#ref-for-idl-DOMString-5">(2)</a>
     <li><a href="#ref-for-idl-DOMString-6">2.2.4.3. Serializers</a> <a href="#ref-for-idl-DOMString-7">(2)</a> <a href="#ref-for-idl-DOMString-8">(3)</a> <a href="#ref-for-idl-DOMString-9">(4)</a> <a href="#ref-for-idl-DOMString-10">(5)</a> <a href="#ref-for-idl-DOMString-11">(6)</a>
     <li><a href="#ref-for-idl-DOMString-12">2.2.4.5. Named properties</a> <a href="#ref-for-idl-DOMString-13">(2)</a>
-    <li><a href="#ref-for-idl-DOMString-14">2.2.6. Overloading</a> <a href="#ref-for-idl-DOMString-15">(2)</a> <a href="#ref-for-idl-DOMString-16">(3)</a> <a href="#ref-for-idl-DOMString-17">(4)</a> <a href="#ref-for-idl-DOMString-18">(5)</a> <a href="#ref-for-idl-DOMString-19">(6)</a> <a href="#ref-for-idl-DOMString-20">(7)</a> <a href="#ref-for-idl-DOMString-21">(8)</a> <a href="#ref-for-idl-DOMString-22">(9)</a> <a href="#ref-for-idl-DOMString-23">(10)</a>
-    <li><a href="#ref-for-idl-DOMString-24">2.5. Exceptions</a>
-    <li><a href="#ref-for-idl-DOMString-25">2.6. Enumerations</a>
-    <li><a href="#ref-for-idl-DOMString-26">2.11. Types</a>
-    <li><a href="#ref-for-idl-DOMString-27">2.11.15. DOMString</a> <a href="#ref-for-idl-DOMString-28">(2)</a> <a href="#ref-for-idl-DOMString-29">(3)</a> <a href="#ref-for-idl-DOMString-30">(4)</a> <a href="#ref-for-idl-DOMString-31">(5)</a> <a href="#ref-for-idl-DOMString-32">(6)</a> <a href="#ref-for-idl-DOMString-33">(7)</a> <a href="#ref-for-idl-DOMString-34">(8)</a> <a href="#ref-for-idl-DOMString-35">(9)</a> <a href="#ref-for-idl-DOMString-36">(10)</a> <a href="#ref-for-idl-DOMString-37">(11)</a>
-    <li><a href="#ref-for-idl-DOMString-38">2.11.16. ByteString</a>
-    <li><a href="#ref-for-idl-DOMString-39">2.11.17. USVString</a> <a href="#ref-for-idl-DOMString-40">(2)</a>
-    <li><a href="#ref-for-idl-DOMString-41">2.11.21. Enumeration types</a> <a href="#ref-for-idl-DOMString-42">(2)</a>
-    <li><a href="#ref-for-idl-DOMString-43">2.11.23. Nullable types — T?</a>
-    <li><a href="#ref-for-idl-DOMString-44">2.11.25. Record types — record&lt;K, V></a>
-    <li><a href="#ref-for-idl-DOMString-45">3.2.1. any</a>
-    <li><a href="#ref-for-idl-DOMString-46">3.2.9. DOMString</a> <a href="#ref-for-idl-DOMString-47">(2)</a> <a href="#ref-for-idl-DOMString-48">(3)</a> <a href="#ref-for-idl-DOMString-49">(4)</a> <a href="#ref-for-idl-DOMString-50">(5)</a>
-    <li><a href="#ref-for-idl-DOMString-51">3.2.11. USVString</a>
-    <li><a href="#ref-for-idl-DOMString-52">3.3.19. [TreatNullAs]</a> <a href="#ref-for-idl-DOMString-53">(2)</a>
+    <li><a href="#ref-for-idl-DOMString-14">2.2.6. Overloading</a> <a href="#ref-for-idl-DOMString-15">(2)</a> <a href="#ref-for-idl-DOMString-16">(3)</a> <a href="#ref-for-idl-DOMString-17">(4)</a> <a href="#ref-for-idl-DOMString-18">(5)</a> <a href="#ref-for-idl-DOMString-19">(6)</a> <a href="#ref-for-idl-DOMString-20">(7)</a> <a href="#ref-for-idl-DOMString-21">(8)</a>
+    <li><a href="#ref-for-idl-DOMString-22">2.5. Exceptions</a>
+    <li><a href="#ref-for-idl-DOMString-23">2.6. Enumerations</a>
+    <li><a href="#ref-for-idl-DOMString-24">2.11. Types</a>
+    <li><a href="#ref-for-idl-DOMString-25">2.11.15. DOMString</a> <a href="#ref-for-idl-DOMString-26">(2)</a> <a href="#ref-for-idl-DOMString-27">(3)</a> <a href="#ref-for-idl-DOMString-28">(4)</a> <a href="#ref-for-idl-DOMString-29">(5)</a> <a href="#ref-for-idl-DOMString-30">(6)</a> <a href="#ref-for-idl-DOMString-31">(7)</a> <a href="#ref-for-idl-DOMString-32">(8)</a> <a href="#ref-for-idl-DOMString-33">(9)</a> <a href="#ref-for-idl-DOMString-34">(10)</a> <a href="#ref-for-idl-DOMString-35">(11)</a>
+    <li><a href="#ref-for-idl-DOMString-36">2.11.16. ByteString</a>
+    <li><a href="#ref-for-idl-DOMString-37">2.11.17. USVString</a> <a href="#ref-for-idl-DOMString-38">(2)</a>
+    <li><a href="#ref-for-idl-DOMString-39">2.11.21. Enumeration types</a> <a href="#ref-for-idl-DOMString-40">(2)</a>
+    <li><a href="#ref-for-idl-DOMString-41">2.11.23. Nullable types — T?</a>
+    <li><a href="#ref-for-idl-DOMString-42">2.11.25. Record types — record&lt;K, V></a>
+    <li><a href="#ref-for-idl-DOMString-43">3.2.1. any</a>
+    <li><a href="#ref-for-idl-DOMString-44">3.2.9. DOMString</a> <a href="#ref-for-idl-DOMString-45">(2)</a> <a href="#ref-for-idl-DOMString-46">(3)</a> <a href="#ref-for-idl-DOMString-47">(4)</a> <a href="#ref-for-idl-DOMString-48">(5)</a>
+    <li><a href="#ref-for-idl-DOMString-49">3.2.11. USVString</a>
+    <li><a href="#ref-for-idl-DOMString-50">3.3.19. [TreatNullAs]</a> <a href="#ref-for-idl-DOMString-51">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-obtain-unicode">
@@ -14893,21 +14883,17 @@ language binding.</p>
   <aside class="dfn-panel" data-for="idl-record">
    <b><a href="#idl-record">#idl-record</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-record-1">2.2.6. Overloading</a>
-    <li><a href="#ref-for-idl-record-2">2.4. Dictionaries</a>
-    <li><a href="#ref-for-idl-record-3">3.2.19. Records — record&lt;K, V></a> <a href="#ref-for-idl-record-4">(2)</a> <a href="#ref-for-idl-record-5">(3)</a> <a href="#ref-for-idl-record-6">(4)</a> <a href="#ref-for-idl-record-7">(5)</a> <a href="#ref-for-idl-record-8">(6)</a> <a href="#ref-for-idl-record-9">(7)</a> <a href="#ref-for-idl-record-10">(8)</a>
+    <li><a href="#ref-for-idl-record-1">2.4. Dictionaries</a>
+    <li><a href="#ref-for-idl-record-2">3.2.19. Records — record&lt;K, V></a> <a href="#ref-for-idl-record-3">(2)</a> <a href="#ref-for-idl-record-4">(3)</a> <a href="#ref-for-idl-record-5">(4)</a> <a href="#ref-for-idl-record-6">(5)</a> <a href="#ref-for-idl-record-7">(6)</a> <a href="#ref-for-idl-record-8">(7)</a> <a href="#ref-for-idl-record-9">(8)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="record-type">
    <b><a href="#record-type">#record-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-record-type-1">2.2.2. Attributes</a>
-    <li><a href="#ref-for-record-type-2">2.2.3. Operations</a> <a href="#ref-for-record-type-3">(2)</a>
-    <li><a href="#ref-for-record-type-4">2.2.6. Overloading</a> <a href="#ref-for-record-type-5">(2)</a> <a href="#ref-for-record-type-6">(3)</a>
-    <li><a href="#ref-for-record-type-7">2.4. Dictionaries</a>
-    <li><a href="#ref-for-record-type-8">2.11.27. Union types</a>
-    <li><a href="#ref-for-record-type-9">3.2.21. Union types</a> <a href="#ref-for-record-type-10">(2)</a>
-    <li><a href="#ref-for-record-type-11">3.5. Overload resolution algorithm</a> <a href="#ref-for-record-type-12">(2)</a> <a href="#ref-for-record-type-13">(3)</a>
+    <li><a href="#ref-for-record-type-2">2.2.6. Overloading</a>
+    <li><a href="#ref-for-record-type-3">3.2.21. Union types</a>
+    <li><a href="#ref-for-record-type-4">3.5. Overload resolution algorithm</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="record-mappings">
@@ -15351,21 +15337,21 @@ language binding.</p>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-28">3.2.18.1. Creating a sequence from an iterable</a>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-29">3.2.19. Records — record&lt;K, V></a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-30">(2)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-31">(3)</a>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-32">3.2.20. Promise types — Promise&lt;T></a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-33">(2)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-34">(3)</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-35">3.2.21. Union types</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-36">(2)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-37">(3)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-38">(4)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-39">(5)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-40">(6)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-41">(7)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-42">(8)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-43">(9)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-44">(10)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-45">(11)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-46">(12)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-47">(13)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-48">(14)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-49">(15)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-50">(16)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-51">(17)</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-52">3.2.22. Error</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-53">3.2.23. DOMException</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-54">3.2.24. Buffer source types</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-55">(2)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-56">(3)</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-57">3.2.25. Frozen arrays — FrozenArray&lt;T></a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-58">(2)</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-59">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-60">(2)</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-61">3.6.6. Attributes</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-62">3.6.10.4. get and has</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-63">3.6.10.6. delete</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-64">3.6.10.7. set</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-65">(2)</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-66">3.6.11.4. has</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-67">3.6.11.5. add and delete</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-68">3.9.8. Abstract operations</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-69">(2)</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-70">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-71">(2)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-72">(3)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-73">(4)</a>
-    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-74">3.11. Invoking callback functions</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-75">(2)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-76">(3)</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-35">3.2.21. Union types</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-36">(2)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-37">(3)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-38">(4)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-39">(5)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-40">(6)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-41">(7)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-42">(8)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-43">(9)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-44">(10)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-45">(11)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-46">(12)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-47">(13)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-48">(14)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-49">(15)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-50">(16)</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-51">3.2.22. Error</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-52">3.2.23. DOMException</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-53">3.2.24. Buffer source types</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-54">(2)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-55">(3)</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-56">3.2.25. Frozen arrays — FrozenArray&lt;T></a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-57">(2)</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-58">3.5. Overload resolution algorithm</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-59">(2)</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-60">3.6.6. Attributes</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-61">3.6.10.4. get and has</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-62">3.6.10.6. delete</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-63">3.6.10.7. set</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-64">(2)</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-65">3.6.11.4. has</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-66">3.6.11.5. add and delete</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-67">3.9.8. Abstract operations</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-68">(2)</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-69">3.10. User objects implementing callback interfaces</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-70">(2)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-71">(3)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-72">(4)</a>
+    <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value-73">3.11. Invoking callback functions</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-74">(2)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value-75">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-convert-idl-to-ecmascript-value">


### PR DESCRIPTION
Basically, make record<> more like sequence<> than like dictionary in terms of things that can be converted to it (without the requirement for iterability, of course)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/bzbarsky/webidl/record-not-dictionarylike.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/8c11c7e..bzbarsky:record-not-dictionarylike:c3530c7.html)