### PR TITLE
Meta: Use OrdinarySetWithOwnDescriptor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -101,7 +101,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: OrdinaryGetOwnProperty; url: sec-ordinarygetownproperty
         text: OrdinaryDefineOwnProperty; url: sec-ordinarydefineownproperty
         text: OrdinaryPreventExtensions; url: sec-ordinarypreventextensions
-        text: OrdinarySet; url: sec-ordinaryset
+        text: OrdinarySetWithOwnDescriptor; url: sec-ordinarysetwithowndescriptor
         text: equally close values; url: sec-ecmascript-language-types-number-type
         text: internal slot; url: sec-object-internal-methods-and-internal-slots
         text: JavaScript execution context stack; url: execution-context-stack
@@ -12086,8 +12086,7 @@ and [[#legacy-platform-object-set]].
             1.  [=Invoke the named property setter=] with |P| and |V|.
             1.  Return <emu-val>true</emu-val>.
     1.  Let |ownDesc| be <a abstract-op>LegacyPlatformObjectGetOwnProperty</a>(|O|, |P|, <emu-val>true</emu-val>).
-    1.  Perform [=?=] [=OrdinarySet=](|O|, |P|, |V|, |Receiver|) from step 3 onwards
-        with its internal "ownDesc" variable set to |ownDesc|.
+    1.  Perform [=?=] [=OrdinarySetWithOwnDescriptor=](|O|, |P|, |V|, |Receiver|, |ownDesc|).
 </div>
 
 


### PR DESCRIPTION
Closes #201.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/heycam/webidl/tobie-OrdinarySetWithOwnDescriptor.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/931394e...2f447b5.html)