### PR TITLE
Only install @@toStringTag on the prototype

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7175,7 +7175,7 @@ Unless otherwise specified, the \[[Prototype]] internal slot
 of objects defined in this section is {{%ObjectPrototype%}}.
 
 Some objects described in this section are defined to have a <dfn id="dfn-class-string" export>class string</dfn>,
-which is the string to include in the string returned from Object.prototype.toString.
+which is the string to include in the string returned from <code>Object.prototype.toString</code>.
 
 If an object has a [=class string=] |classString|, then the object must,
 at the time it is created, have a property whose name is the {{@@toStringTag}} symbol
@@ -11351,8 +11351,7 @@ Issue: Define those properties imperatively instead.
 
 </div>
 
-The [=class string=] of an [=interface prototype object=] is the concatenation of
-the [=interface=]’s [=qualified name=] and the string "<code>Prototype</code>".
+The [=class string=] of an [=interface prototype object=] is the [=interface=]’s [=qualified name=].
 
 
 <h4 id="named-properties-object">Named properties object</h4>
@@ -12241,7 +12240,7 @@ restricted to iterating over an object’s
 [=support indexed properties|supported indexed properties=],
 use standard ECMAScript Array iterator objects.
 
-[=Default iterator objects=] do not have [=class strings=]; when <code
+Note: [=Default iterator objects=] do not have [=class strings=]; when <code
 class="idl">Object.prototype.toString()</code> is called on a [=default
 iterator object=] of a given [=interface=], the [=class string=] of the
 [=iterator prototype object=] of that [=interface=] is used.
@@ -13169,12 +13168,6 @@ the [=Realm=] associated with a platform object is changed, its
 updated to be the [=interface prototype object=]
 of the [=primary interface=]
 from the [=platform object=]’s newly associated [=Realm=].
-
-The [=class string=] of
-a platform object that implements one or more interfaces
-must be the [=qualified name=] of
-the [=primary interface=]
-of the platform object.
 
 Additionally, [=platform objects=] which implement an [=interface=]
 which has a [{{Global}}] [=extended attribute=]


### PR DESCRIPTION
This fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=28244, aligning Web IDL objects with the built-in ECMAScript objects (see #226), and updating the spec to match 1/4 browsers (Chrome) instead of 0/4 as it currently does.

(Currently no non-Chrome browsers install Symbol.toStringTag properties on any objects, but instead contradict the ECMAScript specification and use magic to produce [object InterfaceName] / [object InterfaceNamePrototype].)

---

/cc @bzbarsky, who tried to implement this in https://groups.google.com/forum/#!searchin/mozilla.dev.platform/toStringTag%7Csort:relevance/mozilla.dev.platform/IZNh8QAXkFA/me59gpo5PgAJ but got pushback.

/cc @travisleithead and @samweinig about implementing this in Edge and WebKit.

---

As with #356, if there is interest in introducing a brand-checking API which cannot be fooled by interface prototype objects, we (Chrome) would like to have that proposed separately. But we think it's more important for interop and for specification health to align the spec and browsers on something around this question, and get away from nonstandard violations of the ECMAScript spec. We don't want to block such convergence on an API addition.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/357.html" title="Last updated on Apr 23, 2020, 3:43 PM UTC (b36254e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/357/69fb3d3...b36254e.html" title="Last updated on Apr 23, 2020, 3:43 PM UTC (b36254e)">Diff</a>