### PR TITLE
Use infra notation in Overloading section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2951,7 +2951,12 @@ the same operation or constructor.
             1.  If |arguments|[|i|] is not [=optional argument|optional=]
                 (i.e., it is not marked as "optional" and is not
                 a final, variadic argument), then [=iteration/break=] this loop.
-            1.  Otherwise, [=set/append=] the [=tuple=] (|X|, |types|, |optionality_values|) to |S|.
+            1.  Let |t| be a [=list=] of types.
+            1.  Let |o| be a [=list=] of [=optionality values=].
+            1.  [=list/For each=] |j| in [=the range=] 0 to |i|−1, inclusive:
+                1.  [=list/Append=] |types|[|j|] to |t|.
+                1.  [=list/Append=] |optionality_values|[|j|] to |o|.
+            1.  [=set/Append=] the [=tuple=] (|X|, |t|, |o|) to |S|.
             1.  Set |i| to |i|−1.
 
             Note: if |i| is 0, this means to add to |S| the tuple (|X|, « », « »);

--- a/index.bs
+++ b/index.bs
@@ -2864,12 +2864,12 @@ The [=set/items=] of an [=effective overload set=] are [=tuples=] of the form
 ([=effective overload set tuple/callable=], [=type list=], [=optionality list=])
 whose [=tuple/items=] are described below:
 
-*   The <dfn for="effective overload set tuple" export>callable</dfn> is an operation
+*   A <dfn for="effective overload set tuple" export>callable</dfn> is an operation
     if the effective overload set is for regular operations, static operations or legacy callers;
     it is an extended attribute if the effective overload set is for constructors or named constructors;
     and it is the callback function itself if the effective overload set is for callback functions.
-*   The <dfn export>type list</dfn> is a [=list=] of IDL types.
-*   The <dfn export>optionality list</dfn> is a [=list=] of
+*   A <dfn export>type list</dfn> is a [=list=] of IDL types.
+*   An <dfn export>optionality list</dfn> is a [=list=] of
     three possible <dfn id="dfn-optionality-value" export>optionality values</dfn>
     – "required", "optional" or "variadic" –
     indicating whether the argument at a given index was

--- a/index.bs
+++ b/index.bs
@@ -2880,7 +2880,7 @@ Each [=tuple=] represents an allowable invocation of the operation,
 constructor, legacy caller or callback function with an argument value list of the given types.
 Due to the use of [=optional arguments=]
 and [=variadic=] operations
-and constructors, there may be multiple entries in an effective overload set identifying
+and constructors, there may be multiple items in an effective overload set identifying
 the same operation or constructor.
 
 <div algorithm="compute an effective overload set">
@@ -3270,7 +3270,7 @@ that has a given [=type list=] [=list/size=],
 then for those items there must be an index |i| such that
 for each pair of items the types at index |i| are [=distinguishable=].
 The lowest such index is termed the <dfn id="dfn-distinguishing-argument-index" export>distinguishing argument index</dfn>
-for the entries of the effective overload set with the given type list size.
+for the items of the effective overload set with the given type list size.
 
 <div class="example">
 
@@ -3321,7 +3321,7 @@ be the same.
       »
     </pre>
 
-    Looking at entries with type list size 4, the
+    Looking at items with type list size 4, the
     [=distinguishing argument index=]
     is 2, since <code class="idl">Node</code> and
     {{DOMString}} are [=distinguishable=].

--- a/index.bs
+++ b/index.bs
@@ -2864,12 +2864,12 @@ The [=set/items=] of an [=effective overload set=] are [=tuples=] of the form
 ([=effective overload set tuple/callable=], [=type list=], [=optionality list=])
 whose [=tuple/items=] are described below:
 
-*   A <dfn for="effective overload set tuple" export>callable</dfn> is an operation
-    if the effective overload set is for regular operations, static operations or legacy callers;
-    it is an extended attribute if the effective overload set is for constructors or named constructors;
-    and it is the callback function itself if the effective overload set is for callback functions.
-*   A <dfn export>type list</dfn> is a [=list=] of IDL types.
-*   An <dfn export>optionality list</dfn> is a [=list=] of
+*   A <dfn for="effective overload set tuple">callable</dfn> is an [=operation=]
+    if the [=effective overload set=] is for [=regular operations=], [=static operations=] or [=legacy callers=];
+    it is an [=extended attribute=] if the [=effective overload set=] is for constructors or [=named constructors=];
+    and it is the [=callback function=] itself if the [=effective overload set=] is for [=callback functions=].
+*   A <dfn>type list</dfn> is a [=list=] of IDL types.
+*   An <dfn>optionality list</dfn> is a [=list=] of
     three possible <dfn id="dfn-optionality-value" export>optionality values</dfn>
     – "required", "optional" or "variadic" –
     indicating whether the argument at a given index was
