### PR TITLE
Add frozen array types to the list of JSON types

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2006,6 +2006,7 @@ The <dfn id="dfn-json-types" export lt="JSON type">JSON types</dfn> are:
 *   [=annotated types=] whose [=annotated types/inner type=] is a [=JSON type=],
 *   [=union types=] whose [=member types=] are [=JSON types=],
 *   [=sequence types=] whose parameterized type is a [=JSON type=],
+*   [=frozen array types=] whose parameterized type is a [=JSON type=],
 *   [=dictionaries=] where all of their [=dictionary members|members=] are [=JSON types=],
 *   [=records=] where all of their [=map/values=] are [=JSON types=],
 *   {{object}},


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tobie/webidl/frozen-array-json-type.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/b323f1a...tobie:2db2816.html)