### PR TITLE
Standardize around typography of IDL true/false/null

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -32,6 +32,9 @@ Default Biblio Status: current
 spec: infra; type: dfn; text: list
 spec: url; type: interface; text: URL
 spec: dom; type: interface; text: Document
+spec: ecma-262; type: dfn; for: /
+    text:internal method
+    text:internal slot
 </pre>
 
 <pre class="anchors">

--- a/index.bs
+++ b/index.bs
@@ -1536,7 +1536,7 @@ empty sequence <code>[]</code> cannot be used as the value of a
 
 The value of the boolean literal tokens <emu-t>true</emu-t> and
 <emu-t>false</emu-t> are the IDL {{boolean}} values
-<code class="idl">true</code> and <code class="idl">false</code>.
+true and false.
 
 <div algorithm="value of integer tokens">
 
@@ -1616,7 +1616,7 @@ Also, <emu-t>Infinity</emu-t>, <emu-t>-Infinity</emu-t> and <emu-t>NaN</emu-t> m
 be used as the value of a {{float}} or {{double}}.
 
 The value of the <emu-t>null</emu-t> token is the special
-<emu-val>null</emu-val> value that is a member of the
+null value that is a member of the
 [=nullable types=].  The type of
 the <emu-t>null</emu-t> token is the same as the
 type of the constant, dictionary member or optional argument it is being used as the value of.
@@ -2154,9 +2154,9 @@ corresponding argument omitted.
 
 <p class="advisement">
     It is strongly suggested not to use a [=optional argument/default value=]
-    of <emu-val>true</emu-val> for {{boolean}}-typed arguments,
+    of true for {{boolean}}-typed arguments,
     as this can be confusing for authors who might otherwise expect the default
-    conversion of <emu-val>undefined</emu-val> to be used (i.e., <emu-val>false</emu-val>).
+    conversion of <emu-val>undefined</emu-val> to be used (i.e., false).
 </p>
 
 If the type of an argument is a [=dictionary type=] or a [=union type=] that has a dictionary as one
@@ -2735,10 +2735,10 @@ a [=static attribute=].
         Objects that implement the <code class="idl">Student</code>
         interface must stringify as follows.  If the value of the
         <code class="idl">familyName</code> attribute is
-        <emu-val>null</emu-val>, the stringification of the
+        null, the stringification of the
         object is the value of the <code class="idl">givenName</code>
         attribute.  Otherwise, if the value of the
-        <code class="idl">familyName</code> attribute is not <emu-val>null</emu-val>,
+        <code class="idl">familyName</code> attribute is not null,
         the stringification of the object is the concatenation of the
         value of the <code class="idl">givenName</code> attribute,
         a single space character, and the value of
@@ -2866,7 +2866,7 @@ The following requirements apply to the definitions of indexed property getters 
     operations with identifiers, the only additional prose
     that is necessary is that which describes what keys those sets
     have.  Assuming that the <code>get()</code> operation is
-    defined to return <emu-val>null</emu-val> if an
+    defined to return null if an
     attempt is made to look up a non-existing entry in the
     <code class="idl">OrderedMap</code>, then the following
     two sentences would suffice:
@@ -3294,7 +3294,7 @@ the same operation or constructor.
 </div>
 
 Two types are <dfn id="dfn-distinguishable" export>distinguishable</dfn> if
-the following algorithm returns <i>true</i>.
+the following algorithm returns true.
 
 <ol class="algorithm">
 1.  If one type [=includes a nullable type=]
@@ -3334,21 +3334,21 @@ the following algorithm returns <i>true</i>.
         </ul>
     </div>
 1.  If both types are either a [=union type=] or [=nullable type|nullable=] [=union type=],
-    return <i>true</i> if each member type of the one
+    return true if each member type of the one
     is distinguishable with each member type of the other,
-    or <i>false</i> otherwise.
+    or false otherwise.
 1.  If one type is a [=union type=] or nullable union type,
-    return <i>true</i> if each
+    return true if each
     [=member type=] of the union type is distinguishable
     with the non-union type,
-    or <i>false</i> otherwise.
+    or false otherwise.
 1.  Consider the two "innermost" types derived by taking each type's [=annotated types/inner type=]
     if it is an [=annotated type=], and then taking its [=nullable types/inner type=] inner type
     if the result is a [=nullable type=]. If these two innermost types appear or are in categories
     appearing in the following table and there is a “●” mark in the corresponding entry
     or there is a letter in the corresponding entry and the designated additional
-    requirement below the table is satisfied, then return <i>true</i>.
-    Otherwise return <i>false</i>.
+    requirement below the table is satisfied, then return true.
+    Otherwise return false.
 
     Categories:
     <dl>
@@ -4380,12 +4380,12 @@ dictionary members.
 
 <p class="advisement">
     As with [=optional argument/default value|operation argument default values=],
-    it is strongly suggested not to use <emu-val>true</emu-val> as the
+    it is strongly suggested not to use true as the
     [=dictionary member/default value=] for
     {{boolean}}-typed
     [=dictionary members=],
     as this can be confusing for authors who might otherwise expect the default
