### PR TITLE
Add post-processor

### DIFF
--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,4 +1,7 @@
 {
     "src_file": "index.bs",
-    "type": "bikeshed"
+    "type": "bikeshed",
+    "post_processing": {
+        "name": "webidl-grammar"
+    }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,32 @@
-bs := $(shell command -v bikeshed 2> /dev/null)
+bs_installed  := $(shell command -v bikeshed 2> /dev/null)
+npm_installed := $(shell command -v npm 2> /dev/null)
+pp_webidl_installed := $(shell npm ls webidl-grammar-post-processor --parseable --depth=0 2> /dev/null)
 
 all : index.html
 
 index.html : index.bs
-ifdef bs
+ifdef bs_installed
 	bikeshed spec index.bs
 else
-	@echo Cannot find a local version of Bikeshed. To install it, visit:
+	@echo Can't find a local version of Bikeshed. To install it, visit:
 	@echo
 	@echo https://github.com/tabatkins/bikeshed/blob/master/docs/install.md
 	@echo
 	@echo Trying to build the spec using the online API at: https://api.csswg.org/bikeshed/
 	@echo This will fail if you are not connected to the network.
 	curl https://api.csswg.org/bikeshed/ -F file=@index.bs > index.html
+endif
+ifdef pp_webidl_installed
+	npm run pp-webidl -- --input index.html
+else ifdef npm_installed
+	npm install
+	npm run pp-webidl -- --input index.html
+else
+	@echo You need node.js and npm to apply post-processing. To install it, visit:
+	@echo
+	@echo https://nodejs.org/en/download/
+	@echo
+	@echo Until then, post-processing will be done dynamically, in JS, on page load.
 endif
 
 clean :

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,6 +7,7 @@ TARGET_BRANCH="gh-pages"
 function doCompile {
   curl https://api.csswg.org/bikeshed/ -F file=@index.bs > out/index.html
   node ./check-grammar.js ./out/index.html
+  npm run pp-webidl -- --input ./out/index.html
 }
 
 # Pull requests and commits to other branches shouldn't try to deploy, just build to verify

--- a/index.bs
+++ b/index.bs
@@ -13632,7 +13632,7 @@ The following conformance classes are defined by this specification:
     criteria in this specification that apply to implementations for the ECMAScript
     language binding.
 
-<script>
+<script class="remove">
     // Grammar
     (function() {
         function wrap(s) { return "<pre class=grammar>" + s + "</pre>"; }
@@ -13661,8 +13661,9 @@ The following conformance classes are defined by this specification:
         });
         document.querySelector("div[data-fill-with=\"grammar-index\"]").innerHTML = wrap(output);
     })();
+</script>
 
-
+<script>
     // Rotated Table Headers
     /*! modernizr 3.3.1 (Custom Build) | MIT *
      * https://modernizr.com/download/?-csstransforms-setclasses !*/

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "description": "Checks that the WebIDL grammar is LL(1)",
   "devDependencies": {
     "jsdom": "^11.3.0",
-    "syntax-cli": "0.0.97"
+    "syntax-cli": "0.0.97",
+    "webidl-grammar-post-processor": "^0.4.0"
+  },
+  "scripts": {
+    "pp-webidl": "pp-webidl"
   }
 }


### PR DESCRIPTION
Now that the deploy-script relies on node.js to test the grammar, adding an extra-step to get rid of the dynamic generation of the IDL grammar index and formatting isn't that complicated.

This is split up in three commits: 

1. only uses post-processing for pr-preview (which makes it possible to have good HTML diffs of the grammar).
2. adds it to the deploy script, so the published spec no longer needs JS for content generation.
3. Adds-it to the Makefile (but defaults to dynamic generation if node isn't installed).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tobie/webidl/post-process.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/c3e67b3...tobie:d95debc.html)