### PR TITLE
Fix #461 - clarify applicability of overload resolution

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10296,7 +10296,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
 
 <div algorithm>
 
-    In order to define how overloaded function invocations are resolved, the
+    In order to define how function invocations are resolved, the
     <dfn id="dfn-overload-resolution-algorithm" export>overload resolution algorithm</dfn>
     is defined.  Its input is an [=effective overload set=],
     |S|, and a list of ECMAScript values, |arg|<sub>0..|n|−1</sub>.


### PR DESCRIPTION
This algorithm applies to all function invocations, not
just those described in the spec as overloaded - see #461 for discussion.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/timruffles/webidl/tr/specific.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/6673a82...timruffles:c3e0be1.html)