### PR TITLE
Link function objects and constructors to relevant DFNs in ES

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -129,6 +129,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: Call; url: sec-call
         text: Get; url: sec-get-o-p
         text: Set; url: sec-set-o-p-v-throw
+        text: constructor; url: constructor
         text: IsConstructor; url: sec-isconstructor
         text: Construct; url: sec-construct
         text: own property; url: sec-own-property
@@ -147,7 +148,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: 9.3.1; url: sec-built-in-function-objects-call-thisargument-argumentslist
         text: ECMA-262 section 9.3; url: sec-built-in-function-objects
         text: built-in function object; url: sec-built-in-function-objects
-        text: function object; url: sec-object-internal-methods-and-internal-slots
+        text: function object; url: function-object
         text: Array methods; url: sec-properties-of-the-array-prototype-object
         text: typed arrays; url: sec-typedarray-objects
         text: GetMethod; url: sec-getmethod
@@ -443,7 +444,7 @@ in [[#es-extended-attributes]].
 
     The [{{Constructor}}] that appears on <code class="idl">GraphicalWindow</code>
     is an [=extended attribute=].
-    This extended attribute causes a constructor to exist in ECMAScript implementations,
+    This extended attribute causes a [=constructor=] to exist in ECMAScript implementations,
     so that calling <code>new GraphicalWindow()</code> would return a new object
     that implemented the interface.
 
@@ -8767,7 +8768,7 @@ If the [{{NamedConstructor}}]
 [=extended attribute=]
 appears on an [=interface=],
 it indicates that the ECMAScript global object will have a property with the
-specified name whose value is a constructor function that can
+specified name whose value is a [=constructor=] that can
 create objects that implement the interface.
 Multiple [{{NamedConstructor}}] extended
 attributes may appear on a given interface.
@@ -8782,7 +8783,7 @@ has the same meaning as using an empty argument list,
 <code>[NamedConstructor=<emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t>()]</code>.
 For each [{{NamedConstructor}}] extended attribute on the interface,
 there will be a way to construct an object that
-implements the interface by passing the specified arguments to the constructor function
+implements the interface by passing the specified arguments to the [=constructor=]
 that is the value of the aforementioned property.
 
 The [=NamedConstructor identifier|identifier=] used for the named constructor must not
@@ -8826,17 +8827,17 @@ are to be implemented.
 
     An ECMAScript implementation that supports this interface will
     allow the construction of <code class="idl">HTMLAudioElement</code>
-    objects using the <code class="idl">Audio</code> constructor.
+    objects using the <code class="idl">Audio</code> [=constructor=].
 
     <pre highlight="js">
         typeof Audio;                   // Evaluates to 'function'.
 
         var a1 = new Audio();           // Creates a new object that implements
                                         // HTMLAudioElement, using the zero-argument
-                                        // constructor.
+                                        // [=constructor=].
 
         var a2 = new Audio('a.flac');   // Creates an HTMLAudioElement using the
-                                        // one-argument constructor.
+                                        // one-argument [=constructor=].
     </pre>
 </div>
 
@@ -10041,13 +10042,13 @@ defined on that interface,
 as described in sections [[#es-constants]] and [[#es-operations]].
 
 If the [=interface=] is declared with a [{{Constructor}}] [=extended attribute=],
-then the [=interface object=] can be called as a constructor
+then the [=interface object=] can be called as a [=constructor=]
 to create an object that implements that interface.
 Calling that interface as a function will throw an exception.
 
 [=Interface objects=] whose [=interfaces=] are not declared
 with a [{{Constructor}}] [=extended attribute=] will throw when called,
-both as a function and as a constructor.
+both as a function and as a [=constructor=].
 
 An [=interface object=] for a non-callback [=interface=]
 has an associated object called the [=interface prototype object=].
@@ -12456,7 +12457,7 @@ described in the previous section).
             |rejectedPromise| to the callback function's return type.
 </div>
 
-Some callback functions are instead used as constructors. Such callback functions must not have
+Some callback functions are instead used as [=constructors=]. Such callback functions must not have
 a return type that is a [=promise type=].
 
 <div algorithm>
@@ -12572,7 +12573,7 @@ A {{DOMException}} is represented by a
              :: |X| is the {{DOMException}} [=interface object=]
                 from the [=current Realm=].
              :  |E| is a [=simple exception=]
-             :: |X| is the constructor for the corresponding ECMAScript error
+             :: |X| is the [=constructor=] for the corresponding ECMAScript error
                 from the [=current Realm=].
         </dl>
     1.  Return [=!=] [=Construct=](|X|, |args|).

--- a/index.bs
+++ b/index.bs
@@ -8834,10 +8834,10 @@ are to be implemented.
 
         var a1 = new Audio();           // Creates a new object that implements
                                         // HTMLAudioElement, using the zero-argument
-                                        // [=constructor=].
+                                        // constructor.
 
         var a2 = new Audio('a.flac');   // Creates an HTMLAudioElement using the
-                                        // one-argument [=constructor=].
+                                        // one-argument constructor.
     </pre>
 </div>
 


### PR DESCRIPTION
Closes #410.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tobie/webidl/fix-410.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/48f1e62...tobie:718ea3c.html)