### PR TITLE
Link function objects to ES spec directly.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -138,8 +138,8 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: immutable prototype exotic object; url: sec-immutable-prototype-exotic-objects
         text: sections 9.1; url: sec-ordinary-object-internal-methods-and-internal-slots
         text: 9.3.1; url: sec-built-in-function-objects-call-thisargument-argumentslist
-        text: ECMA-262 section 9.1.8; url: sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver
-        text: ECMA-262 section 19.2.2.3; url: sec-function-@@create
+        text: ECMA-262 section 9.3; url: sec-built-in-function-objects
+        text: function object; url: sec-built-in-function-objects
         text: Array methods; url: sec-properties-of-the-array-prototype-object
         text: typed arrays; url: sec-typedarray-objects
         text: GetMethod; url: sec-getmethod
@@ -6166,17 +6166,8 @@ and whose value is the specified string.
     and configurable.
 </p>
 
-If an object is defined to be a <dfn id="dfn-function-object" export>function object</dfn>, then
-it has characteristics as follows:
-
-*   Its \[[Prototype]] internal property is
-    [=%FunctionPrototype%=] unless otherwise specified.
-*   Its \[[Get]] internal property is set as described in [=ECMA-262 section 9.1.8=].
-*   Its \[[Construct]] internal property is set as described in [=ECMA-262 section 19.2.2.3=].
-
-<p class="issue">
-    The list above needs updating for the latest ES6 draft.
-</p>
+If an object is defined to be a [=function object=], then
+it has characteristics as described in [=ECMA-262 section 9.3=].
 
 <p id="ecmascript-abstractop">
     Algorithms in this section use the conventions described in [=ECMA-262 section 5.2=], such as the use of steps and substeps, the use of mathematical


### PR DESCRIPTION
Fixes #280.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tobie/webidl/fix-280.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/b085536...tobie:c49be36.html)