### PR TITLE
Editorial: fix incorrect sentence about dictionaries

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4048,10 +4048,7 @@ Dictionaries must not be used as the type of an
 [=attribute=] or
 [=constant=].
 
-The following extended attributes are applicable to dictionaries:
-[{{Constructor}}],
-[{{Exposed}}],
-[{{SecureContext}}],
+No [=extended attributes=] are applicable to dictionaries.
 
 <div data-fill-with="grammar-Partial"></div>
 


### PR DESCRIPTION
This sentence mistakenly suggested dictionaries could be annotated
with various extended attributes. When in fact they cannot.

Closes #422


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tobie/webidl/fix-422.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/080bcea...tobie:cf5c1a4.html)