### PR TITLE
Replace remaining emu-t.symbol

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -13685,7 +13685,7 @@ The following conformance classes are defined by this specification:
             var html = pre.textContent.replace(/("[^"]+")|([a-zA-Z]+)|(:)/g, m => {
                 if (/^"/.test(m)) { return "<emu-t>" + m.replace(/^"|"$/g, "") + "</emu-t>"; }
                 if (/^(integer|float|identifier|string|whitespace|comment|other)$/.test(m)) {
-                  return "<emu-t class=\"symbol\"><a href=\"#prod-" + m + "\">" + m + "</a></emu-t>";
+                  return "<emu-t class=\"regex\"><a href=\"#prod-" + m + "\">" + m + "</a></emu-t>";
                 }
                 if (m == ":") { return "::"; }
                 if (document.querySelector("#prod-" + m)) {


### PR DESCRIPTION
This follows e2832d1fbff744f9a73658dbb9ac5b992be4c730.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/saschanaz/webidl/emu-t-regex.html) | [Diff](https://s3.amazonaws.com/pr-preview/heycam/webidl/95aeaf7...saschanaz:faffdcb.html)