### PR TITLE
Link legacy APIs within the advisements

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9015,6 +9015,24 @@ for the specific requirements that the use of
 
 <h4 id="OverrideBuiltins" extended-attribute lt="OverrideBuiltins">[OverrideBuiltins]</h4>
 
+<div class="advisement">
+
+    Specifications should not use [{{OverrideBuiltins}}] unless
+    required to specify the behavior of legacy APIs
+    or for consistency with these APIs.
+    Editors who wish to use this feature are strongly advised to discuss this
+    by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
+    before proceeding.
+
+    <small class="non-normative">
+        The [{{OverrideBuiltins}}] [=extended attribute=] appears on the
+        {{DOMStringMap}},
+        {{Document}}, and
+        {{HTMLFormElement}} [=interfaces=]. [[HTML]]
+    </small>
+
+</div>
+
 If the [{{OverrideBuiltins}}]
 [=extended attribute=]
 appears on an [=interface=],

--- a/index.bs
+++ b/index.bs
@@ -8570,6 +8570,9 @@ entails.
     They exist only so that legacy Web platform features can be specified.
     They should not be used in specifications
     unless required to specify the behavior of legacy APIs.
+    Editors who wish to use this feature are strongly advised to discuss this
+    by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
+    before proceeding.
 
     <small class="non-normative">
         The [{{LegacyWindowAlias}}] [=extended attribute=] appears on the following [=interfaces=]:
@@ -8813,6 +8816,9 @@ is to be implemented.
     They exist only so that legacy Web platform features can be specified.
     They should not be used in specifications
     unless required to specify the behavior of legacy APIs.
+    Editors who wish to use this feature are strongly advised to discuss this
+    by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
+    before proceeding.
 
     <small class="non-normative">
         Known [=interfaces=] requiring the use of the [{{NamedConstructor}}] [=extended attribute=] are:

--- a/index.bs
+++ b/index.bs
@@ -29,14 +29,24 @@ Boilerplate: omit issues-index, omit conformance, omit feedback-header
 
 <pre class="link-defaults">
 spec: infra; type: dfn; text: list
+spec: url; type: interface; text: URL
+spec: dom; type: interface; text: Document
 </pre>
 
 <pre class="anchors">
 urlPrefix: https://html.spec.whatwg.org/; spec: HTML
     type: interface
-        text: Audio; url: dom-audio
-        text: Option; url: dom-option
-        text: Image; url: dom-image
+        text: HTMLAudioElement; url: htmlaudioelement
+        text: HTMLOptionElement; url: htmloptionelement
+        text: HTMLImageElement; url: htmlimageelement
+        text: onmouseenter; for: Document; url: handler-onmouseenter
+        text: onmouseleave; for: Document; url: handler-onmouseleave
+        text: onreadystatechange; for: Document; url: handler-onreadystatechange
+urlPrefix: https://fullscreen.spec.whatwg.org/; spec: FULLSCREEN
+    type: interface;
+        text: fullscreenEnabled; for: Document; url: dom-document-fullscreenenabled
+        text: fullscreen; for: Document; url: dom-document-fullscreen
+        text: fullscreenElement; for: DocumentOrShadowRoot; url: dom-document-fullscreenelement
 urlPrefix: http://www.unicode.org/glossary/; spec: UNICODE
     type: dfn
         text: Unicode scalar value; url: unicode_scalar_value
@@ -155,6 +165,14 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: NewTarget; url: sec-built-in-function-objects
         text: Number Type; url: sec-ecmascript-language-types-number-type
         text: JSON.stringify; url: sec-json.stringify
+</pre>
+
+<pre class=biblio>
+{
+    "GEOMETRY": {
+        "aliasOf": "GEOMETRY-1"
+    }
+}
 </pre>
 
 <style>
@@ -8546,6 +8564,23 @@ entails.
 
 <h4 id="LegacyWindowAlias" extended-attribute lt="LegacyWindowAlias">[LegacyWindowAlias]</h4>
 
+<div class="advisement">
+
+    [{{LegacyWindowAlias}}] [=extended attributes=] are an undesirable feature.
+    They exist only so that legacy Web platform features can be specified.
+    They should not be used in specifications
+    unless required to specify the behavior of legacy APIs.
+
+    <p class="note">
+        The [{{LegacyWindowAlias}}] [=extended attribute=] appears on the following [=interfaces=]:
+        {{DOMPoint}},
+        {{DOMRect}},
+        {{DOMMatrix}}, and
+        {{URL}}. [[GEOMETRY]] [[URL]]
+    </p>
+
+</div>
+
 If the [{{LegacyWindowAlias}}] [=extended attribute=] appears on an [=interface=],
 it indicates that the [=primary global interface=] will have a property
 for each [=identifier=] mentioned in the extended attribute,