@@ -2930,7 +2930,7 @@ the same operation or constructor.
 
         Note: So <code>void f(long x, long... y);</code> is considered to be declared to take two arguments.
     1.  Let |max| be [=max=](|maxarg|, |N|).
-    1.  [=set/For each=] operation, extended attribute or callback function |X| in |F|:
+    1.  [=set/For each=] operation, extended attribute, or callback function |X| in |F|:
         1.  Let |arguments| be the [=list=] of arguments |X| is declared to take.
         1.  Let |n| be the [=list/size=] of |arguments|.
         1.  Let |types| be a [=type list=].

--- a/index.bs
+++ b/index.bs
@@ -2923,7 +2923,7 @@ the same operation or constructor.
 
         Note: So <code>void f(long x, long... y);</code> is considered to be declared to take two arguments.
     1.  Let |max| be [=max=](|maxarg|, |N|).
-    1.  For each operation, extended attribute or callback function |X| in |F|:
+    1.  [=Set/For each=] operation, extended attribute or callback function |X| in |F|:
         1.  Let |arguments| be the [=list=] of arguments |X| is declared to take.
         1.  Let |n| be the [=list/size=] of |arguments|.
         1.  Let |types| be a [=list=] of types.

--- a/index.bs
+++ b/index.bs
@@ -82,7 +82,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: element; url: sec-ecmascript-language-types-string-type
         url: sec-iscallable
             text: IsCallable
-            text: callable
+            text: callable; for: ECMAScript
         url: sec-well-known-intrinsic-objects
             text: %ArrayPrototype%
             text: %ArrayProto_values%
@@ -2860,15 +2860,22 @@ the inputs to the algorithm needed to compute the set.
 An effective overload set is used, among other things, to determine whether there are ambiguities in the
 overloaded operations, constructors and callers specified on an interface.
 
-The elements of an effective overload set are [=tuples=] of the form
-(|callable|, |type list|, |optionality list|).  If the effective overload
-set is for regular operations, static operations or legacy callers, then |callable| is an operation;
-if it is for constructors or named constructors, then |callable| is an
-extended attribute; and if it is for callback functions, then |callable|
-is the callback function itself. In all cases, |type list| is a [=list=]
-of IDL types, and |optionality list| is a [=list=] of three possible <dfn id="dfn-optionality-value" export>optionality values</dfn> – "required", "optional" or "variadic" – indicating whether
-the argument at a given index was declared as being [=optional argument|optional=]
-or corresponds to a [=variadic=] argument.
+The [=set/items=] of an [=effective overload set=] are [=tuples=] of the form
+([=effective overload set tuple/callable=], [=type list=], [=optionality list=])
+whose [=tuple/items=] are described below:
+
+*   The <dfn for="effective overload set tuple" export>callable</dfn> is an operation
+    if the effective overload set is for regular operations, static operations or legacy callers;
+    it is an extended attribute if the effective overload set is for constructors or named constructors;
+    and it is the callback function itself if the effective overload set is for callback functions.
+*   The <dfn export>type list</dfn> is a [=list=] of IDL types.
+*   The <dfn export>optionality list</dfn> is a [=list=] of
+    three possible <dfn id="dfn-optionality-value" export>optionality values</dfn>
+    – "required", "optional" or "variadic" –
+    indicating whether the argument at a given index was
+    declared as being [=optional argument|optional=]
+    or corresponds to a [=variadic=] argument.
+
 Each [=tuple=] represents an allowable invocation of the operation,
 constructor, legacy caller or callback function with an argument value list of the given types.
 Due to the use of [=optional arguments=]
@@ -2926,8 +2933,8 @@ the same operation or constructor.
     1.  [=set/For each=] operation, extended attribute or callback function |X| in |F|:
         1.  Let |arguments| be the [=list=] of arguments |X| is declared to take.
         1.  Let |n| be the [=list/size=] of |arguments|.
-        1.  Let |types| be a [=list=] of types.
-        1.  Let |optionalityValues| be a list of [=optionality values=].
+        1.  Let |types| be a [=type list=].
+        1.  Let |optionalityValues| be an [=optionality list=].
         1.  [=list/For each=] |argument| in |arguments|:
             1.  [=list/Append=] the type of |argument| to |types|.
             1.  [=list/Append=] "variadic" to |optionalityValues| if |argument| is a final, variadic argument,
