### PR TITLE
Use <emu-val> only for constant values

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7028,9 +7028,8 @@ values.
 
 <h4 id="es-callback-function">Callback function types</h4>
 
-IDL [=callback function types=] are represented by ECMAScript function
-objects, except in the [{{TreatNonObjectAsNull}}] case,
-when they can be any object.
+IDL [=callback function types=] are represented by ECMAScript [=function objects=], except in the
+[{{TreatNonObjectAsNull}}] case, when they can be any object.
 
 <div id="es-to-callback-function" algorithm="convert an ECMAScript value to callback function">
 
@@ -10984,7 +10983,7 @@ The value of the [=@@iterator=] [=function object=]’s “name” property
 is the String value “entries”
 if the interface has a [=pair iterator=] or a [=maplike declaration=]
 and the String “values”
-if the interface has a [=setlike declaration=] or defines an [=indexed property getter=].
+if the interface has a [=setlike declaration=].
 
 
 <h5 id="es-forEach">forEach</h5>
@@ -11736,8 +11735,8 @@ each property that corresponds to one of the
 [=setlike declarations=]
 that exist on all of the interface prototype objects of |A|’s
 [=consequential interfaces=].
-For operations, where the property is a data property with a function
-object value, each copy of the property must have
+For operations, where the property is a data property with a [=function object=]
+value, each copy of the property must have
 distinct [=function objects=].  For attributes, each
 copy of the accessor property must have
 distinct [=function objects=] for their getters,

--- a/index.bs
+++ b/index.bs
@@ -44,7 +44,13 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
     type: interface; for: ECMAScript
         text: ArrayBuffer; url: sec-arraybuffer-objects
         text: DataView; url: sec-dataview-objects
+        text: Map; url: sec-map-objects
+        text: Promise; url: sec-promise-objects
+        text: Set; url: sec-set-objects
         text: SharedArrayBuffer; url: sec-sharedarraybuffer-objects
+    type: exception; for: ECMAScript
+        text: Error; url: sec-error-objects
+        text: SyntaxError; url: sec-native-error-types-used-in-this-standard-syntaxerror
     type: dfn
         text: NumericLiteral; url: sec-literals-numeric-literals
         text: ECMAScript error objects; url: sec-error-objects
@@ -139,7 +145,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: sections 9.1; url: sec-ordinary-object-internal-methods-and-internal-slots
         text: 9.3.1; url: sec-built-in-function-objects-call-thisargument-argumentslist
         text: ECMA-262 section 9.3; url: sec-built-in-function-objects
-        text: function object; url: sec-built-in-function-objects
+        text: function object; url: sec-ecmascript-function-objects
         text: Array methods; url: sec-properties-of-the-array-prototype-object
         text: typed arrays; url: sec-typedarray-objects
         text: GetMethod; url: sec-getmethod
@@ -312,7 +318,7 @@ commonly used on the web, ECMAScript, are consistently specified with
 low enough precision as to result in interoperability issues.  In
 addition, each specification must describe the same basic information,
 such as DOM interfaces described in IDL corresponding to properties
-on the ECMAScript global object, or the {{unsigned long}} IDL type mapping to the <emu-val>Number</emu-val>
+on the ECMAScript global object, or the {{unsigned long}} IDL type mapping to the Number
 type in ECMAScript.
 
 This specification defines an IDL language similar to OMG IDL
