### PR TITLE
Remove custom [[HasInstance]] behavior from interface objects

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6383,8 +6383,9 @@ more of the following are redefined in accordance with the rules for exotic obje
 \[[Call]],
 \[[Set]],
 \[[DefineOwnProperty]],
-\[[GetOwnProperty]], and
-\[[Delete]].
+\[[GetOwnProperty]],
+\[[Delete]] and
+\[[HasInstance]].
 
 Other specifications may override the definitions
 of any internal method of a [=platform object=]

--- a/index.bs
+++ b/index.bs
@@ -6383,9 +6383,8 @@ more of the following are redefined in accordance with the rules for exotic obje
 \[[Call]],
 \[[Set]],
 \[[DefineOwnProperty]],
-\[[GetOwnProperty]],
-\[[Delete]] and
-\[[HasInstance]].
+\[[GetOwnProperty]], and
+\[[Delete]].
 
 Other specifications may override the definitions
 of any internal method of a [=platform object=]
@@ -10283,16 +10282,6 @@ when applied to a [=legacy callback interface object=].
     1.  Perform [=!=] [=SetFunctionName=](|F|, |id|).
     1.  Perform [=!=] [=DefinePropertyOrThrow=](|F|, "length",
         PropertyDescriptor{\[[Value]]: 0, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
-</div>
-
-<h5 id="es-legacy-callback-interface-object-hasinstance">\[[HasInstance]]</h5>
-
-<div algorithm="to invoke the internal [[HasInstance]] method of legacy callback interface objects">
-
-    The internal \[[HasInstance]] method of a [=legacy callback interface object=]
-    must behave as follows:
-
-    1.  [=ECMAScript/Throw=] a <emu-val>TypeError</emu-val> exception.
 </div>
 
 

--- a/index.bs
+++ b/index.bs
@@ -135,7 +135,6 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: 9.3.1; url: sec-built-in-function-objects-call-thisargument-argumentslist
         text: ECMA-262 section 9.1.8; url: sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver
         text: ECMA-262 section 19.2.2.3; url: sec-function-@@create
-        text: ECMA-262 section 19.2.3.8; url: sec-function.prototype-@@hasinstance
         text: Array methods; url: sec-properties-of-the-array-prototype-object
         text: typed arrays; url: sec-typedarray-objects
         text: GetMethod; url: sec-getmethod
@@ -6384,9 +6383,8 @@ more of the following are redefined in accordance with the rules for exotic obje
 \[[Call]],
 \[[Set]],
 \[[DefineOwnProperty]],
-\[[GetOwnProperty]],
-\[[Delete]] and
-\[[HasInstance]].
+\[[GetOwnProperty]], and
+\[[Delete]].
 
 Other specifications may override the definitions
 of any internal method of a [=platform object=]
@@ -6426,7 +6424,6 @@ it has characteristics as follows:
     [=%FunctionPrototype%=] unless otherwise specified.
 *   Its \[[Get]] internal property is set as described in [=ECMA-262 section 9.1.8=].
 *   Its \[[Construct]] internal property is set as described in [=ECMA-262 section 19.2.2.3=].
-*   Its @@hasInstance property is set as described in [=ECMA-262 section 19.2.3.8=], unless otherwise specified.
 
 <p class="issue">
     The list above needs updating for the latest ES6 draft.
@@ -10094,26 +10091,6 @@ the <code>typeof</code> operator will return "function" when applied to an inter
     1.  Let |proto| be the [=interface prototype object=] of [=interface=] |I|.
     1.  Perform [=!=] [=DefinePropertyOrThrow=](|F|, "prototype",
         PropertyDescriptor{\[[Value]]: |proto|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>false</emu-val>}).
-</div>
-
-<h5 id="es-interface-hasinstance">\[[HasInstance]]</h5>
-
-<div algorithm="to invoke the internal [[HasInstance]] method of interface objects">
-
-    The internal \[[HasInstance]] method of every [=interface object=] |A|
-    must behave as follows, assuming |V| is the object argument passed to \[[HasInstance]]:
-
-    1.  If Type(|V|) is not Object, return <emu-val>false</emu-val>.
-    1.  Let |O| be [=?=] [=Get=](|A|, "prototype").
-    1.  If Type(|O|) is not Object, [=ECMAScript/throw=] a <emu-val>TypeError</emu-val> exception.
-    1.  If |V| is a [=platform object=] that implements the interface
-        for which |O| is the [=interface prototype object=],
-        return <emu-val>true</emu-val>.
-    1.  Repeat:
-        1.  Set |V| to the value of the \[[Prototype]] internal property of |V|.
-        1.  If |V| is <emu-val>null</emu-val>, return <emu-val>false</emu-val>.
-        1.  If |O| and |V| refer to the same object,
-            return <emu-val>true</emu-val>.
 </div>
 
 


### PR DESCRIPTION
This was only ever implemented in Firefox. It was added in 5982ce7e323cffd7a673cb9af973c1c4f1e76fbe. after being removed as a result of https://www.w3.org/Bugs/Public/show_bug.cgi?id=12295.

Closes #129.

---

This ensures that authors can maintain the invariant they are used to where `x instanceof Y` means that `Y.prototype`'s methods are available on `x` (which is not true in Firefox). It also aligns with normal author-created or built-in ECMAScript objects, where e.g. `{} instanceof otherWindow.Object` returns false.

As pointed out in #129, only @travisleithead from a non-Firefox browser expressed support for the currently-specced behavior, and they have not implemented it in the intervening 4 years; Travis, I'd be curious if your team's feelings have changed. Chrome strongly objects to the currently-specced behavior. /cc @cdumez (EDIT: I guess @samweinig is probably the right person for Web IDL) to hear about WebKit's opinion.

As such, we'd like to remove this from the spec, as it seems that it never got consensus for being added, although people may not have voiced their objections in a timely manner when it was originally proposed.

---

If there is a desire for adding a brand-checking API to the platform, we'd like that to be proposed separately. But simply as a matter of matching reality and improving interop, we think it's important to get the spec fixed on this matter sooner, and not block on such an API addition.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/heycam/webidl/hasinstance-non-exotic.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/9d039f6...0881b62.html)