-    conversion of <emu-val>undefined</emu-val> to be used (i.e., <emu-val>false</emu-val>).
+    conversion of <emu-val>undefined</emu-val> to be used (i.e., false).
 </p>
 
 Each [=dictionary member=] (matching
@@ -5423,7 +5423,7 @@ value is known as its <dfn id="dfn-specific-type" export>specific type</dfn>.
 <h4 oldids="dom-boolean" id="idl-boolean" interface>boolean</h4>
 
 The {{boolean}} type has two values:
-<code class="idl">true</code> and <code class="idl">false</code>.
+true and false.
 
 {{boolean}} constant values in IDL are
 represented with the <emu-t>true</emu-t> and
@@ -5614,11 +5614,11 @@ this document defines {{DOMString}} to be an intrinsic type
 so as to avoid special casing that sequence type
 in various situations where a string is required.
 
-Note: Note also that <emu-val>null</emu-val>
+Note: Note also that null
 is not a value of type {{DOMString}}.
-To allow <emu-val>null</emu-val>, a
+To allow null, a
 [=nullable type|nullable=] {{DOMString}},
-written as <code>DOMString?</code> in IDL, needs to be used.
+written as <code class="idl">DOMString?</code> in IDL, needs to be used.
 
 Nothing in this specification requires a {{DOMString}}
 value to be a valid UTF-16 string.  For example, a {{DOMString}}
@@ -5738,7 +5738,7 @@ There is no way to represent a constant {{object}}
 value in IDL.
 
 To denote a type that includes all possible object references plus the
-<emu-val>null</emu-val> value, use the [=nullable type=]
+null value, use the [=nullable type=]
 <code class="idl">object?</code>.
 
 The [=type name=] of the
@@ -5775,7 +5775,7 @@ There is no way to represent a constant object reference value for
 a particular interface type in IDL.
 
 To denote a type that includes all possible references to objects implementing
-the given interface plus the <emu-val>null</emu-val> value,
+the given interface plus the null value,
 use a [=nullable type=].
 
 The [=type name=] of an interface type
@@ -5841,7 +5841,7 @@ is the [=identifier=] of the callback function.
 
 A <dfn id="dfn-nullable-type" export>nullable type</dfn> is an IDL type constructed
 from an existing type (called the <dfn id="dfn-inner-type" export for="nullable types">inner type</dfn>),
-which just allows the additional value <emu-val>null</emu-val>
+which just allows the additional value null
 to be a member of its set of values.  [=Nullable types=]
 are represented in IDL by placing a <span class="char">U+003F QUESTION MARK ("?")</span>
 character after an existing type.
@@ -5866,8 +5866,8 @@ the string “OrNull”.
 
 <div class="example">
 
-    For example, a type that allows the values <emu-val>true</emu-val>,
-    <emu-val>false</emu-val> and <emu-val>null</emu-val>
+    For example, a type that allows the values true,
+    false and null
     is written as <code class="idl">boolean?</code>:
 
     <pre highlight="webidl">
@@ -5878,9 +5878,9 @@ the string “OrNull”.
 
     The following [=interface=] has two
     [=attributes=]: one whose value can
-    be a {{DOMString}} or the <emu-val>null</emu-val>
+    be a {{DOMString}} or the null
     value, and another whose value can be a reference to a <code class="idl">Node</code>
-    object or the <emu-val>null</emu-val> value:
+    object or the null value:
 
     <pre highlight="webidl">
         interface Node {
@@ -6576,7 +6576,7 @@ which alternative definitions are not given are the same as [=ordinary object/in
 methods|those=] of ordinary objects.
 
 Unless otherwise specified, the \[[Extensible]] internal slot
-of objects defined in this section has the value <emu-val>true</emu-val>.
+of objects defined in this section has the value true.
 
 Unless otherwise specified, the \[[Prototype]] internal slot
 of objects defined in this section is {{%ObjectPrototype%}}.
@@ -6733,11 +6733,11 @@ ECMAScript value type.
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL {{any}} value by running the following algorithm:
 
-    1.  If |V| is <emu-val>undefined</emu-val>, then
+    1.  If <a abstract-op>Type</a>(|V|) is Undefined, then
         return an {{object}} reference to a special object that represents
         the ECMAScript <emu-val>undefined</emu-val> value.
-    1.  If |V| is <emu-val>null</emu-val>, then
-        return the <emu-val>null</emu-val> {{object|object?}} reference.
+    1.  If <a abstract-op>Type</a>(|V|) is Null, then
+        return the null {{object}}<code class="idl">[=nullable type|?=]</code> reference.
     1.  If <a abstract-op>Type</a>(|V|) is Boolean, then
         return the {{boolean}} value that represents the same truth value.
     1.  If <a abstract-op>Type</a>(|V|) is Number, then
@@ -6794,10 +6794,10 @@ may return any value, which will be discarded.
 </div>
 
 <p id="boolean-to-es">
-    The IDL {{boolean}} value <code class="idl">true</code>
+    The IDL {{boolean}} value true
     is [=converted to an ECMAScript value|converted=] to
     the ECMAScript <emu-val>true</emu-val> value and the IDL {{boolean}}
-    value <code class="idl">false</code> is converted to the ECMAScript
+    value false is converted to the ECMAScript
     <emu-val>false</emu-val> value.
 </p>
 
@@ -7414,7 +7414,7 @@ IDL [=callback function types=] are represented by ECMAScript [=function objects
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL [=callback function type=] value by running the following algorithm:
 
-    1.  If the result of calling <a abstract-op>IsCallable</a>(|V|) is <emu-val>false</emu-val>
+    1.  If the result of calling <a abstract-op>IsCallable</a>(|V|) is false
         and the conversion to an IDL value
         is not being performed due
         to |V| being assigned to an [=attribute=]
@@ -7455,10 +7455,10 @@ the ECMAScript <emu-val>null</emu-val> value.
         that is annotated with [{{TreatNonObjectAsNull}}],
         then return the IDL
         [=nullable type=] <code class="idl">|T|?</code>
-        value <emu-val>null</emu-val>.
+        value null.
     1.  Otherwise, if |V| is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, then return the IDL
         [=nullable type=] <code class="idl">|T|?</code>
-        value <emu-val>null</emu-val>.
+        value null.
     1.  Otherwise, return the result of
         [=converted to an IDL value|converting=] |V|
         using the rules for the [=nullable types/inner type|inner IDL type=] <code class="idl">T</code>.
@@ -7470,7 +7470,7 @@ the ECMAScript <emu-val>null</emu-val> value.
     an IDL [=nullable type=] value to an ECMAScript value is:
 
     1.  If the IDL [=nullable type=] <code class="idl">|T|?</code>
-        value is <emu-val>null</emu-val>,
+        value is null,
         then the ECMAScript value is <emu-val>null</emu-val>.
     1.  Otherwise, the ECMAScript value is the result of
         [=converted to an ECMAScript value|converting=]
@@ -7531,7 +7531,7 @@ ECMAScript Array values.
     1.  Initialize |i| to be 0.
     1.  Repeat
         1.  Let |next| be [=?=] <a abstract-op>IteratorStep</a>(|iter|).
-        1.  If |next| is <emu-val>false</emu-val>,
+        1.  If |next| is false,
             then return an IDL sequence value of type
             <a lt="sequence type">sequence&lt;|T|&gt;</a>
             of length |i|, where the value of the element
@@ -7637,7 +7637,7 @@ ECMAScript Object values.
     1.  [=list/For each=] |key| of |keys|:
         1.  Let |desc| be [=?=] |O|.\[[GetOwnProperty]](|key|).
         1.  If |desc| is not <emu-val>undefined</emu-val>
-            and |desc|.\[[Enumerable]] is <emu-val>true</emu-val>:
+            and |desc|.\[[Enumerable]] is true:
             1.  Let |typedKey| be |key| [=converted to an IDL value=] of type |K|.
             1.  Let |value| be [=?=] <a abstract-op>Get</a>(|O|, |key|).
             1.  Let |typedValue| be |value| [=converted to an IDL value=] of type |V|.
@@ -7659,7 +7659,7 @@ ECMAScript Object values.
         1.  Let |esKey| be |key| [=converted to an ECMAScript value=].
         1.  Let |esValue| be |value| [=converted to an ECMAScript value=].
         1.  Let |created| be [=!=] <a abstract-op>CreateDataProperty</a>(|result|, |esKey|, |esValue|).
-        1.  Assert: |created| is <emu-val>true</emu-val>.
+        1.  Assert: |created| is true.
     1.  Return |result|.
 </div>
 
@@ -7768,7 +7768,7 @@ objects.
         1.  Otherwise, return the result of performing any steps that were required to be run if the promise was rejected,
             with |reason| as the rejection reason.
     1.  Let |then| be the result of calling the internal \[[Get]] method of |promise| with property name “then”.
-    1.  If <a abstract-op>IsCallable</a>(|then|) is <emu-val>false</emu-val>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+    1.  If <a abstract-op>IsCallable</a>(|then|) is false, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return the result of calling |then| with |promise| as the <emu-val>this</emu-val> value and |onFulfilled| and |onRejected|
         as its two arguments.
 </div>
@@ -7791,7 +7791,7 @@ that correspond to the union’s [=member types=].
     1.  If the [=union type=]
         [=includes a nullable type=] and
         |V| is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>,
-        then return the IDL value <emu-val>null</emu-val>.
+        then return the IDL value null.
     1.  Let |types| be the [=flattened member types=]
         of the [=union type=].
     1.  If |V| is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, then:
@@ -9993,7 +9993,7 @@ then it indicates that any value assigned to an [=attribute=]
 whose type is a [=nullable type|nullable=]
 [=callback function=]
 that is not an object will be converted to
-the <emu-val>null</emu-val> value.
+the null value.
 
 See [[#es-nullable-type]]
 for the specific requirements that the use of
@@ -10068,7 +10068,7 @@ The [{{TreatNullAs}}] extended attribute must not be
 [=extended attribute associated with|associated with=] a type that is not {{DOMString}}.
 
 Note: This means that even <code class="idl">DOMString?</code> must not use [{{TreatNullAs}}], since
-<emu-val>null</emu-val> is a valid value of that type.
+null is a valid value of that type.
 
 See [[#es-DOMString]] for the specific requirements that the use of [{{TreatNullAs}}] entails.
 
@@ -10606,7 +10606,7 @@ the [{{NoInterfaceObject}}] or [{{LegacyNamespace}}] [=extended attributes=],
 a corresponding property must exist on the ECMAScript environment's global object.
 The name of the property is the [=identifier=] of the interface,
 and its value is an object called the <dfn id="dfn-interface-object" export>interface object</dfn>.
-The property has the attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
+The property has the attributes { \[[Writable]]: true, \[[Enumerable]]: false, \[[Configurable]]: true }.
 The characteristics of an interface object are described in [[#interface-object]].
 
 If the [{{LegacyWindowAlias}}] extended attribute was specified on an [=exposed=] interface,
@@ -10615,7 +10615,7 @@ there must be a corresponding property on the [=primary global interface=].
 The name of the property is the given [=LegacyWindowAlias identifier|identifier=],
 and its value is a reference to the [=interface object=] for the [=interface=].
 The property has the attributes
-{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
+{ \[[Writable]]: true, \[[Enumerable]]: false, \[[Configurable]]: true }.
 
 In addition, for every [{{NamedConstructor}}] extended attribute on an [=exposed=] interface,
 a corresponding property must exist on the ECMAScript global object.
@@ -10623,7 +10623,7 @@ The name of the property is the [{{NamedConstructor}}]'s [=NamedConstructor iden
 and its value is an object called a <dfn id="dfn-named-constructor" export>named constructor</dfn>,
 which allows construction of objects that implement the interface.
 The property has the attributes
-{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
+{ \[[Writable]]: true, \[[Enumerable]]: false, \[[Configurable]]: true }.
 The characteristics of a named constructor are described in [[#named-constructors]].
 
 
@@ -10693,10 +10693,10 @@ the <code>typeof</code> operator will return "function" when applied to an inter
         1.  Set |length| to the length of the
             shortest argument list of the entries in |S|.
     1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "length",
-        PropertyDescriptor{\[[Value]]: |length|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
+        PropertyDescriptor{\[[Value]]: |length|, \[[Writable]]: false, \[[Enumerable]]: false, \[[Configurable]]: true}).
     1.  Let |proto| be the [=interface prototype object=] of [=interface=] |I|.
     1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "prototype",
-        PropertyDescriptor{\[[Value]]: |proto|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>false</emu-val>}).
+        PropertyDescriptor{\[[Value]]: |proto|, \[[Writable]]: false, \[[Enumerable]]: false, \[[Configurable]]: false}).
 </div>
 
 
@@ -10739,10 +10739,10 @@ This object's relevant [=Realm=] must be the same as that of the [=named constru
         and with argument count 0.
     1.  Let |length| be the length of the shortest argument list of the entries in |S|.
     1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "length",
-        PropertyDescriptor{\[[Value]]: |length|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
+        PropertyDescriptor{\[[Value]]: |length|, \[[Writable]]: false, \[[Enumerable]]: false, \[[Configurable]]: true}).
     1.  Let |proto| be the [=interface prototype object=] of [=interface=] |I|.
     1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "prototype",
-        PropertyDescriptor{\[[Value]]: |proto|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>false</emu-val>}).
+        PropertyDescriptor{\[[Value]]: |proto|, \[[Writable]]: false, \[[Enumerable]]: false, \[[Configurable]]: false}).
 </div>
 
 
@@ -10766,7 +10766,7 @@ described in [[#es-constants]].
 If the [{{NoInterfaceObject}}] extended attribute was not specified on the interface,
 then the [=interface prototype object=] must also
 have a property named “constructor” with attributes
-{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
+{ \[[Writable]]: true, \[[Enumerable]]: false, \[[Configurable]]: true }
 whose value is a reference to the [=interface object=] for the interface.
 
 <div algorithm="value of internal prototype property">
@@ -10827,7 +10827,7 @@ whose value is a reference to the [=interface object=] for the interface.
     then there must be a property on the
     interface prototype object whose name is the {{@@unscopables}} symbol,
     which has the attributes
-    { \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> },
+    { \[[Writable]]: false, \[[Enumerable]]: false, \[[Configurable]]: true },
     and whose value is an object created as follows:
 
     1.  Let |object| be a new object created as if by the expression <code>({})</code>.
@@ -10835,7 +10835,7 @@ whose value is a reference to the [=interface object=] for the interface.
         declared with the [{{Unscopable}}] extended attribute,
         call <a abstract-op>CreateDataProperty</a>(|object|,
         the [=identifier=] of the
-        interface member, <emu-val>true</emu-val>).
+        interface member, true).
     1.  Return |object|.
 </div>
 
@@ -10858,7 +10858,7 @@ a corresponding property must exist on the ECMAScript environment's global objec
 The name of the property is the [=identifier=] of the interface,
 and its value is an object called the
 <dfn id="dfn-legacy-callback-interface-object" export>legacy callback interface object</dfn>.
-The property has the attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
+The property has the attributes { \[[Writable]]: true, \[[Enumerable]]: false, \[[Configurable]]: true }.
 
 The [=legacy callback interface object=] for a given [=callback interface=]
 is a [=built-in function object=].
@@ -10880,7 +10880,7 @@ when applied to a [=legacy callback interface object=].
     1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|realm|, |steps|, the {{%FunctionPrototype%}} of |realm|).
     1.  Perform [=!=] <a abstract-op>SetFunctionName</a>(|F|, |id|).
     1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "length",
-        PropertyDescriptor{\[[Value]]: 0, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
+        PropertyDescriptor{\[[Value]]: 0, \[[Writable]]: false, \[[Enumerable]]: false, \[[Configurable]]: true}).
 </div>
 
 
@@ -10944,10 +10944,10 @@ is the concatenation of the [=interface=]’s
         1.  If |A| implements an interface with the
             [{{LegacyUnenumerableNamedProperties}}]
             [=extended attribute=],
-            then set |desc|.\[[Enumerable]] to <emu-val>false</emu-val>,
-            otherwise set it to <emu-val>true</emu-val>.
-        1.  Set |desc|.\[[Writable]] to <emu-val>true</emu-val> and
-            |desc|.\[[Configurable]] to <emu-val>true</emu-val>.
+            then set |desc|.\[[Enumerable]] to false,
+            otherwise set it to true.
+        1.  Set |desc|.\[[Writable]] to true and
+            |desc|.\[[Configurable]] to true.
         1.  Return |desc|.
 
     1.  Return <a abstract-op>OrdinaryGetOwnProperty</a>(|O|, |P|).
@@ -10961,7 +10961,7 @@ is the concatenation of the [=interface=]’s
     When the \[[DefineOwnProperty]] internal method of a [=named properties object=] is called,
     the following steps are taken:
 
-    1.  Return <emu-val>false</emu-val>.
+    1.  Return false.
 </div>
 
 <h5 id="named-properties-object-delete">\[[Delete]]</h5>
@@ -10971,7 +10971,7 @@ is the concatenation of the [=interface=]’s
     When the \[[Delete]] internal method of a [=named properties object=] is called,
     the following steps are taken:
 
-    1.  Return <emu-val>false</emu-val>.
+    1.  Return false.
 </div>
 
 
@@ -10994,7 +10994,7 @@ is the concatenation of the [=interface=]’s
     When the \[[PreventExtensions]] internal method of a [=named properties object=] is called,
     the following steps are taken:
 
-    1.  Return <emu-val>false</emu-val>.
+    1.  Return false.
 
     Note: this keeps [=named properties object=] extensible by
     making \[[PreventExtensions]] fail.
@@ -11013,7 +11013,7 @@ The property has the following characteristics:
     *   Otherwise, if the interface has an [=interface prototype object=],
         then the property exists on it.
 *   The value of the property is that which is obtained by [=converted to an ECMAScript value|converting=] the [=constant=]’s IDL value to an ECMAScript value.
-*   The property has attributes { \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>false</emu-val> }.
+*   The property has attributes { \[[Writable]]: false, \[[Enumerable]]: true, \[[Configurable]]: false }.
 
 In addition, a property with the same characteristics must
 exist on the [=interface object=] or the [=legacy callback interface object=],
@@ -11034,10 +11034,10 @@ The characteristics of this property are as follows:
         the interface or if the interface was declared with the [{{Global}}] or [{{PrimaryGlobal}}] extended attribute,
         then the property exists on every object that implements the interface.
     *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
-*   The property has attributes { \[[Get]]: |G|, \[[Set]]: |S|, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: |configurable| },
+*   The property has attributes { \[[Get]]: |G|, \[[Set]]: |S|, \[[Enumerable]]: true, \[[Configurable]]: |configurable| },
     where:
-    *   |configurable| is <emu-val>false</emu-val> if the attribute was
-        declared with the [{{Unforgeable}}] extended attribute and <emu-val>true</emu-val> otherwise;
+    *   |configurable| is false if the attribute was
+        declared with the [{{Unforgeable}}] extended attribute and true otherwise;
     *   |G| is the [=attribute getter=] created given the attribute, the interface,
         and the [=relevant Realm=] of the object that is the location of the property; and
     *   |S| is the [=attribute setter=] created given the attribute, the interface,
@@ -11050,7 +11050,7 @@ The characteristics of this property are as follows:
 
     1.  Let |steps| be the following series of steps:
         1.  Try running the following steps:
-            1.  Let |O| be <emu-val>null</emu-val>.
+            1.  Let |O| be null.
             1.  If |target| is an [=interface=], and |attribute| is a [=regular attribute=]:
                 1.  If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or
                     <emu-val>undefined</emu-val>, set |O| to |realm|'s [=Realm/global object=].
@@ -11081,7 +11081,7 @@ The characteristics of this property are as follows:
     1.  Let |name| be the string "get " prepended to |attribute|'s [=identifier=].
     1.  Perform [=!=] <a abstract-op>SetFunctionName</a>(|F|, |name|).
     1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "length",
-        PropertyDescriptor{\[[Value]]: 0, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
+        PropertyDescriptor{\[[Value]]: 0, \[[Writable]]: false, \[[Enumerable]]: false, \[[Configurable]]: true}).
     1. Return |F|.
 
 </div>
@@ -11099,7 +11099,7 @@ The characteristics of this property are as follows:
         1.  If no arguments were passed, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |V| be the value of the first argument passed.
         1.  Let |id| be |attribute|'s [=identifier=].
-        1.  Let |O| be <emu-val>null</emu-val>.
+        1.  Let |O| be null.
         1.  If |attribute| is a [=regular attribute=]:
             1.  If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or
                 <emu-val>undefined</emu-val>, set |O| to |realm|'s [=Realm/global object=].
@@ -11126,7 +11126,7 @@ The characteristics of this property are as follows:
                     {{ECMAScript/TypeError}}.
                 1.  Let |forwardId| be the identifier argument of the [{{PutForwards}}] extended
                     attribute.
-                1.  Perform [=?=] <a abstract-op>Set</a>(|Q|, |forwardId|, |V|, <emu-val>true</emu-val>).
+                1.  Perform [=?=] <a abstract-op>Set</a>(|Q|, |forwardId|, |V|, true).
                 1.  Return <emu-val>undefined</emu-val>.
         1.  Let |idlValue| be determined as follows:
 
@@ -11147,14 +11147,14 @@ The characteristics of this property are as follows:
             </dl>
 
         1.  Perform the actions listed in the description of |attribute| that occur on setting, on
-            |O| if |O| is not <emu-val>null</emu-val>.
+            |O| if |O| is not null.
         1.  Return <emu-val>undefined</emu-val>
     1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|realm|,
         |steps|, the {{%FunctionPrototype%}} of |realm|).
     1.  Let |name| be the string "set " prepended to |id|.
     1.  Perform [=!=] <a abstract-op>SetFunctionName</a>(|F|, |name|).
     1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "length",
-        PropertyDescriptor{\[[Value]]: 1, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
+        PropertyDescriptor{\[[Value]]: 1, \[[Writable]]: false, \[[Enumerable]]: false, \[[Configurable]]: true}).
     1. Return |F|.
 </div>
 
@@ -11191,10 +11191,10 @@ The characteristics of this property are as follows:
         then the property exists on every object that implements the interface.
     *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 *   The property has attributes
-    { \[[Writable]]: |B|, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: |B| },
-    where |B| is <emu-val>false</emu-val> if the operation is
+    { \[[Writable]]: |B|, \[[Enumerable]]: true, \[[Configurable]]: |B| },
+    where |B| is false if the operation is
     [=unforgeable=] on the interface,
-    and <emu-val>true</emu-val> otherwise.
+    and true otherwise.
 *   The value of the property is the result of [=creating an operation function=] given the operation,
     the interface, and the [=relevant Realm=] of the object that is the location of the property.
 
@@ -11220,9 +11220,9 @@ property-installation style as namespaces.)
     1.  Let |steps| be the following series of steps, given function argument
         values |arg|<sub>0..|n|−1</sub>:
         1.  Try running the following steps:
-            1.  Let |O| be <emu-val>null</emu-val>.
+            1.  Let |O| be null.
             1.  If |target| is an [=interface=], and |op| is not a [=static operation=]:
-                1.  If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or
+                1.  If the <emu-val>this</emu-val> value is null or
                     <emu-val>undefined</emu-val>, set |O| to |realm|'s [=Realm/global object=]. (This
                     will subsequently cause a {{ECMAScript/TypeError}} in a few steps, if the global
                     object does not implement |target|.)
@@ -11237,7 +11237,7 @@ property-installation style as namespaces.)
                 [=identifier=] |id| on |target| and with argument count |n|.
             1.  Let &lt;|operation|, |values|&gt; be the result of passing
                 |S| and |arg|<sub>0..|n|−1</sub> to the [=overload resolution algorithm=].
-            1.  Let |R| be <emu-val>null</emu-val>.
+            1.  Let |R| be null.
             1.  If |operation| is declared with a [{{Default}}] [=extended attribute=],
                 then:
                 1.  Set |R| be the result of performing the actions listed in
@@ -11245,7 +11245,7 @@ property-installation style as namespaces.)
                     with |values| as the argument values.
             1.  Otherwise:
                 1.  Set |R| be the result of performing the actions listed in the
-                    description of |operation|, on |O| if |O| is not <emu-val>null</emu-val>, with |values|
+                    description of |operation|, on |O| if |O| is not null, with |values|
                     as the argument values.
                 1.  Return the result of [=converted to an ECMAScript value|converting=] |R| to
                     an ECMAScript value of the type |op| is declared to return.
@@ -11264,7 +11264,7 @@ property-installation style as namespaces.)
         on |target| and with argument count 0.
     1.  Let |length| be the length of the shortest argument list in the entries in |S|.
     1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "length",
-        PropertyDescriptor{\[[Value]]: |length|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
+        PropertyDescriptor{\[[Value]]: |length|, \[[Writable]]: false, \[[Enumerable]]: false, \[[Configurable]]: true}).
     1.  Return |F|.
 </div>
 
@@ -11434,9 +11434,9 @@ then there must exist a property with the following characteristics:
     then the property exists on every object that implements the interface.
     Otherwise, the property exists on the [=interface prototype object=].
 *   The property has attributes
-    { \[[Writable]]: |B|, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: |B| },
-    where |B| is <emu-val>false</emu-val> if the stringifier is [=unforgeable=] on the interface,
-    and <emu-val>true</emu-val> otherwise.
+    { \[[Writable]]: |B|, \[[Enumerable]]: true, \[[Configurable]]: |B| },
+    where |B| is false if the stringifier is [=unforgeable=] on the interface,
+    and true otherwise.
 *   <div algorithm="to invoke the toString method of interfaces">
 
         The value of the property is a [=built-in function object=], which behaves as follows:
@@ -11488,7 +11488,7 @@ If the [=interface=] has any of the following:
 
 then a property must exist
 whose name is the {{@@iterator}} symbol, with attributes
-{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
+{ \[[Writable]]: true, \[[Enumerable]]: false, \[[Configurable]]: true }
 and whose value is a [=function object=].
 
 The location of the property is determined as follows:
@@ -11546,7 +11546,7 @@ then the [=function object=] is {{%ArrayProto_values%}}.
 </div>
 
 The value of the {{@@iterator}} [=function object=]’s “length”
-property is the Number value <emu-val>0</emu-val>.
+property is the Number value 0.
 
 The value of the {{@@iterator}} [=function object=]’s “name” property
 is the String value “entries”
@@ -11564,7 +11564,7 @@ If the [=interface=] has any of the following:
 *   a [=setlike declaration=]
 
 then a property named “forEach” must exist with attributes
-{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
+{ \[[Writable]]: true, \[[Enumerable]]: true, \[[Configurable]]: true }
 and whose value is a [=function object=].
 
 The location of the property is determined as follows:
@@ -11625,7 +11625,7 @@ then the [=function object=] is {{%ArrayProto_forEach%}}.
         that implements |interface|,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |callbackFn| be the value of the first argument passed to the function, or <emu-val>undefined</emu-val> if the argument was not supplied.
-    1.  If <a abstract-op>IsCallable</a>(|callbackFn|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+    1.  If <a abstract-op>IsCallable</a>(|callbackFn|) is false, [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |thisArg| be the value of the second argument passed to the function, or <emu-val>undefined</emu-val> if the argument was not supplied.
     1.  Let |backing| be the value of the \[[BackingMap]] [=internal slot=] of |object|,
         if the interface has a [=maplike declaration=],
@@ -11645,13 +11645,13 @@ then the [=function object=] is {{%ArrayProto_forEach%}}.
         </p>
     1.  Let |forEach| be the result of calling the \[[Get]] internal method of
         |backing| with “forEach” and |backing| as arguments.
-    1.  If <a abstract-op>IsCallable</a>(|forEach|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+    1.  If <a abstract-op>IsCallable</a>(|forEach|) is false, [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  <a abstract-op>Call</a>(|forEach|, |backing|, «|callbackWrapper|, |thisArg|»).
     1.  Return <emu-val>undefined</emu-val>.
 </div>
 
 The value of the [=function object=]’s “length”
-property is the Number value <emu-val>1</emu-val>.
+property is the Number value 1.
 
 The value of the [=function object=]’s “name”
 property is the String value “forEach”.
@@ -11664,7 +11664,7 @@ property is the String value “forEach”.
 
 If the [=interface=] has an [=iterable declaration=],
 then a property named “entries” must exist with attributes
-{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
+{ \[[Writable]]: true, \[[Enumerable]]: true, \[[Configurable]]: true }
 and whose value is a [=function object=].
 
 The location of the property is determined as follows:
@@ -11685,7 +11685,7 @@ the value of the {{@@iterator}} property.
 
 If the [=interface=] has an [=iterable declaration=],
 then a property named “keys” must exist with attributes
-{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
+{ \[[Writable]]: true, \[[Enumerable]]: true, \[[Configurable]]: true }
 and whose value is a [=function object=].
 
 The location of the property is determined as follows:
@@ -11718,7 +11718,7 @@ then the [=function object=] is {{%ArrayProto_keys%}}.
     1.  Return |iterator|.
 </div>
 
-The value of the [=function object=]’s “length” property is the Number value <emu-val>0</emu-val>.
+The value of the [=function object=]’s “length” property is the Number value 0.
 
 The value of the [=function object=]’s “name” property is the String value “keys”.
 
@@ -11728,7 +11728,7 @@ The value of the [=function object=]’s “name” property is the String value
 If the [=interface=] has an
 [=iterable declaration=],
 then a property named “values” must exist
-with attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
+with attributes { \[[Writable]]: true, \[[Enumerable]]: true, \[[Configurable]]: true }
 and whose value is a [=function object=].
 
 The location of the property is determined as follows:
@@ -11762,7 +11762,7 @@ the value of the {{@@iterator}} property.
     1.  Return |iterator|.
 </div>
 
-The value of the [=function object=]’s “length” property is the Number value <emu-val>0</emu-val>.
+The value of the [=function object=]’s “length” property is the Number value 0.
 
 The value of the [=function object=]’s “name” property is the String value “values”.
 
@@ -11811,7 +11811,7 @@ must be {{%IteratorPrototype%}}.
 <div algorithm="to invoke the next property of iterators">
 
     An [=iterator prototype object=] must have a property named “next” with attributes
-    { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
+    { \[[Writable]]: true, \[[Enumerable]]: true, \[[Configurable]]: true }
     and whose value is a [=built-in function object=] that behaves as follows:
 
     1.  Let |interface| be the [=interface=] for which the
@@ -11829,7 +11829,7 @@ must be {{%IteratorPrototype%}}.
     1.  Let |values| be the list of [=value pairs to iterate over=].
     1.  Let |len| be the length of |values|.
     1.  If |index| is greater than or equal to |len|, then
-        return <a abstract-op>CreateIterResultObject</a>(<emu-val>undefined</emu-val>, <emu-val>true</emu-val>).
+        return <a abstract-op>CreateIterResultObject</a>(<emu-val>undefined</emu-val>, true).
     1.  Let |pair| be the entry in |values| at index |index|.
     1.  Set |object|’s index to |index| + 1.
     1.  Let |result| be a value determined by the value of |kind|:
@@ -11852,7 +11852,7 @@ must be {{%IteratorPrototype%}}.
                 1.  Call <a abstract-op>CreateDataProperty</a>(|array|, "1", |value|).
                 1.  |result| is |array|.
         </dl>
-    1.  Return <a abstract-op>CreateIterResultObject</a>(|result|, <emu-val>false</emu-val>).
+    1.  Return <a abstract-op>CreateIterResultObject</a>(|result|, false).
 </div>
 
 The [=class string=] of an [=iterator prototype object=] for a given [=interface=]
@@ -11892,7 +11892,7 @@ These additional properties are described in the sub-sections below.
     1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
     1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing |name| and |map| as arguments.
-    1.  If <a abstract-op>IsCallable</a>(|function|) is <emu-val>false</emu-val>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+    1.  If <a abstract-op>IsCallable</a>(|function|) is false, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return <a abstract-op>Call</a>(|function|, |map|, |arguments|).
 </div>
 
@@ -11904,7 +11904,7 @@ There must exist a property named “size” on
 with the following characteristics:
 
 *   The property has attributes
-    { \[[Get]]: |G|, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> },
+    { \[[Get]]: |G|, \[[Enumerable]]: false, \[[Configurable]]: true },
     where |G| is the interface’s <dfn id="dfn-map-size-getter" export>map size getter</dfn>,
     defined below.
 *   <div algorithm="to invoke the size method of Maps">
@@ -11923,7 +11923,7 @@ with the following characteristics:
         1.  Return the result of calling the \[[Get]] internal method of |map| passing “size” and |map| as arguments.
     </div>
 
-    The value of the [=function object=]’s “length” property is the Number value <emu-val>0</emu-val>.
+    The value of the [=function object=]’s “length” property is the Number value 0.
 
     The value of the [=function object=]’s “name” property is the String value “size”.
 
@@ -11932,7 +11932,7 @@ with the following characteristics:
 
 A property named “entries” must exist on
 |A|’s [=interface prototype object=]
-with attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
+with attributes { \[[Writable]]: true, \[[Enumerable]]: false, \[[Configurable]]: true }
 and whose value is the [=function object=] that is the value of
 the {{@@iterator}} property.
 
@@ -11943,10 +11943,10 @@ For both of “keys” and “values”, there must exist a property with that n
 |A|’s [=interface prototype object=]
 with the following characteristics:
 
-*   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
+*   The property has attributes { \[[Writable]]: true, \[[Enumerable]]: false, \[[Configurable]]: true }.
 *   The value of the property is a [=built-in function object=] that [=forwards to the internal map object|forwards that name to the internal map object=].
 
-The value of the [=function objects=]’ “length” properties is the Number value <emu-val>0</emu-val>.
+The value of the [=function objects=]’ “length” properties is the Number value 0.
 
 The value of the [=function object=]’s “name” property is the String value “keys” or “values”, correspondingly.
 
@@ -11957,7 +11957,7 @@ For both of “get” and “has”, there must exist a property with that name 
 |A|’s [=interface prototype object=] with the following characteristics:
 
 *   The property has attributes
-    { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
+    { \[[Writable]]: true, \[[Enumerable]]: false, \[[Configurable]]: true }.
 *   <div algorithm="to invoke the get and has methods of Maps">
 
         The value of the property is a [=built-in function object=]
@@ -11980,7 +11980,7 @@ For both of “get” and “has”, there must exist a property with that name 
         1.  Return <a abstract-op>Call</a>(|function|, |map|, «|key|»).
     </div>
 
-The value of the [=function object=]’s “length” properties is the Number value <emu-val>1</emu-val>.
+The value of the [=function object=]’s “length” properties is the Number value 1.
 
 The value of the [=function object=]’s “name” property is the String value “get” or “has”, correspondingly.
 
@@ -11994,10 +11994,10 @@ then a property named “clear” and the following characteristics
 must exist on |A|’s
 [=interface prototype object=]:
 
-*   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
+*   The property has attributes { \[[Writable]]: true, \[[Enumerable]]: false, \[[Configurable]]: true }.
 *   The value of the property is a [=built-in function object=] that [=forwards to the internal map object|forwards “clear” to the internal map object=].
 
-The value of the [=function object=]’s “length” property is the Number value <emu-val>0</emu-val>.
+The value of the [=function object=]’s “length” property is the Number value 0.
 
 The value of the [=function object=]’s “name” property is the String value “clear”.
 
@@ -12011,7 +12011,7 @@ then a property named “delete” and the following characteristics
 must exist on |A|’s
 [=interface prototype object=]:
 
-*   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
+*   The property has attributes { \[[Writable]]: true, \[[Enumerable]]: false, \[[Configurable]]: true }.
 *   <div algorithm="to invoke the delete method of Maps">
 
         The value of the property is a [=built-in function object=] that behaves as follows when invoked:
@@ -12032,7 +12032,7 @@ must exist on |A|’s
         1.  Return <a abstract-op>Call</a>(|function|, |map|, «|key|»).
     </div>
 
-The value of the [=function object=]’s “length” property is the Number value <emu-val>1</emu-val>.
+The value of the [=function object=]’s “length” property is the Number value 1.
 
 The value of the [=function object=]’s “name” property is the String value “delete”.
 
@@ -12045,7 +12045,7 @@ then a property named “set” and the following characteristics
 must exist on |A|’s [=interface prototype object=]:
 
 *   The property has attributes
-    { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
+    { \[[Writable]]: true, \[[Enumerable]]: false, \[[Configurable]]: true }.
 *   <div algorithm="to invoke the set method of Maps">
 
         The value of the property is a [=built-in function object=] that behaves as follows when invoked:
@@ -12070,7 +12070,7 @@ must exist on |A|’s [=interface prototype object=]:
         1.  Return |O|.
     </div>
 
-The value of the [=function object=]’s “length” property is the Number value <emu-val>2</emu-val>.
+The value of the [=function object=]’s “length” property is the Number value 2.
 
 The value of the [=function object=]’s “name” property is the String value “set”.
 
@@ -12109,7 +12109,7 @@ These additional properties are described in the sub-sections below.
         the value of |O|’s \[[BackingSet]] [=internal slot=].
     1.  Let |function| be the result of calling the \[[Get]] internal method of |set|
         passing |name| and |set| as arguments.
-    1.  If <a abstract-op>IsCallable</a>(|function|) is <emu-val>false</emu-val>,
+    1.  If <a abstract-op>IsCallable</a>(|function|) is false,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return <a abstract-op>Call</a>(|function|, |set|, |arguments|).
 </div>
@@ -12120,7 +12120,7 @@ These additional properties are described in the sub-sections below.
 There must exist a property named “size” on |A|’s [=interface prototype object=]
 with the following characteristics:
 
-*   The property has attributes { \[[Get]]: |G|, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> },
+*   The property has attributes { \[[Get]]: |G|, \[[Enumerable]]: false, \[[Configurable]]: true },
     where |G| is the interface’s <dfn id="dfn-set-size-getter" export>set size getter</dfn>,
     defined below.
 *   <div algorithm="to invoke the size method of Sets">
@@ -12139,7 +12139,7 @@ with the following characteristics:
         1.  Return the result of calling the \[[Get]] internal method of |set| passing “size” and |set| as arguments.
     </div>
 
-    The value of the [=function object=]’s “length” property is the Number value <emu-val>0</emu-val>.
+    The value of the [=function object=]’s “length” property is the Number value 0.
 
     The value of the [=function object=]’s “name” property is the String value “size”.
 
@@ -12147,7 +12147,7 @@ with the following characteristics:
 <h5 id="es-set-values">values</h5>
 
 A property named “values” must exist on |A|’s [=interface prototype object=]
-with attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
+with attributes { \[[Writable]]: true, \[[Enumerable]]: false, \[[Configurable]]: true }
 and whose value is the [=function object=] that is the value of
 the {{@@iterator}} property.
 
@@ -12158,12 +12158,12 @@ For both of “entries” and “keys”, there must exist a property with that 
 |A|’s [=interface prototype object=] with the following characteristics:
 
 *   The property has attributes
-    { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
+    { \[[Writable]]: true, \[[Enumerable]]: false, \[[Configurable]]: true }.
 *   The value of the property is a [=built-in function object=] that
     [=forwards to the internal set object|forwards that name to the internal set object=].
 
 The value of the [=function object=]’s “length” properties is
-the Number value <emu-val>0</emu-val>.
+the Number value 0.
 
 The value of the [=function object=]’s “name” property is
 the String value “entries” or “keys”, correspondingly.
@@ -12175,7 +12175,7 @@ There must exist a property with named “has” on |A|’s [=interface prototyp
 with the following characteristics:
 
 *   The property has attributes
-    { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
+    { \[[Writable]]: true, \[[Enumerable]]: false, \[[Configurable]]: true }.
 *   <div algorithm="to invoke the has method of Sets">
 
         The value of the property is a [=built-in function object=] that behaves as follows when invoked:
@@ -12196,7 +12196,7 @@ with the following characteristics:
         1.  <a abstract-op>Call</a>(|function|, |set|, «|value|»).
     </div>
 
-The value of the [=function object=]’s “length” property is a Number value <emu-val>1</emu-val>.
+The value of the [=function object=]’s “length” property is a Number value 1.
 
 The value of the [=function object=]’s “name” property is the String value “has”.
 
@@ -12211,7 +12211,7 @@ For both of “add” and “delete”, if:
 then a property with that name and the following characteristics
 must exist on |A|’s [=interface prototype object=]:
 
-*   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
+*   The property has attributes { \[[Writable]]: true, \[[Enumerable]]: false, \[[Configurable]]: true }.
 *   <div algorithm="to invoke the add and delete methods of Sets">
 
         The value of the property is a [=built-in function object=] that behaves as follows when invoked:
@@ -12235,7 +12235,7 @@ must exist on |A|’s [=interface prototype object=]:
         1.  Otherwise, return |O|.
     </div>
 
-The value of the [=function object=]’s “length” property is the Number value <emu-val>1</emu-val>.
+The value of the [=function object=]’s “length” property is the Number value 1.
 
 The value of the [=function object=]’s “name” property is the String value “add” or “delete”, correspondingly.
 
@@ -12249,10 +12249,10 @@ then a property named “clear” and the following characteristics
 must exist on |A|’s
 [=interface prototype object=]:
 
-*   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
+*   The property has attributes { \[[Writable]]: true, \[[Enumerable]]: false, \[[Configurable]]: true }.
 *   The value of the property is a [=built-in function object=] that [=forwards to the internal set object|forwards “clear” to the internal set object=].
 
-The value of the [=function object=]’s “length” property is the Number value <emu-val>0</emu-val>.
+The value of the [=function object=]’s “length” property is the Number value 0.
 
 The value of the [=function object=]’s “name” property is the String value “clear”.
 
@@ -12348,7 +12348,7 @@ and [[#legacy-platform-object-set]].
     The internal \[[GetOwnProperty]] method of every [=legacy platform object=] |O|
     must behave as follows when called with property name |P|:
 
-    1. Return <a abstract-op>LegacyPlatformObjectGetOwnProperty</a>(|O|, |P|, <emu-val>false</emu-val>).
+    1. Return <a abstract-op>LegacyPlatformObjectGetOwnProperty</a>(|O|, |P|, false).
 </div>
 
 
@@ -12363,13 +12363,13 @@ and [[#legacy-platform-object-set]].
     1.  If |O| and |Receiver| are the same object, then:
         1.  If |O| [=support indexed properties|supports indexed properties=], |P| [=is an array index=], and |O| implements an interface with an [=indexed property setter=], then:
             1.  [=Invoke the indexed property setter=] with |P| and |V|.
-            1.  Return <emu-val>true</emu-val>.
+            1.  Return true.
         1.  If |O| [=support named properties|supports named properties=], <a abstract-op>Type</a>(|P|) is String,
             |P| [=is not an array index=],
             and |O| implements an interface with a [=named property setter=], then:
             1.  [=Invoke the named property setter=] with |P| and |V|.
-            1.  Return <emu-val>true</emu-val>.
-    1.  Let |ownDesc| be <a abstract-op>LegacyPlatformObjectGetOwnProperty</a>(|O|, |P|, <emu-val>true</emu-val>).
+            1.  Return true.
+    1.  Let |ownDesc| be <a abstract-op>LegacyPlatformObjectGetOwnProperty</a>(|O|, |P|, true).
     1.  Perform [=?=] <a abstract-op>OrdinarySetWithOwnDescriptor</a>(|O|, |P|, |V|, |Receiver|, |ownDesc|).
 </div>
 
@@ -12385,12 +12385,12 @@ and [[#legacy-platform-object-set]].
     1.  If |O| [=support indexed properties|supports indexed properties=] and
         |P| [=is an array index=], then:
         1.  If the result of calling <a abstract-op>IsDataDescriptor</a>(|Desc|) is
-            <emu-val>false</emu-val>, then return
-            <emu-val>false</emu-val>.
+            false, then return
+            false.
         1.  If |O| does not implement an interface with an
-            [=indexed property setter=], then return <emu-val>false</emu-val>.
+            [=indexed property setter=], then return false.
         1.  [=Invoke the indexed property setter=] with |P| and |Desc|.\[[Value]].
-        1.  Return <emu-val>true</emu-val>.
+        1.  Return true.
     1.  If |O| [=support named properties|supports named properties=],
         |O| does not implement an [=interface=] with the
         [{{Global}}] or [{{PrimaryGlobal}}] [=extended attribute=],
@@ -12402,21 +12402,21 @@ and [[#legacy-platform-object-set]].
             [=extended attribute=] or |O| does not have an own property
             named |P|, then:
             1.  If |creating| is false and |O| does not implement an
-                interface with a [=named property setter=], then return <emu-val>false</emu-val>.
+                interface with a [=named property setter=], then return false.
             1.  If |O| implements an interface with a
                 [=named property setter=], then:
                 1.  If the result of calling <a abstract-op>IsDataDescriptor</a>(|Desc|) is
-                    <emu-val>false</emu-val>, then return
-                    <emu-val>false</emu-val>.
+                    false, then return
+                    false.
                 1.  [=Invoke the named property setter=] with |P| and |Desc|.\[[Value]].
-                1.  Return <emu-val>true</emu-val>.
+                1.  Return true.
     1.  If |O| does not implement an
         [=interface=] with the
         [{{Global}}] or
         [{{PrimaryGlobal}}]
         [=extended attribute=], then set
         |Desc|.\[[Configurable]] to
-        <emu-val>true</emu-val>.
+        true.
     1.  Return <a abstract-op>OrdinaryDefineOwnProperty</a>(|O|, |P|, |Desc|).
 </div>
 
@@ -12431,29 +12431,29 @@ and [[#legacy-platform-object-set]].
     1.  If |O| [=support indexed properties|supports indexed properties=] and
         |P| [=is an array index=], then:
         1.  Let |index| be the result of calling <a abstract-op>ToUint32</a>(|P|).
-        1.  If |index| is not a [=supported property indices|supported property index=], then return <emu-val>true</emu-val>.
-        1.  Return <emu-val>false</emu-val>.
+        1.  If |index| is not a [=supported property indices|supported property index=], then return true.
+        1.  Return false.
     1.  If |O| [=support named properties|supports named properties=],
         |O| does not implement an [=interface=] with the
         [{{Global}}] or [{{PrimaryGlobal}}] [=extended attribute=]
         and the result of calling the [=named property visibility algorithm=]
         with property name |P| and object |O| is true, then:
-        1.  If |O| does not implement an interface with a [=named property deleter=], then return <emu-val>false</emu-val>.
+        1.  If |O| does not implement an interface with a [=named property deleter=], then return false.
         1.  Let |operation| be the operation used to declare the named property deleter.
         1.  If |operation| was defined without an [=identifier=], then:
             1.  Perform the steps listed in the interface description to
                 [=delete an existing named property=]
                 with |P| as the name.
-            1.  If the steps indicated that the deletion failed, then return <emu-val>false</emu-val>.
+            1.  If the steps indicated that the deletion failed, then return false.
         1.  Otherwise, |operation| was defined with an identifier:
             1.  Perform the steps listed in the description of |operation| with |P| as the only argument value.
             1.  If |operation| was declared with a [=return type=] of {{boolean}}
-                and the steps returned <emu-val>false</emu-val>, then return <emu-val>false</emu-val>.
-        1.  Return <emu-val>true</emu-val>.
+                and the steps returned false, then return false.
+        1.  Return true.
     1.  If |O| has an own property with name |P|, then:
-        1.  If the property is not configurable, then return <emu-val>false</emu-val>.
+        1.  If the property is not configurable, then return false.
         1.  Otherwise, remove the property from |O|.
-    1.  Return <emu-val>true</emu-val>.
+    1.  Return true.
 </div>
 
 
@@ -12464,7 +12464,7 @@ and [[#legacy-platform-object-set]].
     When the \[[PreventExtensions]] internal method of a [=legacy platform object=] is called,
     the following steps are taken:
 
-    1.  Return <emu-val>false</emu-val>.
+    1.  Return false.
 
     Note: this keeps [=legacy platform objects=] extensible by
     making \[[PreventExtensions]] fail for them.
@@ -12508,15 +12508,15 @@ internal method as follows.
     oldids="dfn-array-index-property-name">is an [=array index=]</dfn>, the following algorithm is
     applied:
 
-    1.  If <a abstract-op>Type</a>(|P|) is not String, then return <emu-val>false</emu-val>.
+    1.  If <a abstract-op>Type</a>(|P|) is not String, then return false.
     1.  Let |index| be [=!=] <a abstract-op>CanonicalNumericIndexString</a>(|P|).
-    1.  If |index| is <emu-val>undefined</emu-val>, then return <emu-val>false</emu-val>.
+    1.  If |index| is <emu-val>undefined</emu-val>, then return false.
     1.  If |index| is less than 0 or is greater than or equal to 2<sup>32</sup> − 1, then return
-        <emu-val>false</emu-val>.
+        false.
 
           Note: 2<sup>32</sup> − 1 is the maximum array length allowed by ECMAScript.
 
-    1.  Return <emu-val>true</emu-val>.
+    1.  Return true.
 
 </div>
 
@@ -12623,9 +12623,9 @@ internal method as follows.
             1.  Set |desc|.\[[Value]] to the result of [=converted to an ECMAScript value|converting=]
                 |value| to an ECMAScript value.
             1.  If |O| implements an interface with an [=indexed property setter=], then set
-                |desc|.\[[Writable]] to <emu-val>true</emu-val>, otherwise set it to
-                <emu-val>false</emu-val>.
-            1.  Set |desc|.\[[Enumerable]] and |desc|.\[[Configurable]] to <emu-val>true</emu-val>.
+                |desc|.\[[Writable]] to true, otherwise set it to
+                false.
+            1.  Set |desc|.\[[Enumerable]] and |desc|.\[[Configurable]] to true.
             1.  Return |desc|.
         1.  Set |ignoreNamedProps| to true.
     1.  If |O| [=support named properties|supports named properties=],
@@ -12643,14 +12643,14 @@ internal method as follows.
         1.  Set |desc|.\[[Value]] to the result of [=converted to an ECMAScript value|converting=]
             |value| to an ECMAScript value.
         1.  If |O| implements an interface with a [=named property setter=], then set
-            |desc|.\[[Writable]] to <emu-val>true</emu-val>, otherwise set it to
-            <emu-val>false</emu-val>.
+            |desc|.\[[Writable]] to true, otherwise set it to
+            false.
         1.  If |O| implements an interface with the
             [{{LegacyUnenumerableNamedProperties}}]
             [=extended attribute=],
-            then set |desc|.\[[Enumerable]] to <emu-val>false</emu-val>,
-            otherwise set it to <emu-val>true</emu-val>.
-        1.  Set |desc|.\[[Configurable]] to <emu-val>true</emu-val>.
+            then set |desc|.\[[Enumerable]] to false,
+            otherwise set it to true.
+        1.  Set |desc|.\[[Configurable]] to true.
         1.  Return |desc|.
     1.  Return <a abstract-op>OrdinaryGetOwnProperty</a>(|O|, |P|).
 </div>
@@ -12745,12 +12745,12 @@ the special value “missing”, which represents a missing optional argument.
             1.  If |getResult| is an [=abrupt completion=], set |completion|
                 to |getResult| and jump to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.
             1.  Set |X| to |getResult|.\[[Value]].
-    1.  If [=!=] <a abstract-op>IsCallable</a>(|X|) is <emu-val>false</emu-val>,
+    1.  If [=!=] <a abstract-op>IsCallable</a>(|X|) is false,
         then set |completion| to a new <a abstract-op>Completion</a>{\[[Type]]: throw, \[[Value]]: a
         newly created {{ECMAScript/TypeError}} object, \[[Target]]: empty}, and jump
         to the step labeled <a href="#call-user-object-operation-return"><i>return</i></a>.
     1.  If |value|'s interface is not a [=single operation callback interface=],
-        or if [=!=] <a abstract-op>IsCallable</a>(|O|) is <emu-val>false</emu-val>,
+        or if [=!=] <a abstract-op>IsCallable</a>(|O|) is false,
         set |thisArg| to |O| (overriding the provided value).
     1.  Let |esArgs| be the result of [=Web IDL arguments list/converting=] |args| to an ECMAScript
         arguments list. If this throws an exception, set |completion| to the completion value
@@ -12829,10 +12829,10 @@ the special value “missing”, which represents a missing optional argument.
     1.  If |convertResult| is an [=abrupt completion=], set |completion| to
         |convertResult| and jump to the step labeled <a href="#set-user-object-attribute-return"><i>return</i></a>.
     1.  Set |completion| to <a abstract-op>Set</a>(|O|, |attributeName|,
-        |convertResult|.\[[Value]], <emu-val>true</emu-val>).
+        |convertResult|.\[[Value]], true).
     1.  <i id="set-user-object-attribute-return">Return:</i> at this
         point |completion| will be set to an ECMAScript completion value, which is
-        either an [=abrupt completion=] or a normal completion for the value <emu-val>true</emu-val> (as returned by <a abstract-op>Set</a>).
+        either an [=abrupt completion=] or a normal completion for the value true (as returned by <a abstract-op>Set</a>).
         1.  [=Clean up after running a callback=] with |stored settings|.
         1.  [=Clean up after running script=] with |relevant settings|.
         1.  If |completion| is an [=abrupt completion=], return |completion|.
@@ -12859,7 +12859,7 @@ described in the previous section).
     1.  Let |completion| be an uninitialized variable.
     1.  If |thisArg| was not given, let |thisArg| be <emu-val>undefined</emu-val>.
     1.  Let |F| be the ECMAScript object corresponding to |callable|.
-    1.  If [=!=] <a abstract-op>IsCallable</a>(|F|) is <emu-val>false</emu-val>:
+    1.  If [=!=] <a abstract-op>IsCallable</a>(|F|) is false:
         1.  If the callback function's return type is {{void}}, return.
 
             Note: This is only possible when the callback function came from an attribute
@@ -12907,7 +12907,7 @@ a return type that is a [=promise type=].
 
     1.  Let |completion| be an uninitialized variable.
     1.  Let |F| be the ECMAScript object corresponding to |callable|.
-    1.  If [=!=] <a abstract-op>IsConstructor</a>(|F|) is <emu-val>false</emu-val>, throw a
+    1.  If [=!=] <a abstract-op>IsConstructor</a>(|F|) is false, throw a
         {{ECMAScript/TypeError}} exception.
     1.  Let |realm| be |F|'s [=associated Realm=].
     1.  Let |relevant settings| be |realm|'s [=Realm/settings object=].
@@ -12940,7 +12940,7 @@ environment's global object. The name of the property is the [=identifier=] of t
 called the <dfn id="dfn-namespace-object" export>namespace object</dfn>.
 
 The property has the attributes
-{ \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
+{ \[[Writable]]: true, \[[Enumerable]]: false, \[[Configurable]]: true }.
 The characteristics of a namespace object are described in [[#namespace-object]].
 
 
@@ -12956,8 +12956,8 @@ The characteristics of a namespace object are described in [[#namespace-object]]
     1.  For each [=exposed=] [=regular attribute=] |attr| that is a [=namespace member=] of this namespace,
         1.  Let |F| be the result of creating an [=attribute getter=]
             given |attr|, |namespace|,  and |realm|.
-        1.  Let |newDesc| be the PropertyDescriptor{\[[Get]]: |F|, \[[Enumerable]]: <emu-val>true</emu-val>,
-            \[[Configurable]]: <emu-val>true</emu-val>}.
+        1.  Let |newDesc| be the PropertyDescriptor{\[[Get]]: |F|, \[[Enumerable]]: true,
+            \[[Configurable]]: true}.
         1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|namespaceObject|, |attr|'s [=identifier=], |newDesc|).
     1.  For each [=exposed=] [=regular operation=] |op| that is a [=namespace member=] of this namespace,
         1.  Let |F| be the result of [=creating an operation function|creating an operation function=]
@@ -12966,8 +12966,8 @@ The characteristics of a namespace object are described in [[#namespace-object]]
     1.  For each [=exposed=] [=interface=] |interface| which has the [{{LegacyNamespace}}] extended
         attribute with the identifier of this namespace as its argument,
         1.  Let |I| be the [=interface object=] for |interface|.
-        1.  Let |newDesc| be the PropertyDescriptor{\[[Writable]]: <emu-val>true</emu-val>,
-            \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>, \[[Value]]: |I|}.
+        1.  Let |newDesc| be the PropertyDescriptor{\[[Writable]]: true,
+            \[[Enumerable]]: false, \[[Configurable]]: true, \[[Value]]: |I|}.
         1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|namespaceObject|, |interface|'s [=identifier=], |newDesc|).
 </div>
 
@@ -13519,9 +13519,14 @@ The following typographic conventions are used in this document:
 *   Grammar terminals: <emu-t>sometoken</emu-t>
 *   Grammar non-terminals: <emu-nt>ExampleGrammarNonTerminal</emu-t>
 *   Grammar symbols: <emu-t class="regex">identifier</emu-t>
-*   IDL types: {{unsigned long}}
-*   ECMAScript classes: {{ECMAScript/Map}}
+*   IDL types: <code class="idl">unsigned long</code> <!-- {{unsigned long}} -->
+*   IDL values: true, false, null, 0.42, −0
+*   ECMAScript classes: <code class="idl">Map</code> <!-- {{ECMAScript/Map}} -->
 *   ECMAScript language types: Object
+*   ECMAScript values: generally the same notation as IDL values; bolded type (e.g.
+    <emu-val>true</emu-val>) may be used when it is needed to distinguish between ECMAScript and IDL
+    values, or if the ECMAScript value does not have a single corresponding IDL value of the same
+    name (<emu-val>undefined</emu-val> and <emu-val>NaN</emu-val>).
 *   Code snippets: <code>a = b + obj.f()</code>
 *   Unicode characters: <span class="char">U+0030 DIGIT ZERO ("0")</span>
 *   Extended attributes: [<code class="idl">ExampleExtendedAttribute</code>]


### PR DESCRIPTION
I kept certain constants bolded in the spec for readability. The distinction is basically summarized in the updated Document Conventions:

> * IDL types: `unsigned long`
> * IDL values: true, false, null, 0.42, −0
> * ECMAScript classes: `Map`
> * ECMAScript language types: Object
> * ECMAScript values: generally the same notation as IDL values; bolded type (e.g. **true**) may be used when it is needed to distinguish between ECMAScript and IDL values, or if the ECMAScript value does not have a single corresponding IDL value of the same name (**undefined** and **NaN**).

The last bullet point is especially needed for things like:

> The IDL `boolean` value true is converted to the ECMAScript **true** value and the IDL boolean value false is converted to the ECMAScript **false** value.

which IMO looks odd with either both bolded or both regular-weighted. Also, ECMAScript true is usually not bolded for things like

> The property has the attributes { [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }.

.

Happy to have a discussion about it.

Fixes #437.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/TimothyGu/webidl/true.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/90efe5b...TimothyGu:b1dfa43.html)