### PR TITLE
WIP: add localizable dictionary

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12750,43 +12750,68 @@ The {{VoidFunction}} [=callback function=]
 type is used for representing function values that take no arguments and do not
 return any value.
 
-<h3>Locatlizable dictionary</h3>
 
-A localizable member is a dictionary member that represents a bidirectional algorithm paragraph when displayed, as defined by the bidirectional algorithm’s rules P1, P2, and P3, including, for instance, supporting the paragraph-breaking behavior of U+000A LINE FEED (LF) characters.
-
-A user agent is expected to honor the Unicode semantics of localizable members.
-
-The name of a localizable member is left to the defining specification (e.g., "title").
-
-Dictionaries that specify a localizable member must inherit from the {{Localizable}} dictionary.
-
-Specification authors must specify in prose which member(s) of the inheriting dictionary serve as localizable members. It is RECOMMENDED that specification authors limit localizable member in the prototype chain of inherited dictionaries (ideally to one).
+<h3 id="TextDirection" enum>TextDirection</h3>
 
 <pre class="idl">
-enum TextDirection {
-  "auto",
-  "ltr",
-  "rtl"
-};
+    enum TextDirection {
+      "auto",
+      "ltr",
+      "rtl"
+    };
+</pre>
 
-dictionary Localizable {
-  DOMString lang;
-  TextDirection dir = "auto";
-};</pre>
+The {{TextDirection}} [=enumerable=] is used to represent text directionality as described in [[!BIDI]].
 
-The {{lang}} member specifies the primary language for the localizable members in the prototype chain. Its value is a string. The empty string indicates that the primary language is unknown.
-Any other string must be interpreted as a language tag. Validity or well-formedness are not enforced. [[!LANG]]
 
-The {{dir}} member provides the higher-level override of rules P2 and P3 if has a value other than "auto". [[!BIDI]]
+<h3 id="localizable" dictionary>Localizable</h3>
+
+A <dfn export>localizable member</dfn> is a [=dictionary member=] that
+represents a bidirectional algorithm paragraph when displayed,
+as defined by the bidirectional algorithm’s rules P1, P2, and P3,
+including, for instance, supporting the paragraph-breaking behavior
+of <span class="char">U+000A LINE FEED (LF)</span> characters. [[!BIDI]]
+
+A user agent is expected to honor the Unicode semantics of [=localizable members=].
+
+The [=identifier=] of a [=localizable member=] is left to the defining specification (e.g., "title").
+
+Dictionaries that specify a [=localizable member=] must inherit from the {{Localizable}} dictionary.
+
+Specification authors must specify in prose which [=dictionary members|member(s)=]
+of the inheriting dictionary serve as [=localizable members=].
+
+It is recommended that specification authors limit the number of [=dictionary members=]
+that are [=localizable member=], ideally to one.
+
+<pre class="idl">
+    dictionary Localizable {
+      DOMString lang = "";
+      TextDirection dir = "auto";
+    };
+</pre>
+
+The {{Localizable/lang}} member specifies the primary language for the [=dictionary members=]
+which are [=localizable members=].
+Its value is a {{DOMString}}.
+The empty string indicates that the primary language is unknown.
+Any other string must be interpreted as a language tag.
+Validity or well-formedness are not enforced. [[!BCP47]]
+
+The {{Localizable/dir}} member provides the higher-level override of rules P2 and P3
+if it has a value other than <a for=TextDirection enum-value>"auto"</a>. [[!BIDI]]
 
 <div class=example>
-dictionary PaymentItem : Localizable {
-    // "label" is a localizable member
-    required DOMString             label;
-    required PaymentCurrencyAmount amount;
-             boolean               pending = false;
-};
+   <pre highlight="webidl">
+       dictionary PaymentItem : Localizable {
+           // "label" is a localizable member
+           required DOMString label;
+           required PaymentCurrencyAmount amount;
+           boolean pending = false;
+       };
+    </pre>
 </div>
+
 
 <h2 id="extensibility">Extensibility</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -12766,46 +12766,38 @@ The {{TextDirection}} [=enumerable=] is used to represent text directionality as
 
 <h3 id="localizable" dictionary>Localizable</h3>
 
-A <dfn export>localizable member</dfn> is a [=dictionary member=] that
-represents one or more bidirectional algorithm paragraphs when displayed,
+A <dfn export>localizable member</dfn> is a dictionary member whose type is {{LocalizableString}}.
+Such members represent one or more bidirectional algorithm paragraphs when displayed,
 as defined by the bidirectional algorithm’s rules P1, P2, and P3,
 including, for instance, supporting the paragraph-breaking behavior
 of <span class="char">U+000A LINE FEED (LF)</span> characters. [[!BIDI]]
 
 A user agent is expected to honor the Unicode semantics of [=localizable members=].
 
-The [=identifier=] of a [=localizable member=] is left to the defining specification (e.g., "title").
-
-Dictionaries that specify a [=localizable member=] must inherit from the {{Localizable}} dictionary.
-
-Specification authors must specify in prose which [=dictionary members|member(s)=]
-of the inheriting dictionary serve as [=localizable members=].
-
-Specification authors should limit the number of [=localizable members=] to one per dictionary,
-including in [=inherited dictionaries=] (if any).
-
 <pre class="idl">
     dictionary Localizable {
       DOMString lang = "";
+      DOMString value = "";
       TextDirection dir = "auto";
     };
+    typedef (DOMString or LocalizedValue) LocalizableString;
 </pre>
 
