### PR TITLE
Add [LegacyNamespace] to allow defining an interface in a namespace

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8448,50 +8448,6 @@ corresponding to [=interface members=].
     </pre>
 </div>
 
-
-<h4 id="LegacyNamespace" extended-attribute lt="LegacyNamespace">[LegacyNamespace]</h4>
-
-If the [{{LegacyNamespace}}] [=extended attribute=] appears on an [=interface=], it indicates that
-the [=interface object=] for this interface will not be created as a property of the global
-object, but rather as a property of the [=namespace=] identified by the argument to the extended
-attribute.
-
-The [{{LegacyNamespace}}] extended attribute [=takes an identifier|take an identifier=].
-This identifier must be the identifier of a namespace.
-
-The [{{LegacyNamespace}}] and [{{NoInterfaceObject}}]
-extended attributes must not be specified on the same interface.
-
-The [{{LegacyNamespace}}] extended attribute
-must not be used on a [=callback interface=].
-
-See [[#namespace-object]] for details on how an interface is exposed on a namespace.
-
-<p class="advisement">
-    LegacyNamespace is discouraged for new specifications. Instead, interface names
-    can be formed with a naming convention of starting with a particular prefix for
-    a set of interfaces, as part of the identifier, rather than using a namespace.
-</p>
-
-<div class="example">
-    The following [=IDL fragment=] defines a [=namespace=] and an [=interface=] which
-    uses [{{LegacyNamespace}}] to be defined inside of it.
-
-    <pre highlight="webidl">
-        namespace Foo { };
-
-        [LegacyNamespace=Foo, Constructor]
-        interface Bar { };
-    </pre>
-
-    In an ECMAScript implementation of the above namespace and interface, the
-    constructor Bar can be accessed as follows:
-
-    <pre highlight="js">
-        var instance = new Foo.Bar();
-    </pre>
-</div>
-
 <h4 id="LegacyArrayClass" extended-attribute lt="LegacyArrayClass">[LegacyArrayClass]</h4>
 
 <div class="advisement">
@@ -8585,6 +8541,58 @@ entails.
     succeed on objects implementing <code class="idl">ImmutableItemList</code>.
     The exact behavior depends on the definition of the [=Array methods=] themselves.
 
+</div>
+
+
+<h4 id="LegacyNamespace" extended-attribute lt="LegacyNamespace">[LegacyNamespace]</h4>
+
+<p class="advisement">
+    The [{{LegacyArrayClass}}] [=extended attribute=] is an undesirable feature.
+    It exists only so that legacy Web platform features can be specified.
+    It should not be used in specifications
+    unless required to specify the behavior of legacy APIs,
+    or for consistency with these APIs.
+    Instead, interface names
+    can be formed with a naming convention of starting with a particular prefix for
+    a set of interfaces, as part of the identifier, rather than using a namespace.
+    Editors who wish to use this feature are strongly advised to discuss this
+    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyNamespace]">filing an issue</a>
+    before proceeding.
+</p>
+
+If the [{{LegacyNamespace}}] [=extended attribute=] appears on an [=interface=], it indicates that
+the [=interface object=] for this interface will not be created as a property of the global
+object, but rather as a property of the [=namespace=] identified by the argument to the extended
+attribute.
+
+The [{{LegacyNamespace}}] extended attribute [=takes an identifier|take an identifier=].
+This identifier must be the identifier of a namespace.
+
+The [{{LegacyNamespace}}] and [{{NoInterfaceObject}}]
+extended attributes must not be specified on the same interface.
+
+The [{{LegacyNamespace}}] extended attribute
+must not be used on a [=callback interface=].
+
+See [[#namespace-object]] for details on how an interface is exposed on a namespace.
+
+<div class="example">
+    The following [=IDL fragment=] defines a [=namespace=] and an [=interface=] which
+    uses [{{LegacyNamespace}}] to be defined inside of it.
+
+    <pre highlight="webidl">
+        namespace Foo { };
+
+        [LegacyNamespace=Foo, Constructor]
+        interface Bar { };
+    </pre>
+
+    In an ECMAScript implementation of the above namespace and interface, the
+    constructor Bar can be accessed as follows:
+
+    <pre highlight="js">
+        var instance = new Foo.Bar();
+    </pre>
 </div>
 
 

--- a/index.bs
+++ b/index.bs
@@ -8449,6 +8449,48 @@ corresponding to [=interface members=].
 </div>
 
 
+<h4 id="InNamespace" extended-attribute lt="InNamespace">[InNamespace]</h4>
+
+If the [{{InNamespace}}] [=extended attribute=] appears on an [=interface=], it indicates that
+the [=interface object=] for this interface will not be created as a property of the global
+object, but rather the namespace which is the argument to the extended attribute.
+
+The [{{InNamespace}}] extended attribute [=takes an identifier|take an identifier=].
+This identifier must be the identifier of a namespace.
+
+The [{{InNamespace}}] and [{{NoInterfaceObject}}]
+extended attributes must not be specified on the same interface.
+
+The [{{InNamespace}}] extended attribute
+must not be used on a [=callback interface=].
+
+The [=class string=] of an interface with the [{{InNamespace}}] extended
+attribute is the concatenation of the class string of the namespace, <code>"."</code>,
+and the class string that the interface would otherwise have without this
+extended attribute.
+
+See [[#namespace-object]] for details on how an interface is exposed on a namespace.
+
+
+<div class="example">
+    The following [=IDL fragment=] defines a [=namespace=] and an [=interface=] which
+    uses [{{InNamespace}}] to be defined inside of it.
+
+    <pre highlight="webidl">
+        namespace Foo { };
+
+        [InNamespace=Foo, Constructor]
+        interface Bar { };
+    </pre>
+
+    In an ECMAScript implementation of the above namespace and interface, the
+    constructor Bar can be accessed as follows:
+
+    <pre highlight="js">
+        var instance = new Foo.Bar();
+    </pre>
+</div>
+
 <h4 id="LegacyArrayClass" extended-attribute lt="LegacyArrayClass">[LegacyArrayClass]</h4>
 
 <div class="advisement">
@@ -10135,7 +10177,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
 
 For every non-callback [=interface=] that is [=exposed=] in
 a given ECMAScript global environment and that is not declared with
-the [{{NoInterfaceObject}}] [=extended attribute=],
+the [{{NoInterfaceObject}}] or [{{InNamespace}}] [=extended attribute|extended attributes=],
 a corresponding property must exist on the ECMAScript environment's global object.
 The name of the property is the [=identifier=] of the interface,
 and its value is an object called the <dfn id="dfn-interface-object" export>interface object</dfn>.
@@ -12651,6 +12693,10 @@ The characteristics of a namespace object are described in [[#namespace-object]]
         1.  Let |F| be the result of [=creating an operation function|creating an operation function=]
             given |op|, |namespace|,  and |realm|.
         1.  Perform [=!=] [=CreateDataProperty=](|namespaceObject|, |op|'s [=identifier=], |F|).
+    1.  For each [=exposed=] [=interface=] |intr| which has the [{{InNamespace}}] extended attribute, with the identifier of this namespace as its argument,
+        1.  Let |I| be the [=interface object=] for |intr|.
+        1.  Let |newDesc| be the PropertyDescriptor{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>, \[[Value]]: |I| }.
+        1.  Perform [=!=] [=DefinePropertyOrThrow=](|namespaceObject|, |intr|'s [=identifier=], |newDesc|).
 </div>
 
 

--- a/index.bs
+++ b/index.bs
@@ -8449,37 +8449,46 @@ corresponding to [=interface members=].
 </div>
 
 
-<h4 id="InNamespace" extended-attribute lt="InNamespace">[InNamespace]</h4>
+<h4 id="LegacyNamespace" extended-attribute lt="LegacyNamespace">[LegacyNamespace]</h4>
 
-If the [{{InNamespace}}] [=extended attribute=] appears on an [=interface=], it indicates that
+If the [{{LegacyNamespace}}] [=extended attribute=] appears on an [=interface=], it indicates that
 the [=interface object=] for this interface will not be created as a property of the global
-object, but rather the namespace which is the argument to the extended attribute.
+object, but rather as a property of the [=namespace=] identified by the argument to the extended
+attribute.
 
-The [{{InNamespace}}] extended attribute [=takes an identifier|take an identifier=].
+The [{{LegacyNamespace}}] extended attribute [=takes an identifier|take an identifier=].
 This identifier must be the identifier of a namespace.
 
-The [{{InNamespace}}] and [{{NoInterfaceObject}}]
+The [{{LegacyNamespace}}] and [{{NoInterfaceObject}}]
 extended attributes must not be specified on the same interface.
 
-The [{{InNamespace}}] extended attribute
+The [{{LegacyNamespace}}] extended attribute
 must not be used on a [=callback interface=].
-
-The [=class string=] of an interface with the [{{InNamespace}}] extended
-attribute is the concatenation of the class string of the namespace, <code>"."</code>,
-and the class string that the interface would otherwise have without this
-extended attribute.
 
 See [[#namespace-object]] for details on how an interface is exposed on a namespace.
 
+<p class="advisement">
+    LegacyNamespace is discouraged for new specifications. Instead, interface names
+    can be formed with a naming convention of starting with a particular prefix for
+    a set of interfaces, as part of the identifier, rather than using a namespace.
+</p>
+
+callers are universally recognised as an undesirable feature.  They exist
+    only so that legacy Web platform features can be specified.  Legacy callers
+    should not be used in specifications unless required to
+    specify the behavior of legacy APIs, and even then this should be discussed on
+    the <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
+    mailing list before proceeding.
+</p>
 
 <div class="example">
     The following [=IDL fragment=] defines a [=namespace=] and an [=interface=] which
-    uses [{{InNamespace}}] to be defined inside of it.
+    uses [{{LegacyNamespace}}] to be defined inside of it.
 
     <pre highlight="webidl">
         namespace Foo { };
 
-        [InNamespace=Foo, Constructor]
+        [LegacyNamespace=Foo, Constructor]
         interface Bar { };
     </pre>
 
@@ -10177,7 +10186,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
 
 For every non-callback [=interface=] that is [=exposed=] in
 a given ECMAScript global environment and that is not declared with
-the [{{NoInterfaceObject}}] or [{{InNamespace}}] [=extended attribute|extended attributes=],
+the [{{NoInterfaceObject}}] or [{{LegacyNamespace}}] [=extended attribute|extended attributes=],
 a corresponding property must exist on the ECMAScript environment's global object.
 The name of the property is the [=identifier=] of the interface,
 and its value is an object called the <dfn id="dfn-interface-object" export>interface object</dfn>.
@@ -11998,6 +12007,10 @@ must be the [=identifier=] of
 the [=primary interface=]
 of the platform object.
 
+The [=class string=] of an interface with the [{{LegacyNamespace}}] extended
+attribute is the concatenation of the class string of the namespace, ".",
+and the class string that the interface would otherwise have without this
+extended attribute.
 
 <h4 id="platform-object-setprototypeof" oldids="platformobjectsetprototypeof">\[[SetPrototypeOf]]</h4>
 
@@ -12693,10 +12706,12 @@ The characteristics of a namespace object are described in [[#namespace-object]]
         1.  Let |F| be the result of [=creating an operation function|creating an operation function=]
             given |op|, |namespace|,  and |realm|.
         1.  Perform [=!=] [=CreateDataProperty=](|namespaceObject|, |op|'s [=identifier=], |F|).
-    1.  For each [=exposed=] [=interface=] |intr| which has the [{{InNamespace}}] extended attribute, with the identifier of this namespace as its argument,
-        1.  Let |I| be the [=interface object=] for |intr|.
-        1.  Let |newDesc| be the PropertyDescriptor{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>, \[[Value]]: |I| }.
-        1.  Perform [=!=] [=DefinePropertyOrThrow=](|namespaceObject|, |intr|'s [=identifier=], |newDesc|).
+    1.  For each [=exposed=] [=interface=] |interface| which has the [{{LegacyNamespace}}] extended
+        attribute with the identifier of this namespace as its argument,
+        1.  Let |I| be the [=interface object=] for |interface|.
+        1.  Let |newDesc| be the PropertyDescriptor{\[[Writable]]: <emu-val>true</emu-val>,
+            \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>, \[[Value]]: |I|}.
+        1.  Perform [=!=] [=DefinePropertyOrThrow=](|namespaceObject|, |interface|'s [=identifier=], |newDesc|).
 </div>
 
 

--- a/index.bs
+++ b/index.bs
@@ -8473,14 +8473,6 @@ See [[#namespace-object]] for details on how an interface is exposed on a namesp
     a set of interfaces, as part of the identifier, rather than using a namespace.
 </p>
 
-callers are universally recognised as an undesirable feature.  They exist
-    only so that legacy Web platform features can be specified.  Legacy callers
-    should not be used in specifications unless required to
-    specify the behavior of legacy APIs, and even then this should be discussed on
-    the <a href="mailto:public-script-coord@w3.org">public-script-coord@w3.org</a>
-    mailing list before proceeding.
-</p>
-
 <div class="example">
     The following [=IDL fragment=] defines a [=namespace=] and an [=interface=] which
     uses [{{LegacyNamespace}}] to be defined inside of it.

--- a/index.bs
+++ b/index.bs
@@ -8547,7 +8547,7 @@ entails.
 <h4 id="LegacyNamespace" extended-attribute lt="LegacyNamespace">[LegacyNamespace]</h4>
 
 <p class="advisement">
-    The [{{LegacyArrayClass}}] [=extended attribute=] is an undesirable feature.
+    The [{{LegacyNamespace}}] [=extended attribute=] is an undesirable feature.
     It exists only so that legacy Web platform features can be specified.
     It should not be used in specifications
     unless required to specify the behavior of legacy APIs,
@@ -10186,7 +10186,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
 
 For every non-callback [=interface=] that is [=exposed=] in
 a given ECMAScript global environment and that is not declared with
-the [{{NoInterfaceObject}}] or [{{LegacyNamespace}}] [=extended attribute|extended attributes=],
+the [{{NoInterfaceObject}}] or [{{LegacyNamespace}}] [=extended attributes=],
 a corresponding property must exist on the ECMAScript environment's global object.
 The name of the property is the [=identifier=] of the interface,
 and its value is an object called the <dfn id="dfn-interface-object" export>interface object</dfn>.


### PR DESCRIPTION
This is necessary to specify certain APIs such as WebAssembly,
which includes several constructors as properties of the root
WebAssembly object. See a WebAssembly draft specification where
this is in use at https://github.com/littledan/spec/blob/new-js.bs/document/JS.bs


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/littledan/webidl/namespace-interface.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/f869be8...littledan:7f1899b.html)