@@ -2936,8 +2943,8 @@ the same operation or constructor.
         1.  [=set/Append=] the [=tuple=] (|X|, |types|, |optionalityValues|) to |S|.
         1.  If |X| is declared to be [=variadic=], then:
             1.  [=list/For each=] |i| in [=the range=] |n| to |max| − 1, inclusive:
-                1.  Let |t| be a [=list=] of types.
-                1.  Let |o| be a [=list=] of [=optionality values=].
+                1.  Let |t| be a [=type list=].
+                1.  Let |o| be an [=optionality list=].
                 1.  [=list/For each=] |j| in [=the range=] 0 to |n| − 1, inclusive:
                     1.  [=list/Append=] |types|[|j|] to |t|.
                     1.  [=list/Append=] |optionalityValues|[|j|] to |o|.
@@ -2950,8 +2957,8 @@ the same operation or constructor.
             1.  If |arguments|[|i|] is not [=optional argument|optional=]
                 (i.e., it is not marked as "optional" and is not
                 a final, variadic argument), then [=iteration/break=].
-            1.  Let |t| be a [=list=] of types.
-            1.  Let |o| be a [=list=] of [=optionality values=].
+            1.  Let |t| be a [=type list=].
+            1.  Let |o| be an [=optionality list=].
             1.  [=list/For each=] |j| in [=the range=] 0 to |i| − 1, inclusive:
                 1.  [=list/Append=] |types|[|j|] to |t|.
                 1.  [=list/Append=] |optionalityValues|[|j|] to |o|.
@@ -3258,19 +3265,18 @@ the following algorithm returns <i>true</i>.
 
 </ol>
 
-If there is more than one entry in an [=effective overload set=]
-that has a given type list length, then for those entries there
-must be an index |i| such
-that for each pair of entries the types at index |i| are
-[=distinguishable=].
+If there is more than one [=list/item=] in an [=effective overload set=]
+that has a given [=type list=] [=list/size=],
+then for those items there must be an index |i| such that
+for each pair of items the types at index |i| are [=distinguishable=].
 The lowest such index is termed the <dfn id="dfn-distinguishing-argument-index" export>distinguishing argument index</dfn>
-for the entries of the effective overload set with the given type list length.
+for the entries of the effective overload set with the given type list size.
 
 <div class="example">
 
     Consider the effective overload set shown in the previous example.
-    There are multiple entries in the set with type lists 2, 3 and 4.
-    For each of these type list lengths, the [=distinguishing argument index=] is 0, since <code class="idl">Node</code> and
+    There are multiple items in the set with type lists 2, 3 and 4.
+    For each of these type list size, the [=distinguishing argument index=] is 0, since <code class="idl">Node</code> and
     <code class="idl">Event</code> are [=distinguishable=].
 
     The following use of overloading however is invalid:
@@ -3288,9 +3294,9 @@ for the entries of the effective overload set with the given type list length.
 
 In addition, for each index |j|, where |j| is less than the
 [=distinguishing argument index=]
-for a given type list length, the types at index |j| in
-all of the entries’ type lists must be the same,
-and the [=optionality values=] at index |j| in all of the entries’ optionality lists must
+for a given type list size, the types at index |j| in
+all of the items’ type lists must be the same,
+and the [=optionality values=] at index |j| in all of the items’ optionality lists must
 be the same.
 
 <div class="example">
@@ -3315,7 +3321,7 @@ be the same.
       »
     </pre>
 
-    Looking at entries with type list length 4, the
+    Looking at entries with type list size 4, the
     [=distinguishing argument index=]
     is 2, since <code class="idl">Node</code> and
     {{DOMString}} are [=distinguishable=].
@@ -7412,7 +7418,7 @@ objects.
         1.  Otherwise, return the result of performing any steps that were required to be run if the promise was rejected,
             with |reason| as the rejection reason.
     1.  Let |then| be the result of calling the internal \[[Get]] method of |promise| with property name “then”.
-    1.  If |then| is not [=callable=], then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+    1.  If |then| is not [=ECMAScript/callable=], then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return the result of calling |then| with |promise| as the <emu-val>this</emu-val> value and |onFulfilled| and |onRejected|
         as its two arguments.
 </div>
@@ -12214,10 +12220,10 @@ is considered to be a user object implementing a callback interface:
     (defined below) then any object is considered to implement the interface.
     The implementation of the operation (or set of overloaded operations) is
     as follows:
-    *   If the object is [=callable=],
+    *   If the object is [=ECMAScript/callable=],
         then the implementation of the operation (or set of overloaded operations) is
         the callable object itself.
