### PR TITLE
Introduce the CSSOMString type, impls choice of DOMString or USVString

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2248,7 +2248,7 @@ can also be placed on an [=attribute=].
 In this case, the string to convert the object to is the
 value of the attribute.  The <emu-t>stringifier</emu-t> keyword
 must not be placed on an attribute unless
-it is declared to be of type {{DOMString}} or {{USVString}}.
+it is declared to be of type {{DOMString}}, {{USVString}}, or {{CSSOMString}}.
 It also must not be placed on
 a [=static attribute=].
 
@@ -5118,7 +5118,7 @@ The <dfn id="dfn-primitive-type" export>primitive types</dfn> are
 
 The <dfn id="dfn-string-type" export>string types</dfn> are
 {{DOMString}}, all [=enumeration types=],
-{{ByteString}} and {{USVString}}.
+{{ByteString}}, {{USVString}}, and {{CSSOMString}}.
 
 The <dfn id="dfn-exception-type" export>exception types</dfn> are
 {{Error!!interface}} and {{DOMException}}.
@@ -5260,6 +5260,7 @@ type.
         "ByteString"
         "DOMString"
         "USVString"
+        "CSSOMString"
 </pre>
 
 <pre class="grammar" id="prod-PromiseType">
@@ -5609,6 +5610,26 @@ The [=type name=] of the
 </p>
 
 
+<h4 oldids="dom-CSSOMString" id="idl-CSSOMString" interface>CSSOMString</h4>
+
+The {{CSSOMString}} type is,
+at the choice of each implementation,
+either {{DOMString}} or {{USVString}}.
+
+The [=type name=] of the
+{{CSSOMString}} type is “CSSOMString”.
+
+<div class="advisement">
+    This type is used in [[CSSOM]].
+
+    It allows implementation to choose:
+
+    * Use {{DOMString}}-like 16-bit strings internally and avoid the cost of
+        [=obtain Unicode|converting to Unicode scalar values=].
+    * Use UTF-8 internally, which cannot represent surrogate code points.
+</div>
+
+
 <h4 oldids="dom-object" id="idl-object" interface>object</h4>
 
 The {{object}} type corresponds to the set of
@@ -5803,7 +5824,7 @@ only [=list/items=] that are of type |T|.
 
 A <dfn export>record type</dfn> is a parameterized type whose values are [=ordered maps=] with
 [=map/keys=] that are instances of |K| and [=map/values=] that are instances of |V|. |K| must be one
-of {{DOMString}}, {{USVString}}, or {{ByteString}}.
+of {{DOMString}}, {{USVString}}, {{CSSOMString}}, or {{ByteString}}.
 
 The literal syntax for [=ordered maps=] may also be used to represent records, when it is implicitly
 understood from context that the map is being treated as a record. However, there is no way to
@@ -6305,6 +6326,7 @@ five forms are allowed.
         "&gt;"
         "?"
         "ByteString"
+        "CSSOMString"
         "DOMString"
         "FrozenArray"
         "Infinity"


### PR DESCRIPTION
The observable behavior difference is whether surrogate code units are preserved or replaced with U+FFFD REPLACEMENT CHARACTER.

CSSWG resolved to allow either in CSSOM: https://github.com/w3c/csswg-drafts/issues/1217#issuecomment-295053842


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/SimonSapin/webidl/cssomstring.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/9d039f6...SimonSapin:74c0019.html)