### PR TITLE
Editorial: improve array index property name algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11995,8 +11995,9 @@ Note: Future versions of the ECMAScript specification may define a total order f
     which is a property name |P| such that [=Type=](|P|) is String
     and for which the following algorithm returns <emu-val>true</emu-val>:
 
-    1.  Let |i| be [=ToUint32=](|P|).
-    1.  Let |s| be [=ToString=](|i|).
+    1.  Assert: [=Type=](|P|) is String.
+    1.  Let |i| be [=!=] [=ToUint32=](|P|).
+    1.  Let |s| be [=!=] [=ToString=](|i|).
     1.  If |s| ≠ |P| or |i| = 2<sup>32</sup> − 1, then return <emu-val>false</emu-val>.
     1.  Return <emu-val>true</emu-val>.
 </div>

--- a/index.bs
+++ b/index.bs
@@ -11992,14 +11992,13 @@ Note: Future versions of the ECMAScript specification may define a total order f
 
     The name of each property that appears to exist due to an object supporting indexed properties
     is an <dfn id="dfn-array-index-property-name" export>array index property name</dfn>,
-    which is a property name |P| such that [=Type=](|P|) is String
-    and for which the following algorithm returns <emu-val>true</emu-val>:
+    which is a property name |P| for which the following algorithm returns true:
 
-    1.  Assert: [=Type=](|P|) is String.
+    1.  If [=Type=](|P|) is not String, then return false.
     1.  Let |i| be [=!=] [=ToUint32=](|P|).
     1.  Let |s| be [=!=] [=ToString=](|i|).
-    1.  If |s| ≠ |P| or |i| = 2<sup>32</sup> − 1, then return <emu-val>false</emu-val>.
-    1.  Return <emu-val>true</emu-val>.
+    1.  If |s| is not equal to |P| or |i| = 2<sup>32</sup> − 1, then return false.
+    1.  Return true.
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -11996,8 +11996,9 @@ Note: Future versions of the ECMAScript specification may define a total order f
 
     1.  If [=Type=](|P|) is not String, then return false.
     1.  Let |i| be [=!=] [=ToUint32=](|P|).
+    1.  If |i| is equal to 2<sup>32</sup> − 1, then return false.
     1.  Let |s| be [=!=] [=ToString=](|i|).
-    1.  If |s| is not equal to |P| or |i| = 2<sup>32</sup> − 1, then return false.
+    1.  If |s| is not equal to |P|, then return false.
     1.  Return true.
 </div>
 


### PR DESCRIPTION
Make it explicit that the algorithm only accepts strings as input and does not throw.

Fixes #346.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tobie/webidl/fix-346.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/b085536...tobie:9cc61a6.html)