@@ -8579,13 +8614,6 @@ An interface must not have more than one [{{LegacyWindowAlias}}] extended attrib
 
 See [[#es-interfaces]] for details on how legacy window aliases
 are to be implemented.
-
-<p class="advisement">
-    [{{LegacyWindowAlias}}] extended attributes are an undesirable feature.
-    They exist only so that legacy Web platform features can be specified.
-    They should not be used in specifications
-    unless required to specify the behavior of legacy APIs.
-</p>
 
 <div class="example">
 
@@ -8621,14 +8649,6 @@ are to be implemented.
 
 <h4 id="LenientSetter" extended-attribute lt="LenientSetter">[LenientSetter]</h4>
 
-If the [{{LenientSetter}}]
-[=extended attribute=]
-appears on a [=read only=]
-[=regular attribute=],
-it indicates that a no-op setter will be generated for the attribute’s
-accessor property.  This results in erroneous assignments to the property
-in strict mode to be ignored rather than causing an exception to be thrown.
-
 <div class="advisement">
 
     Specifications should not use [{{LenientSetter}}]
@@ -8644,7 +8664,23 @@ in strict mode to be ignored rather than causing an exception to be thrown.
     <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
     mailing list before proceeding.
 
+    <p class="note">
+        The [{{LenientSetter}}] [=extended attribute=] appears on
+        the {{Document/fullscreenEnabled}} and {{Document/fullscreenEnabled}} [=attributes=]
+        of the {{Document}} interface, and on
+        the {{DocumentOrShadowRoot/fullscreenElement}} [=attribute=]
+        of the {{DocumentOrShadowRoot}} mixin. [[FULLSCREEN]]
+    </p>
+
 </div>
+
+If the [{{LenientSetter}}]
+[=extended attribute=]
+appears on a [=read only=]
+[=regular attribute=],
+it indicates that a no-op setter will be generated for the attribute’s
+accessor property.  This results in erroneous assignments to the property
+in strict mode to be ignored rather than causing an exception to be thrown.
 
 The [{{LenientThis}}] extended attribute
 must [=takes no arguments|take no arguments=].
@@ -8695,6 +8731,22 @@ See the <a href="#es-attributes">Attributes</a> section for how
 
 <h4 id="LenientThis" extended-attribute lt="LenientThis">[LenientThis]</h4>
 
+<div class="advisement">
+    Specifications should not use [{{LenientThis}}]
+    unless required for compatibility reasons.  Specification authors who
+    wish to use this feature are strongly advised to discuss this on the
+    <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
+    mailing list before proceeding.
+
+    <p class="note">
+        The [{{LenientThis}}] [=extended attribute=] appears on
+        the {{Document/onreadystatechange}},
+        {{Document/onmouseenter}}, and
+        {{Document/onmouseleave}} [=attributes=]
+        of the {{Document}} interface. [[HTML]]
+    </p>
+</div>
+
 If the [{{LenientThis}}]
 [=extended attribute=]
 appears on a [=regular attribute=],
@@ -8711,14 +8763,6 @@ It must not be used on a
 
 The [{{LenientThis}}] extended attribute must not be used on an attribute declared on a
 [=namespace=].
-
-<p class="advisement">
-    Specifications should not use [{{LenientThis}}]
-    unless required for compatibility reasons.  Specification authors who
-    wish to use this feature are strongly advised to discuss this on the
-    <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
-    mailing list before proceeding.
-</p>
 
 See the <a href="#es-attributes">Attributes</a> section for how
 [{{LenientThis}}]
@@ -8763,6 +8807,20 @@ is to be implemented.
 
 <h4 id="NamedConstructor" extended-attribute lt="NamedConstructor">[NamedConstructor]</h4>
 
+<div class="advisement">
+
+    [{{NamedConstructor}}] [=extended attributes=] are an undesirable feature.
+    They exist only so that legacy Web platform features can be specified.
+    They should not be used in specifications
+    unless required to specify the behavior of legacy APIs.
+
+    <p class="note">
+        Known [=interfaces=] requiring the use of the [{{NamedConstructor}}] [=extended attribute=] are:
+        {{HTMLAudioElement}}, {{HTMLOptionElement}} and {{HTMLImageElement}}. [[HTML]]
+    </p>
+
+</div>
+
 If the [{{NamedConstructor}}]
 [=extended attribute=]
 appears on an [=interface=],
@@ -8800,15 +8858,6 @@ must not be used on a [=callback interface=].
 
 See [[#named-constructors]] for details on how named constructors
 are to be implemented.
-
-<p class="advisement">
-    [{{NamedConstructor}}] extended attributes are an undesirable feature.
-    They exist only so that legacy Web platform features can be specified.
-    They should not be used in specifications
-    unless required to specify the behavior of legacy APIs.
-    Known APIs requiring the use of [{{NamedConstructor}}] extended attributes are:
-    {{Audio}}, {{Option}} and {{Image}}.
-</p>
 
 <div class="example">
 

--- a/index.bs
+++ b/index.bs
@@ -8848,7 +8848,7 @@ is to be implemented.
 
 <div class="advisement">
 
-    [{{NamedConstructor}}] [=extended attributes=] is an undesirable feature.
+    [{{NamedConstructor}}] [=extended attribute=] is an undesirable feature.
     It exists only so that legacy Web platform features can be specified.
     It should not be used in specifications
     unless required to specify the behavior of legacy APIs,
@@ -8858,8 +8858,10 @@ is to be implemented.
     before proceeding.
 
     <small class="non-normative">
-        Known [=interfaces=] requiring the use of the [{{NamedConstructor}}] [=extended attribute=] are:
-        {{HTMLAudioElement}}, {{HTMLOptionElement}} and {{HTMLImageElement}}. [[HTML]]
+        The [{{NamedConstructor}}] [=extended attribute=] appears on the following [=interfaces=]:
+        {{HTMLAudioElement}},
+        {{HTMLOptionElement}}, and
+        {{HTMLImageElement}}. [[HTML]]
     </small>
 
 </div>
@@ -9056,8 +9058,10 @@ for the specific requirements that the use of
 
 <div class="advisement">
 
-    Specifications should not use [{{OverrideBuiltins}}] unless
-    required to specify the behavior of legacy APIs
+    The [{{OverrideBuiltins}}] [=extended attribute=] is an undesirable feature.
+    It exists only so that legacy Web platform features can be specified.
+    It should not be used in specifications
+    unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
     by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
@@ -9495,18 +9499,19 @@ that does specify [{{SecureContext}}].
 <h4 id="TreatNonObjectAsNull" extended-attribute lt="TreatNonObjectAsNull">[TreatNonObjectAsNull]</h4>
 
 <div class="advisement">
-
-    Specifications should not use [{{TreatNonObjectAsNull}}] unless
-    required to specify the behavior of legacy APIs
+    
+    The [{{TreatNonObjectAsNull}}] [=extended attribute=] is an undesirable feature.
+    It exists only so that legacy Web platform features can be specified.
+    It should not be used in specifications
+    unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
     by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
-        At the time of writing,
-        the only known valid use of [{{TreatNonObjectAsNull}}]
-        is for the [=callback functions=] {{EventHandlerNonNull}},
+        The [{{TreatNonObjectAsNull}}] [=extended attribute=] appears on
+        the [=callback functions=] {{EventHandlerNonNull}},
         {{OnBeforeUnloadEventHandlerNonNull}}, and
         {{OnErrorEventHandlerNonNull}}
         used as the type of [=event handler IDL attributes=]
@@ -9573,6 +9578,17 @@ for the specific requirements that the use of
 
 
 <h4 id="TreatNullAs" extended-attribute lt="TreatNullAs">[TreatNullAs]</h4>
+
+<p class="advisement">
+    The [{{TreatNullAs}}] [=extended attribute=] is an undesirable feature.
+    It exists only so that legacy Web platform features can be specified.
+    It should not be used in specifications
+    unless required to specify the behavior of legacy APIs,
+    or for consistency with these APIs.
+    Editors who wish to use this feature are strongly advised to discuss this
+    by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
+    before proceeding.
+</div>
 
 If the [{{TreatNullAs}}] [=extended attribute=] appears on the {{DOMString}} type, it creates a new
 IDL type such that that when an ECMAScript <emu-val>null</emu-val> is converted to the IDL type, it

--- a/index.bs
+++ b/index.bs
@@ -8453,6 +8453,27 @@ corresponding to [=interface members=].
 
 <h4 id="LegacyArrayClass" extended-attribute lt="LegacyArrayClass">[LegacyArrayClass]</h4>
 
+<div class="advisement">
+
+    The [{{LegacyArrayClass}}] [=extended attribute=] is an undesirable feature.
+    It exists only so that legacy Web platform features can be specified.
+    It should not be used in specifications
+    unless required to specify the behavior of legacy APIs.
+    Editors who wish to use this feature are strongly advised to discuss this
+    by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
+    before proceeding.
+
+    <small class="non-normative">
+        The [{{LegacyArrayClass}}] [=extended attribute=] appears on
+        the following [=interfaces=]:
+        {{DOMRectList}},
+        {{MediaList}},
+        {{StyleSheetList}}, and
+        {{CSSRuleList}}. [[GEOMETRY]] [CSSOM]
+    </small>
+
+</div>
+
 If the [{{LegacyArrayClass}}]
 [=extended attribute=]
 appears on an [=interface=]

--- a/index.bs
+++ b/index.bs
@@ -8527,6 +8527,31 @@ entails.
 
 <h4 id="LegacyUnenumerableNamedProperties" extended-attribute lt="LegacyUnenumerableNamedProperties">[LegacyUnenumerableNamedProperties]</h4>
 
+<div class="advisement">
+
+    The [{{LegacyUnenumerableNamedProperties}}] [=extended attribute=] is an undesirable feature.
+    It exists only so that legacy Web platform features can be specified.
+    It should not be used in specifications
+    unless required to specify the behavior of legacy APIs.
+    Editors who wish to use this feature are strongly advised to discuss this
+    by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
+    before proceeding.
+
+    <small class="non-normative">
+        The [{{LegacyUnenumerableNamedProperties}}] [=extended attribute=] appears on
+        the following [=interfaces=]:
+        {{HTMLCollection}},
+        {{NamedNodeMap}},
+        {{HTMLAllCollection}},
+        {{HTMLFormElement}},
+        {{PluginArray}},
+        {{MimeTypeArray}},
+        {{Plugin}}, and
+        {{Window}}. [[DOM]] [[HTML]]
+    </small>
+
+</div>
+
 If the [{{LegacyUnenumerableNamedProperties}}]
 [=extended attribute=]
 appears on a [=interface=]

--- a/index.bs
+++ b/index.bs
@@ -8470,7 +8470,7 @@ corresponding to [=interface members=].
         {{DOMRectList}},
         {{MediaList}},
         {{StyleSheetList}}, and
-        {{CSSRuleList}}. [[GEOMETRY]] [CSSOM]
+        {{CSSRuleList}}. [[GEOMETRY]] [[CSSOM]]
     </small>
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -8932,17 +8932,14 @@ a [=promise type=].
 
 <h4 id="NoInterfaceObject" extended-attribute lt="NoInterfaceObject">[NoInterfaceObject]</h4>
 
-If the [{{NoInterfaceObject}}]
-[=extended attribute=]
-appears on an [=interface=],
-it indicates that an
-[=interface object=]
+If the [{{NoInterfaceObject}}] [=extended attribute=] appears on an [=interface=],
+it indicates that an [=interface object=]
 will not exist for the interface in the ECMAScript binding.
 
 <p class="advisement">
-    The [{{NoInterfaceObject}}] extended attribute
-    should not be used on interfaces that are not
-    solely used as [=supplemental interfaces|supplemental=] interfaces,
+    The [{{NoInterfaceObject}}] [=extended attribute=]
+    should not be used on [=interfaces=] that are not
+    solely used as [=supplemental interfaces=],
     unless there are clear Web compatibility reasons for doing so. 
     Editors who wish to use this feature are strongly advised to discuss this
     by <a href="https://github.com/w3c/respec/issues/new?title=[NoInterfaceObject]">filing an issue</a>

--- a/index.bs
+++ b/index.bs
@@ -8990,7 +8990,7 @@ will not exist for the interface in the ECMAScript binding.
     solely used as [=supplemental interfaces=],
     unless there are clear Web compatibility reasons for doing so. 
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/w3c/respec/issues/new?title=[NoInterfaceObject]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=[NoInterfaceObject]">filing an issue</a>
     before proceeding.
 </p>
 

--- a/index.bs
+++ b/index.bs
@@ -42,11 +42,6 @@ urlPrefix: https://html.spec.whatwg.org/; spec: HTML
         text: onmouseenter; for: Document; url: handler-onmouseenter
         text: onmouseleave; for: Document; url: handler-onmouseleave
         text: onreadystatechange; for: Document; url: handler-onreadystatechange
-urlPrefix: https://fullscreen.spec.whatwg.org/; spec: FULLSCREEN
-    type: interface;
-        text: fullscreenEnabled; for: Document; url: dom-document-fullscreenenabled
-        text: fullscreen; for: Document; url: dom-document-fullscreen
-        text: fullscreenElement; for: DocumentOrShadowRoot; url: dom-document-fullscreenelement
 urlPrefix: http://www.unicode.org/glossary/; spec: UNICODE
     type: dfn
         text: Unicode scalar value; url: unicode_scalar_value

--- a/index.bs
+++ b/index.bs
@@ -3412,8 +3412,8 @@ is.
     [=support indexed properties=],
     or (b) with a forEach method that instead invokes its callback like
     Set.protoype.forEach (where the key is the same as the value).
-    If you’re creating an API that needs such a forEach method, please send a request to
-    <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>.
+    If you’re creating an API that needs such a forEach method, please
+    <a href="https://github.com/w3c/respec/issues/new?title=[Iterable forEach]">file an issue</a>.
 
 </div>
 
@@ -8951,10 +8951,10 @@ will not exist for the interface in the ECMAScript binding.
     The [{{NoInterfaceObject}}] extended attribute
     should not be used on interfaces that are not
     solely used as [=supplemental interfaces|supplemental=] interfaces,
-    unless there are clear Web compatibility reasons for doing so.  Specification authors who
-    wish to use this feature are strongly advised to discuss this on the
-    <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
-    mailing list before proceeding.
+    unless there are clear Web compatibility reasons for doing so. 
+    Editors who wish to use this feature are strongly advised to discuss this
+    by <a href="https://github.com/w3c/respec/issues/new?title=[NoInterfaceObject]">filing an issue</a>
+    before proceeding.
 </p>
 
 The [{{NoInterfaceObject}}] extended attribute

--- a/index.bs
+++ b/index.bs
@@ -36,9 +36,6 @@ spec: dom; type: interface; text: Document
 <pre class="anchors">
 urlPrefix: https://html.spec.whatwg.org/; spec: HTML
     type: interface
-        text: HTMLAudioElement; url: htmlaudioelement
-        text: HTMLOptionElement; url: htmloptionelement
-        text: HTMLImageElement; url: htmlimageelement
         text: onmouseenter; for: Document; url: handler-onmouseenter
         text: onmouseleave; for: Document; url: handler-onmouseleave
         text: onreadystatechange; for: Document; url: handler-onreadystatechange

--- a/index.bs
+++ b/index.bs
@@ -8661,11 +8661,9 @@ are to be implemented.
     exists.  In strict mode, this would cause an exception to be thrown,
     potentially breaking page.  Without [{{LenientSetter}}],
     this could prevent a browser from shipping the feature.
-
-    Specification authors who
-    wish to use this feature are strongly advised to discuss this on the
-    <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
-    mailing list before proceeding.
+    Editors who wish to use this feature are strongly advised to discuss this
+    by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
+    before proceeding.
 
     <small class="non-normative">
         The [{{LenientSetter}}] [=extended attribute=] appears on
@@ -8736,10 +8734,10 @@ See the <a href="#es-attributes">Attributes</a> section for how
 
 <div class="advisement">
     Specifications should not use [{{LenientThis}}]
-    unless required for compatibility reasons.  Specification authors who
-    wish to use this feature are strongly advised to discuss this on the
-    <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
-    mailing list before proceeding.
+    unless required for compatibility reasons. 
+    Editors who wish to use this feature are strongly advised to discuss this
+    by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
+    before proceeding.
 
     <small class="non-normative">
         The [{{LenientThis}}] [=extended attribute=] appears on

--- a/index.bs
+++ b/index.bs
@@ -8458,7 +8458,8 @@ corresponding to [=interface members=].
     The [{{LegacyArrayClass}}] [=extended attribute=] is an undesirable feature.
     It exists only so that legacy Web platform features can be specified.
     It should not be used in specifications
-    unless required to specify the behavior of legacy APIs.
+    unless required to specify the behavior of legacy APIs,
+    or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
     by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
     before proceeding.
@@ -8553,7 +8554,8 @@ entails.
     The [{{LegacyUnenumerableNamedProperties}}] [=extended attribute=] is an undesirable feature.
     It exists only so that legacy Web platform features can be specified.
     It should not be used in specifications
-    unless required to specify the behavior of legacy APIs.
+    unless required to specify the behavior of legacy APIs,
+    or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
     by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
     before proceeding.
@@ -8602,7 +8604,8 @@ entails.
     The [{{LegacyWindowAlias}}] [=extended attribute=] is an undesirable feature.
     It exists only so that legacy Web platform features can be specified.
     It should not be used in specifications
-    unless required to specify the behavior of legacy APIs.
+    unless required to specify the behavior of legacy APIs,
+    or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
     by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
     before proceeding.
@@ -8845,10 +8848,11 @@ is to be implemented.
 
 <div class="advisement">
 
-    [{{NamedConstructor}}] [=extended attributes=] are an undesirable feature.
-    They exist only so that legacy Web platform features can be specified.
-    They should not be used in specifications
-    unless required to specify the behavior of legacy APIs.
+    [{{NamedConstructor}}] [=extended attributes=] is an undesirable feature.
+    It exists only so that legacy Web platform features can be specified.
+    It should not be used in specifications
+    unless required to specify the behavior of legacy APIs,
+    or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
     by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
     before proceeding.

--- a/index.bs
+++ b/index.bs
@@ -8553,9 +8553,9 @@ entails.
 
 <div class="advisement">
 
-    [{{LegacyWindowAlias}}] [=extended attributes=] are an undesirable feature.
-    They exist only so that legacy Web platform features can be specified.
-    They should not be used in specifications
+    The [{{LegacyWindowAlias}}] [=extended attribute=] is an undesirable feature.
+    It exists only so that legacy Web platform features can be specified.
+    It should not be used in specifications
     unless required to specify the behavior of legacy APIs.
     Editors who wish to use this feature are strongly advised to discuss this
     by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>

--- a/index.bs
+++ b/index.bs
@@ -3401,7 +3401,7 @@ is.
     or (b) with a forEach method that instead invokes its callback like
     Set.protoype.forEach (where the key is the same as the value).
     If you’re creating an API that needs such a forEach method, please
-    <a href="https://github.com/heycam/webidl/issues/new?title=[Iterable%20forEach]">file an issue</a>.
+    <a href="https://github.com/heycam/webidl/issues/new?title=Enhancement%20request%20for%20Iterables">file an issue</a>.
 
 </div>
 
@@ -8462,7 +8462,7 @@ corresponding to [=interface members=].
     unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=[legacy]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyArrayClass]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
@@ -8558,7 +8558,7 @@ entails.
     unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=[legacy]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyUnenumerableNamedProperties]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
@@ -8608,7 +8608,7 @@ entails.
     unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=[legacy]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyWindowAlias]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
@@ -8699,7 +8699,7 @@ are to be implemented.
     potentially breaking page.  Without [{{LenientSetter}}],
     this could prevent a browser from shipping the feature.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=[legacy]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LenientSetter]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
