### PR TITLE
Clarify that unrestricted doubles and floats include NaNs.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5122,7 +5122,7 @@ The [=type name=] of the
 
 The {{float}} type is a floating point numeric
 type that corresponds to the set of finite single-precision 32 bit
-IEEE 754 floating point numbers.  [[!IEEE-754]]
+IEEE 754 floating point numbers. [[!IEEE-754]]
 
 {{float}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-float">float</a></emu-t>
@@ -5144,7 +5144,7 @@ The [=type name=] of the
 
 The {{unrestricted float}} type is a floating point numeric
 type that corresponds to the set of all possible single-precision 32 bit
-IEEE 754 floating point numbers, finite and non-finite.  [[!IEEE-754]]
+IEEE 754 floating point numbers, finite, non-finite, and special "not a number" values (NaNs). [[!IEEE-754]]
 
 {{unrestricted float}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-float">float</a></emu-t>
@@ -5158,7 +5158,7 @@ The [=type name=] of the
 
 The {{double}} type is a floating point numeric
 type that corresponds to the set of finite double-precision 64 bit
-IEEE 754 floating point numbers.  [[!IEEE-754]]
+IEEE 754 floating point numbers. [[!IEEE-754]]
 
 {{double}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-float">float</a></emu-t>
@@ -5172,7 +5172,7 @@ The [=type name=] of the
 
 The {{unrestricted double}} type is a floating point numeric
 type that corresponds to the set of all possible double-precision 64 bit
-IEEE 754 floating point numbers, finite and non-finite.  [[!IEEE-754]]
+IEEE 754 floating point numbers, finite, non-finite, and special "not a number" values (NaNs). [[!IEEE-754]]
 
 {{unrestricted double}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-float">float</a></emu-t>


### PR DESCRIPTION
Closes https://www.w3.org/Bugs/Public/show_bug.cgi?id=29240.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tobie/webidl/fix-29240.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/5c1fce0...tobie:42db137.html)