### PR TITLE
Deprecate "IndexSizeError" DOMException.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4454,10 +4454,10 @@ entails in the ECMAScript language binding.
         [=exception/Throw=] a {{TypeError}}.
     </blockquote>
 
-    To throw a new {{DOMException}} with [=error name=] "{{IndexSizeError!!exception}}":
+    To throw a new {{DOMException}} with [=error name=] "{{NotAllowedError!!exception}}":
 
     <blockquote>
-        [=exception/Throw=] an "{{IndexSizeError!!exception}}" {{DOMException}}.
+        [=exception/Throw=] an "{{NotAllowedError!!exception}}" {{DOMException}}.
     </blockquote>
 
     To create a new {{DOMException}} with [=error name=] "{{SyntaxError!!exception}}":

--- a/index.bs
+++ b/index.bs
@@ -4484,9 +4484,9 @@ Note: If an error name is not listed here, please file a bug as indicated at the
         <tr><th>Name</th><th>Description</th><th>Legacy code name and value</th></tr>
     </thead>
     <tbody>
-        <tr>
+        <tr class="deprecated">
             <td>"<dfn id="indexsizeerror" exception export><code>IndexSizeError</code></dfn>"</td>
-            <td>The index is not in the allowed range.</td>
+            <td><strong>Deprecated.</strong> Use {{RangeError}} instead.</td></td>
             <td><dfn id="dom-domexception-index_size_err" for="DOMException" const export><code>INDEX_SIZE_ERR</code></dfn>&nbsp;(1)</td>
         </tr>
         <tr class="deprecated">


### PR DESCRIPTION
Fixes #343.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tobie/webidl/fix-343.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/faaaaa9...tobie:2831845.html)