-    *   Otherwise, the object is not [=callable=].
+    *   Otherwise, the object is not [=ECMAScript/callable=].
         The implementation of the operation (or set of overloaded operations) is
         the result of invoking the internal \[[Get]] method
         on the object with a property name that is the [=identifier=]
@@ -12393,7 +12399,7 @@ the special value “missing”, which represents a missing optional argument.
 
 <h3 id="es-invoking-callback-functions">Invoking callback functions</h3>
 
-An ECMAScript [=callable=] object that is being
+An ECMAScript [=ECMAScript/callable=] object that is being
 used as a [=callback function=] value is
 called in a manner similar to how [=operations=]
 on [=user objects=] are called (as

--- a/index.bs
+++ b/index.bs
@@ -2949,7 +2949,7 @@ the same operation or constructor.
         1.  [=iteration/While=] |i| ≥ 0:
             1.  If |arguments|[|i|] is not [=optional argument|optional=]
                 (i.e., it is not marked as "optional" and is not
-                a final, variadic argument), then [=iteration/break=] this loop.
+                a final, variadic argument), then [=iteration/break=].
             1.  Let |t| be a [=list=] of types.
             1.  Let |o| be a [=list=] of [=optionality values=].
             1.  [=list/For each=] |j| in [=the range=] 0 to |i| − 1, inclusive:

--- a/index.bs
+++ b/index.bs
@@ -2923,7 +2923,7 @@ the same operation or constructor.
 
         Note: So <code>void f(long x, long... y);</code> is considered to be declared to take two arguments.
     1.  Let |max| be [=max=](|maxarg|, |N|).
-    1.  [=Set/For each=] operation, extended attribute or callback function |X| in |F|:
+    1.  [=set/For each=] operation, extended attribute or callback function |X| in |F|:
         1.  Let |arguments| be the [=list=] of arguments |X| is declared to take.
         1.  Let |n| be the [=list/size=] of |arguments|.
         1.  Let |types| be a [=list=] of types.

--- a/index.bs
+++ b/index.bs
@@ -2922,39 +2922,41 @@ the same operation or constructor.
         the argument on which the ellipsis appears counts as a single argument.
 
         Note: So <code>void f(long x, long... y);</code> is considered to be declared to take two arguments.
-    1.  Let |m| be the maximum of |maxarg| and |N|.
+    1.  Let |max| be the maximum of |maxarg| and |N|.
     1.  For each operation, extended attribute or callback function |X| in |F|:
-        1.  Let |n| be the number of arguments |X| is declared to take.
-        1.  Let |t| be a [=list=] of types, where |t|[|i|]
-            is the type of |X|[|i|].
-        1.  Let |o| be a list of [=optionality values=], where |o|[|i|]
-            is "variadic" if |X|[|i|] is a final, variadic argument,
-            "optional" if the argument is [=optional argument|optional=],
-            and "required" otherwise.
-        1.  [=set/Append=] the [=tuple=] (|X|, |t|, |o|) to |S|.
+        1.  Let |arguments| be the [=list=] of arguments |X| is declared to take.
+        1.  Let |n| be the [=list/size=] of |arguments|.
+        1.  Let |types| be a [=list=] of types.
+        1.  Let |optionality_values| be a list of [=optionality values=].
+        1.  [=list/For each=] |argument| in |arguments|:
+            1.  [=list/Append=] the type of |argument| to |types|.
+            1.  [=list/Append=] "variadic" to |optionality_values| if |argument| is a final, variadic argument,
+                "optional" if |argument| is [=optional argument|optional=],
+                and "required" otherwise.
+        1.  [=set/Append=] the [=tuple=] (|X|, |types|, |optionality_values|) to |S|.
         1.  If |X| is declared to be [=variadic=], then:
-            1.  [=list/For each=] |i| in [=the range=] |n| to |m|−1, inclusive:
-                1.  Let |u| be a [=list=] of types.
-                1.  Let |p| be a [=list=] of [=optionality values=].
+            1.  [=list/For each=] |i| in [=the range=] |n| to |max|−1, inclusive:
+                1.  Let |t| be a [=list=] of types.
+                1.  Let |o| be a [=list=] of [=optionality values=].
                 1.  [=list/For each=] |j| in [=the range=] 0 to |i|, inclusive:
                     1.  If |j| &lt; |n|, then:
-                        1.  [=list/Append=] |t|[|j|] to |u|.
-                        1.  [=list/Append=] |o|[|j|] to |p|.
+                        1.  [=list/Append=] |types|[|j|] to |t|.
+                        1.  [=list/Append=] |optionality_values|[|j|] to |o|.
                     1.  Otherwise:
