### PR TITLE
Add a note on the difference of SyntaxError

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4401,6 +4401,10 @@ for {{DOMException}}, a description, and legacy code values.
 
 Note: If an error name is not listed here, please file a bug as indicated at the top of this specification and it will be addressed shortly. Thanks!
 
+Note: Do not confuse {{SyntaxError!!exception}} defined here with ECMAScript's
+{{ECMAScript/SyntaxError}}. The ECMAScript one should not be used outside
+ECMAScript and it is deliberately omitted from [=simple exception=].
+
 <table id="error-names" class="vert data">
     <thead>
         <tr><th>Name</th><th>Description</th><th>Legacy code name and value</th></tr>

--- a/index.bs
+++ b/index.bs
@@ -4402,8 +4402,9 @@ for {{DOMException}}, a description, and legacy code values.
 Note: If an error name is not listed here, please file a bug as indicated at the top of this specification and it will be addressed shortly. Thanks!
 
 Note: Do not confuse {{SyntaxError!!exception}} defined here with ECMAScript's
-{{ECMAScript/SyntaxError}}. The ECMAScript one should not be used outside
-ECMAScript and it is deliberately omitted from [=simple exception=].
+{{ECMAScript/SyntaxError}}. The ECMAScript one is deliberately omitted from
+[=simple exception=], and cannot be used for reporting non ECMAScript errors
+such as parsing errors of CSS selector.
 
 <table id="error-names" class="vert data">
     <thead>

--- a/index.bs
+++ b/index.bs
@@ -4408,7 +4408,7 @@ for example when parsing selectors,
 while the ECMAScript {{ECMAScript/SyntaxError}} is reserved for the ECMAScript parser.
 To help disambiguate this further,
 always favor the "{{SyntaxError!!exception}}" {{DOMException}} notation
-over just using {{SyntaxError!!exception}} to refer to the {{DOMException}}.
+over just using {{SyntaxError!!exception}} to refer to the {{DOMException}}. [[DOM]]
 
 <table id="error-names" class="vert data">
     <thead>

--- a/index.bs
+++ b/index.bs
@@ -4401,10 +4401,14 @@ for {{DOMException}}, a description, and legacy code values.
 
 Note: If an error name is not listed here, please file a bug as indicated at the top of this specification and it will be addressed shortly. Thanks!
 
-Note: Do not confuse {{SyntaxError!!exception}} defined here with ECMAScript's
-{{ECMAScript/SyntaxError}}. The ECMAScript one is deliberately omitted from
-[=simple exception=], and cannot be used for reporting non ECMAScript errors
-such as parsing errors of CSS selector.
+Note: Don't confuse the "{{SyntaxError!!exception}}" {{DOMException}} defined here
+with ECMAScript's {{ECMAScript/SyntaxError}}.
+"{{SyntaxError!!exception}}" {{DOMException}} is used to report parsing errors in web APIs,
+for example when parsing selectors,
+while the ECMAScript {{ECMAScript/SyntaxError}} is reserved for the ECMAScript parser.
+To help disambiguate this further,
+always favor the "{{SyntaxError!!exception}}" {{DOMException}} notation
+over just using {{SyntaxError!!exception}} to refer to the {{DOMException}}.
 
 <table id="error-names" class="vert data">
     <thead>
@@ -13228,6 +13232,7 @@ Jim Jewett,
 Wolfgang Keller,
 Anne van Kesteren,
 Olav Junker Kjær,
+Takayoshi Kochi,
 Magnus Kristiansen,
 Takeshi Kurosawa,
 Yves Lafon,


### PR DESCRIPTION
Add a note on the difference of ECMAScript's SyntaxError and
"SyntaxError", which is one of the DOMException's names.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/TakayoshiKochi/webidl/syntax_error.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/76c5192...TakayoshiKochi:358c37e.html)