### PR TITLE
Editorial: fix spelling mistakes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4983,7 +4983,7 @@ an implementation of a given set of IDL fragments needs to be able to recognize 
 that are created by the implementation.  This might be done by having some internal state that records whether
 a given object is indeed a platform object for that implementation, or perhaps by observing
 that the object is implemented by a given internal C++ class.  How exactly platform objects
-are recognised by a given implementation of a set of IDL fragments is implementation specific.
+are recognized by a given implementation of a set of IDL fragments is implementation specific.
 
 All other objects in the system would not be treated as platform objects.  For example, assume that
 a web page opened in a browser loads an ECMAScript library that implements DOM Core.  This library
@@ -5403,7 +5403,7 @@ While {{DOMString}} is defined to be
 an OMG IDL boxed [=sequence type|sequence=]&lt;{{unsigned short}}&gt; valuetype
 in [[DOM-LEVEL-3-CORE/core#ID-C74D1578|DOM Level 3 Core §The DOMString Type]],
 this document defines {{DOMString}} to be an intrinsic type
-so as to avoidspecial casing that sequence type
+so as to avoid special casing that sequence type
 in various situations where a string is required.
 
 Note: Note also that <emu-val>null</emu-val>
@@ -5483,7 +5483,7 @@ The [=type name=] of the
 <p class="advisement">
     Specifications should only use
     {{ByteString}} for interfacing with protocols
-    that use bytes and strings interchangably, such as HTTP.  In general,
+    that use bytes and strings interchangeably, such as HTTP.  In general,
     strings should be represented with
     {{DOMString}} values, even if it is expected
     that values of the string will always be in ASCII or some
@@ -6053,7 +6053,7 @@ byte values using that reference.
 <div class="advisement">
 
     Extreme care must be taken when writing specification text that gets a reference
-    to the bytes held by a buffer source, as the underyling data can easily be changed
+    to the bytes held by a buffer source, as the underlying data can easily be changed
     by the script author or other APIs at unpredictable times.  If you are using a buffer source type
     as an operation argument to obtain a chunk of binary data that will not be modified,
     it is strongly recommended to get a copy of the buffer source’s bytes at the beginning
@@ -8322,7 +8322,7 @@ See
 [[#es-interfaces]],
 [[#es-constants]],
 [[#es-attributes]],
-[[#es-operations]] and
+[[#es-operations]], and
 [[#es-iterators]]
 for the specific requirements that the use of
 [{{Exposed}}] entails.
@@ -10539,7 +10539,7 @@ whose value is a reference to the [=interface object=] for the interface.
     the [=interface object=]
     (since it does not exist as <code>window.Foo</code>).  However, an instance
     of <code class="idl">Foo</code> can expose the interface prototype
-    object by gettings its internal \[[Prototype]]
+    object by getting its internal \[[Prototype]]
     property value – <code>Object.getPrototypeOf(window.foo)</code> in
     this example.
 
@@ -11582,7 +11582,7 @@ When a [=default iterator object=] is first created,
 its index is set to 0.
 
 The [=class string=] of a [=default iterator object=] for a given [=interface=]
-is the result of concatenting the [=identifier=] of the [=interface=]
+is the result of concatenating the [=identifier=] of the [=interface=]
 and the string “Iterator”.
 
 
@@ -11646,7 +11646,7 @@ must be [=%IteratorPrototype%=].
 </div>
 
 The [=class string=] of an [=iterator prototype object=] for a given [=interface=]
-is the result of concatenting the [=identifier=] of the [=interface=]
+is the result of concatenating the [=identifier=] of the [=interface=]
 and the string “Iterator”.
 
 
@@ -12030,7 +12030,7 @@ must exist on |A|’s
         1.  Let |idlValue| be the result of [=converted to an IDL value|converting=] |arg| to an IDL value of type |type|.
         1.  Let |value| be the result of [=converted to ECMAScript values|converting=] |idlValue| to an ECMAScript value.
         1.  Let |result| be [=!=] <a abstract-op>Call</a>(|function|, |set|, «|value|»).
-        1.  If |name| is "delete", then retun |result|.
+        1.  If |name| is "delete", then return |result|.
         1.  Otherwise, return |O|.
     </div>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tobie/webidl/fix-spelling.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/93f9ef0...tobie:bdd1a64.html)