-                        1.  [=list/Append=] |t|[|n|−1] to |u|.
-                        1.  [=list/Append=] "variadic" to |p|.
-                1.  [=set/Append=] the [=tuple=] (|X|, |u|, |p|) to |S|.
+                        1.  [=list/Append=] |types|[|n|−1] to |t|.
+                        1.  [=list/Append=] "variadic" to |o|.
+                1.  [=set/Append=] the [=tuple=] (|X|, |t|, |o|) to |S|.
         1.  Let |i| be |n|−1.
         1.  [=iteration/While=] |i| ≥ 0:
-            1.  If |X|[|i|] is not [=optional argument|optional=]
+            1.  If |arguments|[|i|] is not [=optional argument|optional=]
                 (i.e., it is not marked as "optional" and is not
                 a final, variadic argument), then [=iteration/break=] this loop.
-            1.  Otherwise, [=set/append=] the [=tuple=] (|X|, |t|, |o|) to |S|.
+            1.  Otherwise, [=set/append=] the [=tuple=] (|X|, |types|, |optionality_values|) to |S|.
             1.  Set |i| to |i|−1.
-            
+
             Note: if |i| is 0, this means to add to |S| the tuple (|X|, « », « »);
             (where "« »" represents an [=list/is empty|empty list=]).
-    1.  The effective overload set is |S|.
+    1.  Return |S|.
 </div>
 
 <div class="example">

--- a/index.bs
+++ b/index.bs
@@ -2927,20 +2927,20 @@ the same operation or constructor.
         1.  Let |arguments| be the [=list=] of arguments |X| is declared to take.
         1.  Let |n| be the [=list/size=] of |arguments|.
         1.  Let |types| be a [=list=] of types.
-        1.  Let |optionality_values| be a list of [=optionality values=].
+        1.  Let |optionalityValues| be a list of [=optionality values=].
         1.  [=list/For each=] |argument| in |arguments|:
             1.  [=list/Append=] the type of |argument| to |types|.
-            1.  [=list/Append=] "variadic" to |optionality_values| if |argument| is a final, variadic argument,
+            1.  [=list/Append=] "variadic" to |optionalityValues| if |argument| is a final, variadic argument,
                 "optional" if |argument| is [=optional argument|optional=],
                 and "required" otherwise.
-        1.  [=set/Append=] the [=tuple=] (|X|, |types|, |optionality_values|) to |S|.
+        1.  [=set/Append=] the [=tuple=] (|X|, |types|, |optionalityValues|) to |S|.
         1.  If |X| is declared to be [=variadic=], then:
             1.  [=list/For each=] |i| in [=the range=] |n| to |max| − 1, inclusive:
                 1.  Let |t| be a [=list=] of types.
                 1.  Let |o| be a [=list=] of [=optionality values=].
                 1.  [=list/For each=] |j| in [=the range=] 0 to |n| − 1, inclusive:
                     1.  [=list/Append=] |types|[|j|] to |t|.
-                    1.  [=list/Append=] |optionality_values|[|j|] to |o|.
+                    1.  [=list/Append=] |optionalityValues|[|j|] to |o|.
                 1.  [=list/For each=] |j| in [=the range=] |n| to |i|, inclusive:
                     1.  [=list/Append=] |types|[|n| − 1] to |t|.
                     1.  [=list/Append=] "variadic" to |o|.
@@ -2954,7 +2954,7 @@ the same operation or constructor.
             1.  Let |o| be a [=list=] of [=optionality values=].
             1.  [=list/For each=] |j| in [=the range=] 0 to |i| − 1, inclusive:
                 1.  [=list/Append=] |types|[|j|] to |t|.
-                1.  [=list/Append=] |optionality_values|[|j|] to |o|.
+                1.  [=list/Append=] |optionalityValues|[|j|] to |o|.
             1.  [=set/Append=] the [=tuple=] (|X|, |t|, |o|) to |S|.
             1.  Set |i| to |i| − 1.
 

--- a/index.bs
+++ b/index.bs
@@ -2890,7 +2890,7 @@ the same operation or constructor.
     [=takes a named argument list|named argument list=].
 
     1.  Let |S| be an [=ordered set=].
-    1.  Let |F| be an [=ordered set=] with elements as follows,
+    1.  Let |F| be an [=ordered set=] with [=set/items=] as follows,
         according to the kind of effective overload set:
         <dl class="switch">
              :  For regular operations

