### PR TITLE
Fix sentence that required optionality values to be boolean

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3254,7 +3254,7 @@ for the entries of the effective overload set with the given type list length.
 In addition, for each index |j|, where |j| is less than the
 [=distinguishing argument index=]
 for a given type list length, the types at index |j| in
-all of the entries’ type lists must be the same
+all of the entries’ type lists must be the same,
 and the [=optionality values=] at index |j| in all of the entries’ optionality lists must
 be the same.
 

--- a/index.bs
+++ b/index.bs
@@ -3255,7 +3255,7 @@ In addition, for each index |j|, where |j| is less than the
 [=distinguishing argument index=]
 for a given type list length, the types at index |j| in
 all of the entries’ type lists must be the same
-and the booleans in the corresponding list indicating argument optionality must
+and the [=optionality values=] at index |j| in all of the entries’ optionality lists must
 be the same.
 
 <div class="example">


### PR DESCRIPTION
Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=25628.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tobie/webidl/fix-25628.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/5c1fce0...tobie:42c6415.html)