### PR TITLE
static/stringifer RegularOperation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1967,8 +1967,8 @@ are applicable only to regular attributes:
 <h4 id="idl-operations">Operations</h4>
 
 An <dfn id="dfn-operation" export>operation</dfn> is an [=interface member=]
-(matching <emu-t>static</emu-t> <emu-nt><a href="#prod-OperationRest">OperationRest</a></emu-nt>,
-<emu-t>stringifier</emu-t> <emu-nt><a href="#prod-OperationRest">OperationRest</a></emu-nt>,
+(matching <emu-t>static</emu-t> <emu-nt><a href="#prod-RegularOperation">RegularOperation</a></emu-nt>,
+<emu-t>stringifier</emu-t> <emu-nt><a href="#prod-RegularOperation">RegularOperation</a></emu-nt>,
 <emu-nt><a href="#prod-RegularOperation">RegularOperation</a></emu-nt> or
 <emu-nt><a href="#prod-SpecialOperation">SpecialOperation</a></emu-nt>)
 that defines a behavior that can be invoked on objects implementing the interface.


### PR DESCRIPTION
This PR fixes [2.4.3. Operations](https://heycam.github.io/webidl/#idl-operations) which currently says:

>An operation is an interface member (matching static OperationRest, stringifier OperationRest, RegularOperation or SpecialOperation) that defines a behavior that can be invoked on objects implementing the interface.

In fact, both StaticMember and Stringifier requires RegularOperation:

https://heycam.github.io/webidl/#prod-StaticMember

```
StaticMember ::
    static StaticMemberRest
StaticMemberRest ::
    ReadOnly AttributeRest
    RegularOperation
```

https://heycam.github.io/webidl/#prod-Stringifier

```
Stringifier ::
    stringifier StringifierRest
StringifierRest ::
    ReadOnly AttributeRest
    RegularOperation
    ;
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/saschanaz/webidl/static-regular.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/95aeaf7...saschanaz:34bece0.html)