--- a/index.bs
+++ b/index.bs
@@ -2963,10 +2963,10 @@ the same operation or constructor.
                 1.  [=list/Append=] |types|[|j|] to |t|.
                 1.  [=list/Append=] |optionalityValues|[|j|] to |o|.
             1.  [=set/Append=] the [=tuple=] (|X|, |t|, |o|) to |S|.
-            1.  Set |i| to |i| − 1.
 
-            Note: if |i| is 0, this means to add to |S| the tuple (|X|, « », « »);
-            (where "« »" represents an [=list/is empty|empty list=]).
+                Note: if |i| is 0, this means to add to |S| the tuple (|X|, « », « »);
+                (where "« »" represents an [=list/is empty|empty list=]).
+            1.  Set |i| to |i| − 1.
     1.  Return |S|.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -2860,17 +2860,16 @@ the inputs to the algorithm needed to compute the set.
 An effective overload set is used, among other things, to determine whether there are ambiguities in the
 overloaded operations, constructors and callers specified on an interface.
 
-The elements of an effective overload set are tuples of the form
-&lt;|callable|, |type list|, |optionality list|&gt;.  If the effective overload
+The elements of an effective overload set are [=tuples=] of the form
+(|callable|, |type list|, |optionality list|).  If the effective overload
 set is for regular operations, static operations or legacy callers, then |callable| is an operation;
 if it is for constructors or named constructors, then |callable| is an
 extended attribute; and if it is for callback functions, then |callable|
-is the callback function itself.  In all cases, |type list| is a list
-of IDL types, and |optionality list| is a list of three possible <dfn id="dfn-optionality-value" export>optionality values</dfn> –
-“required”, “optional” or “variadic” – indicating whether
+is the callback function itself. In all cases, |type list| is a [=list=]
+of IDL types, and |optionality list| is a [=list=] of three possible <dfn id="dfn-optionality-value" export>optionality values</dfn> – "required", "optional" or "variadic" – indicating whether
 the argument at a given index was declared as being [=optional argument|optional=]
 or corresponds to a [=variadic=] argument.
-Each tuple represents an allowable invocation of the operation,
+Each [=tuple=] represents an allowable invocation of the operation,
 constructor, legacy caller or callback function with an argument value list of the given types.
 Due to the use of [=optional arguments=]
 and [=variadic=] operations
@@ -2890,8 +2889,8 @@ the same operation or constructor.
     it is referring to an argument of the extended attribute’s
     [=takes a named argument list|named argument list=].
 
-    1.  Initialize |S| to ∅.
-    1.  Let |F| be a set with elements as follows,
+    1.  Let |S| be an [=ordered set=].
+    1.  Let |F| be an [=ordered set=] with elements as follows,
         according to the kind of effective overload set:
         <dl class="switch">
              :  For regular operations
@@ -2923,37 +2922,38 @@ the same operation or constructor.
         the argument on which the ellipsis appears counts as a single argument.
 
         Note: So <code>void f(long x, long... y);</code> is considered to be declared to take two arguments.
-
     1.  Let |m| be the maximum of |maxarg| and |N|.
     1.  For each operation, extended attribute or callback function |X| in |F|:
         1.  Let |n| be the number of arguments |X| is declared to take.
-        1.  Let |t|<sub>0..|n|−1</sub> be a list of types, where |t|<sub>|i|</sub>
-            is the type of |X|’s argument at index |i|.
-        1.  Let |o|<sub>0..|n|−1</sub> be a list of [=optionality values=], where |o|<sub>|i|</sub>
-            is “variadic” if |X|’s argument at index |i| is a final, variadic argument,
-            “optional” if the argument is [=optional argument|optional=],
-            and “required” otherwise.
-        1.  Add to |S| the tuple &lt;|X|, |t|<sub>0..|n|−1</sub>, |o|<sub>0..|n|−1</sub>&gt;.
+        1.  Let |t| be a [=list=] of types, where |t|[|i|]
+            is the type of |X|[|i|].
+        1.  Let |o| be a list of [=optionality values=], where |o|[|i|]
+            is "variadic" if |X|[|i|] is a final, variadic argument,
+            "optional" if the argument is [=optional argument|optional=],
+            and "required" otherwise.
+        1.  [=set/Append=] the [=tuple=] (|X|, |t|, |o|) to |S|.
         1.  If |X| is declared to be [=variadic=], then:
