### PR TITLE
Handle Symbols correctly in legacy platform object's [[DefineOwnProperty]]

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11911,7 +11911,8 @@ and [[#legacy-platform-object-set]].
         1.  Return <emu-val>true</emu-val>.
     1.  If |O| [=support named properties|supports named properties=],
         |O| does not implement an [=interface=] with the
-        [{{Global}}] or [{{PrimaryGlobal}}] [=extended attribute=]
+        [{{Global}}] or [{{PrimaryGlobal}}] [=extended attribute=],
+        [=Type=](|P|) is String,
         and |P| is not an [=unforgeable property name=]
         of |O|, then:
         1.  Let |creating| be true if |P| is not a [=supported property name=], and false otherwise.


### PR DESCRIPTION
Fixes #175.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/TimothyGu/webidl/named-properties-symbol.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/8b83d25...TimothyGu:b0077c9.html)