### PR TITLE
Fix [TreatNullAs] usage in example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9531,7 +9531,7 @@ See [[#es-DOMString]] for the specific requirements that the use of [{{TreatNull
     <pre highlight="webidl">
         interface Dog {
           attribute DOMString name;
-          [TreatNullAs=EmptyString] attribute DOMString owner;
+          attribute [TreatNullAs=EmptyString] DOMString owner;
 
           boolean isMemberOfBreed([TreatNullAs=EmptyString] DOMString breedName);
         };


### PR DESCRIPTION
This was not corrected as part of #286. Thanks @cdumez for spotting it!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/heycam/webidl/fixup-xattr.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/d0899e9...c0485ed.html)