### PR TITLE
Add [LegacyWindowAlias] extended attribute for WebKitCSSMatrix et al

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -940,6 +940,7 @@ limitations.  The following extended attributes must not
 be specified on partial interface definitions:
 [{{Constructor}}],
 [{{LegacyArrayClass}}],
+[{{LegacyWindowAlias}}],
 [{{NamedConstructor}}],
 [{{NoInterfaceObject}}].
 
@@ -965,6 +966,7 @@ The following extended attributes are applicable to interfaces:
 [{{Exposed}}],
 [{{Global}}],
 [{{LegacyArrayClass}}],
+[{{LegacyWindowAlias}}],
 [{{NamedConstructor}}],
 [{{NoInterfaceObject}}],
 [{{OverrideBuiltins}}],
@@ -8865,6 +8867,34 @@ is to be implemented.
         Example.prototype.y;
     </pre>
 </div>
+
+
+<h4 id="LegacyWindowAlias" extended-attribute lt="LegacyWindowAlias">[LegacyWindowAlias]</h4>
+
+The [{{LegacyWindowAlias}}]
+[=extended attribute=]
+must either
+[=takes an identifier|take an identifier=] or
+[=takes an identifier list|take an identifier list=].
+
+If the [{{LegacyWindowAlias}}] extended attribute was specified on an interface,
+then for each identifier |id| mentioned in the extended attribute,
+the [=primary global interface=] must
+have a property named |id|,
+which is the <dfn id="dfn-legacy-window-alias" export>legacy window alias</dfn>,
+with attributes
+{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
+whose value is a reference to the [=interface object=] for the interface.
+
+The [{{LegacyWindowAlias}}] and [{{NoInterfaceObject}}]
+extended attributes must not be specified on the same interface.
+
+<p class="advisement">
+    [{{LegacyWindowAlias}}] extended attributes are an undesirable feature.
+    They exist only so that legacy Web platform features can be specified.
+    They should not be used in specifications
+    unless required to specify the behavior of legacy APIs.
+</p>
 
 
 <h4 id="NamedConstructor" extended-attribute lt="NamedConstructor">[NamedConstructor]</h4>

--- a/index.bs
+++ b/index.bs
@@ -8750,7 +8750,7 @@ on a [=callback interface=].
 
 An interface must not have more than one [{{LegacyWindowAlias}}] extended attributes specified.
 
-See [[#legacy-window-alias]] for details on how legacy window aliases
+See [[#es-interfaces]] for details on how legacy window aliases
 are to be implemented.
 
 <p class="advisement">
@@ -10186,6 +10186,15 @@ and its value is an object called the <dfn id="dfn-interface-object" export>inte
 The property has the attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 The characteristics of an interface object are described in [[#interface-object]].
 
+If the [{{LegacyWindowAlias}}] extended attribute was specified on an interface,
+then for each [=identifier=] mentioned in the extended attribute,
+there must be a corresponding property on the [=primary global interface=],
+known as the <dfn id="dfn-legacy-window-alias" export>legacy window alias</dfn>.
+The name of the property is the [=legacy window alias=]'s [=identifier=],
+and its value is a reference to the [=interface object=] for the [=interface=].
+The property has the attributes
+{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
+
 In addition, for every [{{NamedConstructor}}] extended attribute on an [=exposed=] interface,
 a corresponding property must exist on the ECMAScript global object.
 The name of the property is the [{{NamedConstructor}}]'s [=NamedConstructor identifier|identifier=],
@@ -10267,21 +10276,6 @@ the <code>typeof</code> operator will return "function" when applied to an inter
     1.  Perform [=!=] [=DefinePropertyOrThrow=](|F|, "prototype",
         PropertyDescriptor{\[[Value]]: |proto|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>false</emu-val>}).
 </div>
-
-
-<h4 id="legacy-window-alias">Legacy window alias</h4>
-
-If the [{{LegacyWindowAlias}}] extended attribute was specified on an interface,
-then for each identifier |id| mentioned in the extended attribute,
-there must be a corresponding property,
-known as the <dfn id="dfn-legacy-window-alias" export>legacy window alias</dfn>,
-on the [=primary global interface=].
-The property has the following characteristics:
-
-*   The name of the property is |id|.
-*   The value of the property is a reference to the [=interface object=] for the interface.
-*   The property has attributes
-    { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 
 
 <h4 id="named-constructors">Named constructors</h4>

--- a/index.bs
+++ b/index.bs
@@ -8731,12 +8731,24 @@ entails.
 
 If the [{{LegacyWindowAlias}}] [=extended attribute=] appears on an [=interface=],
 it indicates that the [=primary global interface=] will have a property
-for each identifier mentioned in the extended attribute,
+for each [=identifier=] mentioned in the extended attribute,
 whose value is the [=interface object=] for the interface.
 
 The [{{LegacyWindowAlias}}] [=extended attribute=] must either
 [=takes an identifier|take an identifier=] or
 [=takes an identifier list|take an identifier list=].
+
+A [{{LegacyWindowAlias}}]'s <dfn lt="LegacyWindowAlias identifiers">identifiers</dfn>
+is a list containing all of the [=identifiers=] mentioned in the extended attribute.
+
+Each of the [=identifiers=] in the
+[{{LegacyWindowAlias}}]'s [=LegacyWindowAlias identifiers|identifiers=]
+must not be the same as one used by a [{{LegacyWindowAlias}}]
+extended attribute on this interface or another interface,
+must not be the same as that used by a [{{NamedConstructor}}]
+extended attribute on this interface or another interface,
+must not be the same as an identifier of an interface that has an [=interface object=],
+and must not be one of the [=reserved identifiers=].
 
 The [{{LegacyWindowAlias}}] and [{{NoInterfaceObject}}]
 extended attributes must not be specified on the same interface.
@@ -8961,6 +8973,8 @@ that is the value of the aforementioned property.
 The [=NamedConstructor identifier|identifier=] used for the named constructor must not
 be the same as that used by an [{{NamedConstructor}}]
 extended attribute on another interface, must not
+be the same as one used by an [{{LegacyWindowAlias}}]
+extended attribute on this interface or another interface,
 be the same as an identifier of an interface
 that has an [=interface object=],
 and must not be one of the
@@ -10186,11 +10200,10 @@ and its value is an object called the <dfn id="dfn-interface-object" export>inte
 The property has the attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 The characteristics of an interface object are described in [[#interface-object]].
 
-If the [{{LegacyWindowAlias}}] extended attribute was specified on an interface,
-then for each [=identifier=] mentioned in the extended attribute,
-there must be a corresponding property on the [=primary global interface=],
-known as the <dfn id="dfn-legacy-window-alias" export>legacy window alias</dfn>.
-The name of the property is the [=legacy window alias=]'s [=identifier=],
+If the [{{LegacyWindowAlias}}] extended attribute was specified on an [=exposed=] interface,
+then for each [=identifier=] in the [{{LegacyWindowAlias}}]'s [=LegacyWindowAlias identifiers|identifiers=],
+there must be a corresponding property on the [=primary global interface=].
+The name of the property is the given [=identifier=],
 and its value is a reference to the [=interface object=] for the [=interface=].
 The property has the attributes
 { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.

--- a/index.bs
+++ b/index.bs
@@ -8727,6 +8727,71 @@ for the specific requirements that the use of
 entails.
 
 
+<h4 id="LegacyWindowAlias" extended-attribute lt="LegacyWindowAlias">[LegacyWindowAlias]</h4>
+
+If the [{{LegacyWindowAlias}}] [=extended attribute=] appears on an [=interface=],
+it indicates that the [=primary global interface=] will have a property
+for each identifier mentioned in the extended attribute,
+whose value is the [=interface object=] for the interface.
+
+The [{{LegacyWindowAlias}}] [=extended attribute=] must either
+[=takes an identifier|take an identifier=] or
+[=takes an identifier list|take an identifier list=].
+
+The [{{LegacyWindowAlias}}] and [{{NoInterfaceObject}}]
+extended attributes must not be specified on the same interface.
+
+The [{{LegacyWindowAlias}}] extended attribute must not be specified
+on an interface that does not include the [=primary global interface=]
+in its [=exposure set=].
+
+The [{{LegacyWindowAlias}}] extended attribute must not be specified
+on a [=callback interface=].
+
+An interface must not have more than one [{{LegacyWindowAlias}}] extended attributes specified.
+
+See [[#legacy-window-alias]] for details on how legacy window aliases
+are to be implemented.
+
+<p class="advisement">
+    [{{LegacyWindowAlias}}] extended attributes are an undesirable feature.
+    They exist only so that legacy Web platform features can be specified.
+    They should not be used in specifications
+    unless required to specify the behavior of legacy APIs.
+</p>
+
+<div class="example">
+
+    The following IDL defines an interface that uses the
+    [{{LegacyWindowAlias}}] extended attribute.
+
+    <pre highlight="webidl">
+        [Constructor,
+         LegacyWindowAlias=WebKitCSSMatrix]
+        interface DOMMatrix : DOMMatrixReadOnly {
+          // ...
+        };
+    </pre>
+
+    An ECMAScript implementation that supports this interface will
+    expose two properties on the {{Window}} object with the same value
+    and the same characteristics;
+    one for exposing the [=interface object=] normally,
+    and one for exposing it with a legacy name.
+
+    <pre highlight="js">
+        WebKitCSSMatrix === DOMMatrix;     // Evaluates to true.
+
+        var m = new WebKitCSSMatrix();     // Creates a new object that
+                                           // implements DOMMatrix.
+
+        m.constructor === DOMMatrix;       // Evaluates to true.
+        m.constructor === WebKitCSSMatrix; // Evaluates to true.
+        {}.toString.call(m);               // Evaluates to '[object DOMMatrix]'.
+    </pre>
+</div>
+
+
 <h4 id="LenientSetter" extended-attribute lt="LenientSetter">[LenientSetter]</h4>
 
 If the [{{LenientSetter}}]
@@ -8867,34 +8932,6 @@ is to be implemented.
         Example.prototype.y;
     </pre>
 </div>
-
-
-<h4 id="LegacyWindowAlias" extended-attribute lt="LegacyWindowAlias">[LegacyWindowAlias]</h4>
-
-The [{{LegacyWindowAlias}}]
-[=extended attribute=]
-must either
-[=takes an identifier|take an identifier=] or
-[=takes an identifier list|take an identifier list=].
-
-If the [{{LegacyWindowAlias}}] extended attribute was specified on an interface,
-then for each identifier |id| mentioned in the extended attribute,
-the [=primary global interface=] must
-have a property named |id|,
-which is the <dfn id="dfn-legacy-window-alias" export>legacy window alias</dfn>,
-with attributes
-{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
-whose value is a reference to the [=interface object=] for the interface.
-
-The [{{LegacyWindowAlias}}] and [{{NoInterfaceObject}}]
-extended attributes must not be specified on the same interface.
-
-<p class="advisement">
-    [{{LegacyWindowAlias}}] extended attributes are an undesirable feature.
-    They exist only so that legacy Web platform features can be specified.
-    They should not be used in specifications
-    unless required to specify the behavior of legacy APIs.
-</p>
 
 
 <h4 id="NamedConstructor" extended-attribute lt="NamedConstructor">[NamedConstructor]</h4>
@@ -10230,6 +10267,21 @@ the <code>typeof</code> operator will return "function" when applied to an inter
     1.  Perform [=!=] [=DefinePropertyOrThrow=](|F|, "prototype",
         PropertyDescriptor{\[[Value]]: |proto|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>false</emu-val>}).
 </div>
+
+
+<h4 id="legacy-window-alias">Legacy window alias</h4>
+
+If the [{{LegacyWindowAlias}}] extended attribute was specified on an interface,
+then for each identifier |id| mentioned in the extended attribute,
+there must be a corresponding property,
+known as the <dfn id="dfn-legacy-window-alias" export>legacy window alias</dfn>,
+on the [=primary global interface=].
+The property has the following characteristics:
+
+*   The name of the property is |id|.
+*   The value of the property is a reference to the [=interface object=] for the interface.
+*   The property has attributes
+    { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 
 
 <h4 id="named-constructors">Named constructors</h4>

--- a/index.bs
+++ b/index.bs
@@ -8734,20 +8734,18 @@ it indicates that the [=primary global interface=] will have a property
 for each [=identifier=] mentioned in the extended attribute,
 whose value is the [=interface object=] for the interface.
 
-The [{{LegacyWindowAlias}}] [=extended attribute=] must either
+The [{{LegacyWindowAlias}}] extended attribute must either
 [=takes an identifier|take an identifier=] or
 [=takes an identifier list|take an identifier list=].
+The <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t>s that occur after the
+“<emu-t>=</emu-t>” are the [{{LegacyWindowAlias}}]'s <dfn lt="LegacyWindowAlias identifier">identifiers</dfn>.
 
-A [{{LegacyWindowAlias}}]'s <dfn lt="LegacyWindowAlias identifiers">identifiers</dfn>
-is a list containing all of the [=identifiers=] mentioned in the extended attribute.
-
-Each of the [=identifiers=] in the
-[{{LegacyWindowAlias}}]'s [=LegacyWindowAlias identifiers|identifiers=]
+Each of the [=LegacyWindowAlias identifier|identifiers=] of [{{LegacyWindowAlias}}]
 must not be the same as one used by a [{{LegacyWindowAlias}}]
 extended attribute on this interface or another interface,
-must not be the same as that used by a [{{NamedConstructor}}]
+must not be the same as the [=NamedConstructor identifier|identifier=] used by a [{{NamedConstructor}}]
 extended attribute on this interface or another interface,
-must not be the same as an identifier of an interface that has an [=interface object=],
+must not be the same as an [=identifier=] of an interface that has an [=interface object=],
 and must not be one of the [=reserved identifiers=].
 
 The [{{LegacyWindowAlias}}] and [{{NoInterfaceObject}}]
@@ -8971,11 +8969,11 @@ implements the interface by passing the specified arguments to the constructor f
 that is the value of the aforementioned property.
 
 The [=NamedConstructor identifier|identifier=] used for the named constructor must not
-be the same as that used by an [{{NamedConstructor}}]
+be the same as that used by a [{{NamedConstructor}}]
 extended attribute on another interface, must not
-be the same as one used by an [{{LegacyWindowAlias}}]
+be the same as an [=LegacyWindowAlias identifier|identifier=] used by a [{{LegacyWindowAlias}}]
 extended attribute on this interface or another interface,
-be the same as an identifier of an interface
+must not be the same as an [=identifier=] of an interface
 that has an [=interface object=],
 and must not be one of the
 [=reserved identifiers=].
@@ -10201,9 +10199,9 @@ The property has the attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enu
 The characteristics of an interface object are described in [[#interface-object]].
 
 If the [{{LegacyWindowAlias}}] extended attribute was specified on an [=exposed=] interface,
-then for each [=identifier=] in the [{{LegacyWindowAlias}}]'s [=LegacyWindowAlias identifiers|identifiers=],
+then for each [=LegacyWindowAlias identifier|identifier=] in [{{LegacyWindowAlias}}]'s [=LegacyWindowAlias identifier|identifiers=]
 there must be a corresponding property on the [=primary global interface=].
-The name of the property is the given [=identifier=],
+The name of the property is the given [=LegacyWindowAlias identifier|identifier=],
 and its value is a reference to the [=interface object=] for the [=interface=].
 The property has the attributes
 { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.


### PR DESCRIPTION
Fixes #362.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/zcorpan/webidl/zcorpan/legacywindowalias.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/4dbd7d2...zcorpan:d346eb0.html)