@@ -8774,7 +8774,7 @@ See the <a href="#es-attributes">Attributes</a> section for how
     Specifications should not use [{{LenientThis}}]
     unless required for compatibility reasons. 
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=[legacy]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LenientThis]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
@@ -8855,7 +8855,7 @@ is to be implemented.
     unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=[legacy]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[NamedConstructor]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
@@ -8990,7 +8990,7 @@ will not exist for the interface in the ECMAScript binding.
     solely used as [=supplemental interfaces=],
     unless there are clear Web compatibility reasons for doing so. 
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=[NoInterfaceObject]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[NoInterfaceObject]%20on%20a%20non-supplemental%20interface">filing an issue</a>
     before proceeding.
 </p>
 
@@ -9065,7 +9065,7 @@ for the specific requirements that the use of
     unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=[legacy]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[OverrideBuiltins]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
@@ -9507,7 +9507,7 @@ that does specify [{{SecureContext}}].
     unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=[legacy]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[TreatNonObjectAsNull]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
@@ -9587,7 +9587,7 @@ for the specific requirements that the use of
     unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=[legacy]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[TreatNullAs]">filing an issue</a>
     before proceeding.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -34,11 +34,6 @@ spec: dom; type: interface; text: Document
 </pre>
 
 <pre class="anchors">