-The {{Localizable/lang}} member specifies the primary language for the [=dictionary members=]
-which are [=localizable members=].
+The {{Localizable/lang}} member specifies the primary language for the {{Localizable/value}} member.
 Its value is a {{DOMString}}.
 The empty string indicates that the primary language is unknown.
 Any other string must be interpreted as a language tag.
 Validity or well-formedness are not enforced. [[!BCP47]]
 
-For the [=localizable members=], the {{Localizable/dir}} member provides the higher-level override of rules P2 and P3
+The {{Localizable/value}} is a {{DOMString}} to be localized.
+
+For the {{Localizable/value}}, the {{Localizable/dir}} member provides the higher-level override of rules P2 and P3
 if it has a value other than <a for=TextDirection enum-value>"auto"</a>. [[!BIDI]]
 
 <div class=example>
    <pre highlight="webidl">
-       dictionary PaymentItem : Localizable {
-           // "label" is a localizable member
-           required DOMString label;
+       dictionary PaymentItem {
+           required LocalizableString label;
            required PaymentCurrencyAmount amount;
            boolean pending = false;
        };

--- a/index.bs
+++ b/index.bs
@@ -12767,7 +12767,7 @@ The {{TextDirection}} [=enumerable=] is used to represent text directionality as
 <h3 id="localizable" dictionary>Localizable</h3>
 
 A <dfn export>localizable member</dfn> is a [=dictionary member=] that
-represents a bidirectional algorithm paragraph when displayed,
+represents one or more bidirectional algorithm paragraphs when displayed,
 as defined by the bidirectional algorithm’s rules P1, P2, and P3,
 including, for instance, supporting the paragraph-breaking behavior
 of <span class="char">U+000A LINE FEED (LF)</span> characters. [[!BIDI]]

--- a/index.bs
+++ b/index.bs
@@ -12750,6 +12750,43 @@ The {{VoidFunction}} [=callback function=]
 type is used for representing function values that take no arguments and do not
 return any value.
 
+<h3>Locatlizable dictionary</h3>
+
+A localizable member is a dictionary member that represents a bidirectional algorithm paragraph when displayed, as defined by the bidirectional algorithm’s rules P1, P2, and P3, including, for instance, supporting the paragraph-breaking behavior of U+000A LINE FEED (LF) characters.
+
+A user agent is expected to honor the Unicode semantics of localizable members.
+
+The name of a localizable member is left to the defining specification (e.g., "title").
+
+Dictionaries that specify a localizable member must inherit from the {{Localizable}} dictionary.
+
+Specification authors must specify in prose which member(s) of the inheriting dictionary serve as localizable members. It is RECOMMENDED that specification authors limit localizable member in the prototype chain of inherited dictionaries (ideally to one).
+
+<pre class="idl">
+enum TextDirection {
+  "auto",
+  "ltr",
+  "rtl"
+};
+
+dictionary Localizable {
+  DOMString lang;
+  TextDirection dir = "auto";
+};</pre>
+
+The {{lang}} member specifies the primary language for the localizable members in the prototype chain. Its value is a string. The empty string indicates that the primary language is unknown.
+Any other string must be interpreted as a language tag. Validity or well-formedness are not enforced. [[!LANG]]
+
+The {{dir}} member provides the higher-level override of rules P2 and P3 if has a value other than "auto". [[!BIDI]]
+
+<div class=example>
+dictionary PaymentItem : Localizable {
+    // "label" is a localizable member
+    required DOMString             label;
+    required PaymentCurrencyAmount amount;
+             boolean               pending = false;
+};
+</div>
 
 <h2 id="extensibility">Extensibility</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -12781,8 +12781,8 @@ Dictionaries that specify a [=localizable member=] must inherit from the {{Local
 Specification authors must specify in prose which [=dictionary members|member(s)=]
 of the inheriting dictionary serve as [=localizable members=].
 
-It is recommended that specification authors limit the number of [=dictionary members=]
-that are [=localizable member=], ideally to one.
+Specification authors should limit the number of [=localizable members=] to one per dictionary,
+including in [=inherited dictionaries=] (if any).
 
 <pre class="idl">
     dictionary Localizable {
@@ -12798,7 +12798,7 @@ The empty string indicates that the primary language is unknown.
 Any other string must be interpreted as a language tag.
 Validity or well-formedness are not enforced. [[!BCP47]]
 
-The {{Localizable/dir}} member provides the higher-level override of rules P2 and P3
+For the [=localizable member=], the {{Localizable/dir}} member provides the higher-level override of rules P2 and P3
 if it has a value other than <a for=TextDirection enum-value>"auto"</a>. [[!BIDI]]
 
 <div class=example>

--- a/index.bs
+++ b/index.bs
@@ -12798,7 +12798,7 @@ The empty string indicates that the primary language is unknown.
 Any other string must be interpreted as a language tag.
 Validity or well-formedness are not enforced. [[!BCP47]]
 
-For the [=localizable member=], the {{Localizable/dir}} member provides the higher-level override of rules P2 and P3
+For the [=localizable members=], the {{Localizable/dir}} member provides the higher-level override of rules P2 and P3
 if it has a value other than <a for=TextDirection enum-value>"auto"</a>. [[!BIDI]]
 
 <div class=example>


### PR DESCRIPTION
Bringing this over from https://github.com/w3c/browser-payment-api/pull/455 where [it was suggested](https://github.com/w3c/browser-payment-api/pull/455#issuecomment-286342385) there that this be uplifted here.

I omitted the xrefs because: 
 1. like to get the prose right first.
 1. I don't know how to do it in BS yet.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/marcoscaceres/webidl/localizable.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/9d039f6...marcoscaceres:e78d5f5.html)