### PR TITLE
Define 'CancelationError'.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -142,6 +142,11 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: @@unscopables; url: sec-well-known-symbols
         text: NewTarget; url: sec-built-in-function-objects
         text: Number Type; url: sec-ecmascript-language-types-number-type
+
+<!-- Remove once DOM takes https://github.com/whatwg/dom/pull/434 -->
+urlPrefix: https://github.com/whatwg/dom/pull/434; spec: DOM
+    type: interface
+        text: CancelationController
 </pre>
 
 <style>
@@ -4666,7 +4671,7 @@ Note: If an error name is not listed here, please file a bug as indicated at the
         </tr>
         <tr>
             <td>"<dfn id="cancelationerror" exception export><code>CancelationError</code></dfn>"</td>
-            <td>The operation was canceled before completion.</td>
+            <td>The operation was canceled via a {{CancelationController}}.</td>
             <td>—</td>
         </tr>
     </tbody>

--- a/index.bs
+++ b/index.bs
@@ -4664,6 +4664,11 @@ Note: If an error name is not listed here, please file a bug as indicated at the
             <td>The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.</td>
             <td>—</td>
         </tr>
+        <tr>
+            <td>"<dfn id="cancelationerror" exception export><code>CancelationError</code></dfn>"</td>
+            <td>The operation was canceled before completion.</td>
+            <td>—</td>
+        </tr>
     </tbody>
 </table>
 


### PR DESCRIPTION
In order to support the 'CancelationController' concept defined in
whatwg/dom#434, this patch specifies a new 'DOMException' named
'CancelationError' in order to ensure that APIs that consume this
new concept have a standard way of responding to its signals.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/mikewest/webidl/cancelationerror.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/faaaaa9...mikewest:1bb6c7b.html)