-urlPrefix: https://html.spec.whatwg.org/; spec: HTML
-    type: interface
-        text: onmouseenter; for: Document; url: handler-onmouseenter
-        text: onmouseleave; for: Document; url: handler-onmouseleave
-        text: onreadystatechange; for: Document; url: handler-onreadystatechange
 urlPrefix: http://www.unicode.org/glossary/; spec: UNICODE
     type: dfn
         text: Unicode scalar value; url: unicode_scalar_value

--- a/index.bs
+++ b/index.bs
@@ -25,6 +25,7 @@ Abstract: and that newly published specifications reference this
 Abstract: document to ensure conforming implementations of interfaces
 Abstract: are interoperable.
 Boilerplate: omit issues-index, omit conformance, omit feedback-header
+Default Biblio Status: current
 </pre>
 
 <pre class="link-defaults">

--- a/index.bs
+++ b/index.bs
@@ -3400,7 +3400,7 @@ is.
     or (b) with a forEach method that instead invokes its callback like
     Set.protoype.forEach (where the key is the same as the value).
     If you’re creating an API that needs such a forEach method, please
-    <a href="https://github.com/w3c/respec/issues/new?title=[Iterable forEach]">file an issue</a>.
+    <a href="https://github.com/heycam/webidl/issues/new?title=[Iterable%20forEach]">file an issue</a>.
 
 </div>
 
