### PR TITLE
Remove DOMException terminal from the grammar

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4911,7 +4911,6 @@ type.
         "sequence" "&lt;" TypeWithExtendedAttributes "&gt;" Null
         "object" Null
         "Error" Null
-        "DOMException" Null
         BufferRelatedType Null
         "FrozenArray" "&lt;" TypeWithExtendedAttributes "&gt;" Null
         RecordType Null


### PR DESCRIPTION
This is a fixup of 5c8eb310ef7a6bcb3c4813e9791212ee1624f2d3, which forgot to remove the DOMException terminal from the grammar when giving it a new definition.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/heycam/webidl/domexception-fixup.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/f3b6a2a...25c1044.html)