@@ -428,8 +434,8 @@ in [[#es-extended-attributes]].
     particular language being used.
 
     In ECMAScript, the attributes on the IDL interfaces will be exposed as accessor
-    properties and the operations as <emu-val>Function</emu-val>-valued
-    data properties on a prototype object for all <code class="idl">GraphicalWindow</code>
+    properties and the operations as data properties whose value is a [=function object=] on a
+    prototype object for all <code class="idl">GraphicalWindow</code>
     objects; each ECMAScript object that implements <code class="idl">GraphicalWindow</code>
     will have that prototype object in its prototype chain.
 
@@ -842,7 +848,7 @@ be defined on a [=callback interface=].
     given property (in this case “handleEvent”) to be considered to implement the interface.
     For new APIs, and those for which there are no compatibility concerns,
     using a [=callback function=] will allow
-    only a <emu-val>Function</emu-val> object (in the ECMAScript
+    only a [=function object=] (in the ECMAScript
     language binding).
 
 </div>
@@ -1138,7 +1144,7 @@ The identifier also must not
 be “length”, “name” or “prototype”.
 
 Note: These three names are the names of properties that exist on all
-<emu-val>Function</emu-val> objects.
+[=function objects=].
 
 The type of a constant (matching <emu-nt><a href="#prod-ConstType">ConstType</a></emu-nt>)
 must not be any type other than
@@ -2741,7 +2747,7 @@ declared on [=callback interfaces=].
         };
     </pre>
 
-    In the ECMAScript language binding, the <emu-val>Function</emu-val> object for
+    In the ECMAScript language binding, the [=function object=] for
     <code>triangulate</code> and the accessor property for <code>triangulationCount</code>
     will exist on the [=interface object=]
     for <code class="idl">Circle</code>:
@@ -3519,7 +3525,7 @@ the map entries.
 
 Note: In the ECMAScript language binding, the API for interacting
 with the map entries is similar to that available on ECMAScript
-<emu-val>Map</emu-val> objects.  If the <emu-t>readonly</emu-t>
+{{Map}} objects.  If the <emu-t>readonly</emu-t>
 keyword is used, this includes “entries”, “forEach”, “get”, “has”,
 “keys”, “values”, [=@@iterator=] methods and a “size” getter.
 For read–write maplikes, it also includes “clear”, “delete” and
@@ -3609,7 +3615,7 @@ the set entries.
 
 Note: In the ECMAScript language binding, the API for interacting
 with the set entries is similar to that available on ECMAScript
-<emu-val>Set</emu-val> objects.  If the <emu-t>readonly</emu-t>
+{{Set}} objects.  If the <emu-t>readonly</emu-t>
 keyword is used, this includes “entries”, “forEach”, “has”,
 “keys”, “values”, [=@@iterator=] methods and a “size” getter.
 For read–write setlikes, it also includes “add”, “clear”, and “delete” methods.
@@ -4086,7 +4092,7 @@ The following extended attributes are applicable to dictionaries:
         };
     </pre>
 
-    In an ECMAScript implementation of the IDL, an <emu-val>Object</emu-val>
+    In an ECMAScript implementation of the IDL, an Object
     can be passed in for the optional <code class="idl">PaintOptions</code> dictionary:
 
     <pre highlight="js">
@@ -4130,7 +4136,7 @@ is identified by one of the following types:
 *   <dfn exception>URIError</dfn>
 
 These correspond to all of the [=ECMAScript error objects=]
-(apart from <emu-val>SyntaxError</emu-val> and <emu-val>Error</emu-val>,
+(apart from {{ECMAScript/SyntaxError}} and {{ECMAScript/Error}},
 which are deliberately omitted as they are reserved for use
 by the ECMAScript parser and by authors, respectively).
 The meaning of each [=simple exception=] matches
@@ -4543,7 +4549,7 @@ The following extended attribute is applicable to callback functions:
         };
     </pre>
 
-    In the ECMAScript language binding, a <emu-val>Function</emu-val> object is
+    In the ECMAScript language binding, a [=function object=] is
     passed as the operation argument.
 
     <pre highlight="js">
@@ -5156,7 +5162,7 @@ The [=type name=] of the
     specifications should use
     {{double}} rather than {{float}},
     since the set of values that a {{double}} can
-    represent more closely matches an ECMAScript <emu-val>Number</emu-val>.
+    represent more closely matches an ECMAScript Number.
 </p>
 
 
@@ -5370,7 +5376,7 @@ The [=callback context=] is a language
 binding specific value, and is used to store information about the execution context at
 the time the language binding specific object reference is converted to an IDL value.
 
-Note: For ECMAScript objects, the [=callback context=] is used to hold a reference to the [=incumbent settings object=] at the time the <emu-val>Object</emu-val> value
+Note: For ECMAScript objects, the [=callback context=] is used to hold a reference to the [=incumbent settings object=] at the time the Object value
 is converted to an IDL callback interface type value. See [[#es-interface]].
 
 There is no way to represent a constant object reference value for
@@ -5429,7 +5435,7 @@ reference and a [=callback context=].
 
 Note: As with [=interface type|callback interface types=], the [=callback context=] is used to hold a
 reference to the [=incumbent settings object=] at
-the time an ECMAScript <emu-val>Object</emu-val> value is converted to an IDL
+the time an ECMAScript Object value is converted to an IDL
 callback function type value.  See [[#es-callback-function]].
 
 There is no way to represent a constant [=callback function=]
@@ -6181,7 +6187,7 @@ Unless otherwise specified, the \[[Extensible]] internal property
 of objects defined in this section has the value <emu-val>true</emu-val>.
 
 Unless otherwise specified, the \[[Prototype]] internal property
-of objects defined in this section is the <emu-val>Object</emu-val> prototype object.
+of objects defined in this section is the Object prototype object.
 
 Some objects described in this section are defined to have a <dfn id="dfn-class-string" export>class string</dfn>,
 which is the string to include in the string returned from Object.prototype.toString.
@@ -6215,8 +6221,8 @@ it has characteristics as described in [=ECMA-262 section 9.3=].
 </p>
 
 When an algorithm says to
-<dfn noexport lt="ECMAScript throw" local-lt="throw" for="ECMAScript" id="ecmascript-throw">throw</dfn> a <emu-val><i>Something</i>Error</emu-val>
-then this means to construct a new ECMAScript <emu-val><i>Something</i>Error</emu-val> object in
+<dfn noexport lt="ECMAScript throw" local-lt="throw" for="ECMAScript" id="ecmascript-throw">throw</dfn> a <code>|Something|Error</code>
+then this means to construct a new ECMAScript <code>|Something|Error</code> object in
 the [=current Realm=] and to throw it, just as the algorithms in ECMA-262 do.
 
 Note that algorithm steps can call in to other algorithms and abstract operations and
@@ -6262,9 +6268,9 @@ and comprise the following:
 *   [=iterator prototype objects=]
 *   [=attribute getters=]
 *   [=attribute setters=]
-*   <a href="#es-operations">the <emu-val>Function</emu-val> objects that correspond to operations</a>
-*   <a href="#es-stringifier">the <emu-val>Function</emu-val> objects that correspond to stringifiers</a>
-*   <a href="#es-iterators">the <emu-val>Function</emu-val> objects that correspond to iterators</a>
+*   <a href="#es-operations">the function objects that correspond to operations</a>
+*   <a href="#es-stringifier">the function objects that correspond to stringifiers</a>
+*   <a href="#es-iterators">the function objects that correspond to iterators</a>
 *   [=map size getters=]
 
 Each [=Realms|ECMAScript global environment=]
@@ -6316,8 +6322,8 @@ every ECMAScript object must have an <dfn id="dfn-associated-realm" export>assoc
 for associating objects with Realms are, for now, underspecified. However, we note that
 in the case of [=platform objects=], the
 associated Realm is equal to the object's [=relevant Realm=], and
-for non-exotic function objects (i.e. not callable proxies, and not bound functions)
-the associated Realm is equal to the value of the function object's \[[Realm]] internal
+for non-exotic [=function objects=] (i.e. not callable proxies, and not bound functions)
+the associated Realm is equal to the value of the [=function object=]'s \[[Realm]] internal
 slot.
 
 
@@ -6404,7 +6410,7 @@ may return any value, which will be discarded.
     1.  Let |x| be the result of computing [=ToBoolean=](|V|).
     1.  Return the IDL {{boolean}} value that is the one that
         represents the same truth value as the
-        ECMAScript <emu-val>Boolean</emu-val> value |x|.
+        ECMAScript Boolean value |x|.
 </div>
 
 <p id="boolean-to-es">
@@ -6422,7 +6428,7 @@ including those defined in [=ECMA-262 section 5.2=],
 are to be understood as computing exact mathematical results
 on mathematical real numbers.
 
-In effect, where <var ignore>x</var> is a <emu-val>Number</emu-val> value,
+In effect, where <var ignore>x</var> is a Number value,
 “operating on <var ignore>x</var>” is shorthand for
 “operating on the mathematical real number that represents the same numeric value as <var ignore>x</var>”.
 
@@ -6440,9 +6446,9 @@ In effect, where <var ignore>x</var> is a <emu-val>Number</emu-val> value,
 <p id="byte-to-es">
     The result of [=converted to an ECMAScript value|converting=]
     an IDL {{byte}} value to an ECMAScript
-    value is a <emu-val>Number</emu-val> that represents
+    value is a Number that represents
     the same numeric value as the IDL {{byte}} value.
-    The <emu-val>Number</emu-val> value will be an integer in the range [−128, 127].
+    The Number value will be an integer in the range [−128, 127].
 </p>
 
 
@@ -6460,10 +6466,10 @@ In effect, where <var ignore>x</var> is a <emu-val>Number</emu-val> value,
 <p id="octet-to-es">
     The result of [=converted to an ECMAScript value|converting=]
     an IDL {{octet}} value to an ECMAScript
-    value is a <emu-val>Number</emu-val> that represents
+    value is a Number that represents
     the same numeric value as the IDL
     {{octet}} value.
-    The <emu-val>Number</emu-val> value will be an integer in the range [0, 255].
+    The Number value will be an integer in the range [0, 255].
 </p>
 
 
@@ -6482,10 +6488,10 @@ In effect, where <var ignore>x</var> is a <emu-val>Number</emu-val> value,
 <p id="short-to-es">
     The result of [=converted to an ECMAScript value|converting=]
     an IDL {{short}} value to an ECMAScript
-    value is a <emu-val>Number</emu-val> that represents the
+    value is a Number that represents the
     same numeric value as the IDL
     {{short}} value.
-    The <emu-val>Number</emu-val> value will be an integer in the range [−32768, 32767].
+    The Number value will be an integer in the range [−32768, 32767].
 </p>
 
 
@@ -6503,10 +6509,10 @@ In effect, where <var ignore>x</var> is a <emu-val>Number</emu-val> value,
 <p id="unsigned-short-to-es">
     The result of [=converted to an ECMAScript value|converting=]
     an IDL {{unsigned short}} value to an ECMAScript
-    value is a <emu-val>Number</emu-val> that
+    value is a Number that
     represents the same numeric value as the IDL
     {{unsigned short}} value.
-    The <emu-val>Number</emu-val> value will be an integer in the range [0, 65535].
+    The Number value will be an integer in the range [0, 65535].
 </p>
 
 
@@ -6524,10 +6530,10 @@ In effect, where <var ignore>x</var> is a <emu-val>Number</emu-val> value,
 <p id="long-to-es">
     The result of [=converted to an ECMAScript value|converting=]
     an IDL {{long}} value to an ECMAScript
-    value is a <emu-val>Number</emu-val> that
+    value is a Number that
     represents the same numeric value as the IDL
     {{long}} value.
-    The <emu-val>Number</emu-val> value will be an integer in the range [−2147483648, 2147483647].
+    The Number value will be an integer in the range [−2147483648, 2147483647].
 </p>
 
 
@@ -6545,10 +6551,10 @@ In effect, where <var ignore>x</var> is a <emu-val>Number</emu-val> value,
 <p id="unsigned-long-to-es">
     The result of [=converted to an ECMAScript value|converting=]
     an IDL {{unsigned long}} value to an ECMAScript
-    value is a <emu-val>Number</emu-val> that
+    value is a Number that
     represents the same numeric value as the IDL
     {{unsigned long}} value.
-    The <emu-val>Number</emu-val> value will be an integer in the range [0, 4294967295].
+    The Number value will be an integer in the range [0, 4294967295].
 </p>
 
 
@@ -6566,12 +6572,12 @@ In effect, where <var ignore>x</var> is a <emu-val>Number</emu-val> value,
 <p id="long-long-to-es">
     The result of [=converted to an ECMAScript value|converting=]
     an IDL {{long long}} value to an ECMAScript
-    value is a <emu-val>Number</emu-val> value that
+    value is a Number value that
     represents the closest numeric value to the {{long long}},
     choosing the numeric value with an <em>even significand</em> if there are
     two [=equally close values=].
     If the {{long long}} is in the range
-    [−2<sup>53</sup> + 1, 2<sup>53</sup> − 1], then the <emu-val>Number</emu-val>
+    [−2<sup>53</sup> + 1, 2<sup>53</sup> − 1], then the Number
     will be able to represent exactly the same value as the
     {{long long}}.
 </p>
@@ -6591,12 +6597,12 @@ In effect, where <var ignore>x</var> is a <emu-val>Number</emu-val> value,
 <p id="unsigned-long-long-to-es">
     The result of [=converted to an ECMAScript value|converting=]
     an IDL {{unsigned long long}} value to an ECMAScript
-    value is a <emu-val>Number</emu-val> value that
+    value is a Number value that
     represents the closest numeric value to the {{unsigned long long}},
     choosing the numeric value with an <em>even significand</em> if there are
     two [=equally close values=].
     If the {{unsigned long long}} is less than or equal to 2<sup>53</sup> − 1,
-    then the <emu-val>Number</emu-val> will be able to
+    then the Number will be able to
     represent exactly the same value as the
     {{unsigned long long}}.
 </p>
@@ -6637,10 +6643,10 @@ In effect, where <var ignore>x</var> is a <emu-val>Number</emu-val> value,
     1.  If the conversion is to an IDL type [=extended attribute associated with|associated with=]
         the [{{EnforceRange}}] [=extended attribute=], then:
         1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
-            then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+            then [=ECMAScript/throw=] a {{TypeError}}.
         1.  Set |x| to [=!=] <a abstract-op>IntegerPart</a>(|x|).
         1.  If |x| &lt; |lowerBound| or |x| &gt; |upperBound|,
-            then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+            then [=ECMAScript/throw=] a {{TypeError}}.
         1.  Return |x|.
     1.  If |x| is not <emu-val>NaN</emu-val> and the conversion is to an IDL type
         [=extended attribute associated with|associated with=] the [{{Clamp}}] extended attribute,
@@ -6668,7 +6674,7 @@ In effect, where <var ignore>x</var> is a <emu-val>Number</emu-val> value,
 
     1.  Let |x| be [=?=] [=ToNumber=](|V|).
     1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
-        then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Let |S| be the set of finite IEEE 754 single-precision floating
         point values except −0, but with two special values added: 2<sup>128</sup> and
         −2<sup>128</sup>.
@@ -6677,7 +6683,7 @@ In effect, where <var ignore>x</var> is a <emu-val>Number</emu-val> value,
         <em>even significand</em> if there are two [=equally close values=].
         (The two special values 2<sup>128</sup> and −2<sup>128</sup>
         are considered to have even significands for this purpose.)
-    1.  If |y| is 2<sup>128</sup> or −2<sup>128</sup>, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+    1.  If |y| is 2<sup>128</sup> or −2<sup>128</sup>, then [=ECMAScript/throw=] a {{TypeError}}.
     1.  If |y| is +0 and |x| is negative, return −0.
     1.  Return |y|.
 </div>
@@ -6685,7 +6691,7 @@ In effect, where <var ignore>x</var> is a <emu-val>Number</emu-val> value,
 <p id="float-to-es">
     The result of [=converted to an ECMAScript value|converting=]
     an IDL {{float}} value to an ECMAScript
-    value is the <emu-val>Number</emu-val> value that represents the same numeric value as the IDL
+    value is the Number value that represents the same numeric value as the IDL
     {{float}} value.
 </p>
 
@@ -6722,11 +6728,11 @@ value when its bit pattern is interpreted as an unsigned 32 bit integer.
 
     The result of [=converted to an ECMAScript value|converting=]
     an IDL {{unrestricted float}} value to an ECMAScript
-    value is a <emu-val>Number</emu-val>:
+    value is a Number:
 
     1.  If the IDL {{unrestricted float}} value is a NaN,
-        then the <emu-val>Number</emu-val> value is <emu-val>NaN</emu-val>.
-    1.  Otherwise, the <emu-val>Number</emu-val> value is
+        then the Number value is <emu-val>NaN</emu-val>.
+    1.  Otherwise, the Number value is
         the one that represents the same numeric value as the IDL
         {{unrestricted float}} value.
 </div>
@@ -6741,7 +6747,7 @@ value when its bit pattern is interpreted as an unsigned 32 bit integer.
 
     1.  Let |x| be [=?=] [=ToNumber=](|V|).
     1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
-        then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the IDL {{double}} value
         that represents the same numeric value as |x|.
 </div>
@@ -6749,7 +6755,7 @@ value when its bit pattern is interpreted as an unsigned 32 bit integer.
 <p id="double-to-es">
     The result of [=converted to an ECMAScript value|converting=]
     an IDL {{double}} value to an ECMAScript
-    value is the <emu-val>Number</emu-val> value that represents the
+    value is the Number value that represents the
     same numeric value as the IDL {{double}} value.
 </p>
 
@@ -6778,11 +6784,11 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
 
     The result of [=converted to an ECMAScript value|converting=]
     an IDL {{unrestricted double}} value to an ECMAScript
-    value is a <emu-val>Number</emu-val>:
+    value is a Number:
 
     1.  If the IDL {{unrestricted double}} value is a NaN,
-        then the <emu-val>Number</emu-val> value is <emu-val>NaN</emu-val>.
-    1.  Otherwise, the <emu-val>Number</emu-val> value is
+        then the Number value is <emu-val>NaN</emu-val>.
+    1.  Otherwise, the Number value is
         the one that represents the same numeric value as the IDL
         {{unrestricted double}} value.
 </div>
@@ -6799,13 +6805,13 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
         [=extended attribute associated with|associated with=] the [{{TreatNullAs}}] extended
         attribute, then return the {{DOMString}} value that represents the empty string.
     1.  Let |x| be [=ToString=](|V|).
-    1.  Return the IDL {{DOMString}} value that represents the same sequence of code units as the one the ECMAScript <emu-val>String</emu-val> value |x| represents.
+    1.  Return the IDL {{DOMString}} value that represents the same sequence of code units as the one the ECMAScript String value |x| represents.
 </div>
 
 <p id="DOMString-to-es">
     The result of [=converted to an ECMAScript value|converting=]
     an IDL {{DOMString}} value to an ECMAScript
-    value is the <emu-val>String</emu-val>
+    value is the String
     value that represents the same sequence of [=code units=] that the
     IDL {{DOMString}} represents.
 </p>
@@ -6820,7 +6826,7 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
 
     1.  Let |x| be [=ToString=](|V|).
     1.  If the value of any [=element=]
-        of |x| is greater than 255, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        of |x| is greater than 255, then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return an IDL {{ByteString}} value
         whose length is the length of |x|, and where the value of each element is
         the value of the corresponding element of |x|.
@@ -6829,7 +6835,7 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
 <p id="ByteString-to-es">
     The result of [=converted to an ECMAScript value|converting=]
     an IDL {{ByteString}} value to an ECMAScript
-    value is a <emu-val>String</emu-val>
+    value is a String
     value whose length is the length of the {{ByteString}},
     and the value of each element of which is the value of the corresponding element
     of the {{ByteString}}.
@@ -6856,47 +6862,47 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
 
     1.  Let |scalarValues| be the sequence of [=Unicode scalar values=] the {{USVString}} represents.
     1.  Let |string| be the sequence of [=code units=] that results from encoding |scalarValues| in UTF-16.
-    1.  Return the <emu-val>String</emu-val> value that represents the same sequence of [=code units=] as |string|.
+    1.  Return the String value that represents the same sequence of [=code units=] as |string|.
 </div>
 
 
 <h4 id="es-object">object</h4>
 
 IDL {{object}}
-values are represented by ECMAScript <emu-val>Object</emu-val> values.
+values are represented by ECMAScript Object values.
 
 <div id="es-to-object" algorithm="convert an ECMAScript value to object">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL {{object}} value by running the following algorithm:
 
-    1.  If [=Type=](|V|) is not Object, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+    1.  If [=Type=](|V|) is not Object, then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the IDL {{object}} value that is a reference to the same object as |V|.
 </div>
 
 <p id="object-to-es">
     The result of [=converted to an ECMAScript value|converting=]
     an IDL {{object}} value to an ECMAScript
-    value is the <emu-val>Object</emu-val> value that represents a reference to the same object that the
+    value is the Object value that represents a reference to the same object that the
     IDL {{object}} represents.
 </p>
 
 
 <h4 id="es-symbol">symbol</h4>
 
-IDL {{symbol}} values are represented by ECMAScript <emu-val>Symbol</emu-val> values.
+IDL {{symbol}} values are represented by ECMAScript Symbol values.
 
 <div id="es-to-symbol" algorithm="convert an ECMAScript value to a symbol">
     An ECMAScript value |V| is [=converted to an IDL value|converted=] to an IDL {{symbol}} value
     by running the following algorithm:
 
-    1.  If [=Type=](|V|) is not Symbol, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+    1.  If [=Type=](|V|) is not Symbol, then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the IDL {{symbol}} value that is a reference to the same symbol as |V|.
 </div>
 
 <p id="symbol-to-es">
     The result of [=converted to an ECMAScript value|converting=] an IDL {{symbol}} value to an
-    ECMAScript value is the <emu-val>Symbol</emu-val> value that represents a reference to the same
+    ECMAScript value is the Symbol value that represents a reference to the same
     symbol that the IDL {{symbol}} represents.
 </p>
 
@@ -6904,26 +6910,25 @@ IDL {{symbol}} values are represented by ECMAScript <emu-val>Symbol</emu-val> va
 <h4 id="es-interface">Interface types</h4>
 
 IDL [=interface type=]
-values are represented by ECMAScript <emu-val>Object</emu-val> or
-<emu-val>Function</emu-val> values.
+values are represented by ECMAScript Object values (including [=function objects=]).
 
 <div id="es-to-interface" algorithm="convert an ECMAScript value to interface">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL [=interface type=] value by running the following algorithm (where |I| is the [=interface=]):
 
-    1.  If [=Type=](|V|) is not Object, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+    1.  If [=Type=](|V|) is not Object, then [=ECMAScript/throw=] a {{TypeError}}.
     1.  If |V| is a [=platform object=] that implements |I|, then return the IDL [=interface type=] value that represents a reference to that platform object.
     1.  If |V| is a [=user object=]
         that is considered to implement |I| according to the rules in [[#es-user-objects]], then return the IDL [=interface type=] value that represents a reference to that
         user object, with the [=incumbent settings object=] as the [=callback context=].
-    1.  [=ECMAScript/Throw=] a <emu-val>TypeError</emu-val>.
+    1.  [=ECMAScript/Throw=] a {{TypeError}}.
 </div>
 
 <p id="interface-to-es">
     The result of [=converted to an ECMAScript value|converting=]
     an IDL [=interface type=]
-    value to an ECMAScript value is the <emu-val>Object</emu-val>
+    value to an ECMAScript value is the Object
     value that represents a reference to the same object that the IDL
     [=interface type=] value represents.
 </p>
@@ -6932,7 +6937,7 @@ values are represented by ECMAScript <emu-val>Object</emu-val> or
 <h4 id="es-dictionary">Dictionary types</h4>
 
 IDL [=dictionary type=] values are represented
-by ECMAScript <emu-val>Object</emu-val> values.  Properties on
+by ECMAScript Object values.  Properties on
 the object (or its prototype chain) correspond to [=dictionary members=].
 
 <div id="es-to-dictionary" algorithm="convert an ECMAScript value to dictionary">
@@ -6941,7 +6946,7 @@ the object (or its prototype chain) correspond to [=dictionary members=].
     to an IDL [=dictionary type=] value by
     running the following algorithm (where |D| is the [=dictionary type=]):
 
-    1.  If [=Type=](|V|) is not Undefined, Null or Object, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+    1.  If [=Type=](|V|) is not Undefined, Null or Object, then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Let |dict| be an empty dictionary value of type |D|;
         every [=dictionary member=]
         is initially considered to be [=not present=].
@@ -6966,7 +6971,7 @@ the object (or its prototype chain) correspond to [=dictionary members=].
                 1.  Set the dictionary member on |dict| with key name |key| to the value |idlValue|.  This dictionary member is considered to be [=present=].
             1.  Otherwise, if |value| is
                 <emu-val>undefined</emu-val> and |member| is a
-                [=required dictionary member=], then throw a <emu-val>TypeError</emu-val>.
+                [=required dictionary member=], then throw a {{TypeError}}.
     1.  Return |dict|.
 </div>
 
@@ -6976,7 +6981,7 @@ up on the ECMAScript object are not necessarily the same as the object’s prope
 <div id="dictionary-to-es" algorithm="convert a dictionary to an ECMAScript value">
 
     An IDL dictionary value |V| is [=converted to an ECMAScript value|converted=]
-    to an ECMAScript <emu-val>Object</emu-val> value by
+    to an ECMAScript Object value by
     running the following algorithm (where |D| is the [=dictionary=]):
 
     1.  Let |O| be [=!=] [=ObjectCreate=]([=%ObjectPrototype%=]).
@@ -6995,7 +7000,7 @@ up on the ECMAScript object are not necessarily the same as the object’s prope
 
 <h4 id="es-enumeration">Enumeration types</h4>
 
-IDL [=enumeration types=] are represented by ECMAScript <emu-val>String</emu-val>
+IDL [=enumeration types=] are represented by ECMAScript String
 values.
 
 <div id="es-to-enumeration" algorithm="convert an ECMAScript value to enumeration">
@@ -7006,14 +7011,14 @@ values.
 
     1.  Let |S| be the result of calling [=ToString=](|V|).
     1.  If |S| is not one of |E|’s [=enumeration values=],
-        then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the enumeration value of type |E| that is equal to |S|.
 </div>
 
 <p id="enumeration-to-es">
     The result of [=converted to an ECMAScript value|converting=]
     an IDL [=enumeration|enumeration type=] value to an ECMAScript
-    value is the <emu-val>String</emu-val>
+    value is the String
     value that represents the same sequence of [=code units=] as
     the [=enumeration value=].
 </p>
@@ -7021,7 +7026,7 @@ values.
 
 <h4 id="es-callback-function">Callback function types</h4>
 
-IDL [=callback function types=] are represented by ECMAScript <emu-val>Function</emu-val>
+IDL [=callback function types=] are represented by ECMAScript function
 objects, except in the [{{TreatNonObjectAsNull}}] case,
 when they can be any object.
 
@@ -7037,7 +7042,7 @@ when they can be any object.
         whose type is a [=nullable type|nullable=]
         [=callback function=]
         that is annotated with [{{TreatNonObjectAsNull}}],
-        then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the IDL [=callback function type=] value
         that represents a reference to the same object that |V| represents, with the
         [=incumbent settings object=] as the [=callback context=].
@@ -7097,7 +7102,7 @@ the ECMAScript <emu-val>null</emu-val> value.
 <h4 id="es-sequence">Sequences — sequence&lt;|T|&gt;</h4>
 
 IDL <a lt="sequence type">sequence&lt;|T|&gt;</a> values are represented by
-ECMAScript <emu-val>Array</emu-val> values.
+ECMAScript Array values.
 
 <div id="es-to-sequence" algorithm="convert an ECMAScript value to sequence">
 
@@ -7105,12 +7110,12 @@ ECMAScript <emu-val>Array</emu-val> values.
     to an IDL <a lt="sequence type">sequence&lt;<var ignore>T</var>&gt;</a> value as follows:
 
     1.  If [=Type=](|V|) is not Object,
-        [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        [=ECMAScript/throw=] a {{TypeError}}.
     1.  Let |method| be the result of
         [=GetMethod=](|V|, [=@@iterator=]).
     1.  [=ReturnIfAbrupt=](|method|).
     1.  If |method| is <emu-val>undefined</emu-val>,
-        [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the result of [=creating a sequence from an iterable|creating a sequence=]
         from |V| and |method|.
 </div>
@@ -7120,11 +7125,11 @@ ECMAScript <emu-val>Array</emu-val> values.
     An IDL sequence value |S| of type
     <a lt="sequence type">sequence&lt;<var ignore>T</var>&gt;</a> is
     [=converted to an ECMAScript value|converted=]
-    to an ECMAScript <emu-val>Array</emu-val> object as follows:
+    to an ECMAScript Array object as follows:
 
 
     1.  Let |n| be the length of |S|.
-    1.  Let |A| be a new <emu-val>Array</emu-val> object created as if by the expression <code>[]</code>.
+    1.  Let |A| be a new Array object created as if by the expression <code>[]</code>.
     1.  Initialize |i| to be 0.
     1.  While |i| &lt; |n|:
         1.  Let |V| be the value in |S| at index |i|.
@@ -7186,15 +7191,15 @@ ECMAScript <emu-val>Array</emu-val> values.
         };
     </pre>
 
-    In an ECMAScript implementation of this interface, an <emu-val>Array</emu-val>
-    object with elements of type <emu-val>String</emu-val> is used to
+    In an ECMAScript implementation of this interface, an Array
+    object with elements of type String is used to
     represent a <code class="idl">sequence&lt;DOMString&gt;</code>, while an
-    <emu-val>Array</emu-val> with elements of type <emu-val>Number</emu-val>
+    Array with elements of type Number
     represents a <code class="idl">sequence&lt;double&gt;</code>.  The
-    <emu-val>Array</emu-val> objects are effectively passed by
+    Array objects are effectively passed by
     value; every time the <code>getSupportedImageCodecs()</code>
-    function is called a new <emu-val>Array</emu-val> is
-    returned, and whenever an <emu-val>Array</emu-val> is
+    function is called a new Array is
+    returned, and whenever an Array is
     passed to <code>drawPolygon</code> no reference
     will be kept after the call completes.
 
@@ -7246,7 +7251,7 @@ ECMAScript <emu-val>Array</emu-val> values.
 <h4 id="es-record">Records — record&lt;|K|, |V|&gt;</h4>
 
 IDL [=record=]&lt;|K|, |V|&gt; values are represented by
-ECMAScript <emu-val>Object</emu-val> values.
+ECMAScript Object values.
 
 <div id="es-to-record" algorithm="convert an ECMAScript value to record">
 
@@ -7254,7 +7259,7 @@ ECMAScript <emu-val>Object</emu-val> values.
     to an IDL <code>[=record=]&lt;|K|, |V|></code> value as follows:
 
     1.  If [=Type=](|O|) is not Object,
-        [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        [=ECMAScript/throw=] a {{TypeError}}.
     1.  Let |result| be a new empty instance of <code>[=record=]&lt;|K|, |V|></code>.
     1.  Let |keys| be [=?=] |O|.\[[OwnPropertyKeys]]().
     1.  [=list/For each=] |key| of |keys|:
@@ -7321,7 +7326,7 @@ ECMAScript <emu-val>Object</emu-val> values.
         <tr>
             <td><code>{"😞": 1}</code></td>
             <td><code>[=record=]&lt;ByteString, double></code></td>
-            <td><emu-val>TypeError</emu-val></td>
+            <td>{{TypeError}}</td>
         </tr>
         <tr>
             <td><code>{"\uD83D": 1}</code></td>
@@ -7340,7 +7345,7 @@ ECMAScript <emu-val>Object</emu-val> values.
 <h4 id="es-promise">Promise types — Promise&lt;|T|&gt;</h4>
 
 IDL [=promise type=] values are
-represented by ECMAScript <emu-val>Promise</emu-val>
+represented by ECMAScript {{ECMAScript/Promise}}
 objects.
 
 <div id="es-to-promise" algorithm="convert an ECMAScript value to promise">
@@ -7361,7 +7366,7 @@ objects.
 <p id="promise-to-es">
     The result of [=converted to an ECMAScript value|converting=]
     an IDL [=promise type=] value to an ECMAScript
-    value is the <emu-val>Promise</emu-val> value that represents a reference to the same object that the
+    value is the {{ECMAScript/Promise}} value that represents a reference to the same object that the
     IDL [=promise type=] represents.
 </p>
 
@@ -7396,7 +7401,7 @@ objects.
         1.  Otherwise, return the result of performing any steps that were required to be run if the promise was rejected,
             with |reason| as the rejection reason.
     1.  Let |then| be the result of calling the internal \[[Get]] method of |promise| with property name “then”.
-    1.  If |then| is not [=callable=], then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+    1.  If |then| is not [=callable=], then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the result of calling |then| with |promise| as the <emu-val>this</emu-val> value and |onFulfilled| and |onRejected|
         as its two arguments.
 </div>
@@ -7515,7 +7520,7 @@ that correspond to the union’s [=member types=].
     1.  If |types| includes a {{boolean}},
         then return the result of [=converted to an IDL value|converting=]
         |V| to {{boolean}}.
-    1.  [=ECMAScript/Throw=] a <emu-val>TypeError</emu-val>.
+    1.  [=ECMAScript/Throw=] a {{TypeError}}.
 </div>
 
 <p id="union-to-es">
@@ -7533,7 +7538,7 @@ that correspond to the union’s [=member types=].
 <h4 id="es-Error">Error</h4>
 
 IDL {{Error!!interface}} values are represented
-by native ECMAScript <emu-val>Error</emu-val> objects and
+by native ECMAScript {{ECMAScript/Error}} objects and
 by {{DOMException}} platform objects.
 
 <div id="es-to-Error" algorithm="convert an ECMAScript value to Error">
@@ -7543,7 +7548,7 @@ by {{DOMException}} platform objects.
 
     1.  If [=Type=](|V|) is not Object,
         or |V| does not have an \[[ErrorData]] [=internal slot=],
-        then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the IDL {{Error!!interface}} value that is a reference
         to the same object as |V|.
 </div>
@@ -7551,7 +7556,7 @@ by {{DOMException}} platform objects.
 <p id="Error-to-es">
     The result of [=converted to an ECMAScript value|converting=]
     an IDL {{Error!!interface}} value to an ECMAScript
-    value is the <emu-val>Error</emu-val> value that represents a reference to the same object that the
+    value is the {{ECMAScript/Error}} value that represents a reference to the same object that the
     IDL {{Error!!interface}} represents.
 </p>
 
@@ -7559,7 +7564,7 @@ by {{DOMException}} platform objects.
 <h4 id="es-DOMException">DOMException</h4>
 
 IDL {{DOMException}} values are represented by
-ECMAScript <emu-val>Object</emu-val> values.
+ECMAScript Object values.
 
 <div id="es-to-DOMException" algorithm="convert an ECMAScript value to DOMException">
 
@@ -7568,7 +7573,7 @@ ECMAScript <emu-val>Object</emu-val> values.
 
     1.  If [=Type=](|V|) is not Object,
         or |V| is not a platform object that represents a {{DOMException}},
-        then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the IDL {{DOMException}} value that is a reference
         to the same object as |V|.
 </div>
@@ -7576,7 +7581,7 @@ ECMAScript <emu-val>Object</emu-val> values.
 <p id="DOMException-to-es">
     The result of [=converted to an ECMAScript value|converting=]
     an IDL {{DOMException}} value to an ECMAScript
-    value is the <emu-val>Object</emu-val> value that represents a reference to the same object that the
+    value is the Object value that represents a reference to the same object that the
     IDL {{DOMException}} represents.
 </p>
 
@@ -7596,11 +7601,11 @@ that unless the type is [=extended attributes associated with|associated with=] 
 
     1.  If [=Type=](|V|) is not Object,
         or |V| does not have an \[[ArrayBufferData]] [=internal slot=],
-        then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowShared}}]
         [=extended attribute=], and [=IsSharedArrayBuffer=](|V|) is true, then [=ECMAScript/throw=]
-        a <emu-val>TypeError</emu-val>.
+        a {{TypeError}}.
     1.  Return the IDL {{ArrayBuffer}} value that is a reference
         to the same object as |V|.
 </div>
@@ -7612,11 +7617,11 @@ that unless the type is [=extended attributes associated with|associated with=] 
 
     1.  If [=Type=](|V|) is not Object,
         or |V| does not have a \[[DataView]] [=internal slot=],
-        then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowShared}}]
         [=extended attribute=], and [=IsSharedArrayBuffer=](|V|.\[[ViewedArrayBuffer]]) is true,
-        then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the IDL {{DataView}} value that is a reference
         to the same object as |V|.
 </div>
@@ -7642,17 +7647,17 @@ that unless the type is [=extended attributes associated with|associated with=] 
     1.  If [=Type=](|V|) is not Object,
         or |V| does not have a \[[TypedArrayName]] [=internal slot=]
         with a value equal to |typedArrayName|,
-        then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowShared}}]
         [=extended attribute=], and [=IsSharedArrayBuffer=](|V|.\[[ViewedArrayBuffer]]) is true,