@@ -8461,7 +8461,7 @@ corresponding to [=interface members=].
     unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=[legacy]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
@@ -8557,7 +8557,7 @@ entails.
     unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=[legacy]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
@@ -8607,7 +8607,7 @@ entails.
     unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=[legacy]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
@@ -8698,7 +8698,7 @@ are to be implemented.
     potentially breaking page.  Without [{{LenientSetter}}],
     this could prevent a browser from shipping the feature.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=[legacy]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
@@ -8773,7 +8773,7 @@ See the <a href="#es-attributes">Attributes</a> section for how
     Specifications should not use [{{LenientThis}}]
     unless required for compatibility reasons. 
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=[legacy]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
@@ -8854,7 +8854,7 @@ is to be implemented.
     unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=[legacy]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
@@ -9064,7 +9064,7 @@ for the specific requirements that the use of
     unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=[legacy]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
@@ -9506,7 +9506,7 @@ that does specify [{{SecureContext}}].
     unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=[legacy]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
@@ -9586,7 +9586,7 @@ for the specific requirements that the use of
     unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=[legacy]">filing an issue</a>
     before proceeding.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -9436,6 +9436,26 @@ that does specify [{{SecureContext}}].
 
 <h4 id="TreatNonObjectAsNull" extended-attribute lt="TreatNonObjectAsNull">[TreatNonObjectAsNull]</h4>
 