-            1.  For every integer |i|, such that |n| ≤ |i| ≤ |m|−1:
-                1.  Let |u|<sub>0..|i|</sub> be a list of types,
-                    where |u|<sub>j</sub> = |t|<sub>j</sub> (for |j| &lt; |n|) and
-                    |u|<sub>j</sub> = |t|<sub>|n|−1</sub> (for |j| ≥ |n|).
-                1.  Let |p|<sub>0..|i|</sub> be a list of [=optionality values=],
-                    where |p|<sub>j</sub> = |o|<sub>j</sub> (for |j| &lt; |n|) and
-                    |p|<sub>j</sub> = “variadic” (for |j| ≥ |n|).
-                1.  Add to |S| the tuple &lt;|X|, |u|<sub>0..|i|</sub>, |p|<sub>0..|i|</sub>&gt;.
-        1.  Initialize |i| to |n|−1.
-        1.  While |i| ≥ 0:
-            1.  If argument |i| of |X| is not
-                [=optional argument|optional=]
-                (i.e., it is not marked as <code>optional</code> and is not
-                a final, variadic argument), then break this loop.
-            1.  Otherwise, add to |S| the tuple &lt;|X|, |t|<sub>0..|i|−1</sub>, |o|<sub>0..|i|−1</sub>&gt;.
-
-                Note: if |i| is 0, this means to add to |S| the tuple &lt;|X|, « », « »&gt;
-                (where "« »" represents an [=list/is empty|empty list=]).
+            1.  [=list/For each=] |i| in [=the range=] |n| to |m|−1, inclusive:
+                1.  Let |u| be a [=list=] of types.
+                1.  Let |p| be a [=list=] of [=optionality values=].
+                1.  [=list/For each=] |j| in [=the range=] 0 to |i|, inclusive:
+                    1.  If |j| &lt; |n|, then:
+                        1.  [=list/Append=] |t|[|j|] to |u|.
+                        1.  [=list/Append=] |o|[|j|] to |p|.
+                    1.  Otherwise:
+                        1.  [=list/Append=] |t|[|n|−1] to |u|.
+                        1.  [=list/Append=] "variadic" to |p|.
+                1.  [=set/Append=] the [=tuple=] (|X|, |u|, |p|) to |S|.
+        1.  Let |i| be |n|−1.
+        1.  [=iteration/While=] |i| ≥ 0:
+            1.  If |X|[|i|] is not [=optional argument|optional=]
+                (i.e., it is not marked as "optional" and is not
+                a final, variadic argument), then [=iteration/break=] this loop.
+            1.  Otherwise, [=set/append=] the [=tuple=] (|X|, |t|, |o|) to |S|.
             1.  Set |i| to |i|−1.
+            
+            Note: if |i| is 0, this means to add to |S| the tuple (|X|, « », « »);
+            (where "« »" represents an [=list/is empty|empty list=]).
     1.  The effective overload set is |S|.
 </div>
 
@@ -2977,14 +2977,16 @@ the same operation or constructor.
     identifier <code>f</code> and argument count 4 is:
 
     <pre class="set">
-      { &lt;f1, (DOMString), (required)&gt;,
-        &lt;f2, (Node, DOMString), (required, required)&gt;,
-        &lt;f2, (Node, DOMString, double), (required, required, variadic)&gt;,
-        &lt;f2, (Node, DOMString, double, double), (required, required, variadic, variadic)&gt;,
-        &lt;f3, (), ()&gt;,
-        &lt;f4, (Event, DOMString), (required, required)&gt;,
-        &lt;f4, (Event, DOMString, DOMString), (required, required, optional)&gt;,
-        &lt;f4, (Event, DOMString, DOMString, double), (required, required, optional, variadic)&gt; }
+      « 
+        (f1, « DOMString »,                           « required »),
+        (f2, « Node, DOMString »,                     « required, required »),
+        (f2, « Node, DOMString, double »,             « required, required, variadic »),
+        (f2, « Node, DOMString, double, double »,     « required, required, variadic, variadic »),
+        (f3, « »,                                     « »),
+        (f4, « Event, DOMString »,                    « required, required »),
+        (f4, « Event, DOMString, DOMString »,         « required, required, optional »),
+        (f4, « Event, DOMString, DOMString, double », « required, required, optional, variadic »)
+      »
     </pre>
 </div>
 
@@ -3300,9 +3302,11 @@ be the same.
     For argument count 4, the effective overload set is:
 
     <pre class="set">
-      { &lt;f1, (DOMString), (required)&gt;,
-        &lt;f2, (long, double, Node, Node), (required, required, required, required)&gt;,
-        &lt;f3, (double, double, DOMString, Node), (required, required, required, required)&gt; }
+      « 
+        (f1, « DOMString »,                       « required »),
+        (f2, « long, double, Node, Node »,        « required, required, required, required »),
+        (f3, « double, double, DOMString, Node », « required, required, required, required »)
+      »
     </pre>
 
     Looking at entries with type list length 4, the

