### PR TITLE
Add the symbol type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3074,6 +3074,9 @@ the following algorithm returns <i>true</i>.
                     <span>object</span>
             </div></th>
                 <th><div>
+                    <span>symbol</span>
+            </div></th>
+                <th><div>
                     <span>interface-like</span>
                 </div></th>
                 <th><div>
@@ -3096,11 +3099,13 @@ the following algorithm returns <i>true</i>.
             <td>●</td>
             <td>●</td>
             <td>●</td>
+            <td>●</td>
         </tr>
         <tr>
             <th>numeric types</th>
             <td class="belowdiagonal"></td>
             <td></td>
+            <td>●</td>
             <td>●</td>
             <td>●</td>
             <td>●</td>
@@ -3118,6 +3123,7 @@ the following algorithm returns <i>true</i>.
             <td>●</td>
             <td>●</td>
             <td>●</td>
+            <td>●</td>
         </tr>
         <tr>
             <th>object</th>
@@ -3125,13 +3131,27 @@ the following algorithm returns <i>true</i>.
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td></td>
+            <td>●</td>
             <td></td>
             <td></td>
             <td></td>
             <td></td>
         </tr>
         <tr>
+            <th>symbol</th>
+            <td class="belowdiagonal"></td>
+            <td class="belowdiagonal"></td>
+            <td class="belowdiagonal"></td>
+            <td class="belowdiagonal"></td>
+            <td></td>
+            <td>●</td>
+            <td>●</td>
+            <td>●</td>
+            <td>●</td>
+        </tr>
+        <tr>
             <th>interface-like</th>
+            <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
@@ -3143,6 +3163,7 @@ the following algorithm returns <i>true</i>.
         </tr>
         <tr>
             <th>callback function</th>
+            <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
@@ -3160,11 +3181,13 @@ the following algorithm returns <i>true</i>.
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
+            <td class="belowdiagonal"></td>
             <td></td>
             <td>●</td>
         </tr>
         <tr>
             <th>sequence-like</th>
+            <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
@@ -4910,6 +4933,7 @@ type.
         identifier Null
         "sequence" "&lt;" TypeWithExtendedAttributes "&gt;" Null
         "object" Null
+        "symbol" Null
         "Error" Null
         "DOMException" Null
         BufferRelatedType Null
@@ -5326,6 +5350,15 @@ To denote a type that includes all possible object references plus the
 
 The [=type name=] of the
 {{object}} type is “Object”.
+
+<h4 id="idl-symbol" interface>symbol</h4>
+
+The {{symbol}} type corresponds to the set of all possible symbol values. Symbol values are opaque,
+non-{{object}} values which nevertheless have identity (i.e., are only equal to themselves).
+
+There is no way to represent a constant {{symbol}} value in IDL.
+
+The [=type name=] of the {{symbol}} type is “Symbol”.
 
 
 <h4 id="idl-interface" dfn>Interface types</h4>
@@ -6356,6 +6389,9 @@ ECMAScript value type.
     1.  If [=Type=](|V|) is String, then
         return the result of <a href="#es-DOMString">converting</a> |V|
         to a {{DOMString}}.
+    1.  If [=Type=](|V|) is Symbol, then
+        return the result of <a href="#es-symbol">converting</a> |V|
+        to a {{symbol}}.
     1.  If [=Type=](|V|) is Object, then
         return an IDL {{object}} value that references |V|.
 </div>
@@ -6872,6 +6908,25 @@ values are represented by ECMAScript <emu-val>Object</emu-val> values.
     an IDL {{object}} value to an ECMAScript
     value is the <emu-val>Object</emu-val> value that represents a reference to the same object that the
     IDL {{object}} represents.
+</p>
+
+
+<h4 id="es-symbol">symbol</h4>
+
+IDL {{symbol}} values are represented by ECMAScript <emu-val>Symbol</emu-val> values.
+
+<div id="es-to-symbol" algorithm="convert an ECMAScript value to a symbol">
+    An ECMAScript value |V| is [=converted to an IDL value|converted=] to an IDL {{symbol}} value
+    by running the following algorithm:
+
+    1.  If [=Type=](|V|) is not Symbol, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+    1.  Return the IDL {{symbol}} value that is a reference to the same symbol as |V|.
+</div>
+
+<p id="symbol-to-es">
+    The result of [=converted to an ECMAScript value|converting=] an IDL {{symbol}} value to an
+    ECMAScript value is the <emu-val>Symbol</emu-val> value that represents a reference to the same
+    symbol that the IDL {{symbol}} represents.
 </p>
 
 


### PR DESCRIPTION
Fixes part of https://www.w3.org/Bugs/Public/show_bug.cgi?id=27553. Fixes #301.

This will be necessary for https://github.com/whatwg/dom/pull/469, as feedback in https://github.com/whatwg/dom/issues/208 has been that we should restrict the type of the group to either a string or a symbol.

https://www.w3.org/Bugs/Public/show_bug.cgi?id=27553 also contains speculative stuff about interfaces declaring their own symbols which is not included here.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/heycam/webidl/symbols.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/4269cc0...1ae927b.html)