### PR TITLE
Fix incorrect example in Overloading section.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3242,12 +3242,11 @@ for the entries of the effective overload set with the given type list length.
     <pre highlight="webidl">
         interface B {
           void f(DOMString x);
-          void f(double x);
+          void f(USVString x);
         };
     </pre>
 
-    since {{DOMString}} and
-    {{double}} are not distinguishable.
+    since {{DOMString}} and {{USVString}} are not distinguishable.
 
 </div>
 


### PR DESCRIPTION
Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=23879.
Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=25630.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tobie/webidl/fix-23879.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/b085536...tobie:0940651.html)