### PR TITLE
Make [Exposed] mandatory, remove [PrimaryGlobal]

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -482,19 +482,22 @@ in [[#es-extended-attributes]].
     The following is an example of an [=IDL fragment=].
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Paint { };
 
+        [Exposed=Window]
         interface SolidColor : Paint {
           attribute double red;
           attribute double green;
           attribute double blue;
         };
 
+        [Exposed=Window]
         interface Pattern : Paint {
           attribute DOMString imageURL;
         };
 
-        [Constructor]
+        [Exposed=Window, Constructor]
         interface GraphicalWindow {
           readonly attribute unsigned long width;
           readonly attribute unsigned long height;
@@ -573,6 +576,7 @@ in the declaration:
     the final <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> token before the
     semicolon at the end of the declaration determines the identifier.
     <pre highlight="webidl" class="syntax">
+        [extended_attributes]
         interface identifier {
           attribute type <mark>attribute_identifier</mark>;
         };
@@ -700,10 +704,12 @@ across [=IDL fragments=].
     Therefore, the following [=IDL fragment=] is valid:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface B : A {
           void f(SequenceOfLongs x);
         };
 
+        [Exposed=Window]
         interface A {
         };
 
@@ -722,6 +728,7 @@ across [=IDL fragments=].
         typedef double number;
 
         // Interface identifier: "System"
+        [Exposed=Window]
         interface System {
 
           // Operation identifier:          "createObject"
@@ -736,6 +743,7 @@ across [=IDL fragments=].
         };
 
         // Interface identifier: "TextField"
+        [Exposed=Window]
         interface TextField {
 
           // Attribute identifier: "const"
@@ -766,6 +774,7 @@ An <dfn id="dfn-interface" export>interface</dfn> is a definition (matching
 state and behavior that an object implementing that interface will expose.
 
 <pre highlight="webidl" class="syntax">
+    [extended_attributes]
     interface identifier {
       /* interface_members... */
     };
@@ -810,11 +819,13 @@ accessed on the object.
     Consider the following two interfaces.
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface A {
           void f();
           void g();
         };
 
+        [Exposed=Window]
         interface B : A {
           void f();
           void g(DOMString x);
@@ -867,6 +878,7 @@ Each interface member can be preceded by a list of [=extended attributes=] (matc
 which can control how the interface member will be handled in language bindings.
 
 <pre highlight="webidl" class="syntax">
+    [extended_attributes]
     interface identifier {
 
       [<mark>extended_attributes</mark>]
@@ -958,6 +970,7 @@ be defined on a [=callback interface=].
           attribute long? option3;
         };
 
+        [Exposed=Window]
         interface A {
           void doTask(DOMString type, Options options);
         };
@@ -980,6 +993,7 @@ be defined on a [=callback interface=].
           long? option3;
         };
 
+        [Exposed=Window]
         interface A {
           void doTask(DOMString type, optional Options options);
         };
@@ -1033,8 +1047,7 @@ is all of those defined in this document that are applicable to
 [=interfaces=] except for
 [{{Exposed}}],
 [{{Global}}],
-[{{OverrideBuiltins}}],
-[{{PrimaryGlobal}}], and
+[{{OverrideBuiltins}}], and
 [{{SecureContext}}].
 
 Any [=extended attribute=] specified
@@ -1053,9 +1066,13 @@ The following extended attributes are applicable to interfaces:
 [{{LegacyWindowAlias}}],
 [{{NamedConstructor}}],
 [{{NoInterfaceObject}}],
-[{{OverrideBuiltins}}],
-[{{PrimaryGlobal}}], and
+[{{OverrideBuiltins}}], and
 [{{SecureContext}}].
+
+Non-callback [=interfaces=] which are not annotated
+with a [{{NoInterfaceObject}}] [=extended attribute=],
+and [=callback interfaces=] which declare [=constants=]
+must be annotated with an [{{Exposed}}] [=extended attribute=].
 
 <pre class="grammar" id="prod-CallbackOrInterfaceOrMixin">
     CallbackOrInterfaceOrMixin :
@@ -1137,14 +1154,17 @@ The following extended attributes are applicable to interfaces:
     either of those two interfaces will thus have a <code>name</code> attribute.
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Animal {
           attribute DOMString name;
         };
 
+        [Exposed=Window]
         interface Human : Animal {
           attribute Dog? pet;
         };
 
+        [Exposed=Window]
         interface Dog : Animal {
           attribute Human? owner;
         };
@@ -1158,6 +1178,7 @@ The following extended attributes are applicable to interfaces:
     is a [=callback interface=].
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Node {
           readonly attribute DOMString nodeName;
           readonly attribute Node? parentNode;
@@ -1684,6 +1705,7 @@ on which they appear.  It is language binding specific whether
     For example, with the following IDL:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface A {
           const short rambaldi = 47;
         };
@@ -1738,6 +1760,7 @@ The following extended attributes are applicable to constants:
     of the above types can be defined.
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Util {
           const boolean DEBUG = false;
           const octet LF = 10;
@@ -1849,10 +1872,12 @@ must not appear on a [=read only=]
 attribute or a [=static attribute=].
 
 <pre highlight="webidl" class="syntax">
+    [Exposed=Window]
     interface Ancestor {
       readonly attribute TheType theIdentifier;
     };
 
+    [Exposed=Window]
     interface Derived : Ancestor {
       inherit attribute TheType theIdentifier;
     };
@@ -1945,6 +1970,7 @@ are applicable only to regular attributes:
     can be declared on an [=interface=]:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Animal {
 
           // A simple attribute that can be set to any string value.
@@ -1954,6 +1980,7 @@ are applicable only to regular attributes:
           attribute unsigned short age;
         };
 
+        [Exposed=Window]
         interface Person : Animal {
 
           // An attribute whose getter behavior is inherited from Animal, and need not be
@@ -2093,11 +2120,13 @@ language bindings.
     can be declared on an [=interface=]:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Dimensions {
           attribute unsigned long width;
           attribute unsigned long height;
         };
 
+        [Exposed=Window]
         interface Button {
 
           // An operation that takes no arguments and returns a boolean.
@@ -2141,6 +2170,7 @@ when the <emu-t>...</emu-t> token is used in their argument lists.
     two variadic operations:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface IntegerSet {
           readonly attribute unsigned long cardinality;
 
@@ -2277,6 +2307,7 @@ that has a [=sequence type=] in its [=flattened member types=].
     that can be invoked with two different argument list lengths:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface ColorCreator {
           object createColor(double v1, double v2, double v3, optional double alpha);
         };
@@ -2287,6 +2318,7 @@ that has a [=sequence type=] in its [=flattened member types=].
     [=operations=]:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface ColorCreator {
           object createColor(double v1, double v2, double v3);
           object createColor(double v1, double v2, double v3, double alpha);
@@ -2451,6 +2483,7 @@ in which case the [=default toJSON operation=] is exposed instead.
     that has a <code>toJSON</code> method defined in prose:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Transaction {
           readonly attribute DOMString from;
           readonly attribute DOMString to;
@@ -2562,6 +2595,7 @@ will not be such functionality.
     The following IDL fragment defines an interface with a getter and a setter:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Dictionary {
           readonly attribute unsigned long propertyCount;
 
@@ -2586,6 +2620,7 @@ simplify prose descriptions of an interface’s operations.
     The following two interfaces are equivalent:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Dictionary {
           readonly attribute unsigned long propertyCount;
 
@@ -2594,6 +2629,7 @@ simplify prose descriptions of an interface’s operations.
         };
     </pre>
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Dictionary {
           readonly attribute unsigned long propertyCount;
 
@@ -2690,11 +2726,13 @@ argument list can be omitted.
     The following two interfaces are equivalent:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface A {
           stringifier DOMString ();
         };
     </pre>
     <pre highlight="webidl">
+        [Exposed=Window]
         interface A {
           stringifier;
         };
@@ -2735,7 +2773,7 @@ a [=static attribute=].
     <code class="idl">name</code> attribute:
 
     <pre highlight="webidl">
-        [Constructor]
+        [Exposed=Window, Constructor]
         interface Student {
           attribute unsigned long id;
           stringifier attribute DOMString name;
@@ -2760,7 +2798,7 @@ a [=static attribute=].
     not specified in the IDL itself.
 
     <pre highlight="webidl">
-        [Constructor]
+        [Exposed=Window, Constructor]
         interface Student {
           attribute unsigned long id;
           attribute DOMString? familyName;
@@ -2865,6 +2903,7 @@ The following requirements apply to the definitions of indexed property getters 
     In the ECMAScript language binding, a regular property lookup is done.  For example, take the following IDL:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface A {
           getter DOMString toWord(unsigned long index);
         };
@@ -2894,6 +2933,7 @@ The following requirements apply to the definitions of indexed property getters 
     retrieving and setting values by name or by index number:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface OrderedMap {
           readonly attribute unsigned long size;
 
@@ -3077,8 +3117,10 @@ declared on [=callback interfaces=].
     operation declared on it:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Point { /* ... */ };
 
+        [Exposed=Window]
         interface Circle {
           attribute double cx;
           attribute double cy;
@@ -3145,6 +3187,7 @@ definitions.
     are disallowed:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface A {
           void f();
         };
@@ -3308,6 +3351,7 @@ the same operation or constructor.
     For the following interface:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface A {
           /* f1 */ void f(DOMString a);
           /* f2 */ void f(Node a, DOMString b, double... c);
@@ -3576,6 +3620,7 @@ the following algorithm returns <i>true</i>.
                 attribute DOMString attr1;
             };
 
+            [Exposed=Window]
             interface Iface {
                 attribute DOMString attr2;
             };
@@ -3615,6 +3660,7 @@ for the items of the effective overload set with the given type list size.
     The following use of overloading however is invalid:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface B {
           void f(DOMString x);
           void f(USVString x);
@@ -3637,6 +3683,7 @@ be the same.
     The following is invalid:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface B {
           /* f1 */ void f(DOMString w);
           /* f2 */ void f(long w, double x, Node y, Node z);
@@ -3993,12 +4040,14 @@ that have [=members=] with these names.
     a number of <code class="idl">Session</code> objects keyed by username:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface SessionManager {
           Session getSessionForUser(DOMString username);
 
           iterable&lt;DOMString, Session&gt;;
         };
 
+        [Exposed=Window]
         interface Session {
           readonly attribute DOMString username;
           // ...
@@ -4302,8 +4351,9 @@ The order that members appear in has significance for property enumeration in th
 
 Note that unlike interfaces or dictionaries, namespaces do not create types.
 
-Of the extended attributes defined in this specification, only the [{{Exposed}}] and [{{SecureContext}}] extended attributes are applicable to
-namespaces.
+Of the extended attributes defined in this specification, only the [{{Exposed}}] and [{{SecureContext}}] extended attributes are applicable to namespaces.
+
+[=Namespaces=] must be annotated with the [{{Exposed}}] [=extended attribute=].
 
 <div data-fill-with="grammar-Partial"></div>
 
@@ -4580,6 +4630,7 @@ identifiers.
     following additional interface:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Something {
           void f(A a);
         };
@@ -4664,7 +4715,7 @@ No [=extended attributes=] are applicable to dictionaries.
     consider the following [=IDL fragment=]:
 
     <pre highlight="webidl">
-        [Constructor]
+        [Exposed=Window, Constructor]
         interface Point {
           attribute double x;
           attribute double y;
@@ -4676,6 +4727,7 @@ No [=extended attributes=] are applicable to dictionaries.
           Point position;
         };
 
+        [Exposed=Window]
         interface GraphicsContext {
           void drawRectangle(double width, double height, optional PaintOptions options);
         };
@@ -5068,6 +5120,7 @@ defined in this specification are applicable to [=enumerations=].
     <pre highlight="webidl">
         enum MealType { "rice", "noodles", "other" };
 
+        [Exposed=Window]
         interface Meal {
           attribute MealType type;
           attribute double size;     // in grams
@@ -5142,6 +5195,7 @@ The following extended attribute is applicable to callback functions:
     <pre highlight="webidl">
         callback AsyncOperationCallback = void (DOMString status);
 
+        [Exposed=Window]
         interface AsyncOperations {
           void performOperation(AsyncOperationCallback whenFinished);
         };
@@ -5195,6 +5249,7 @@ defined in this specification are applicable to [=typedefs=].
     [=sequence type=].
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Point {
           attribute double x;
           attribute double y;
@@ -5202,6 +5257,7 @@ defined in this specification are applicable to [=typedefs=].
 
         typedef sequence&lt;Point&gt; Points;
 
+        [Exposed=Window]
         interface Widget {
           boolean pointWithinBounds(Point p);
           boolean allPointsWithinBounds(Points ps);
@@ -5222,7 +5278,7 @@ object that are considered to be platform objects:
 
 <dfn id="dfn-legacy-platform-object" export>Legacy platform objects</dfn> are
 [=platform objects=] that implement an [=interface=] which
-does not have a [{{Global}}] or [{{PrimaryGlobal}}] [=extended attribute=],
+does not have a [{{Global}}] [=extended attribute=],
 [=support indexed properties|supports indexed=] or
 [=support named properties|named properties=].
 
@@ -5914,6 +5970,7 @@ the string “OrNull”.
     is written as <code class="idl">boolean?</code>:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface NetworkFetcher {
           void get(optional boolean? areWeThereYet = false);
         };
@@ -5926,6 +5983,7 @@ the string “OrNull”.
     object or the <emu-val>null</emu-val> value:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Node {
           readonly attribute DOMString? namespaceURI;
           readonly attribute Node? parentNode;
@@ -6163,6 +6221,7 @@ The following extended attributes are <dfn for="extended attributes">applicable 
 
         <div class="example">
             <pre class="idl">
+                [Exposed=Window]
                 interface I {
                     attribute [XAttr] long attrib;
                     void f1(sequence<[XAttr] long> arg);
@@ -6181,6 +6240,7 @@ The following extended attributes are <dfn for="extended attributes">applicable 
 
         <div class="example">
             <pre class="idl">
+                [Exposed=Window]
                 interface I {
                     attribute [XAttr] (long or Node) attrib;
                 };
@@ -6195,6 +6255,7 @@ The following extended attributes are <dfn for="extended attributes">applicable 
 
         <div class="example">
             <pre class="idl">
+                [Exposed=Window]
                 interface I {
                     void f([XAttr] long attrib);
                 };
@@ -7595,6 +7656,7 @@ ECMAScript Array values.
     with an argument of a sequence type.
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Canvas {
 
           sequence&lt;DOMString&gt; getSupportedImageCodecs();
@@ -8177,6 +8239,7 @@ See the rules for converting ECMAScript values to IDL [=buffer source types=] in
     attribute, while the other does not:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface RenderingContext {
           void readPixels(long width, long height, BufferSource pixels);
           void readPixelsShared(long width, long height, [AllowShared] BufferSource pixels);
@@ -8220,6 +8283,7 @@ for the specific requirements that the use of
     on all three arguments, while the other does not:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface GraphicsContext {
           void setColor(octet red, octet green, octet blue);
           void setColorClamped([Clamp] octet red, [Clamp] octet green, [Clamp] octet blue);
@@ -8289,12 +8353,14 @@ for an interface is to be implemented.
     attribute, while the first does not.
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface NodeList {
           Node item(unsigned long index);
           readonly attribute unsigned long length;
         };
 
-        [Constructor,
+        [Exposed=Window,
+         Constructor,
          Constructor(double radius)]
         interface Circle {
           attribute double r;
@@ -8345,17 +8411,20 @@ for which a [=corresponding default operation=] has been defined.
     for use on <code>toJSON</code> [=regular operations=]:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Animal {
           attribute DOMString name;
           attribute unsigned short age;
           [Default] object toJSON();
         };
 
+        [Exposed=Window]
         interface Human : Animal {
           attribute Dog? pet;
           [Default] object toJSON();
         };
 
+        [Exposed=Window]
         interface Dog : Animal {
           attribute DOMString? breed;
         };
@@ -8428,6 +8497,7 @@ for the specific requirements that the use of
     on all three arguments, while the other does not:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface GraphicsContext {
           void setColor(octet red, octet green, octet blue);
           void setColorEnforcedRange([EnforceRange] octet red, [EnforceRange] octet green, [EnforceRange] octet blue);
@@ -8460,9 +8530,7 @@ for the specific requirements that the use of
 
 <h4 id="Exposed" extended-attribute lt="Exposed">[Exposed]</h4>
 
-If the [{{Exposed}}]
-[=extended attribute=]
-appears on
+When the [{{Exposed}}] [=extended attribute=] appears on
 an [=interface=],
 [=partial interface=],
 [=interface mixin=],
@@ -8473,8 +8541,7 @@ an individual [=interface member=],
 [=interface mixin member=], or
 [=namespace member=],
 it indicates that the construct is exposed
-on a particular set of global interfaces,
-rather than the default implicit exposition described below.
+on that particular set of global interfaces.
 
 The [{{Exposed}}] [=extended attribute=] must either
 [=takes an identifier|take an identifier=] or
@@ -8514,10 +8581,8 @@ This list of identifiers is known as the construct's
             and |H|'s [=exposure set=].
         1.  Otherwise, set |C| to |H|.
     1.  Assert: |C| is a [=interface=] or [=namespace=].
-    1.  If the [{{Exposed}}] [=extended attribute=] is specified on |C|,
-        then return |C|'s [=own exposure set=].
-    1.  Otherwise, return « [=primary global interface=] ».
-
+    1.  Assert: The [{{Exposed}}] [=extended attribute=] is specified on |C|.
+    1.  Return |C|'s [=own exposure set=].
 </div>
 
 If [{{Exposed}}] appears on an [=overloaded=] [=operation=],
@@ -8596,7 +8661,7 @@ for the specific requirements that the use of
     The following IDL fragment shows how that might be achieved:
 
     <pre highlight="webidl">
-        [PrimaryGlobal]
+        [Exposed=Window, Global=Window]
         interface Window {
           // ...
         };
@@ -8604,12 +8669,12 @@ for the specific requirements that the use of
         // By using the same identifier Worker for both SharedWorkerGlobalScope
         // and DedicatedWorkerGlobalScope, both can be addressed in an [Exposed]
         // extended attribute at once.
-        [Global=Worker]
+        [Exposed=Worker, Global=Worker]
         interface SharedWorkerGlobalScope : WorkerGlobalScope {
           // ...
         };
 
-        [Global=Worker]
+        [Exposed=Worker, Global=Worker]
         interface DedicatedWorkerGlobalScope : WorkerGlobalScope {
           // ...
         };
@@ -8631,6 +8696,7 @@ for the specific requirements that the use of
 
         // Node is only available on the main thread.  Evaluating Node
         // in the global scope of a worker would give you a ReferenceError.
+        [Exposed=Window]
         interface Node {
           // ...
         };
@@ -8651,6 +8717,7 @@ for the specific requirements that the use of
 
         // NodeUtils is only available in the main thread.  Evaluating NodeUtils
         // in the global scope of a worker would give you a ReferenceError.
+        [Exposed=Window]
         namespace NodeUtils {
           DOMString getAllText(Node node);
         };
@@ -8658,12 +8725,9 @@ for the specific requirements that the use of
 </div>
 
 
-<h4 oldids="PrimaryGlobal" id="Global" extended-attribute lt="Global|PrimaryGlobal" dfn>[Global] and [PrimaryGlobal]</h4>
+<h4 oldids="PrimaryGlobal" id="Global" extended-attribute lt="Global" dfn>[Global]</h4>
 
-If the [{{Global}}]
-or [{{PrimaryGlobal}}]
-[=extended attribute=]
-appears on an [=interface=],
+If the [{{Global}}] [=extended attribute=] appears on an [=interface=],
 it indicates that objects implementing this interface can
 be used as the global object in an ECMAScript environment,
 and that the structure of the prototype chain and how
@@ -8708,7 +8772,7 @@ interfaces. Specifically:
 
 </div>
 
-If the [{{Global}}] or [{{PrimaryGlobal}}] [=extended attributes=] is
+If the [{{Global}}] [=extended attributes=] is
 used on an [=interface=], then:
 
 *   The interface must not define a [=named property setter=].
@@ -8719,14 +8783,13 @@ used on an [=interface=], then:
     [{{OverrideBuiltins}}] extended attribute.
 *   Any other interface must not [=interface/inherit=] from it.
 
-If [{{Global}}] or [{{PrimaryGlobal}}] is specified on
+If [{{Global}}] is specified on
 a [=partial interface=]
 definition, then that partial interface definition must
 be the part of the interface definition that defines
 the [=named property getter=].
 
-The [{{Global}}] and [{{PrimaryGlobal}}]
-[=extended attribute=] must not
+The [{{Global}}] [=extended attribute=] must not
 be used on an [=interface=] that can have more
 than one object implementing it in the same ECMAScript global environment.
 
@@ -8735,9 +8798,7 @@ which exposes the named properties, is in the prototype chain, and it would not 
 sense for more than one object’s named properties to be exposed on an object that
 all of those objects inherit from.
 
-If an interface is declared with the [{{Global}}] or
-[{{PrimaryGlobal}}]
-[=extended attribute=], then
+If an interface is declared with the [{{Global}}] [=extended attribute=], then
 there must not be more than one
 [=member=] across
 the interface
@@ -8752,53 +8813,29 @@ across those interfaces.
 Note: This is because all of the [=members=] of the interface
 get flattened down on to the object that implements the interface.
 
-The [{{Global}}] and
-[{{PrimaryGlobal}}] extended attributes
+The [{{Global}}] extended attribute
 can also be used to give a name to one or more global interfaces,
 which can then be referenced by the [{{Exposed}}]
 extended attribute.
 
-The [{{Global}}] and
-[{{PrimaryGlobal}}]
-extended attributes must either
-[=takes no arguments|take no arguments=]
-or [=takes an identifier list|take an identifier list=].
+The [{{Global}}] extended attribute must either
+[=takes an identifier|take an identifier=] or
+[=takes an identifier list|take an identifier list=].
 
-If the [{{Global}}] or
-[{{PrimaryGlobal}}]
-[=extended attribute=]
-is declared with an identifier list argument, then those identifiers are the interface’s
-<dfn id="dfn-global-name" export>global names</dfn>; otherwise, the interface has
-a single global name, which is the interface's identifier.
+The identifier argument or identifier list argument the [{{Global}}] [=extended attribute=] is declared with
+define the interface’s <dfn id="dfn-global-name" export>global names</dfn>.
 
 Note: The identifier argument list exists so that more than one global interface can
-be addressed with a single name in an [{{Exposed}}]
-[=extended attribute=].
+be addressed with a single name in an [{{Exposed}}] [=extended attribute=].
 
-The [{{Global}}] and
-[{{PrimaryGlobal}}]
-[=extended attributes=]
-must not be declared on the same
-interface.  The [{{PrimaryGlobal}}]
-extended attribute must be declared on
-at most one interface.  The interface [{{PrimaryGlobal}}]
-is declared on, if any, is known as the <dfn id="dfn-primary-global-interface" export>primary global interface</dfn>.
-
-See [[#named-properties-object]]
-for the specific requirements that the use of
-[{{Global}}] and [{{PrimaryGlobal}}]
-entails for named properties,
-and [[#es-constants]],
-[[#es-attributes]] and
-[[#es-operations]]
+See [[#named-properties-object]] for the specific requirements
+that the use of [{{Global}}] entails for [=named properties=],
+and [[#es-constants]], [[#es-attributes]] and [[#es-operations]]
 for the requirements relating to the location of properties
 corresponding to [=interface members=].
 
 <div class="example">
 
-    The [{{PrimaryGlobal}}] [=extended attribute=] is intended
-    to be used by the {{Window}} interface.
-    ([{{Global}}] is intended to be used by worker global interfaces.)
     The <code class="idl">Window</code> interface exposes frames as properties on the <code class="idl">Window</code>
     object.  Since the <code class="idl">Window</code> object also serves as the
     ECMAScript global object, variable declarations or assignments to the named properties
@@ -8806,7 +8843,7 @@ corresponding to [=interface members=].
     attributes will not create a property that replaces the existing one.
 
     <pre highlight="webidl">
-        [PrimaryGlobal]
+        [Exposed=Window, Global]
         interface Window {
           getter any (DOMString name);
           attribute DOMString name;
@@ -8905,14 +8942,14 @@ entails.
     that use [{{LegacyArrayClass}}].
 
     <pre highlight="webidl">
-        [LegacyArrayClass]
+        [Exposed=Window, LegacyArrayClass]
         interface ItemList {
           attribute unsigned long length;
           getter object getItem(unsigned long index);
           setter object setItem(unsigned long index, object item);
         };
 
-        [LegacyArrayClass]
+        [Exposed=Window, LegacyArrayClass]
         interface ImmutableItemList {
           readonly attribute unsigned long length;
           getter object getItem(unsigned long index);
@@ -9068,7 +9105,7 @@ entails.
 </div>
 
 If the [{{LegacyWindowAlias}}] [=extended attribute=] appears on an [=interface=],
-it indicates that the [=primary global interface=] will have a property
+it indicates that the {{Window}} [=interface=] will have a property
 for each [=identifier=] mentioned in the extended attribute,
 whose value is the [=interface object=] for the interface.
 
@@ -9090,7 +9127,7 @@ The [{{LegacyWindowAlias}}] and [{{NoInterfaceObject}}]
 extended attributes must not be specified on the same interface.
 
 The [{{LegacyWindowAlias}}] extended attribute must not be specified
-on an interface that does not include the [=primary global interface=]
+on an interface that does not include the {{Window}} [=interface=]
 in its [=exposure set=].
 
 The [{{LegacyWindowAlias}}] extended attribute must not be specified
@@ -9107,7 +9144,8 @@ are to be implemented.
     [{{LegacyWindowAlias}}] extended attribute.
 
     <pre highlight="webidl">
-        [Constructor,
+        [Exposed=Window,
+         Constructor,
          LegacyWindowAlias=WebKitCSSMatrix]
         interface DOMMatrix : DOMMatrixReadOnly {
           // ...
@@ -9189,6 +9227,7 @@ See the <a href="#es-attributes">Attributes</a> section for how
     attribute.
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Example {
           [LenientSetter] readonly attribute DOMString x;
           readonly attribute DOMString y;
@@ -9261,6 +9300,7 @@ is to be implemented.
     attribute.
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Example {
           [LenientThis] attribute DOMString x;
           attribute DOMString y;
@@ -9358,7 +9398,8 @@ are to be implemented.
     attribute.
 
     <pre highlight="webidl">
-        [NamedConstructor=Audio,
+        [Exposed=Window,
+         NamedConstructor=Audio,
          NamedConstructor=Audio(DOMString src)]
         interface HTMLAudioElement : HTMLMediaElement {
           // ...
@@ -9416,6 +9457,7 @@ a [=promise type=].
     it is called.
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Document : Node {
           [NewObject] Element createElement(DOMString localName);
           // ...
@@ -9510,11 +9552,13 @@ for the specific requirements that the use of
     is exposed on the ECMAScript global object, and one whose isn’t:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Storage {
           void addEntry(unsigned long key, any value);
         };
 
-        [NoInterfaceObject]
+        [Exposed=Window,
+         NoInterfaceObject]
         interface Query {
           any lookupEntry(unsigned long key);
         };
@@ -9581,9 +9625,8 @@ extended attribute must
 [=takes no arguments|take no arguments=]
 and must not appear on an interface
 that does not define a [=named property getter=]
-or that also is declared with the [{{Global}}]
-or [{{PrimaryGlobal}}]
-extended attribute.  If the extended attribute is specified on
+or that also is declared with the [{{Global}}] [=extended attribute=].
+If the extended attribute is specified on
 a [=partial interface=]
 definition, then that partial interface definition must
 be the part of the interface definition that defines
@@ -9602,12 +9645,14 @@ for the specific requirements that the use of
     and one that does not.
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface StringMap {
           readonly attribute unsigned long length;
           getter DOMString lookup(DOMString key);
         };
 
-        [OverrideBuiltins]
+        [Exposed=Window,
+         OverrideBuiltins]
         interface StringMap2 {
           readonly attribute unsigned long length;
           getter DOMString lookup(DOMString key);
@@ -9729,12 +9774,14 @@ is to be implemented.
     <code class="idl">Person</code> object:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Name {
           attribute DOMString full;
           attribute DOMString family;
           attribute DOMString given;
         };
 
+        [Exposed=Window]
         interface Person {
           [PutForwards=full] readonly attribute Name name;
           attribute unsigned short age;
@@ -9801,6 +9848,7 @@ for the specific requirements that the use of
     that exposes the counter’s value, which is initially 0:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Counter {
           [Replaceable] readonly attribute unsigned long value;
           void increment();
@@ -9868,6 +9916,7 @@ or {{object}}.
     <code class="idl">Document</code> object.
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Document : Node {
           [SameObject] readonly attribute DOMImplementation implementation;
           // ...
@@ -9961,6 +10010,7 @@ that does specify [{{SecureContext}}].
     contexts, and two which are executable only from secure contexts.
 
     <pre class="webidl">
+        [Exposed=Window]
         interface PowerfulFeature {
           // This call will succeed in all contexts.
           Promise &lt;Result&gt; calculateNotSoSecretResult();
@@ -10055,6 +10105,7 @@ for the specific requirements that the use of
         [TreatNonObjectAsNull]
         callback ErrorHandler = void (DOMString details);
 
+        [Exposed=Window]
         interface Manager {
           attribute OccurrenceHandler? handler1;
           attribute ErrorHandler? handler2;
@@ -10120,6 +10171,7 @@ See [[#es-DOMString]] for the specific requirements that the use of [{{TreatNull
     extended attribute, and one operation whose argument's type has the extended attribute:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Dog {
           attribute DOMString name;
           attribute [TreatNullAs=EmptyString] DOMString owner;
@@ -10197,13 +10249,16 @@ must not have a [=regular attribute=] or
     For example, the following is disallowed:
 
     <pre class="webidl">
+        [Exposed=Window]
         interface A1 {
           [Unforgeable] readonly attribute DOMString x;
         };
+        [Exposed=Window]
         interface B1 : A1 {
           void x();  // Invalid; would be shadowed by A1's x.
         };
 
+        [Exposed=Window]
         interface B2 : A1 { };
         B2 includes M1;
         interface mixin M1 {
@@ -10227,6 +10282,7 @@ for the specific requirements that the use of
     one of which is designated as [{{Unforgeable}}]:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface System {
           [Unforgeable] readonly attribute DOMString username;
           readonly attribute long long loginTime;
@@ -10295,6 +10351,7 @@ for the specific requirements that the use of
     For example, with the following IDL:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Thing {
           void f();
           [Unscopable] g();
@@ -10654,7 +10711,7 @@ The characteristics of an interface object are described in [[#interface-object]
 
 If the [{{LegacyWindowAlias}}] extended attribute was specified on an [=exposed=] interface,
 then for each [=LegacyWindowAlias identifier|identifier=] in [{{LegacyWindowAlias}}]'s [=LegacyWindowAlias identifier|identifiers=]
-there must be a corresponding property on the [=primary global interface=].
+there must be a corresponding property on the {{Window}} [=interface=].
 The name of the property is the given [=LegacyWindowAlias identifier|identifier=],
 and its value is a reference to the [=interface object=] for the [=interface=].
 The property has the attributes
@@ -10819,10 +10876,8 @@ whose value is a reference to the [=interface object=] for the interface.
     \[[Prototype]] property whose value is returned from
     the following steps:
 
-    1.  If |A| is declared with the [{{Global}}]
-        or [{{PrimaryGlobal}}]
-        [=extended attribute=], and |A|
-        [=support named properties|supports named properties=], then
+    1.  If |A| is declared with the [{{Global}}] [=extended attribute=], and
+        |A| =support named properties|supports named properties=], then
         return the [=named properties object=]
         for |A|, as defined in [[#named-properties-object]].
     1.  Otherwise, if |A| is declared to inherit from another
@@ -10844,7 +10899,8 @@ whose value is a reference to the [=interface object=] for the interface.
     For example, with the following IDL:
 
     <pre highlight="webidl">
-        [NoInterfaceObject]
+        [Exposed=Window,
+         NoInterfaceObject]
         interface Foo {
         };
 
@@ -10882,10 +10938,10 @@ whose value is a reference to the [=interface object=] for the interface.
     1.  Return |object|.
 </div>
 
-If the interface is declared with the [{{Global}}] or
-[{{PrimaryGlobal}}] [=extended attribute=], or the interface is in the set
-of [=inherited interfaces=] for any
-other interface that is declared with one of these attributes, then the [=interface prototype object=]
+If the interface is declared with the [{{Global}}] [=extended attribute=],
+or the interface is in the set of [=inherited interfaces=] for
+any other interface that is declared with one of these attributes,
+then the [=interface prototype object=]
 must be an [=immutable prototype exotic object=].
 
 The [=class string=] of an [=interface prototype object=] is the concatenation of
@@ -10929,8 +10985,7 @@ when applied to a [=legacy callback interface object=].
 
 <h4 id="named-properties-object">Named properties object</h4>
 
-For every [=interface=] declared with the
-[{{Global}}] or [{{PrimaryGlobal}}] [=extended attribute=]
+For every [=interface=] declared with the [{{Global}}] [=extended attribute=]
 that [=support named properties|supports named properties=],
 there must exist an object known as the
 <dfn id="dfn-named-properties-object" export>named properties object</dfn>
@@ -11051,7 +11106,7 @@ The property has the following characteristics:
 
 *   The name of the property is the [=identifier=] of the [=constant=].
 *   The location of the property is determined as follows:
-    *   If the interface was declared with the [{{Global}}] or [{{PrimaryGlobal}}] extended attribute,
+    *   If the interface was declared with the [{{Global}}] [=extended attribute=],
         then the property exists on the single object that implements the interface.
     *   Otherwise, if the interface has an [=interface prototype object=],
         then the property exists on it.
@@ -11074,7 +11129,7 @@ The characteristics of this property are as follows:
     *   If the attribute is a [=static attribute=],
         then there is a single corresponding property and it exists on the interface’s [=interface object=].
     *   Otherwise, if the attribute is [=unforgeable=] on
-        the interface or if the interface was declared with the [{{Global}}] or [{{PrimaryGlobal}}] extended attribute,
+        the interface or if the interface was declared with the [{{Global}}] [=extended attribute=],
         then the property exists on every object that implements the interface.
     *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 *   The property has attributes { \[[Get]]: |G|, \[[Set]]: |S|, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: |configurable| },
@@ -11230,7 +11285,7 @@ The characteristics of this property are as follows:
     *   If the operation is [=static operations|static=], then
         the property exists on the [=interface object=].
     *   Otherwise, if the operation is [=unforgeable=] on
-        the interface or if the interface was declared with the [{{Global}}] or [{{PrimaryGlobal}}] extended attribute,
+        the interface or if the interface was declared with the [{{Global}}] [=extended attribute=],
         then the property exists on every object that implements the interface.
     *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 *   The property has attributes
@@ -11406,14 +11461,17 @@ The [=return type=] of the [=default toJSON operation=] must be {{object}}.
     with a [{{Default}}] [=extended attribute=].
 
     <pre class=webidl>
+        [Exposed=Window]
         interface A : B {
           attribute DOMString a;
         };
 
+        [Exposed=Window]
         interface B : C {
           attribute DOMString b;
         };
 
+        [Exposed=Window]
         interface C {
           [Default] object toJSON();
           attribute DOMString c;
@@ -11473,7 +11531,7 @@ then there must exist a property with the following characteristics:
 
 *   The name of the property is “toString”.
 *   If the [=stringifier=] is [=unforgeable=] on the interface
-    or if the interface was declared with the [{{Global}}] or [{{PrimaryGlobal}}] extended attribute,
+    or if the interface was declared with the [{{Global}}] [=extended attribute=],
     then the property exists on every object that implements the interface.
     Otherwise, the property exists on the [=interface prototype object=].
 *   The property has attributes
@@ -11536,7 +11594,7 @@ and whose value is a [=function object=].
 
 The location of the property is determined as follows:
 
-*   If the interface was declared with the [{{Global}}] or [{{PrimaryGlobal}}] extended attribute,
+*   If the interface was declared with the [{{Global}}] [=extended attribute=],
     then the property exists on the single object that implements the interface.
 *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 
@@ -11612,7 +11670,7 @@ and whose value is a [=function object=].
 
 The location of the property is determined as follows:
 
-*   If the interface was declared with the [{{Global}}] or [{{PrimaryGlobal}}] extended attribute,
+*   If the interface was declared with the [{{Global}}] [=extended attribute=],
     then the property exists on the single object that implements the interface.
 *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 
@@ -11628,6 +11686,7 @@ then the [=function object=] is {{%ArrayProto_forEach%}}.
     instead of the [=iterable declaration=]:
 
     <pre highlight="webidl">
+      [Exposed=Window]
       interface Iterable {
         void forEach(Function callback, optional any thisArg);
       };
@@ -11712,7 +11771,7 @@ and whose value is a [=function object=].
 
 The location of the property is determined as follows:
 
-*   If the interface was declared with the [{{Global}}] or [{{PrimaryGlobal}}] extended attribute,
+*   If the interface was declared with the [{{Global}}] [=extended attribute=],
     then the property exists on the single object that implements the interface.
 *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 
@@ -11733,7 +11792,7 @@ and whose value is a [=function object=].
 
 The location of the property is determined as follows:
 
-*   If the interface was declared with the [{{Global}}] or [{{PrimaryGlobal}}] extended attribute,
+*   If the interface was declared with the [{{Global}}] [=extended attribute=],
     then the property exists on the single object that implements the interface.
 *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 
@@ -11776,7 +11835,7 @@ and whose value is a [=function object=].
 
 The location of the property is determined as follows:
 
-*   If the interface was declared with the [{{Global}}] or [{{PrimaryGlobal}}] extended attribute,
+*   If the interface was declared with the [{{Global}}] [=extended attribute=],
     then the property exists on the single object that implements the interface.
 *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 
@@ -12336,10 +12395,10 @@ extended attribute.
 
 <h4 id="platform-object-setprototypeof" oldids="platformobjectsetprototypeof">\[[SetPrototypeOf]]</h4>
 
-<div algorithm="to invoke the internal [[SetPrototypeOf]] method of a platform object that implements an interface with [Global] or [PrimaryGlobal] extended attribute">
+<div algorithm="to invoke the internal [[SetPrototypeOf]] method of a platform object that implements an interface with [Global] extended attribute">
 
     When the \[[SetPrototypeOf]] internal method of a [=platform object=] |O| that implements an
-    [=interface=] with the [{{Global}}] or [{{PrimaryGlobal}}] [=extended attribute=] is called with
+    [=interface=] with the [{{Global}}] [=extended attribute=] is called with
     ECMAScript language value |V|, the following step is taken:
 
     1.  Return [=?=] <a abstract-op>SetImmutablePrototype</a>(|O|, |V|).
@@ -12435,8 +12494,7 @@ and [[#legacy-platform-object-set]].
         1.  [=Invoke the indexed property setter=] with |P| and |Desc|.\[[Value]].
         1.  Return <emu-val>true</emu-val>.
     1.  If |O| [=support named properties|supports named properties=],
-        |O| does not implement an [=interface=] with the
-        [{{Global}}] or [{{PrimaryGlobal}}] [=extended attribute=],
+        |O| does not implement an [=interface=] with the [{{Global}}] [=extended attribute=],
         <a abstract-op>Type</a>(|P|) is String,
         and |P| is not an [=unforgeable property name=]
         of |O|, then:
@@ -12453,13 +12511,8 @@ and [[#legacy-platform-object-set]].
                     <emu-val>false</emu-val>.
                 1.  [=Invoke the named property setter=] with |P| and |Desc|.\[[Value]].
                 1.  Return <emu-val>true</emu-val>.
-    1.  If |O| does not implement an
-        [=interface=] with the
-        [{{Global}}] or
-        [{{PrimaryGlobal}}]
-        [=extended attribute=], then set
-        |Desc|.\[[Configurable]] to
-        <emu-val>true</emu-val>.
+    1.  If |O| does not implement an [=interface=] with the [{{Global}}] [=extended attribute=],
+        then set |Desc|.\[[Configurable]] to <emu-val>true</emu-val>.
     1.  Return <a abstract-op>OrdinaryDefineOwnProperty</a>(|O|, |P|, |Desc|).
 </div>
 
@@ -12477,8 +12530,7 @@ and [[#legacy-platform-object-set]].
         1.  If |index| is not a [=supported property indices|supported property index=], then return <emu-val>true</emu-val>.
         1.  Return <emu-val>false</emu-val>.
     1.  If |O| [=support named properties|supports named properties=],
-        |O| does not implement an [=interface=] with the
-        [{{Global}}] or [{{PrimaryGlobal}}] [=extended attribute=]
+        |O| does not implement an [=interface=] with the [{{Global}}] [=extended attribute=]
         and the result of calling the [=named property visibility algorithm=]
         with property name |P| and object |O| is true, then:
         1.  If |O| does not implement an interface with a [=named property deleter=], then return <emu-val>false</emu-val>.
@@ -13084,6 +13136,7 @@ A {{DOMException}} is represented by a
     executes). For example, consider the IDL:
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface MathUtils {
           // If x is negative, throws a "<a href="#notsupportederror">NotSupportedError</a>" <a href="dfn-DOMException">DOMException</a>.
           double computeSquareRoot(double x);
@@ -13134,10 +13187,12 @@ the exact steps to take if <dfn>an exception was thrown</dfn>, or by explicitly 
     to get its value.
 
     <pre highlight="webidl">
+        [Exposed=Window]
         interface Dahut {
           attribute DOMString type;
         };
 
+        [Exposed=Window]
         interface ExceptionThrower {
           // This attribute always throws a NotSupportedError and never returns a value.
           attribute long valueOf;
@@ -13571,6 +13626,7 @@ The following typographic conventions are used in this document:
 *   Variable names in prose and algorithms: <var ignore>exampleVariableName</var>.
 *   IDL informal syntax examples:
     <pre highlight="webidl" class="syntax">
+        [extended_attributes]
         interface identifier {
           <mark>/* interface_members... */</mark>
         };
@@ -13599,6 +13655,7 @@ The following typographic conventions are used in this document:
 *   Code blocks:
     <pre highlight="webidl">
         // This is an IDL code block.
+        [Exposed=Window]
         interface Example {
           attribute long something;
         };


### PR DESCRIPTION
Additionally:
- Annotate all interfaces in examples with [Exposed].
- Make [Global] allow a single identifier.

Fixes #365. 
Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=26425.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tobie/webidl/fix-365.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/a578ac5...tobie:79a0f33.html)