--- a/index.bs
+++ b/index.bs
@@ -2935,29 +2935,28 @@ the same operation or constructor.
                 and "required" otherwise.
         1.  [=set/Append=] the [=tuple=] (|X|, |types|, |optionality_values|) to |S|.
         1.  If |X| is declared to be [=variadic=], then:
-            1.  [=list/For each=] |i| in [=the range=] |n| to |max|−1, inclusive:
+            1.  [=list/For each=] |i| in [=the range=] |n| to |max| − 1, inclusive:
                 1.  Let |t| be a [=list=] of types.
                 1.  Let |o| be a [=list=] of [=optionality values=].
-                1.  [=list/For each=] |j| in [=the range=] 0 to |i|, inclusive:
-                    1.  If |j| &lt; |n|, then:
-                        1.  [=list/Append=] |types|[|j|] to |t|.
-                        1.  [=list/Append=] |optionality_values|[|j|] to |o|.
-                    1.  Otherwise:
-                        1.  [=list/Append=] |types|[|n|−1] to |t|.
-                        1.  [=list/Append=] "variadic" to |o|.
+                1.  [=list/For each=] |j| in [=the range=] 0 to |n| − 1, inclusive:
+                    1.  [=list/Append=] |types|[|j|] to |t|.
+                    1.  [=list/Append=] |optionality_values|[|j|] to |o|.
+                1.  [=list/For each=] |j| in [=the range=] |n| to |i|, inclusive:
+                    1.  [=list/Append=] |types|[|n| − 1] to |t|.
+                    1.  [=list/Append=] "variadic" to |o|.
                 1.  [=set/Append=] the [=tuple=] (|X|, |t|, |o|) to |S|.
-        1.  Let |i| be |n|−1.
+        1.  Let |i| be |n| − 1.
         1.  [=iteration/While=] |i| ≥ 0:
             1.  If |arguments|[|i|] is not [=optional argument|optional=]
                 (i.e., it is not marked as "optional" and is not
                 a final, variadic argument), then [=iteration/break=] this loop.
             1.  Let |t| be a [=list=] of types.
             1.  Let |o| be a [=list=] of [=optionality values=].
-            1.  [=list/For each=] |j| in [=the range=] 0 to |i|−1, inclusive:
+            1.  [=list/For each=] |j| in [=the range=] 0 to |i| − 1, inclusive:
                 1.  [=list/Append=] |types|[|j|] to |t|.
                 1.  [=list/Append=] |optionality_values|[|j|] to |o|.
             1.  [=set/Append=] the [=tuple=] (|X|, |t|, |o|) to |S|.
-            1.  Set |i| to |i|−1.
+            1.  Set |i| to |i| − 1.
 
             Note: if |i| is 0, this means to add to |S| the tuple (|X|, « », « »);
             (where "« »" represents an [=list/is empty|empty list=]).

--- a/index.bs
+++ b/index.bs
@@ -2990,7 +2990,7 @@ the same operation or constructor.
     identifier <code>f</code> and argument count 4 is:
 
     <pre class="set">
-      « 
+      «
         (f1, « DOMString »,                           « required »),
         (f2, « Node, DOMString »,                     « required, required »),
         (f2, « Node, DOMString, double »,             « required, required, variadic »),
@@ -3314,7 +3314,7 @@ be the same.
     For argument count 4, the effective overload set is:
 
     <pre class="set">
-      « 
+      «
         (f1, « DOMString »,                       « required »),
         (f2, « long, double, Node, Node »,        « required, required, required, required »),
         (f3, « double, double, DOMString, Node », « required, required, required, required »)

--- a/index.bs
+++ b/index.bs
@@ -2922,7 +2922,7 @@ the same operation or constructor.
         the argument on which the ellipsis appears counts as a single argument.
 
         Note: So <code>void f(long x, long... y);</code> is considered to be declared to take two arguments.
-    1.  Let |max| be the maximum of |maxarg| and |N|.
+    1.  Let |max| be [=max=](|maxarg|, |N|).
     1.  For each operation, extended attribute or callback function |X| in |F|:
         1.  Let |arguments| be the [=list=] of arguments |X| is declared to take.
         1.  Let |n| be the [=list/size=] of |arguments|.


### PR DESCRIPTION
Closes #391.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#idl-overloading
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tobie/webidl/fix-391.html#idl-overloading) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/c062489...tobie:b11cc67.html)