### PR TITLE
Carry out math operations on real numbers, not IEEE 754.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6799,7 +6799,7 @@ In effect, where <var ignore>x</var> is a <emu-val>Number</emu-val> value,
         1.  Let |lowerBound| be -2<sup>|bitLength| − 1</sup>.
         1.  Let |upperBound| be 2<sup>|bitLength| − 1</sup> − 1.
     1.  Let |x| be [=?=] [=ToNumber=](|V|).
-    1.  If |x| is −0 or |x| is +0, then set |x| to 0.
+    1.  If |x| is −0, then set |x| to +0.
     1.  If the conversion to an IDL value is being performed due to any of the following:
         *   |V| is being assigned to an [=attribute=] annotated with the [{{EnforceRange}}] [=extended attribute=],
         *   |V| is being passed as an [=operation=] argument annotated with the [{{EnforceRange}}] extended attribute, or
@@ -6825,8 +6825,8 @@ In effect, where <var ignore>x</var> is a <emu-val>Number</emu-val> value,
         1.  Round |x| to the nearest integer, choosing the even integer if it lies halfway between two,
             and choosing +0 rather than −0.
         1.  Return |x|.
-    1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
-        then return 0.
+    1.  If |x| is <emu-val>NaN</emu-val>, +0, +∞, or −∞,
+        then return +0.
     1.  Set |x| to [=!=] <a abstract-op>IntegerPart</a>(|x|).
     1.  Set |x| to |x| [=modulo=] 2<sup>|bitLength|</sup>.
     1.  If |signedness| is "signed" and |x| ≥ 2<sup>|bitLength| − 1</sup>,

--- a/index.bs
+++ b/index.bs
@@ -6584,6 +6584,15 @@ may return any value, which will be discarded.
 
 <h4 id="es-integer-types">Integer types</h4>
 
+Mathematical operations used in this section,
+including those defined in [=ECMA-262 section 5.2=],
+are to be understood as computing exact mathematical results
+on mathematical real numbers.
+
+In effect, where <var ignore>x</var> is a <emu-val>Number</emu-val> value,
+“operating on <var ignore>x</var>” is shorthand for
+“operating on the mathematical real number that has the same numeric value as <var ignore>x</var>”.
+
 <h5 id="es-byte">byte</h5>
 
 <div id="es-to-byte" algorithm="convert an ECMAScript value to byte">
@@ -6789,7 +6798,8 @@ may return any value, which will be discarded.
     1.  Otherwise:
         1.  Let |lowerBound| be -2<sup>|bitLength| − 1</sup>.
         1.  Let |upperBound| be 2<sup>|bitLength| − 1</sup> − 1.
-    1.  Set |x| to [=?=] [=ToNumber=](|V|).
+    1.  Let |x| be [=?=] [=ToNumber=](|V|).
+    1.  If |x| is −0 or |x| is +0, then set |x| to 0.
     1.  If the conversion to an IDL value is being performed due to any of the following:
         *   |V| is being assigned to an [=attribute=] annotated with the [{{EnforceRange}}] [=extended attribute=],
         *   |V| is being passed as an [=operation=] argument annotated with the [{{EnforceRange}}] extended attribute, or
@@ -6815,7 +6825,7 @@ may return any value, which will be discarded.
         1.  Round |x| to the nearest integer, choosing the even integer if it lies halfway between two,
             and choosing +0 rather than −0.
         1.  Return |x|.
-    1.  If |x| is <emu-val>NaN</emu-val>, +0, −0, +∞, or −∞,
+    1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
         then return 0.
     1.  Set |x| to [=!=] <a abstract-op>IntegerPart</a>(|x|).
     1.  Set |x| to |x| [=modulo=] 2<sup>|bitLength|</sup>.


### PR DESCRIPTION
Explicitly convert −0 to +0.

Closes #306.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tobie/webidl/fix-306.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/eb272b6..tobie:fix-306:4006c6b.html)