### PR TITLE
Note what "present" means in ES close to its definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4102,12 +4102,17 @@ to the dictionary members defined on |D| and on any of |D|’s
 On a given dictionary value, the presence of each dictionary member
 is optional, unless that member is specified as required.
 When specified in the dictionary value, a dictionary member is said to be
-<dfn id="dfn-present" export>present</dfn>, otherwise it is [=present|not present=].
+<dfn id="dfn-present" export lt="present|not present" for="dictionary member">present</dfn>, otherwise it is [=not present=].
 Dictionary members can also optionally have a <dfn id="dfn-dictionary-member-default-value" for="dictionary member" export>default value</dfn>, which is
 the value to use for the dictionary member when passing a value to a
 [=platform object=] that does
 not have a specified value.  Dictionary members with default values are
 always considered to be present.
+
+<p class="note">
+    In the ECMAScript binding, a value of <emu-val>undefined</emu-val> is treated as
+    [=not present=], or will trigger the [=dictionary member/default value=] where applicable.
+</p>
 
 An [=ordered map=] with string [=map/keys=] can be implicitly treated as a dictionary value of a
 specific dictionary |D| if all of its [=map/entries=] correspond to [=dictionary members=], in the
@@ -7127,7 +7132,7 @@ the object (or its prototype chain) correspond to [=dictionary members=].
     1.  If [=Type=](|V|) is not Undefined, Null or Object, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
     1.  Let |dict| be an empty dictionary value of type |D|;
         every [=dictionary member=]
-        is initially considered to be [=present|not present=].
+        is initially considered to be [=not present=].
     1.  Let |dictionaries| be a list consisting of |D| and all of |D|’s [=inherited dictionaries=],
         in order from least to most derived.
     1.  For each dictionary |dictionary| in |dictionaries|, in order:


### PR DESCRIPTION
Also change how it's linked to a little bit.

See https://github.com/whatwg/fetch/issues/513 for the motivation.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/heycam/webidl/present.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/fe42994...4442344.html)