-        then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return the IDL value of type |T| that is a reference to the same object as |V|.
 </div>
 
 The result of [=converted to an ECMAScript value|converting=]
 an IDL value of any [=buffer source type=]
-to an ECMAScript value is the <emu-val>Object</emu-val> value that represents
+to an ECMAScript value is the Object value that represents
 a reference to the same object that the IDL value represents.
 
 <div algorithm="get a reference to a buffer source">
@@ -7669,12 +7674,12 @@ a reference to the same object that the IDL value represents.
     1.  If |O| has a \[[ViewedArrayBuffer]] [=internal slot=], then:
         1.  Set |arrayBuffer| to the value of |O|’s \[[ViewedArrayBuffer]] [=internal slot=].
         1.  If |arrayBuffer| is <emu-val>undefined</emu-val>, then
-            [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+            [=ECMAScript/throw=] a {{TypeError}}.
         1.  Set |offset| to the value of |O|’s \[[ByteOffset]] [=internal slot=].
         1.  Set |length| to the value of |O|’s \[[ByteLength]] [=internal slot=].
     1.  Otherwise, set |length| to the value of |O|’s \[[ArrayBufferByteLength]] [=internal slot=].
     1.  If [=IsDetachedBuffer=](|O|), then
-        [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        [=ECMAScript/throw=] a {{TypeError}}.
     1.  Let |data| be the value of |O|’s \[[ArrayBufferData]] [=internal slot=].
     1.  Return a reference to or copy of (as required) the |length| bytes in |data|
         starting at byte offset |offset|.
@@ -7692,7 +7697,7 @@ a reference to the same object that the IDL value represents.
 <h4 id="es-frozen-array">Frozen arrays — FrozenArray&lt;|T|&gt;</h4>
 
 Values of frozen array types are represented by frozen ECMAScript
-<emu-val>Array</emu-val> object references.
+Array object references.
 
 <div algorithm="convert an ECMAScript value to frozen array">
 
@@ -7722,7 +7727,7 @@ Values of frozen array types are represented by frozen ECMAScript
 
 The result of [=converted to an ECMAScript value|converting=]
 an IDL <a interface lt="FrozenArray">FrozenArray&lt;|T|&gt;</a> value to an ECMAScript
-value is the <emu-val>Object</emu-val> value that represents a reference
+value is the Object value that represents a reference
 to the same object that the IDL <a interface lt="FrozenArray">FrozenArray&lt;|T|&gt;</a> represents.
 
 
@@ -7781,7 +7786,7 @@ See the rules for converting ECMAScript values to IDL [=buffer source types=] in
 <h4 id="Clamp" extended-attribute lt="Clamp">[Clamp]</h4>
 
 If the [{{Clamp}}] [=extended attribute=] appears on one of the [=integer types=], it creates a new
-IDL type such that that when an ECMAScript <emu-val>Number</emu-val> is converted to the IDL type,
+IDL type such that that when an ECMAScript Number is converted to the IDL type,
 out-of-range values will be clamped to the range of valid values, rather than using the operators
 that use a modulo operation ([=ToInt32=], [=ToUint32=], etc.).
 
@@ -7815,7 +7820,7 @@ for the specific requirements that the use of
     </pre>
 
     A call to <code>setColorClamped</code> with
-    <emu-val>Number</emu-val> values that are out of range for an
+    Number values that are out of range for an
     {{octet}} are clamped to the range [0, 255].
 
     <pre highlight="js">
@@ -7987,10 +7992,10 @@ for which a [=corresponding default operation=] has been defined.
 <h4 id="EnforceRange" extended-attribute lt="EnforceRange">[EnforceRange]</h4>
 
 If the [{{EnforceRange}}] [=extended attribute=] appears on one of the [=integer types=], it creates
-a new IDL type such that that when an ECMAScript <emu-val>Number</emu-val> is converted to the IDL
+a new IDL type such that that when an ECMAScript Number is converted to the IDL
 type, out-of-range values will cause an exception to be thrown, rather than being converted to a
 valid value using using the operators that use a modulo operation ([=ToInt32=], [=ToUint32=], etc.).
-The <emu-val>Number</emu-val> will be rounded toward zero before being checked against its range.
+The Number will be rounded toward zero before being checked against its range.
 
 The [{{EnforceRange}}]
 extended attribute must
@@ -8023,7 +8028,7 @@ for the specific requirements that the use of
     </pre>
 
     In an ECMAScript implementation of the IDL, a call to setColorEnforcedRange with
-    <emu-val>Number</emu-val> values that are out of range for an
+    Number values that are out of range for an
     {{octet}} will result in an exception being
     thrown.
 
@@ -8432,9 +8437,9 @@ appears on an [=interface=]
 that is not defined to [=interface/inherit=]
 from another, it indicates that the internal \[[Prototype]]
 property of its [=interface prototype object=]
-will be the <emu-val>Array</emu-val> prototype object rather than
-the <emu-val>Object</emu-val> prototype object.  This allows
-<emu-val>Array</emu-val> methods to be used more easily
+will be the Array prototype object rather than
+the Object prototype object.  This allows
+Array methods to be used more easily
 with objects implementing the interface.
 
 The [{{LegacyArrayClass}}] extended attribute
@@ -8445,7 +8450,7 @@ has any [=inherited interfaces=].
 Note: Interfaces using [{{LegacyArrayClass}}] will
 need to define a “length” [=attribute=]
 of type {{unsigned long}} that exposes the length
-of the array-like object, in order for the inherited <emu-val>Array</emu-val>
+of the array-like object, in order for the inherited Array
 methods to operate correctly.  Such interfaces would typically also
 [=support indexed properties=],
 which would provide access to the array elements.
@@ -8477,7 +8482,7 @@ entails.
 
     In an ECMAScript implementation of the above two interfaces,
     with appropriate definitions for getItem, setItem and removeItem,
-    <emu-val>Array</emu-val> methods to inspect and
+    Array methods to inspect and
     modify the array-like object can be used.
 
     <pre highlight="js">
@@ -8491,7 +8496,7 @@ entails.
     <code class="idl">ImmutableItemList</code> has a read only
     length [=attribute=]
     and no indexed property [=indexed property setters|setter=].  The
-    mutating <emu-val>Array</emu-val> methods will generally not
+    mutating Array methods will generally not
     succeed on objects implementing <code class="idl">ImmutableItemList</code>.
     The exact behavior depends on the definition of the [=Array methods=] themselves.
 
@@ -9411,7 +9416,7 @@ for the specific requirements that the use of
     </pre>
 
     In an ECMAScript implementation, assigning a value that is not
-    an object (such as a <emu-val>Number</emu-val> value)
+    an object (such as a Number value)
     to handler1 will have different behavior from that when assigning
     to handler2:
 
@@ -9666,7 +9671,7 @@ allowed.  The security check takes the following three inputs:
     which the operation invocation or attribute access is being done,
 1.  the [=identifier=]
     of the operation or attribute, and
-1.  the type of the <emu-val>Function</emu-val> object –
+1.  the type of the [=function object=] –
     “method” (when it corresponds to an IDL operation), or
     “getter” or “setter” (when it corresponds to the
     getter or setter function of an IDL attribute).
@@ -9689,7 +9694,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
     1.  Let |maxarg| be the length of the longest type list of the entries in |S|.
     1.  Initialize |argcount| to be min(|maxarg|, |n|).
     1.  Remove from |S| all entries whose type list is not of length |argcount|.
-    1.  If |S| is empty, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+    1.  If |S| is empty, then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Initialize |d| to −1.
     1.  Initialize |method| to <emu-val>undefined</emu-val>.
     1.  If there is more than one entry in |S|, then set
@@ -9890,7 +9895,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
 
         1.  Otherwise: if there is an entry in |S| that has {{any}} at position |i|
             of its type list, then remove from |S| all other entries.
-        1.  Otherwise: [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        1.  Otherwise: [=ECMAScript/throw=] a {{TypeError}}.
     1.  Let |callable| be the [=operation=] or [=extended attribute=]
         of the single entry in |S|.
     1.  If |i| = |d| and |method| is not <emu-val>undefined</emu-val>, then
@@ -9938,7 +9943,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
         overload argument list, then they are ignored.
     *   After ignoring these trailing arguments, only overloads
         that can take this exact number of arguments are considered.
-        If there are none, then a <emu-val>TypeError</emu-val> is thrown.
+        If there are none, then a {{TypeError}} is thrown.
 
     Once we have a set of possible overloads with the right number
     of arguments, the ECMAScript values are converted from left to right.
@@ -9958,7 +9963,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
     be invoked.  If the value passed in is <emu-val>undefined</emu-val>
     and there is an overload with an optional argument at this position, then
     we will choose that overload.  If there is no valid overload for the type of
-    value passed in here, then we throw a <emu-val>TypeError</emu-val>.
+    value passed in here, then we throw a {{TypeError}}.
     The inspection of the value at the distinguishing argument index does not have any side effects;
     the only side effects that come from running the overload resolution
     algorithm are those that come from converting the ECMAScript values
@@ -10044,9 +10049,9 @@ the <code>typeof</code> operator will return "function" when applied to an inter
 
     1.  Let |steps| be the following steps:
         1.  If |I| was not declared with a [{{Constructor}}] [=extended attribute=],
-            then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+            then [=ECMAScript/throw=] a {{TypeError}}.
         1.  If [=NewTarget=] is <emu-val>undefined</emu-val>, then
-            [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+            [=ECMAScript/throw=] a {{TypeError}}.
         1.  Let |arg|<sub>0..|n|−1</sub> be the passed arguments.
         1.  Let |id| be the identifier of interface |I|.
         1.  Initialize |S| to the [=effective overload set=]
@@ -10104,7 +10109,7 @@ This object's relevant [=Realm=] must be the same as that of the [=named constru
 
     1.  Let |steps| be the following steps:
         1.  If [=NewTarget=] is <emu-val>undefined</emu-val>, then
-            [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+            [=ECMAScript/throw=] a {{TypeError}}.
         1.  Let |arg|<sub>0..|n|−1</sub> be the passed arguments.
         1.  Initialize |S| to the  [=effective overload set=]
             for constructors with [=identifier=] |id| on [=interface=] |I|
@@ -10267,7 +10272,7 @@ when applied to a [=legacy callback interface object=].
     and in [=Realm=] |realm| is created as follows:
 
     1.  Let |steps| be the following steps:
-        1.  [=ECMAScript/Throw=] a <emu-val>TypeError</emu-val>.
+        1.  [=ECMAScript/Throw=] a {{TypeError}}.
     1.  Let |F| be [=!=] [=CreateBuiltinFunction=](|realm|, |steps|, the [=%FunctionPrototype%=] of |realm|).
     1.  Perform [=!=] [=SetFunctionName=](|F|, |id|).
     1.  Perform [=!=] [=DefinePropertyOrThrow=](|F|, "length",
@@ -10454,7 +10459,7 @@ The characteristics of this property are as follows:
             1.  If |target| is an [=interface=], and |attribute| is a [=regular attribute=]:
                 1.  If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or
                     <emu-val>undefined</emu-val>, set |O| to |realm|'s [=Realm/global object=].
-                    (This will subsequently cause a <emu-val>TypeError</emu-val> in a few steps, if
+                    (This will subsequently cause a {{TypeError}} in a few steps, if
                     the global object does not implement |target| and [{{LenientThis}}] is not
                     specified.)
                     <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
@@ -10465,7 +10470,7 @@ The characteristics of this property are as follows:
                     then:
                     1.  If |attribute| was specified with the [{{LenientThis}}]
                         [=extended attribute=], then return <emu-val>undefined</emu-val>.
-                    1. Otherwise, [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+                    1. Otherwise, [=ECMAScript/throw=] a {{TypeError}}.
             1.  Let |R| be the result of [=get the underlying value|getting the underlying value=]
                 of |attribute| given |O|.
             1.  Return the result of [=converted to an ECMAScript value|converting=] |R| to an
@@ -10498,14 +10503,14 @@ The characteristics of this property are as follows:
         <emu-val>undefined</emu-val>; there is no [=attribute setter=] function.
     1.  Assert: |attribute|'s type is not a [=promise type=].
     1.  Let |steps| be the following series of steps:
-        1.  If no arguments were passed, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        1.  If no arguments were passed, then [=ECMAScript/throw=] a {{TypeError}}.
         1.  Let |V| be the value of the first argument passed.
         1.  Let |id| be |attribute|'s [=identifier=].
         1.  Let |O| be <emu-val>null</emu-val>.
         1.  If |attribute| is a [=regular attribute=]:
             1.  If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or
                 <emu-val>undefined</emu-val>, set |O| to |realm|'s [=Realm/global object=].
-                (This will subsequently cause a <emu-val>TypeError</emu-val> in a few steps, if
+                (This will subsequently cause a {{TypeError}} in a few steps, if
                 the global object does not implement |target| and [{{LenientThis}}] is not
                 specified.)
                 <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
@@ -10515,7 +10520,7 @@ The characteristics of this property are as follows:
             1.  Let |validThis| be true if |O| is a [=platform object=] that implements the
                 interface |target|, or false otherwise.
             1.  If |validThis| is false and |attribute| was not specified with the [{{LenientThis}}]
-                [=extended attribute=], then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+                [=extended attribute=], then [=ECMAScript/throw=] a {{TypeError}}.
             1.  If |attribute| is declared with the [{{Replaceable}}] extended attribute, then:
                 1.  Perform [=?=] [=CreateDataProperty=](|O|, |id|, |V|).
                 1.  Return <emu-val>undefined</emu-val>.
@@ -10525,7 +10530,7 @@ The characteristics of this property are as follows:
             1.  If |attribute| is declared with a [{{PutForwards}}] extended attribute, then:
                 1.  Let |Q| be [=?=] [=Get=](|O|, |id|).
                 1.  If [=Type=](|Q|) is not Object, then [=ECMAScript/throw=] a
-                    <emu-val>TypeError</emu-val>.
+                    {{TypeError}}.
                 1.  Let |forwardId| be the identifier argument of the [{{PutForwards}}] extended
                     attribute.
                 1.  Perform [=?=] [=Set=](|Q|, |forwardId|, |V|).
@@ -10568,7 +10573,7 @@ accessed, they are able to expose instance-specific data.
 Note: Attempting to assign to a property corresponding to a
 [=read only=] [=attribute=]
 results in different behavior depending on whether the script doing so is in strict mode.
-When in strict mode, such an assignment will result in a <emu-val>TypeError</emu-val>
+When in strict mode, such an assignment will result in a {{TypeError}}
 being thrown.  When not in strict mode, the assignment attempt will be ignored.
 
 
@@ -10632,14 +10637,14 @@ property-installation style as namespaces.)
             1.  If |target| is an [=interface=], and |op| is not a [=static operation=]:
                 1.  If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or
                     <emu-val>undefined</emu-val>, set |O| to |realm|'s [=Realm/global object=]. (This
-                    will subsequently cause a <emu-val>TypeError</emu-val> in a few steps, if the global
+                    will subsequently cause a {{TypeError}} in a few steps, if the global
                     object does not implement |target|.)
                     <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
                 1.  Otherwise, set |O| to the <emu-val>this</emu-val> value.
                 1.  If |O| is a [=platform object=], then [=perform a security check=], passing |O|,
                     |id|, and "method".
                 1.  If |O| is not a [=platform object=] that implements the interface |target|,
-                    [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+                    [=ECMAScript/throw=] a {{TypeError}}.
             1.  Let |S| be the [=effective overload set=] for [=regular operations=] (if |op| is a
                 regular operation) or for [=static operations=] (if |op| is a static operation) with
                 [=identifier=] |id| on |target| and with argument count |n|.
@@ -10859,7 +10864,7 @@ then there must exist a property with the following characteristics:
     and <emu-val>true</emu-val> otherwise.
 *   <div algorithm="to invoke the toString method of interfaces">
 
-        The value of the property is a <emu-val>Function</emu-val> object, which behaves as follows:
+        The value of the property is a [=function object=], which behaves as follows:
 
         1.  Let |O| be the result of calling [=ToObject=] on the <emu-val>this</emu-val> value.
         1.  If |O| is a [=platform object=],
@@ -10868,7 +10873,7 @@ then there must exist a property with the following characteristics:
             *   the [=identifier=] of the [=stringifier=], and
             *   the type “method”.
         1.  If |O| is not an object that implements the [=interface=]
-            on which the stringifier was declared, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+            on which the stringifier was declared, then [=ECMAScript/throw=] a {{TypeError}}.
         1.  Let |V| be an uninitialized variable.
         1.  Depending on where <code>stringifier</code> was specified:
             <dl class="switch">
@@ -10885,12 +10890,12 @@ then there must exist a property with the following characteristics:
                  :: Set |V| to the result of performing the [=stringification behavior=]
                     of the interface.
             </dl>
-        1.  Return the result of [=converted to an ECMAScript value|converting=] |V| to a <emu-val>String</emu-val> value.
+        1.  Return the result of [=converted to an ECMAScript value|converting=] |V| to a String value.
     </div>
-*   The value of the <emu-val>Function</emu-val> object’s “length”
-    property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.
-*   The value of the <emu-val>Function</emu-val> object’s “name”
-    property is the <emu-val>String</emu-val> value “toString”.
+*   The value of the [=function object=]’s “length”
+    property is the Number value <emu-val>0</emu-val>.
+*   The value of the [=function object=]’s “name”
+    property is the String value “toString”.
 
 
 <h4 id="es-iterators">Common iterator behavior</h4>
@@ -10923,12 +10928,12 @@ The location of the property is determined as follows:
 *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 
 If the interface defines an [=indexed property getter=],
-then the <emu-val>Function</emu-val> object is [=%ArrayProto_values%=].
+then the [=function object=] is [=%ArrayProto_values%=].
 
 <div algorithm="to invoke the @@iterator property of interfaces with a pair iterator">
 
     If the interface has a [=pair iterator=],
-    then the <emu-val>Function</emu-val>, when invoked, must behave as follows:
+    then the function, when invoked, must behave as follows:
 
     1.  Let |object| be the result of calling [=ToObject=] on the <emu-val>this</emu-val> value.
     1.  If |object| is a [=platform object=],
@@ -10939,7 +10944,7 @@ then the <emu-val>Function</emu-val> object is [=%ArrayProto_values%=].
     1.  Let |interface| be the [=interface=]
         the [=iterable declaration=] is on.
     1.  If |object| is not a [=platform object=] that implements |interface|,
-        then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Let |iterator| be a newly created [=default iterator object=]
         for |interface| with |object| as its target and iterator kind “key+value”.
     1.  Return |iterator|.
@@ -10948,7 +10953,7 @@ then the <emu-val>Function</emu-val> object is [=%ArrayProto_values%=].
 <div algorithm="to invoke the @@iterator property of interfaces with maplike or setlike declarations">
 
     If the interface has a [=maplike declaration=] or [=setlike declaration=],
-    then the <emu-val>Function</emu-val> object that is the value of the [=@@iterator=] property,
+    then the [=function object=] that is the value of the [=@@iterator=] property,
     when invoked, must behave as follows:
 
     1.  Let |object| be the result of calling [=ToObject=] on the <emu-val>this</emu-val> value.
@@ -10961,7 +10966,7 @@ then the <emu-val>Function</emu-val> object is [=%ArrayProto_values%=].
         that implements the [=interface=]
         on which the [=maplike declaration=]
         or [=setlike declaration=] is defined,
-        then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  If the interface has a [=maplike declaration=], then:
         1.  Let |backing| be the value of the \[[BackingMap]] [=internal slot=] of |object|.
         1.  Return [=CreateMapIterator=](|backing|, <code>"key+value"</code>).
@@ -10970,13 +10975,13 @@ then the <emu-val>Function</emu-val> object is [=%ArrayProto_values%=].
         1.  Return [=CreateSetIterator=](|backing|, <code>"value"</code>).
 </div>
 
-The value of the [=@@iterator=] <emu-val>Function</emu-val> object’s “length”
-property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.
+The value of the [=@@iterator=] [=function object=]’s “length”
+property is the Number value <emu-val>0</emu-val>.
 
-The value of the [=@@iterator=] <emu-val>Function</emu-val> object’s “name” property
-is the <emu-val>String</emu-val> value “entries”
+The value of the [=@@iterator=] [=function object=]’s “name” property
+is the String value “entries”
 if the interface has a [=pair iterator=] or a [=maplike declaration=]
-and the <emu-val>String</emu-val> “values”
+and the String “values”
 if the interface has a [=setlike declaration=].
 
 
@@ -11004,13 +11009,13 @@ The location of the property is determined as follows:
 *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 
 If the interface defines an [=indexed property getter=],
-then the <emu-val>Function</emu-val> object is
+then the [=function object=] is
 the initial value of the “forEach” data property of [=%ArrayPrototype%=].
 
 <div algorithm="to invoke the forEach method of interfaces with indexed properties">
 
     If the interface has a [=pair iterator=],
-    then the <emu-val>Function</emu-val> must have the same behavior,
+    then the method must have the same behavior,
     when invoked with argument |callback| and optional argument |thisArg|,
     as one that would exist assuming the interface had this [=operation=]
     instead of the [=iterable declaration=]:
@@ -11041,7 +11046,7 @@ the initial value of the “forEach” data property of [=%ArrayPrototype%=].
 <div algorithm="to invoke the forEach method of interfaces with maplike or setlike declarations">
 
     If the interface has a [=maplike declaration=] or [=setlike declaration=] then
-    the <emu-val>Function</emu-val>, when invoked, must behave as follows:
+    the method, when invoked, must behave as follows:
 
     1.  Let |object| be the result of calling [=ToObject=] on the <emu-val>this</emu-val> value.
     1.  If |object| is a [=platform object=],
@@ -11054,14 +11059,14 @@ the initial value of the “forEach” data property of [=%ArrayPrototype%=].
         or [=setlike declaration=] is declared.
     1.  If |object| is not a [=platform object=]
         that implements |interface|,
-        then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Let |callbackFn| be the value of the first argument passed to the function, or <emu-val>undefined</emu-val> if the argument was not supplied.
-    1.  If [=IsCallable=](|callbackFn|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+    1.  If [=IsCallable=](|callbackFn|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a {{TypeError}}.
     1.  Let |thisArg| be the value of the second argument passed to the function, or <emu-val>undefined</emu-val> if the argument was not supplied.
     1.  Let |backing| be the value of the \[[BackingMap]] [=internal slot=] of |object|,
         if the interface has a [=maplike declaration=],
         or the \[[BackingSet]] [=internal slot=] of |object| otherwise.
-    1.  Let |callbackWrapper| be a <emu-val>Function</emu-val> that, when invoked, behaves as follows:
+    1.  Let |callbackWrapper| be a [=function object=] that, when invoked, behaves as follows:
         1.  Let |v| and |k| be the first two arguments passed to the function.
         1.  Let |thisArg| be the <emu-val>this</emu-val> value.
         1.  [=Call=](|callbackFn|, |thisArg|, «|v|, |k|, |object|»).
@@ -11076,16 +11081,16 @@ the initial value of the “forEach” data property of [=%ArrayPrototype%=].
         </p>
     1.  Let |forEach| be the result of calling the \[[Get]] internal method of
         |backing| with “forEach” and |backing| as arguments.
-    1.  If [=IsCallable=](|forEach|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+    1.  If [=IsCallable=](|forEach|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a {{TypeError}}.
     1.  [=Call=](|forEach|, |backing|, «|callbackWrapper|, |thisArg|»).
     1.  Return <emu-val>undefined</emu-val>.
 </div>
 
-The value of the <emu-val>Function</emu-val> object’s “length”
-property is the <emu-val>Number</emu-val> value <emu-val>1</emu-val>.
+The value of the [=function object=]’s “length”
+property is the Number value <emu-val>1</emu-val>.
 
-The value of the <emu-val>Function</emu-val> object’s “name”
-property is the <emu-val>String</emu-val> value “forEach”.
+The value of the [=function object=]’s “name”
+property is the String value “forEach”.
 
 
 <h4 id="es-iterable">Iterable declarations</h4>
@@ -11110,11 +11115,11 @@ The location of the property is determined as follows:
 *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 
 If the interface has a [=value iterator=],
-then the <emu-val>Function</emu-val> object is
+then the [=function object=] is
 the initial value of the “entries” data property of [=%ArrayPrototype%=].
 
 If the interface has a [=pair iterator=],
-then the <emu-val>Function</emu-val> object is
+then the [=function object=] is
 the value of the [=@@iterator=] property.
 
 
@@ -11137,13 +11142,13 @@ The location of the property is determined as follows:
 *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 
 If the interface has a [=value iterator=],
-then the <emu-val>Function</emu-val> object is
+then the [=function object=] is
 the initial value of the “keys” data property of [=%ArrayPrototype%=].
 
 <div algorithm="to invoke the keys method of interfaces with a pair iterator">
 
     If the interface has a [=pair iterator=],
-    then the <emu-val>Function</emu-val>, when invoked, must behave as follows:
+    then the method, when invoked, must behave as follows:
 
     1.  Let |object| be the result of calling [=ToObject=] on the <emu-val>this</emu-val> value.
     1.  If |object| is a [=platform object=],
@@ -11155,15 +11160,15 @@ the initial value of the “keys” data property of [=%ArrayPrototype%=].
         on which the [=iterable declaration=] is declared on.
     1.  If |object| is not a [=platform object=]
         that implements |interface|,
-        then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Let |iterator| be a newly created [=default iterator object=]
         for |interface| with |object| as its target and iterator kind “key”.
     1.  Return |iterator|.
 </div>
 
-The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.
+The value of the [=function object=]’s “length” property is the Number value <emu-val>0</emu-val>.
 
-The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “keys”.
+The value of the [=function object=]’s “name” property is the String value “keys”.
 
 
 <h5 id="es-iterable-values">values</h5>
@@ -11186,13 +11191,13 @@ The location of the property is determined as follows:
 *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 
 If the interface has a [=value iterator=],
-then the <emu-val>Function</emu-val> object is
+then the [=function object=] is
 the value of the [=@@iterator=] property.
 
 <div algorithm="to invoke the values method of interfaces with a pair iterator">
 
     If the interface has a [=pair iterator=],
-    then the <emu-val>Function</emu-val>, when invoked, must behave as follows:
+    then the method, when invoked, must behave as follows:
 
     1.  Let |object| be the result of calling [=ToObject=] on the <emu-val>this</emu-val> value.
     1.  If |object| is a [=platform object=],
@@ -11204,15 +11209,15 @@ the value of the [=@@iterator=] property.
         on which the [=iterable declaration=] is declared on.
     1.  If |object| is not a [=platform object=]
         that implements |interface|,
-        then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Let |iterator| be a newly created [=default iterator object=]
         for |interface| with |object| as its target and iterator kind “value”.
     1.  Return |iterator|.
 </div>
 
-The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.
+The value of the [=function object=]’s “length” property is the Number value <emu-val>0</emu-val>.
 
-The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “values”.
+The value of the [=function object=]’s “name” property is the String value “values”.
 
 
 <h5 id="es-default-iterator-object">Default iterator objects</h5>
@@ -11271,7 +11276,7 @@ must be [=%IteratorPrototype%=].
         *   the identifier “next”, and
         *   the type “method”.
     1.  If |object| is not a [=default iterator object=] for |interface|,
-        then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Let |index| be |object|’s index.
     1.  Let |kind| be |object|’s kind.
     1.  Let |values| be the list of [=value pairs to iterate over=].
@@ -11313,8 +11318,8 @@ and the string “Iterator”.
 Any object that implements an [=interface=]
 that has a [=maplike declaration=]
 must have a \[[BackingMap]] [=internal slot=], which is
-initially set to a newly created <emu-val>Map</emu-val> object.
-This <emu-val>Map</emu-val> object’s \[[MapData]] internal slot is
+initially set to a newly created {{Map}} object.
+This {{Map}} object’s \[[MapData]] internal slot is
 the object’s [=map entries=].
 
 If an [=interface=] |A| is declared with
@@ -11337,10 +11342,10 @@ These additional properties are described in the sub-sections below.
         *   the platform object |O|,
         *   an identifier equal to |name|, and
         *   the type “method”.
-    1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
-    1.  Let |map| be the <emu-val>Map</emu-val> object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
+    1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{TypeError}}.
+    1.  Let |map| be the {{Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
     1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing |name| and |map| as arguments.
-    1.  If [=IsCallable=](|function|) is <emu-val>false</emu-val>, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+    1.  If [=IsCallable=](|function|) is <emu-val>false</emu-val>, then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return [=Call=](|function|, |map|, |arguments|).
 </div>
 
@@ -11357,7 +11362,7 @@ with the following characteristics:
     defined below.
 *   <div algorithm="to invoke the size method of Maps">
 
-        The [=map size getter=] is a <emu-val>Function</emu-val> object
+        The [=map size getter=] is a [=function object=]
         whose behavior when invoked is as follows:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
@@ -11366,14 +11371,14 @@ with the following characteristics:
             *   the platform object |O|,
             *   the identifier “size”, and
             *   the type “getter”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
-        1.  Let |map| be the <emu-val>Map</emu-val> object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{TypeError}}.
+        1.  Let |map| be the {{Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Return the result of calling the \[[Get]] internal method of |map| passing “size” and |map| as arguments.
     </div>
 
-    The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.
+    The value of the [=function object=]’s “length” property is the Number value <emu-val>0</emu-val>.
 
-    The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “size”.
+    The value of the [=function object=]’s “name” property is the String value “size”.
 
 
 <h5 id="es-map-entries">entries</h5>
@@ -11392,11 +11397,11 @@ For both of “keys” and “values”, there must exist a property with that n
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a <emu-val>Function</emu-val> object that [=forwards to the internal map object|forwards that name to the internal map object=].
+*   The value of the property is a [=function object=] that [=forwards to the internal map object|forwards that name to the internal map object=].
 
-The value of the <emu-val>Function</emu-val> objects’ “length” properties is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.
+The value of the [=function objects=]’ “length” properties is the Number value <emu-val>0</emu-val>.
 
-The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “keys” or “values”, correspondingly.
+The value of the [=function object=]’s “name” property is the String value “keys” or “values”, correspondingly.
 
 
 <h5 id="es-map-get-has">get and has</h5>
@@ -11408,7 +11413,7 @@ For both of “get” and “has”, there must exist a property with that name 
     { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 *   <div algorithm="to invoke the get and has methods of Maps">
 
-        The value of the property is a <emu-val>Function</emu-val> object
+        The value of the property is a [=function object=]
         that behaves as follows when invoked:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
@@ -11418,8 +11423,8 @@ For both of “get” and “has”, there must exist a property with that name 
             *   the platform object |O|,
             *   an identifier equal to |name|, and
             *   the type “method”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
-        1.  Let |map| be the <emu-val>Map</emu-val> object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{TypeError}}.
+        1.  Let |map| be the {{Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| be the key type specified in the [=maplike declaration=].
         1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing |name| and |map| as arguments.
         1.  Let |keyArg| be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
@@ -11428,9 +11433,9 @@ For both of “get” and “has”, there must exist a property with that name 
         1.  Return [=Call=](|function|, |map|, «|key|»).
     </div>
 
-The value of the <emu-val>Function</emu-val> objects’ “length” properties is the <emu-val>Number</emu-val> value <emu-val>1</emu-val>.
+The value of the [=function objects=]’ “length” properties is the Number value <emu-val>1</emu-val>.
 
-The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “get” or “has”, correspondingly.
+The value of the [=function object=]’s “name” property is the String value “get” or “has”, correspondingly.
 
 
 <h5 id="es-map-clear">clear</h5>
@@ -11445,11 +11450,11 @@ must exist on |A|’s
 [=interface prototype object=]:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a <emu-val>Function</emu-val> object that [=forwards to the internal map object|forwards “clear” to the internal map object=].
+*   The value of the property is a [=function object=] that [=forwards to the internal map object|forwards “clear” to the internal map object=].
 
-The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.
+The value of the [=function object=]’s “length” property is the Number value <emu-val>0</emu-val>.
 
-The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “clear”.
+The value of the [=function object=]’s “name” property is the String value “clear”.
 
 
 <h5 id="es-map-delete">delete</h5>
@@ -11466,7 +11471,7 @@ must exist on |A|’s
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 *   <div algorithm="to invoke the delete method of Maps">
 
-        The value of the property is a <emu-val>Function</emu-val> object that behaves as follows when invoked:
+        The value of the property is a [=function object=] that behaves as follows when invoked:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
         1.  If |O| is a [=platform object=],
@@ -11474,8 +11479,8 @@ must exist on |A|’s
             *   the platform object |O|,
             *   the identifier “delete”, and
             *   the type “method”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
-        1.  Let |map| be the <emu-val>Map</emu-val> object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{TypeError}}.
+        1.  Let |map| be the {{Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| be the key type specified in the [=maplike declaration=].
         1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing “delete” and |map| as arguments.
         1.  Let |keyArg| be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
@@ -11484,9 +11489,9 @@ must exist on |A|’s
         1.  Return [=Call=](|function|, |map|, «|key|»).
     </div>
 
-The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>1</emu-val>.
+The value of the [=function object=]’s “length” property is the Number value <emu-val>1</emu-val>.
 
-The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “delete”.
+The value of the [=function object=]’s “name” property is the String value “delete”.
 
 
 <h5 id="es-map-set">set</h5>
@@ -11501,7 +11506,7 @@ must exist on |A|’s [=interface prototype object=]:
     { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 *   <div algorithm="to invoke the set method of Maps">
 
-        The value of the property is a <emu-val>Function</emu-val> object that behaves as follows when invoked:
+        The value of the property is a [=function object=] that behaves as follows when invoked:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
         1.  If |O| is a [=platform object=],
@@ -11509,8 +11514,8 @@ must exist on |A|’s [=interface prototype object=]:
             *   the platform object |O|,
             *   the identifier “set”, and
             *   the type “method”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
-        1.  Let |map| be the <emu-val>Map</emu-val> object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{TypeError}}.
+        1.  Let |map| be the {{Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| and |valueType| be the key and value types specified in the [=maplike declaration=].
         1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing “set” and |map| as arguments.
         1.  Let |keyArg| be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
@@ -11523,9 +11528,9 @@ must exist on |A|’s [=interface prototype object=]:
         1.  Return |O|.
     </div>
 
-The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>2</emu-val>.
+The value of the [=function object=]’s “length” property is the Number value <emu-val>2</emu-val>.
 
-The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “set”.
+The value of the [=function object=]’s “name” property is the String value “set”.
 
 
 <h4 id="es-setlike">Setlike declarations</h4>
@@ -11533,8 +11538,8 @@ The value of the <emu-val>Function</emu-val> object’s “name” property is t
 Any object that implements an [=interface=]
 that has a [=setlike declaration=]
 must have a \[[BackingSet]] [=internal slot=], which is
-initially set to a newly created <emu-val>Set</emu-val> object.
-This <emu-val>Set</emu-val> object’s \[[SetData]] internal slot is
+initially set to a newly created {{Set}} object.
+This {{Set}} object’s \[[SetData]] internal slot is
 the object’s [=set entries=].
 
 If an [=interface=] |A| is declared with a [=setlike declaration=], then
@@ -11557,13 +11562,13 @@ These additional properties are described in the sub-sections below.
         *   an identifier equal to |name|, and
         *   the type “method”.
     1.  If |O| is not an object that implements <var ignore>A</var>,
-        then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
-    1.  Let |set| be the <emu-val>Set</emu-val> object that is
+        then [=ECMAScript/throw=] a {{TypeError}}.
+    1.  Let |set| be the {{Set}} object that is
         the value of |O|’s \[[BackingSet]] [=internal slot=].
     1.  Let |function| be the result of calling the \[[Get]] internal method of |set|
         passing |name| and |set| as arguments.
     1.  If [=IsCallable=](|function|) is <emu-val>false</emu-val>,
-        then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        then [=ECMAScript/throw=] a {{TypeError}}.
     1.  Return [=Call=](|function|, |set|, |arguments|).
 </div>
 
@@ -11578,7 +11583,7 @@ with the following characteristics:
     defined below.
 *   <div algorithm="to invoke the size method of Sets">
 
-        The [=set size getter=] is a <emu-val>Function</emu-val> object
+        The [=set size getter=] is a [=function object=]
         whose behavior when invoked is as follows:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
@@ -11587,14 +11592,14 @@ with the following characteristics:
             *   the platform object |O|,
             *   the identifier “size”, and
             *   the type “getter”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
-        1.  Let |set| be the <emu-val>Set</emu-val> object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{TypeError}}.
+        1.  Let |set| be the {{Set}} object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
         1.  Return the result of calling the \[[Get]] internal method of |set| passing “size” and |set| as arguments.
     </div>
 
-    The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.
+    The value of the [=function object=]’s “length” property is the Number value <emu-val>0</emu-val>.
 
-    The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “size”.
+    The value of the [=function object=]’s “name” property is the String value “size”.
 
 
 <h5 id="es-set-values">values</h5>
@@ -11612,14 +11617,14 @@ For both of “entries” and “keys”, there must exist a property with that 
 
 *   The property has attributes
     { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a <emu-val>Function</emu-val> object that
+*   The value of the property is a [=function object=] that
     [=forwards to the internal set object|forwards that name to the internal set object=].
 
-The value of the <emu-val>Function</emu-val> objects’ “length” properties is
-the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.
+The value of the [=function object=]’s “length” properties is
+the Number value <emu-val>0</emu-val>.
 
-The value of the <emu-val>Function</emu-val> object’s “name” property is
-the <emu-val>String</emu-val> value “entries” or “keys”, correspondingly.
+The value of the [=function object=]’s “name” property is
+the String value “entries” or “keys”, correspondingly.
 
 
 <h5 id="es-set-has">has</h5>
@@ -11631,7 +11636,7 @@ with the following characteristics:
     { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 *   <div algorithm="to invoke the has method of Sets">
 
-        The value of the property is a <emu-val>Function</emu-val> object that behaves as follows when invoked:
+        The value of the property is a [=function object=] that behaves as follows when invoked:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
         1.  If |O| is a [=platform object=],
@@ -11639,8 +11644,8 @@ with the following characteristics:
             *   the platform object |O|,
             *   the identifier “has”, and
             *   the type “method”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
-        1.  Let |set| be the <emu-val>Set</emu-val> object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{TypeError}}.
+        1.  Let |set| be the {{Set}} object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
         1.  Let |type| be the value type specified in the [=setlike declaration=].
         1.  Let |function| be the result of calling the \[[Get]] internal method of |set| passing “has” and |set| as arguments.
         1.  Let |arg| be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
@@ -11649,9 +11654,9 @@ with the following characteristics:
         1.  [=Call=](|function|, |set|, «|value|»).
     </div>
 
-The value of the <emu-val>Function</emu-val> object’s “length” property is a <emu-val>Number</emu-val> value <emu-val>1</emu-val>.
+The value of the [=function object=]’s “length” property is a Number value <emu-val>1</emu-val>.
 
-The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “has”.
+The value of the [=function object=]’s “name” property is the String value “has”.
 
 
 <h5 id="es-add-delete">add and delete</h5>
@@ -11671,7 +11676,7 @@ must exist on |A|’s
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 *   <div algorithm="to invoke the add and delete methods of Sets">
 
-        The value of the property is a <emu-val>Function</emu-val> object that behaves as follows when invoked:
+        The value of the property is a [=function object=] that behaves as follows when invoked:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
         1.  Let |name| be the name of the property – “add” or “delete”.
@@ -11680,8 +11685,8 @@ must exist on |A|’s
             *   the platform object |O|,
             *   an identifier equal to |name|, and
             *   the type “method”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
-        1.  Let |set| be the <emu-val>Set</emu-val> object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{TypeError}}.
+        1.  Let |set| be the {{Set}} object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
         1.  Let |type| be the value type specified in the [=setlike declaration=].
         1.  Let |function| be the result of calling the \[[Get]] internal method of |set| passing |name| and |set| as arguments.
         1.  Let |arg| be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
@@ -11692,9 +11697,9 @@ must exist on |A|’s
         1.  Otherwise, return |O|.
     </div>
 
-The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>1</emu-val>.
+The value of the [=function object=]’s “length” property is the Number value <emu-val>1</emu-val>.
 
-The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “add” or “delete”, correspondingly.
+The value of the [=function object=]’s “name” property is the String value “add” or “delete”, correspondingly.
 
 
 <h5 id="es-set-clear">clear</h5>
@@ -11709,11 +11714,11 @@ must exist on |A|’s
 [=interface prototype object=]:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a <emu-val>Function</emu-val> object that [=forwards to the internal set object|forwards “clear” to the internal set object=].
+*   The value of the property is a [=function object=] that [=forwards to the internal set object|forwards “clear” to the internal set object=].
 
-The value of the <emu-val>Function</emu-val> object’s “length” property is the <emu-val>Number</emu-val> value <emu-val>0</emu-val>.
+The value of the [=function object=]’s “length” property is the Number value <emu-val>0</emu-val>.
 
-The value of the <emu-val>Function</emu-val> object’s “name” property is the <emu-val>String</emu-val> value “clear”.
+The value of the [=function object=]’s “name” property is the String value “clear”.
 
 
 <h3 id="es-implements-statements">Implements statements</h3>
@@ -11729,17 +11734,17 @@ each property that corresponds to one of the
 [=setlike declarations=]
 that exist on all of the interface prototype objects of |A|’s
 [=consequential interfaces=].
-For operations, where the property is a data property with a <emu-val>Function</emu-val>
+For operations, where the property is a data property with a function
 object value, each copy of the property must have
-distinct <emu-val>Function</emu-val> objects.  For attributes, each
+distinct [=function objects=].  For attributes, each
 copy of the accessor property must have
-distinct <emu-val>Function</emu-val> objects for their getters,
+distinct [=function objects=] for their getters,
 and similarly with their setters.
 
 <div class="note">
 
     When invoking an [=operation=] by calling
-    a <emu-val>Function</emu-val> object that is the value of one of the copies that exists
+    a [=function object=] that is the value of one of the copies that exists
     due to an implements statement, the <emu-val>this</emu-val> value is
     checked to ensure that it is an object that implements the
     [=interface=] corresponding to the
@@ -11763,13 +11768,13 @@ and similarly with their setters.
     Attempting to call <code>B.prototype.f</code> on an object that implements
     <code class="idl">A</code> (but not <code class="idl">B</code>) or one
     that implements <code class="idl">C</code> will result in a
-    <emu-val>TypeError</emu-val> being thrown.  However,
+    {{TypeError}} being thrown.  However,
     calling <code>A.prototype.f</code> on an object that implements
     <code class="idl">B</code> or one that implements <code class="idl">C</code>
     would succeed.  This is handled by the algorithm in [[#es-operations]]
     that defines how IDL operation invocation works in ECMAScript.
 
-    Similar behavior is required for the getter and setter <emu-val>Function</emu-val>
+    Similar behavior is required for the getter and setter function
     objects that correspond to an IDL [=attributes=],
     and this is handled in [[#es-attributes]].
 
@@ -11977,7 +11982,7 @@ and [[#legacy-platform-object-set]].
     assuming |arg|<sub>0..|n|−1</sub> is the list of argument values passed to \[[Call]]:
 
     1.  If |I| has no [=legacy callers=],
-        [=ECMAScript/throw=] a <emu-val>TypeError</emu-val>.
+        [=ECMAScript/throw=] a {{TypeError}}.
     1.  Initialize |S| to the [=effective overload set=]
         for legacy callers on |I| and with argument count |n|.
     1.  Let &lt;|operation|, |values|&gt; be the result of passing |S| and
@@ -12277,7 +12282,7 @@ the special value “missing”, which represents a missing optional argument.
             1.  Set |X| to |getResult|.\[[Value]].
     1.  If [=!=] [=IsCallable=](|X|) is <emu-val>false</emu-val>,
         then set |completion| to a new [=Completion=]{\[[Type]]: throw, \[[Value]]: a
-        newly created <emu-val>TypeError</emu-val> object, \[[Target]]: empty}, and jump
+        newly created {{TypeError}} object, \[[Target]]: empty}, and jump
         to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.
     1.  If |value|'s interface is not a [=single operation callback interface=],
         or if [=!=] [=IsCallable=](|O|) is <emu-val>false</emu-val>,
@@ -12444,7 +12449,7 @@ a return type that is a [=promise type=].
     1.  Let |completion| be an uninitialized variable.
     1.  Let |F| be the ECMAScript object corresponding to |callable|.
     1.  If [=!=] [=IsConstructor=](|F|) is <emu-val>false</emu-val>, throw a
-        <emu-val>TypeError</emu-val> exception.
+        {{TypeError}} exception.
     1.  Let |realm| be |F|'s [=associated Realm=].
     1.  Let |relevant settings| be |realm|'s [=Realm/settings object=].
     1.  Let |stored settings| be |callable|'s [=callback context=].
@@ -12511,7 +12516,7 @@ In the ECMAScript binding, the {{DOMException}} type has some additional require
 *   Unlike normal [=interface types=], the [=interface prototype object=] for {{DOMException}} must
     have as its \[[Prototype]] the intrinsic object [=%ErrorPrototype%=].
 
-*   If an implementation gives native <emu-val>Error</emu-val> objects special powers or
+*   If an implementation gives native {{ECMAScript/Error}} objects special powers or
     nonstandard properties (such as a <code>stack</code> property), it should also expose those on
     {{DOMException}} instances.
 
@@ -12566,8 +12571,8 @@ A {{DOMException}} is represented by a
 <div class="note">
 
     The above algorithms restrict [=Exception objects|objects representing exceptions=] propagating
-    out of a <emu-val>Function</emu-val> to be ones that are associated with the [=Realm=] of that
-    <emu-val>Function</emu-val> object (i.e., the [=current Realm=] at the time the function
+    out of a [=function object=] to be ones that are associated with the [=Realm=] of that
+    [=function object=] (i.e., the [=current Realm=] at the time the function
     executes). For example, consider the IDL:
 
     <pre highlight="webidl">
@@ -12603,8 +12608,8 @@ A {{DOMException}} is represented by a
 
 None of the algorithms or processing requirements in the
 ECMAScript language binding catch ECMAScript exceptions.  Whenever
-an ECMAScript <emu-val>Function</emu-val> is invoked due
-to requirements in this section and that <emu-val>Function</emu-val>
+an ECMAScript [=function object=] is invoked due
+to requirements in this section and that function call
 ends due to an exception being thrown, that exception
 must propagate to the caller, and if
 not caught there, to its caller, and so on.

--- a/index.bs
+++ b/index.bs
@@ -146,7 +146,8 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: sections 9.1; url: sec-ordinary-object-internal-methods-and-internal-slots
         text: 9.3.1; url: sec-built-in-function-objects-call-thisargument-argumentslist
         text: ECMA-262 section 9.3; url: sec-built-in-function-objects
-        text: function object; url: sec-ecmascript-function-objects
+        text: built-in function object; url: sec-built-in-function-objects
+        text: function object; url: sec-object-internal-methods-and-internal-slots
         text: Array methods; url: sec-properties-of-the-array-prototype-object
         text: typed arrays; url: sec-typedarray-objects
         text: GetMethod; url: sec-getmethod
@@ -435,7 +436,7 @@ in [[#es-extended-attributes]].
     particular language being used.
 
     In ECMAScript, the attributes on the IDL interfaces will be exposed as accessor
-    properties and the operations as data properties whose value is a [=function object=] on a
+    properties and the operations as data properties whose value is a [=built-in function object=] on a
     prototype object for all <code class="idl">GraphicalWindow</code>
     objects; each ECMAScript object that implements <code class="idl">GraphicalWindow</code>
     will have that prototype object in its prototype chain.
@@ -1144,8 +1145,8 @@ defined on the same interface.
 The identifier also must not
 be “length”, “name” or “prototype”.
 
-Note: These three names are the names of properties that exist on all
-[=function objects=].
+Note: These three names are the names of properties that may exist on
+[=function objects=] at the time the [=function object=] is created in the ECMAScript language binding.
 
 The type of a constant (matching <emu-nt><a href="#prod-ConstType">ConstType</a></emu-nt>)
 must not be any type other than
@@ -6202,7 +6203,7 @@ and whose value is the specified string.
     and configurable.
 </p>
 
-If an object is defined to be a [=function object=], then
+If an object is defined to be a [=built-in function object=], then
 it has characteristics as described in [=ECMA-262 section 9.3=].
 
 <p id="ecmascript-abstractop">
@@ -7380,7 +7381,7 @@ objects.
     the following steps must be followed:
 
     1.  Let |promise| be the promise object of type <a interface lt="Promise">Promise&lt;|T|&gt;</a>.
-    1.  Let |onFulfilled| be a new [=function object=] whose
+    1.  Let |onFulfilled| be a new [=built-in function object=] whose
         behavior when invoked is as follows:
         1.  If |T| is {{void}}, then:
             1.  Return the result of performing any steps that were required to be run if the promise was fulfilled.
@@ -7392,7 +7393,7 @@ objects.
                 return <emu-val>undefined</emu-val>.
             1.  Otherwise, return the result of performing any steps that were required to be run if the promise was fulfilled,
                 with |value| as the promise’s value.
-    1.  Let |onRejected| be a new [=function object=] whose
+    1.  Let |onRejected| be a new [=built-in function object=] whose
         behavior when invoked is as follows:
         1.  Let |R| be the first argument to |onRejected|.
         1.  Let |reason| be the result of [=converted to an IDL value|converting=]
@@ -10019,7 +10020,7 @@ The characteristics of a named constructor are described in [[#named-constructor
 
 <h4 id="interface-object" oldids="es-interface-call,es-constructible-interfaces">Interface object</h4>
 
-The [=interface object=] for a given [=interface=] is a [=function object=].
+The [=interface object=] for a given [=interface=] is a [=built-in function object=].
 It has properties that correspond to the [=constants=] and [=static operations=]
 defined on that interface,
 as described in sections [[#es-constants]] and [[#es-operations]].
@@ -10094,7 +10095,7 @@ the <code>typeof</code> operator will return "function" when applied to an inter
 
 A [=named constructor=] that exists due to one or more
 [{{NamedConstructor}}] [=extended attributes=]
-with a given [=NamedConstructor identifier|identifier=] is a [=function object=].
+with a given [=NamedConstructor identifier|identifier=] is a [=built-in function object=].
 It allows constructing objects that
 implement the interface on which the
 [{{NamedConstructor}}] extended attributes appear.
@@ -10258,7 +10259,7 @@ and its value is an object called the
 The property has the attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 
 The [=legacy callback interface object=] for a given [=callback interface=]
-is a [=function object=].
+is a [=built-in function object=].
 It has properties that correspond to the [=constants=] defined on that interface,
 as described in sections [[#es-constants]].
 
@@ -10865,7 +10866,7 @@ then there must exist a property with the following characteristics:
     and <emu-val>true</emu-val> otherwise.
 *   <div algorithm="to invoke the toString method of interfaces">
 
-        The value of the property is a [=function object=], which behaves as follows:
+        The value of the property is a [=built-in function object=], which behaves as follows:
 
         1.  Let |O| be the result of calling [=ToObject=] on the <emu-val>this</emu-val> value.
         1.  If |O| is a [=platform object=],
@@ -10933,8 +10934,8 @@ then the [=function object=] is [=%ArrayProto_values%=].
 
 <div algorithm="to invoke the @@iterator property of interfaces with a pair iterator">
 
-    If the interface has a [=pair iterator=],
-    then the function, when invoked, must behave as follows:
+    If the interface has a [=pair iterator=], then the [=function object=] is a [=built-in function object=] that,
+    when invoked, must behave as follows:
 
     1.  Let |object| be the result of calling [=ToObject=] on the <emu-val>this</emu-val> value.
     1.  If |object| is a [=platform object=],
@@ -10954,7 +10955,7 @@ then the [=function object=] is [=%ArrayProto_values%=].
 <div algorithm="to invoke the @@iterator property of interfaces with maplike or setlike declarations">
 
     If the interface has a [=maplike declaration=] or [=setlike declaration=],
-    then the [=function object=] that is the value of the [=@@iterator=] property,
+    then the [=function object=] is a [=built-in function object=] that,
     when invoked, must behave as follows:
 
     1.  Let |object| be the result of calling [=ToObject=] on the <emu-val>this</emu-val> value.
@@ -10983,7 +10984,7 @@ The value of the [=@@iterator=] [=function object=]’s “name” property
 is the String value “entries”
 if the interface has a [=pair iterator=] or a [=maplike declaration=]
 and the String “values”
-if the interface has a [=setlike declaration=].
+if the interface has a [=setlike declaration=] or defines an [=indexed property getter=].
 
 
 <h5 id="es-forEach">forEach</h5>
@@ -11067,7 +11068,7 @@ the initial value of the “forEach” data property of [=%ArrayPrototype%=].
     1.  Let |backing| be the value of the \[[BackingMap]] [=internal slot=] of |object|,
         if the interface has a [=maplike declaration=],
         or the \[[BackingSet]] [=internal slot=] of |object| otherwise.
-    1.  Let |callbackWrapper| be a [=function object=] that, when invoked, behaves as follows:
+    1.  Let |callbackWrapper| be a [=built-in function object=] that, when invoked, behaves as follows:
         1.  Let |v| and |k| be the first two arguments passed to the function.
         1.  Let |thisArg| be the <emu-val>this</emu-val> value.
         1.  [=Call=](|callbackFn|, |thisArg|, «|v|, |k|, |object|»).
@@ -11266,7 +11267,7 @@ must be [=%IteratorPrototype%=].
 
     An [=iterator prototype object=] must have a property named “next” with attributes
     { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
-    and whose value is a [=function object=] that behaves as follows:
+    and whose value is a [=built-in function object=] that behaves as follows:
 
     1.  Let |interface| be the [=interface=] for which the
         [=iterator prototype object=] exists.
@@ -11363,7 +11364,7 @@ with the following characteristics:
     defined below.
 *   <div algorithm="to invoke the size method of Maps">
 
-        The [=map size getter=] is a [=function object=]
+        The [=map size getter=] is a [=built-in function object=]
         whose behavior when invoked is as follows:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
@@ -11398,7 +11399,7 @@ For both of “keys” and “values”, there must exist a property with that n
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=function object=] that [=forwards to the internal map object|forwards that name to the internal map object=].
+*   The value of the property is a [=built-in function object=] that [=forwards to the internal map object|forwards that name to the internal map object=].
 
 The value of the [=function objects=]’ “length” properties is the Number value <emu-val>0</emu-val>.
 
@@ -11414,7 +11415,7 @@ For both of “get” and “has”, there must exist a property with that name 
     { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 *   <div algorithm="to invoke the get and has methods of Maps">
 
-        The value of the property is a [=function object=]
+        The value of the property is a [=built-in function object=]
         that behaves as follows when invoked:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
@@ -11434,7 +11435,7 @@ For both of “get” and “has”, there must exist a property with that name 
         1.  Return [=Call=](|function|, |map|, «|key|»).
     </div>
 
-The value of the [=function objects=]’ “length” properties is the Number value <emu-val>1</emu-val>.
+The value of the [=function object=]’s “length” properties is the Number value <emu-val>1</emu-val>.
 
 The value of the [=function object=]’s “name” property is the String value “get” or “has”, correspondingly.
 
@@ -11451,7 +11452,7 @@ must exist on |A|’s
 [=interface prototype object=]:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=function object=] that [=forwards to the internal map object|forwards “clear” to the internal map object=].
+*   The value of the property is a [=built-in function object=] that [=forwards to the internal map object|forwards “clear” to the internal map object=].
 
 The value of the [=function object=]’s “length” property is the Number value <emu-val>0</emu-val>.
 
@@ -11472,7 +11473,7 @@ must exist on |A|’s
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 *   <div algorithm="to invoke the delete method of Maps">
 
-        The value of the property is a [=function object=] that behaves as follows when invoked:
+        The value of the property is a [=built-in function object=] that behaves as follows when invoked:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
         1.  If |O| is a [=platform object=],
@@ -11507,7 +11508,7 @@ must exist on |A|’s [=interface prototype object=]:
     { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 *   <div algorithm="to invoke the set method of Maps">
 
-        The value of the property is a [=function object=] that behaves as follows when invoked:
+        The value of the property is a [=built-in function object=] that behaves as follows when invoked:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
         1.  If |O| is a [=platform object=],
@@ -11550,7 +11551,7 @@ These additional properties are described in the sub-sections below.
 
 <div algorithm>
 
-    Some of the properties below are defined to have a [=function object=] value that
+    Some of the properties below are defined to have a [=built-in function object=] value that
     <dfn id="dfn-forwards-to-the-internal-set-object" export>forwards to the internal set object</dfn>
     for a given function name. Such functions behave as follows when invoked:
 
@@ -11584,7 +11585,7 @@ with the following characteristics:
     defined below.
 *   <div algorithm="to invoke the size method of Sets">
 
-        The [=set size getter=] is a [=function object=]
+        The [=set size getter=] is a [=built-in function object=]
         whose behavior when invoked is as follows:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
@@ -11618,7 +11619,7 @@ For both of “entries” and “keys”, there must exist a property with that 
 
 *   The property has attributes
     { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=function object=] that
+*   The value of the property is a [=built-in function object=] that
     [=forwards to the internal set object|forwards that name to the internal set object=].
 
 The value of the [=function object=]’s “length” properties is
@@ -11637,7 +11638,7 @@ with the following characteristics:
     { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 *   <div algorithm="to invoke the has method of Sets">
 
-        The value of the property is a [=function object=] that behaves as follows when invoked:
+        The value of the property is a [=built-in function object=] that behaves as follows when invoked:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
         1.  If |O| is a [=platform object=],
@@ -11677,7 +11678,7 @@ must exist on |A|’s
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 *   <div algorithm="to invoke the add and delete methods of Sets">
 
-        The value of the property is a [=function object=] that behaves as follows when invoked:
+        The value of the property is a [=built-in function object=] that behaves as follows when invoked:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
         1.  Let |name| be the name of the property – “add” or “delete”.
@@ -11715,7 +11716,7 @@ must exist on |A|’s
 [=interface prototype object=]:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=function object=] that [=forwards to the internal set object|forwards “clear” to the internal set object=].
+*   The value of the property is a [=built-in function object=] that [=forwards to the internal set object|forwards “clear” to the internal set object=].
 
 The value of the [=function object=]’s “length” property is the Number value <emu-val>0</emu-val>.
 

--- a/index.bs
+++ b/index.bs
@@ -51,6 +51,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
     type: exception; for: ECMAScript
         text: Error; url: sec-error-objects
         text: SyntaxError; url: sec-native-error-types-used-in-this-standard-syntaxerror
+        text: TypeError; url: sec-native-error-types-used-in-this-standard-typeerror
     type: dfn
         text: NumericLiteral; url: sec-literals-numeric-literals
         text: ECMAScript error objects; url: sec-error-objects
@@ -6187,7 +6188,7 @@ Unless otherwise specified, the \[[Extensible]] internal property
 of objects defined in this section has the value <emu-val>true</emu-val>.
 
 Unless otherwise specified, the \[[Prototype]] internal property
-of objects defined in this section is the Object prototype object.
+of objects defined in this section is [=%ObjectPrototype%=].
 
 Some objects described in this section are defined to have a <dfn id="dfn-class-string" export>class string</dfn>,
 which is the string to include in the string returned from Object.prototype.toString.
@@ -6643,10 +6644,10 @@ In effect, where <var ignore>x</var> is a Number value,
     1.  If the conversion is to an IDL type [=extended attribute associated with|associated with=]
         the [{{EnforceRange}}] [=extended attribute=], then:
         1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
-            then [=ECMAScript/throw=] a {{TypeError}}.
+            then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Set |x| to [=!=] <a abstract-op>IntegerPart</a>(|x|).
         1.  If |x| &lt; |lowerBound| or |x| &gt; |upperBound|,
-            then [=ECMAScript/throw=] a {{TypeError}}.
+            then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Return |x|.
     1.  If |x| is not <emu-val>NaN</emu-val> and the conversion is to an IDL type
         [=extended attribute associated with|associated with=] the [{{Clamp}}] extended attribute,
@@ -6674,7 +6675,7 @@ In effect, where <var ignore>x</var> is a Number value,
 
     1.  Let |x| be [=?=] [=ToNumber=](|V|).
     1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |S| be the set of finite IEEE 754 single-precision floating
         point values except −0, but with two special values added: 2<sup>128</sup> and
         −2<sup>128</sup>.
@@ -6683,7 +6684,7 @@ In effect, where <var ignore>x</var> is a Number value,
         <em>even significand</em> if there are two [=equally close values=].
         (The two special values 2<sup>128</sup> and −2<sup>128</sup>
         are considered to have even significands for this purpose.)
-    1.  If |y| is 2<sup>128</sup> or −2<sup>128</sup>, then [=ECMAScript/throw=] a {{TypeError}}.
+    1.  If |y| is 2<sup>128</sup> or −2<sup>128</sup>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  If |y| is +0 and |x| is negative, return −0.
     1.  Return |y|.
 </div>
@@ -6747,7 +6748,7 @@ value when its bit pattern is interpreted as an unsigned 32 bit integer.
 
     1.  Let |x| be [=?=] [=ToNumber=](|V|).
     1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return the IDL {{double}} value
         that represents the same numeric value as |x|.
 </div>
@@ -6826,7 +6827,7 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
 
     1.  Let |x| be [=ToString=](|V|).
     1.  If the value of any [=element=]
-        of |x| is greater than 255, then [=ECMAScript/throw=] a {{TypeError}}.
+        of |x| is greater than 255, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return an IDL {{ByteString}} value
         whose length is the length of |x|, and where the value of each element is
         the value of the corresponding element of |x|.
@@ -6876,7 +6877,7 @@ values are represented by ECMAScript Object values.
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL {{object}} value by running the following algorithm:
 
-    1.  If [=Type=](|V|) is not Object, then [=ECMAScript/throw=] a {{TypeError}}.
+    1.  If [=Type=](|V|) is not Object, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return the IDL {{object}} value that is a reference to the same object as |V|.
 </div>
 
@@ -6896,7 +6897,7 @@ IDL {{symbol}} values are represented by ECMAScript Symbol values.
     An ECMAScript value |V| is [=converted to an IDL value|converted=] to an IDL {{symbol}} value
     by running the following algorithm:
 
-    1.  If [=Type=](|V|) is not Symbol, then [=ECMAScript/throw=] a {{TypeError}}.
+    1.  If [=Type=](|V|) is not Symbol, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return the IDL {{symbol}} value that is a reference to the same symbol as |V|.
 </div>
 
@@ -6917,12 +6918,12 @@ values are represented by ECMAScript Object values (including [=function objects
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL [=interface type=] value by running the following algorithm (where |I| is the [=interface=]):
 
-    1.  If [=Type=](|V|) is not Object, then [=ECMAScript/throw=] a {{TypeError}}.
+    1.  If [=Type=](|V|) is not Object, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  If |V| is a [=platform object=] that implements |I|, then return the IDL [=interface type=] value that represents a reference to that platform object.
     1.  If |V| is a [=user object=]
         that is considered to implement |I| according to the rules in [[#es-user-objects]], then return the IDL [=interface type=] value that represents a reference to that
         user object, with the [=incumbent settings object=] as the [=callback context=].
-    1.  [=ECMAScript/Throw=] a {{TypeError}}.
+    1.  [=ECMAScript/Throw=] a {{ECMAScript/TypeError}}.
 </div>
 
 <p id="interface-to-es">
@@ -6946,7 +6947,7 @@ the object (or its prototype chain) correspond to [=dictionary members=].
     to an IDL [=dictionary type=] value by
     running the following algorithm (where |D| is the [=dictionary type=]):
 
-    1.  If [=Type=](|V|) is not Undefined, Null or Object, then [=ECMAScript/throw=] a {{TypeError}}.
+    1.  If [=Type=](|V|) is not Undefined, Null or Object, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |dict| be an empty dictionary value of type |D|;
         every [=dictionary member=]
         is initially considered to be [=not present=].
@@ -6971,7 +6972,7 @@ the object (or its prototype chain) correspond to [=dictionary members=].
                 1.  Set the dictionary member on |dict| with key name |key| to the value |idlValue|.  This dictionary member is considered to be [=present=].
             1.  Otherwise, if |value| is
                 <emu-val>undefined</emu-val> and |member| is a
-                [=required dictionary member=], then throw a {{TypeError}}.
+                [=required dictionary member=], then throw a {{ECMAScript/TypeError}}.
     1.  Return |dict|.
 </div>
 
@@ -7011,7 +7012,7 @@ values.
 
     1.  Let |S| be the result of calling [=ToString=](|V|).
     1.  If |S| is not one of |E|’s [=enumeration values=],
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return the enumeration value of type |E| that is equal to |S|.
 </div>
 
@@ -7042,7 +7043,7 @@ when they can be any object.
         whose type is a [=nullable type|nullable=]
         [=callback function=]
         that is annotated with [{{TreatNonObjectAsNull}}],
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return the IDL [=callback function type=] value
         that represents a reference to the same object that |V| represents, with the
         [=incumbent settings object=] as the [=callback context=].
@@ -7110,12 +7111,12 @@ ECMAScript Array values.
     to an IDL <a lt="sequence type">sequence&lt;<var ignore>T</var>&gt;</a> value as follows:
 
     1.  If [=Type=](|V|) is not Object,
-        [=ECMAScript/throw=] a {{TypeError}}.
+        [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |method| be the result of
         [=GetMethod=](|V|, [=@@iterator=]).
     1.  [=ReturnIfAbrupt=](|method|).
     1.  If |method| is <emu-val>undefined</emu-val>,
-        [=ECMAScript/throw=] a {{TypeError}}.
+        [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return the result of [=creating a sequence from an iterable|creating a sequence=]
         from |V| and |method|.
 </div>
@@ -7259,7 +7260,7 @@ ECMAScript Object values.
     to an IDL <code>[=record=]&lt;|K|, |V|></code> value as follows:
 
     1.  If [=Type=](|O|) is not Object,
-        [=ECMAScript/throw=] a {{TypeError}}.
+        [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |result| be a new empty instance of <code>[=record=]&lt;|K|, |V|></code>.
     1.  Let |keys| be [=?=] |O|.\[[OwnPropertyKeys]]().
     1.  [=list/For each=] |key| of |keys|:
@@ -7326,7 +7327,7 @@ ECMAScript Object values.
         <tr>
             <td><code>{"😞": 1}</code></td>
             <td><code>[=record=]&lt;ByteString, double></code></td>
-            <td>{{TypeError}}</td>
+            <td>{{ECMAScript/TypeError}}</td>
         </tr>
         <tr>
             <td><code>{"\uD83D": 1}</code></td>
@@ -7401,7 +7402,7 @@ objects.
         1.  Otherwise, return the result of performing any steps that were required to be run if the promise was rejected,
             with |reason| as the rejection reason.
     1.  Let |then| be the result of calling the internal \[[Get]] method of |promise| with property name “then”.
-    1.  If |then| is not [=callable=], then [=ECMAScript/throw=] a {{TypeError}}.
+    1.  If |then| is not [=callable=], then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return the result of calling |then| with |promise| as the <emu-val>this</emu-val> value and |onFulfilled| and |onRejected|
         as its two arguments.
 </div>
@@ -7520,7 +7521,7 @@ that correspond to the union’s [=member types=].
     1.  If |types| includes a {{boolean}},
         then return the result of [=converted to an IDL value|converting=]
         |V| to {{boolean}}.
-    1.  [=ECMAScript/Throw=] a {{TypeError}}.
+    1.  [=ECMAScript/Throw=] a {{ECMAScript/TypeError}}.
 </div>
 
 <p id="union-to-es">
@@ -7548,7 +7549,7 @@ by {{DOMException}} platform objects.
 
     1.  If [=Type=](|V|) is not Object,
         or |V| does not have an \[[ErrorData]] [=internal slot=],
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return the IDL {{Error!!interface}} value that is a reference
         to the same object as |V|.
 </div>
@@ -7573,7 +7574,7 @@ ECMAScript Object values.
 
     1.  If [=Type=](|V|) is not Object,
         or |V| is not a platform object that represents a {{DOMException}},
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return the IDL {{DOMException}} value that is a reference
         to the same object as |V|.
 </div>
@@ -7601,11 +7602,11 @@ that unless the type is [=extended attributes associated with|associated with=] 
 
     1.  If [=Type=](|V|) is not Object,
         or |V| does not have an \[[ArrayBufferData]] [=internal slot=],
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowShared}}]
         [=extended attribute=], and [=IsSharedArrayBuffer=](|V|) is true, then [=ECMAScript/throw=]
-        a {{TypeError}}.
+        a {{ECMAScript/TypeError}}.
     1.  Return the IDL {{ArrayBuffer}} value that is a reference
         to the same object as |V|.
 </div>
@@ -7617,11 +7618,11 @@ that unless the type is [=extended attributes associated with|associated with=] 
 
     1.  If [=Type=](|V|) is not Object,
         or |V| does not have a \[[DataView]] [=internal slot=],
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowShared}}]
         [=extended attribute=], and [=IsSharedArrayBuffer=](|V|.\[[ViewedArrayBuffer]]) is true,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return the IDL {{DataView}} value that is a reference
         to the same object as |V|.
 </div>
@@ -7647,11 +7648,11 @@ that unless the type is [=extended attributes associated with|associated with=] 
     1.  If [=Type=](|V|) is not Object,
         or |V| does not have a \[[TypedArrayName]] [=internal slot=]
         with a value equal to |typedArrayName|,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  If the conversion is not to an IDL type
         [=extended attributes associated with|associated with=] the [{{AllowShared}}]
         [=extended attribute=], and [=IsSharedArrayBuffer=](|V|.\[[ViewedArrayBuffer]]) is true,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return the IDL value of type |T| that is a reference to the same object as |V|.
 </div>
 
@@ -7674,12 +7675,12 @@ a reference to the same object that the IDL value represents.
     1.  If |O| has a \[[ViewedArrayBuffer]] [=internal slot=], then:
         1.  Set |arrayBuffer| to the value of |O|’s \[[ViewedArrayBuffer]] [=internal slot=].
         1.  If |arrayBuffer| is <emu-val>undefined</emu-val>, then
-            [=ECMAScript/throw=] a {{TypeError}}.
+            [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Set |offset| to the value of |O|’s \[[ByteOffset]] [=internal slot=].
         1.  Set |length| to the value of |O|’s \[[ByteLength]] [=internal slot=].
     1.  Otherwise, set |length| to the value of |O|’s \[[ArrayBufferByteLength]] [=internal slot=].
     1.  If [=IsDetachedBuffer=](|O|), then
-        [=ECMAScript/throw=] a {{TypeError}}.
+        [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |data| be the value of |O|’s \[[ArrayBufferData]] [=internal slot=].
     1.  Return a reference to or copy of (as required) the |length| bytes in |data|
         starting at byte offset |offset|.
@@ -7778,7 +7779,7 @@ See the rules for converting ECMAScript values to IDL [=buffer source types=] in
 
     With this definition, a call to <code>readPixels</code> with an {{ECMAScript/SharedArrayBuffer}}
     instance, or any typed array or {{ECMAScript/DataView}} backed by one, will throw a
-    {{TypeError}} exception. In contrast, a call to <code>readPixelsShared</code> will allow such
+    {{ECMAScript/TypeError}} exception. In contrast, a call to <code>readPixelsShared</code> will allow such
     objects as input.
 </div>
 
@@ -8437,8 +8438,8 @@ appears on an [=interface=]
 that is not defined to [=interface/inherit=]
 from another, it indicates that the internal \[[Prototype]]
 property of its [=interface prototype object=]
-will be the Array prototype object rather than
-the Object prototype object.  This allows
+will be the intrinsic object [=%ArrayPrototype%=] rather than
+[=%ObjectPrototype%=].  This allows
 Array methods to be used more easily
 with objects implementing the interface.
 
@@ -9694,7 +9695,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
     1.  Let |maxarg| be the length of the longest type list of the entries in |S|.
     1.  Initialize |argcount| to be min(|maxarg|, |n|).
     1.  Remove from |S| all entries whose type list is not of length |argcount|.
-    1.  If |S| is empty, then [=ECMAScript/throw=] a {{TypeError}}.
+    1.  If |S| is empty, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Initialize |d| to −1.
     1.  Initialize |method| to <emu-val>undefined</emu-val>.
     1.  If there is more than one entry in |S|, then set
@@ -9895,7 +9896,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
 
         1.  Otherwise: if there is an entry in |S| that has {{any}} at position |i|
             of its type list, then remove from |S| all other entries.
-        1.  Otherwise: [=ECMAScript/throw=] a {{TypeError}}.
+        1.  Otherwise: [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |callable| be the [=operation=] or [=extended attribute=]
         of the single entry in |S|.
     1.  If |i| = |d| and |method| is not <emu-val>undefined</emu-val>, then
@@ -9943,7 +9944,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
         overload argument list, then they are ignored.
     *   After ignoring these trailing arguments, only overloads
         that can take this exact number of arguments are considered.
-        If there are none, then a {{TypeError}} is thrown.
+        If there are none, then a {{ECMAScript/TypeError}} is thrown.
 
     Once we have a set of possible overloads with the right number
     of arguments, the ECMAScript values are converted from left to right.
@@ -9963,7 +9964,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
     be invoked.  If the value passed in is <emu-val>undefined</emu-val>
     and there is an overload with an optional argument at this position, then
     we will choose that overload.  If there is no valid overload for the type of
-    value passed in here, then we throw a {{TypeError}}.
+    value passed in here, then we throw a {{ECMAScript/TypeError}}.
     The inspection of the value at the distinguishing argument index does not have any side effects;
     the only side effects that come from running the overload resolution
     algorithm are those that come from converting the ECMAScript values
@@ -10049,9 +10050,9 @@ the <code>typeof</code> operator will return "function" when applied to an inter
 
     1.  Let |steps| be the following steps:
         1.  If |I| was not declared with a [{{Constructor}}] [=extended attribute=],
-            then [=ECMAScript/throw=] a {{TypeError}}.
+            then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  If [=NewTarget=] is <emu-val>undefined</emu-val>, then
-            [=ECMAScript/throw=] a {{TypeError}}.
+            [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |arg|<sub>0..|n|−1</sub> be the passed arguments.
         1.  Let |id| be the identifier of interface |I|.
         1.  Initialize |S| to the [=effective overload set=]
@@ -10109,7 +10110,7 @@ This object's relevant [=Realm=] must be the same as that of the [=named constru
 
     1.  Let |steps| be the following steps:
         1.  If [=NewTarget=] is <emu-val>undefined</emu-val>, then
-            [=ECMAScript/throw=] a {{TypeError}}.
+            [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |arg|<sub>0..|n|−1</sub> be the passed arguments.
         1.  Initialize |S| to the  [=effective overload set=]
             for constructors with [=identifier=] |id| on [=interface=] |I|
@@ -10272,7 +10273,7 @@ when applied to a [=legacy callback interface object=].
     and in [=Realm=] |realm| is created as follows:
 
     1.  Let |steps| be the following steps:
-        1.  [=ECMAScript/Throw=] a {{TypeError}}.
+        1.  [=ECMAScript/Throw=] a {{ECMAScript/TypeError}}.
     1.  Let |F| be [=!=] [=CreateBuiltinFunction=](|realm|, |steps|, the [=%FunctionPrototype%=] of |realm|).
     1.  Perform [=!=] [=SetFunctionName=](|F|, |id|).
     1.  Perform [=!=] [=DefinePropertyOrThrow=](|F|, "length",
@@ -10459,7 +10460,7 @@ The characteristics of this property are as follows:
             1.  If |target| is an [=interface=], and |attribute| is a [=regular attribute=]:
                 1.  If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or
                     <emu-val>undefined</emu-val>, set |O| to |realm|'s [=Realm/global object=].
-                    (This will subsequently cause a {{TypeError}} in a few steps, if
+                    (This will subsequently cause a {{ECMAScript/TypeError}} in a few steps, if
                     the global object does not implement |target| and [{{LenientThis}}] is not
                     specified.)
                     <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
@@ -10470,7 +10471,7 @@ The characteristics of this property are as follows:
                     then:
                     1.  If |attribute| was specified with the [{{LenientThis}}]
                         [=extended attribute=], then return <emu-val>undefined</emu-val>.
-                    1. Otherwise, [=ECMAScript/throw=] a {{TypeError}}.
+                    1. Otherwise, [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
             1.  Let |R| be the result of [=get the underlying value|getting the underlying value=]
                 of |attribute| given |O|.
             1.  Return the result of [=converted to an ECMAScript value|converting=] |R| to an
@@ -10503,14 +10504,14 @@ The characteristics of this property are as follows:
         <emu-val>undefined</emu-val>; there is no [=attribute setter=] function.
     1.  Assert: |attribute|'s type is not a [=promise type=].
     1.  Let |steps| be the following series of steps:
-        1.  If no arguments were passed, then [=ECMAScript/throw=] a {{TypeError}}.
+        1.  If no arguments were passed, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |V| be the value of the first argument passed.
         1.  Let |id| be |attribute|'s [=identifier=].
         1.  Let |O| be <emu-val>null</emu-val>.
         1.  If |attribute| is a [=regular attribute=]:
             1.  If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or
                 <emu-val>undefined</emu-val>, set |O| to |realm|'s [=Realm/global object=].
-                (This will subsequently cause a {{TypeError}} in a few steps, if
+                (This will subsequently cause a {{ECMAScript/TypeError}} in a few steps, if
                 the global object does not implement |target| and [{{LenientThis}}] is not
                 specified.)
                 <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
@@ -10520,7 +10521,7 @@ The characteristics of this property are as follows:
             1.  Let |validThis| be true if |O| is a [=platform object=] that implements the
                 interface |target|, or false otherwise.
             1.  If |validThis| is false and |attribute| was not specified with the [{{LenientThis}}]
-                [=extended attribute=], then [=ECMAScript/throw=] a {{TypeError}}.
+                [=extended attribute=], then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
             1.  If |attribute| is declared with the [{{Replaceable}}] extended attribute, then:
                 1.  Perform [=?=] [=CreateDataProperty=](|O|, |id|, |V|).
                 1.  Return <emu-val>undefined</emu-val>.
@@ -10530,7 +10531,7 @@ The characteristics of this property are as follows:
             1.  If |attribute| is declared with a [{{PutForwards}}] extended attribute, then:
                 1.  Let |Q| be [=?=] [=Get=](|O|, |id|).
                 1.  If [=Type=](|Q|) is not Object, then [=ECMAScript/throw=] a
-                    {{TypeError}}.
+                    {{ECMAScript/TypeError}}.
                 1.  Let |forwardId| be the identifier argument of the [{{PutForwards}}] extended
                     attribute.
                 1.  Perform [=?=] [=Set=](|Q|, |forwardId|, |V|).
@@ -10573,7 +10574,7 @@ accessed, they are able to expose instance-specific data.
 Note: Attempting to assign to a property corresponding to a
 [=read only=] [=attribute=]
 results in different behavior depending on whether the script doing so is in strict mode.
-When in strict mode, such an assignment will result in a {{TypeError}}
+When in strict mode, such an assignment will result in a {{ECMAScript/TypeError}}
 being thrown.  When not in strict mode, the assignment attempt will be ignored.
 
 
@@ -10637,14 +10638,14 @@ property-installation style as namespaces.)
             1.  If |target| is an [=interface=], and |op| is not a [=static operation=]:
                 1.  If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or
                     <emu-val>undefined</emu-val>, set |O| to |realm|'s [=Realm/global object=]. (This
-                    will subsequently cause a {{TypeError}} in a few steps, if the global
+                    will subsequently cause a {{ECMAScript/TypeError}} in a few steps, if the global
                     object does not implement |target|.)
                     <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
                 1.  Otherwise, set |O| to the <emu-val>this</emu-val> value.
                 1.  If |O| is a [=platform object=], then [=perform a security check=], passing |O|,
                     |id|, and "method".
                 1.  If |O| is not a [=platform object=] that implements the interface |target|,
-                    [=ECMAScript/throw=] a {{TypeError}}.
+                    [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
             1.  Let |S| be the [=effective overload set=] for [=regular operations=] (if |op| is a
                 regular operation) or for [=static operations=] (if |op| is a static operation) with
                 [=identifier=] |id| on |target| and with argument count |n|.
@@ -10873,7 +10874,7 @@ then there must exist a property with the following characteristics:
             *   the [=identifier=] of the [=stringifier=], and
             *   the type “method”.
         1.  If |O| is not an object that implements the [=interface=]
-            on which the stringifier was declared, then [=ECMAScript/throw=] a {{TypeError}}.
+            on which the stringifier was declared, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |V| be an uninitialized variable.
         1.  Depending on where <code>stringifier</code> was specified:
             <dl class="switch">
@@ -10944,7 +10945,7 @@ then the [=function object=] is [=%ArrayProto_values%=].
     1.  Let |interface| be the [=interface=]
         the [=iterable declaration=] is on.
     1.  If |object| is not a [=platform object=] that implements |interface|,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |iterator| be a newly created [=default iterator object=]
         for |interface| with |object| as its target and iterator kind “key+value”.
     1.  Return |iterator|.
@@ -10966,7 +10967,7 @@ then the [=function object=] is [=%ArrayProto_values%=].
         that implements the [=interface=]
         on which the [=maplike declaration=]
         or [=setlike declaration=] is defined,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  If the interface has a [=maplike declaration=], then:
         1.  Let |backing| be the value of the \[[BackingMap]] [=internal slot=] of |object|.
         1.  Return [=CreateMapIterator=](|backing|, <code>"key+value"</code>).
@@ -11059,9 +11060,9 @@ the initial value of the “forEach” data property of [=%ArrayPrototype%=].
         or [=setlike declaration=] is declared.
     1.  If |object| is not a [=platform object=]
         that implements |interface|,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |callbackFn| be the value of the first argument passed to the function, or <emu-val>undefined</emu-val> if the argument was not supplied.
-    1.  If [=IsCallable=](|callbackFn|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a {{TypeError}}.
+    1.  If [=IsCallable=](|callbackFn|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |thisArg| be the value of the second argument passed to the function, or <emu-val>undefined</emu-val> if the argument was not supplied.
     1.  Let |backing| be the value of the \[[BackingMap]] [=internal slot=] of |object|,
         if the interface has a [=maplike declaration=],
@@ -11081,7 +11082,7 @@ the initial value of the “forEach” data property of [=%ArrayPrototype%=].
         </p>
     1.  Let |forEach| be the result of calling the \[[Get]] internal method of
         |backing| with “forEach” and |backing| as arguments.
-    1.  If [=IsCallable=](|forEach|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a {{TypeError}}.
+    1.  If [=IsCallable=](|forEach|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  [=Call=](|forEach|, |backing|, «|callbackWrapper|, |thisArg|»).
     1.  Return <emu-val>undefined</emu-val>.
 </div>
@@ -11160,7 +11161,7 @@ the initial value of the “keys” data property of [=%ArrayPrototype%=].
         on which the [=iterable declaration=] is declared on.
     1.  If |object| is not a [=platform object=]
         that implements |interface|,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |iterator| be a newly created [=default iterator object=]
         for |interface| with |object| as its target and iterator kind “key”.
     1.  Return |iterator|.
@@ -11209,7 +11210,7 @@ the value of the [=@@iterator=] property.
         on which the [=iterable declaration=] is declared on.
     1.  If |object| is not a [=platform object=]
         that implements |interface|,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |iterator| be a newly created [=default iterator object=]
         for |interface| with |object| as its target and iterator kind “value”.
     1.  Return |iterator|.
@@ -11276,7 +11277,7 @@ must be [=%IteratorPrototype%=].
         *   the identifier “next”, and
         *   the type “method”.
     1.  If |object| is not a [=default iterator object=] for |interface|,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |index| be |object|’s index.
     1.  Let |kind| be |object|’s kind.
     1.  Let |values| be the list of [=value pairs to iterate over=].
@@ -11342,10 +11343,10 @@ These additional properties are described in the sub-sections below.
         *   the platform object |O|,
         *   an identifier equal to |name|, and
         *   the type “method”.
-    1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{TypeError}}.
+    1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |map| be the {{Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
     1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing |name| and |map| as arguments.
-    1.  If [=IsCallable=](|function|) is <emu-val>false</emu-val>, then [=ECMAScript/throw=] a {{TypeError}}.
+    1.  If [=IsCallable=](|function|) is <emu-val>false</emu-val>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return [=Call=](|function|, |map|, |arguments|).
 </div>
 
@@ -11371,7 +11372,7 @@ with the following characteristics:
             *   the platform object |O|,
             *   the identifier “size”, and
             *   the type “getter”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{TypeError}}.
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Return the result of calling the \[[Get]] internal method of |map| passing “size” and |map| as arguments.
     </div>
@@ -11423,7 +11424,7 @@ For both of “get” and “has”, there must exist a property with that name 
             *   the platform object |O|,
             *   an identifier equal to |name|, and
             *   the type “method”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{TypeError}}.
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| be the key type specified in the [=maplike declaration=].
         1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing |name| and |map| as arguments.
@@ -11479,7 +11480,7 @@ must exist on |A|’s
             *   the platform object |O|,
             *   the identifier “delete”, and
             *   the type “method”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{TypeError}}.
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| be the key type specified in the [=maplike declaration=].
         1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing “delete” and |map| as arguments.
@@ -11514,7 +11515,7 @@ must exist on |A|’s [=interface prototype object=]:
             *   the platform object |O|,
             *   the identifier “set”, and
             *   the type “method”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{TypeError}}.
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| and |valueType| be the key and value types specified in the [=maplike declaration=].
         1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing “set” and |map| as arguments.
@@ -11562,13 +11563,13 @@ These additional properties are described in the sub-sections below.
         *   an identifier equal to |name|, and
         *   the type “method”.
     1.  If |O| is not an object that implements <var ignore>A</var>,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |set| be the {{Set}} object that is
         the value of |O|’s \[[BackingSet]] [=internal slot=].
     1.  Let |function| be the result of calling the \[[Get]] internal method of |set|
         passing |name| and |set| as arguments.
     1.  If [=IsCallable=](|function|) is <emu-val>false</emu-val>,
-        then [=ECMAScript/throw=] a {{TypeError}}.
+        then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return [=Call=](|function|, |set|, |arguments|).
 </div>
 
@@ -11592,7 +11593,7 @@ with the following characteristics:
             *   the platform object |O|,
             *   the identifier “size”, and
             *   the type “getter”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{TypeError}}.
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |set| be the {{Set}} object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
         1.  Return the result of calling the \[[Get]] internal method of |set| passing “size” and |set| as arguments.
     </div>
@@ -11644,7 +11645,7 @@ with the following characteristics:
             *   the platform object |O|,
             *   the identifier “has”, and
             *   the type “method”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{TypeError}}.
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |set| be the {{Set}} object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
         1.  Let |type| be the value type specified in the [=setlike declaration=].
         1.  Let |function| be the result of calling the \[[Get]] internal method of |set| passing “has” and |set| as arguments.
@@ -11685,7 +11686,7 @@ must exist on |A|’s
             *   the platform object |O|,
             *   an identifier equal to |name|, and
             *   the type “method”.
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{TypeError}}.
+        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |set| be the {{Set}} object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
         1.  Let |type| be the value type specified in the [=setlike declaration=].
         1.  Let |function| be the result of calling the \[[Get]] internal method of |set| passing |name| and |set| as arguments.
@@ -11768,7 +11769,7 @@ and similarly with their setters.
     Attempting to call <code>B.prototype.f</code> on an object that implements
     <code class="idl">A</code> (but not <code class="idl">B</code>) or one
     that implements <code class="idl">C</code> will result in a
-    {{TypeError}} being thrown.  However,
+    {{ECMAScript/TypeError}} being thrown.  However,
     calling <code>A.prototype.f</code> on an object that implements
     <code class="idl">B</code> or one that implements <code class="idl">C</code>
     would succeed.  This is handled by the algorithm in [[#es-operations]]
@@ -11982,7 +11983,7 @@ and [[#legacy-platform-object-set]].
     assuming |arg|<sub>0..|n|−1</sub> is the list of argument values passed to \[[Call]]:
 
     1.  If |I| has no [=legacy callers=],
-        [=ECMAScript/throw=] a {{TypeError}}.
+        [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Initialize |S| to the [=effective overload set=]
         for legacy callers on |I| and with argument count |n|.
     1.  Let &lt;|operation|, |values|&gt; be the result of passing |S| and
@@ -12282,7 +12283,7 @@ the special value “missing”, which represents a missing optional argument.
             1.  Set |X| to |getResult|.\[[Value]].
     1.  If [=!=] [=IsCallable=](|X|) is <emu-val>false</emu-val>,
         then set |completion| to a new [=Completion=]{\[[Type]]: throw, \[[Value]]: a
-        newly created {{TypeError}} object, \[[Target]]: empty}, and jump
+        newly created {{ECMAScript/TypeError}} object, \[[Target]]: empty}, and jump
         to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.
     1.  If |value|'s interface is not a [=single operation callback interface=],
         or if [=!=] [=IsCallable=](|O|) is <emu-val>false</emu-val>,
@@ -12449,7 +12450,7 @@ a return type that is a [=promise type=].
     1.  Let |completion| be an uninitialized variable.
     1.  Let |F| be the ECMAScript object corresponding to |callable|.
     1.  If [=!=] [=IsConstructor=](|F|) is <emu-val>false</emu-val>, throw a
-        {{TypeError}} exception.
+        {{ECMAScript/TypeError}} exception.
     1.  Let |realm| be |F|'s [=associated Realm=].
     1.  Let |relevant settings| be |realm|'s [=Realm/settings object=].
     1.  Let |stored settings| be |callable|'s [=callback context=].
@@ -12872,6 +12873,7 @@ Aryeh Gregor,
 Dimitry Golubovsky,
 James Graham,
 Aryeh Gregor,
+Tiancheng “Timothy” Gu,
 Kartikaya Gupta,
 Marcin Hanclik,
 Jed Hartman,
@@ -12919,7 +12921,7 @@ Anton Tayanovskyy,
 Peter Van der Beken,
 Jeff Walden,
 Allen Wirfs-Brock,
-Jeffrey Yasskin and
+Jeffrey Yasskin and,
 Collin Xu.
 
 Special thanks also go to Sam Weinig for maintaining this document


### PR DESCRIPTION
- Change <code>&lt;emu-val>*Type*&lt;/emu-val></code> where *Type* is one of the [fundamental ES language types](https://tc39.github.io/ecma262/#sec-ecmascript-language-types) to <code>*Type*</code>.
- Change <code>&lt;emu-val><var>Class</var>&lt;/emu-val></code> where *Class* is `Set`, `Map`, `SyntaxError`, or `Error` to <code>{{ECMAScript/<var>Class</var>}}</code> with appropriate links to ES spec.
- Change <code>&lt;emu-val><var>Exception</var>&lt;/emu-val></code> where *Exception* is one of the IDL simple exceptions to <code>{{<var>Exception</var>}}</code> with appropriate section links.
- Change `<emu-val>Function</emu-val>` to [function object](https://tc39.github.io/ecma262/#sec-ecmascript-function-objects), linked.

Fixes #404.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/TimothyGu/webidl/emu-val.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/14792cb...TimothyGu:ca6a07a.html)