+<div class="advisement">
+    Specifications should not use [{{TreatNonObjectAsNull}}] unless
+    required to specify the behavior of legacy APIs
+    or for consistency with these APIs.
+    Editors who wish to use this feature are strongly advised to discuss this
+    by <a href="https://github.com/w3c/respec/issues/new?title=[legacy]">filing an issue</a>
+    before proceeding.
+
+    <small class="non-normative">
+        At the time of writing,
+        the only known valid use of [{{TreatNonObjectAsNull}}]
+        is for the [=callback functions=] {{EventHandlerNonNull}},
+        {{OnBeforeUnloadEventHandlerNonNull}}, and
+        {{OnErrorEventHandlerNonNull}}
+        used as the type of [=event handler IDL attributes=]
+        such as <code>onclick</code> and <code>onerror</code>. [[HTML]]
+    </small>
+
+</div>
+
 If the [{{TreatNonObjectAsNull}}]
 [=extended attribute=]
 appears on a [=callback function=],
@@ -9444,19 +9464,6 @@ whose type is a [=nullable type|nullable=]
 [=callback function=]
 that is not an object will be converted to
 the <emu-val>null</emu-val> value.
-
-<p class="advisement">
-    Specifications should not use [{{TreatNonObjectAsNull}}]
-    unless required to specify the behavior of legacy APIs or for consistency with these
-    APIs.  Specification authors who
-    wish to use this feature are strongly advised to discuss this on the
-    <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
-    mailing list before proceeding.  At the time of writing, the only known
-    valid use of [{{TreatNonObjectAsNull}}]
-    is for the [=callback functions=] used as the type
-    of [=event handler IDL attributes=]
-    such as <code>onclick</code> and <code>onerror</code>.
-</p>
 
 See [[#es-nullable-type]]
 for the specific requirements that the use of

--- a/index.bs
+++ b/index.bs
@@ -8733,6 +8733,7 @@ See the <a href="#es-attributes">Attributes</a> section for how
 <h4 id="LenientThis" extended-attribute lt="LenientThis">[LenientThis]</h4>
 
 <div class="advisement">
+
     Specifications should not use [{{LenientThis}}]
     unless required for compatibility reasons. 
     Editors who wish to use this feature are strongly advised to discuss this
@@ -8746,6 +8747,7 @@ See the <a href="#es-attributes">Attributes</a> section for how
         {{Document/onmouseleave}} [=attributes=]
         of the {{Document}} interface. [[HTML]]
     </small>
+
 </div>
 
 If the [{{LenientThis}}]
@@ -9441,6 +9443,7 @@ that does specify [{{SecureContext}}].
 <h4 id="TreatNonObjectAsNull" extended-attribute lt="TreatNonObjectAsNull">[TreatNonObjectAsNull]</h4>
 
 <div class="advisement">
+
     Specifications should not use [{{TreatNonObjectAsNull}}] unless
     required to specify the behavior of legacy APIs
     or for consistency with these APIs.

--- a/index.bs
+++ b/index.bs
@@ -8571,13 +8571,13 @@ entails.
     They should not be used in specifications
     unless required to specify the behavior of legacy APIs.
 
-    <p class="note">
+    <small class="non-normative">
         The [{{LegacyWindowAlias}}] [=extended attribute=] appears on the following [=interfaces=]:
         {{DOMPoint}},
         {{DOMRect}},
         {{DOMMatrix}}, and
         {{URL}}. [[GEOMETRY]] [[URL]]
-    </p>
+    </small>
 
 </div>
 
@@ -8664,13 +8664,13 @@ are to be implemented.
     <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
     mailing list before proceeding.
 
-    <p class="note">
+    <small class="non-normative">
         The [{{LenientSetter}}] [=extended attribute=] appears on
         the {{Document/fullscreenEnabled}} and {{Document/fullscreenEnabled}} [=attributes=]
         of the {{Document}} interface, and on
         the {{DocumentOrShadowRoot/fullscreenElement}} [=attribute=]
         of the {{DocumentOrShadowRoot}} mixin. [[FULLSCREEN]]
-    </p>
+    </small>
 
 </div>
 
@@ -8738,13 +8738,13 @@ See the <a href="#es-attributes">Attributes</a> section for how
     <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
     mailing list before proceeding.
 
-    <p class="note">
+    <small class="non-normative">
         The [{{LenientThis}}] [=extended attribute=] appears on
         the {{Document/onreadystatechange}},
         {{Document/onmouseenter}}, and
         {{Document/onmouseleave}} [=attributes=]
         of the {{Document}} interface. [[HTML]]
-    </p>
+    </small>
 </div>
 
 If the [{{LenientThis}}]
@@ -8814,10 +8814,10 @@ is to be implemented.
     They should not be used in specifications
     unless required to specify the behavior of legacy APIs.
 
-    <p class="note">
+    <small class="non-normative">
         Known [=interfaces=] requiring the use of the [{{NamedConstructor}}] [=extended attribute=] are:
         {{HTMLAudioElement}}, {{HTMLOptionElement}} and {{HTMLImageElement}}. [[HTML]]
-    </p>
+    </small>
 
 </div>
 


### PR DESCRIPTION
Make advisements more prominent.

- [x] `[LenientSetter]`
- [x] `[LenientThis]`
- [x] `[NamedConstructor]`
- [x] `[OverrideBuiltins]`
- [x] `[TreatNonObjectAsNull]`
- [x] `[TreatNullAs=EmptyString]` _(didn't gather all examples of legacy usage)._
- [x] `[LegacyUnenumerableNamedProperties]`
- [x] `[LegacyArrayClass]`
- [x] `[NoInterfaceObject]` _(didn't gather all examples of legacy usage)._


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tobie/webidl/link-legacy-apis.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/48f1e62...tobie:580c208.html)