### PR TITLE
Specify the property descriptor of @@unscopables.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10169,7 +10169,9 @@ whose value is a reference to the [=interface object=] for the interface.
     has any [=interface member=] declared with
     the [{{Unscopable}}] extended attribute,
     then there must be a property on the
-    interface prototype object whose name is the [=@@unscopables=] symbol
+    interface prototype object whose name is the [=@@unscopables=] symbol,
+    which has the attributes
+    { \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> },
     and whose value is an object created as follows:
 
     1.  Let |object| be a new object created as if by the expression <code>({})</code>.


### PR DESCRIPTION
Fixes #102.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tobie/webidl/fix-102.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/fb40c8e...tobie:7ac2724.html)