### PR TITLE
Fix typos in advisements relating to using `true` as default values

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1788,7 +1788,7 @@ corresponding argument omitted.
 </pre>
 
 <p class="advisement">
-    It is strongly suggested not to use [=optional argument/default value=]
+    It is strongly suggested not to use a [=optional argument/default value=]
     of <emu-val>true</emu-val> for {{boolean}}-typed arguments,
     as this can be confusing for authors who might otherwise expect the default
     conversion of <emu-val>undefined</emu-val> to be used (i.e., <emu-val>false</emu-val>).
@@ -3811,7 +3811,7 @@ dictionary members.
 
 <p class="advisement">
     As with [=optional argument/default value|operation argument default values=],
-    is strongly suggested not to use of <emu-val>true</emu-val> as the
+    it is strongly suggested not to use <emu-val>true</emu-val> as the
     [=dictionary member/default value=] for
     {{boolean}}-typed
     [=dictionary members=],


### PR DESCRIPTION
Small changes to the documentation to fix some typos and grammar errors in some advisements.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/lerouche/webidl/fix-typos.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/5c8eb31...lerouche:a7fb655.html)