### PR TITLE
Add space to class string of iterator objects

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4038,7 +4038,7 @@ that have [=members=] with these names.
 
         typeof SessionManager.prototype.values;            // Evaluates to "function"
         var it = sm.values();                              // values() returns an iterator object
-<!--    String(it);                                        // Evaluates to "[object SessionManagerIterator]"
+<!--    String(it);                                        // Evaluates to "[object SessionManager Iterator]"
                                                            // TODO: https://github.com/heycam/webidl/issues/419 -->
         typeof it.next;                                    // Evaluates to "function"
 
@@ -11854,7 +11854,7 @@ its index is set to 0.
 
 The [=class string=] of a [=default iterator object=] for a given [=interface=]
 is the result of concatenating the [=identifier=] of the [=interface=]
-and the string "<code>Iterator</code>".
+and the string "<code> Iterator</code>".
 
 
 <h5 id="es-iterator-prototype-object">Iterator prototype object</h5>
@@ -11918,7 +11918,7 @@ must be {{%IteratorPrototype%}}.
 
 The [=class string=] of an [=iterator prototype object=] for a given [=interface=]
 is the result of concatenating the [=identifier=] of the [=interface=]
-and the string "<code>Iterator</code>".
+and the string "<code> Iterator</code>".
 
 
 <h4 id="es-maplike">Maplike declarations</h4>

--- a/index.bs
+++ b/index.bs
@@ -32,6 +32,8 @@ Default Biblio Status: current
 spec: infra; type: dfn; text: list
 spec: url; type: interface; text: URL
 spec: dom; type: interface; text: Document
+spec: ecma-262; type: dfn; for: /; text: internal method
+spec: ecma-262; type: dfn; for: /; text: internal slot
 </pre>
 
 <pre class="anchors">
@@ -7828,10 +7830,9 @@ objects.
             return <emu-val>undefined</emu-val>.
         1.  Otherwise, return the result of performing any steps that were required to be run if the promise was rejected,
             with |reason| as the rejection reason.
-    1.  Let |then| be the result of calling the internal \[[Get]] method of |promise| with property name "<code>then</code>".
-    1.  If <a abstract-op>IsCallable</a>(|then|) is <emu-val>false</emu-val>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
-    1.  Return the result of calling |then| with |promise| as the <emu-val>this</emu-val> value and |onFulfilled| and |onRejected|
-        as its two arguments.
+    1.  Let |then| be [=?=] <a abstract-op>GetMethod</a>(|promise|, "<code>then</code>").
+    1.  If |then| is <emu-val>undefined</emu-val>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+    1.  Return <a abstract-op>Call</a>(|then|, |promise|, «|onFulfilled|, |onRejected|»).
 </div>
 
 <p class="issue">
@@ -8269,7 +8270,7 @@ If the [{{Constructor}}]
 [=extended attribute=]
 appears on an [=interface=], it indicates that
 the [=interface object=] for this interface
-will have an \[[Construct]] internal method,
+will have an \[[Construct]] [=internal method=],
 allowing objects implementing the interface to be constructed.
 
 Multiple [{{Constructor}}] extended
@@ -8892,8 +8893,8 @@ If the [{{LegacyArrayClass}}]
 [=extended attribute=]
 appears on an [=interface=]
 that is not defined to [=interface/inherit=]
-from another, it indicates that the internal \[[Prototype]]
-property of its [=interface prototype object=]
+from another, it indicates that the \[[Prototype]]
+[=internal slot=] of its [=interface prototype object=]
 will be the intrinsic object {{%ArrayPrototype%}} rather than
 {{%ObjectPrototype%}}.  This allows
 {{ECMAScript/Array}} methods to be used more easily
@@ -10830,11 +10831,11 @@ have a <code class="idl">constructor</code> data property with attributes
 { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 whose value is a reference to the [=interface object=] for the interface.
 
-<div algorithm="value of internal prototype property">
+<div algorithm="value of the [[Prototype]] internal slot">
 
     The [=interface prototype object=]
-    for a given interface |A| must have an internal
-    \[[Prototype]] property whose value is returned from
+    for a given interface |A| must have a
+    \[[Prototype]] [=internal slot=] whose value is returned from
     the following steps:
 
     1.  If |A| is declared with the [{{Global}}]
@@ -10875,8 +10876,8 @@ whose value is a reference to the [=interface object=] for the interface.
     the [=interface object=]
     (since it does not exist as <code>window.Foo</code>).  However, an instance
     of <code class="idl">Foo</code> can expose the interface prototype
-    object by getting its internal \[[Prototype]]
-    property value – <code>Object.getPrototypeOf(window.foo)</code> in
+    object by calling its \[[GetPrototypeOf]]
+    [=internal method=] – <code>Object.getPrototypeOf(window.foo)</code> in
     this example.
 
 </div>
@@ -10957,8 +10958,8 @@ for that interface on which named properties are exposed.
 <div algorithm="value of [[Prototype]] property of named properties objects">
 
     The [=named properties object=]
-    for a given interface |A| must have an internal
-    \[[Prototype]] property whose value is returned from
+    for a given interface |A| must have a
+    \[[Prototype]] [=internal slot=] whose value is returned from
     the following steps:
 
     1.  If |A| is declared to inherit from another interface, then return the
@@ -11017,7 +11018,7 @@ is the concatenation of the [=interface=]’s
 
 <h5 id="named-properties-object-defineownproperty">\[[DefineOwnProperty]]</h5>
 
-<div algorithm="to invoke the internal [[DefineOwnProperty]] method of named properties object">
+<div algorithm="to invoke the [[DefineOwnProperty]] internal method of named properties object">
 
     When the \[[DefineOwnProperty]] internal method of a [=named properties object=] is called,
     the following steps are taken:
@@ -11027,7 +11028,7 @@ is the concatenation of the [=interface=]’s
 
 <h5 id="named-properties-object-delete">\[[Delete]]</h5>
 
-<div algorithm="to invoke the internal [[Delete]] method of named properties object">
+<div algorithm="to invoke the [[Delete]] internal method of named properties object">
 
     When the \[[Delete]] internal method of a [=named properties object=] is called,
     the following steps are taken:
@@ -11038,7 +11039,7 @@ is the concatenation of the [=interface=]’s
 
 <h5 id="named-properties-object-setprototypeof">\[[SetPrototypeOf]]</h5>
 
-<div algorithm="to invoke the internal [[SetPrototypeOf]] method of a named properties object">
+<div algorithm="to invoke the [[SetPrototypeOf]] internal method of a named properties object">
 
     When the \[[SetPrototypeOf]] internal method of a [=named properties object=] |O| is called with
     ECMAScript language value |V|, the following step is taken:
@@ -11050,7 +11051,7 @@ is the concatenation of the [=interface=]’s
 
 <h5 id="named-properties-object-preventextensions">\[[PreventExtensions]]</h5>
 
-<div algorithm="to invoke the internal [[PreventExtensions]] method of named properties object">
+<div algorithm="to invoke the [[PreventExtensions]] internal method of named properties object">
 
     When the \[[PreventExtensions]] internal method of a [=named properties object=] is called,
     the following steps are taken:
@@ -11704,9 +11705,8 @@ then the [=function object=] is {{%ArrayProto_forEach%}}.
             every time forEach is called?  What's the best way of specifying that there's only
             one function that has captured an environment?
         </p>
-    1.  Let |forEach| be the result of calling the \[[Get]] internal method of
-        |backing| with "<code>forEach</code>" and |backing| as arguments.
-    1.  If <a abstract-op>IsCallable</a>(|forEach|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+    1.  Let |forEach| be [=?=] <a abstract-op>GetMethod</a>(|backing|, "<code>forEach</code>").
+    1.  If |forEach| is <emu-val>undefined</emu-val>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  <a abstract-op>Call</a>(|forEach|, |backing|, «|callbackWrapper|, |thisArg|»).
     1.  Return <emu-val>undefined</emu-val>.
 </div>
@@ -11832,7 +11832,7 @@ The value of the [=function object=]’s <code class="idl">name</code> property 
 
 A <dfn id="dfn-default-iterator-object" export>default iterator object</dfn> for a given
 [=interface=], target and iteration kind
-is an object whose internal \[[Prototype]] property is the
+is an object whose \[[Prototype]] [=internal slot=] is the
 [=iterator prototype object=]
 for the [=interface=].
 
@@ -11866,7 +11866,7 @@ is an object that exists for every interface that has a
 prototype for [=default iterator objects=]
 for the interface.
 
-The internal \[[Prototype]] property of an [=iterator prototype object=]
+The \[[Prototype]] [=internal slot=] of an [=iterator prototype object=]
 must be {{%IteratorPrototype%}}.
 
 <div algorithm="to invoke the next property of iterators">
@@ -11952,8 +11952,8 @@ These additional properties are described in the sub-sections below.
         *   the type "<code>method</code>".
     1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
-    1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing |name| and |map| as arguments.
-    1.  If <a abstract-op>IsCallable</a>(|function|) is <emu-val>false</emu-val>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+    1.  Let |function| be [=?=] <a abstract-op>GetMethod</a>(|map|, |name|).
+    1.  If |function| is <emu-val>undefined</emu-val>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return <a abstract-op>Call</a>(|function|, |map|, |arguments|).
 </div>
 
@@ -11981,7 +11981,7 @@ with the following characteristics:
             *   the type "<code>getter</code>".
         1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
-        1.  Return the result of calling the \[[Get]] internal method of |map| passing "<code>size</code>" and |map| as arguments.
+        1.  Return <a abstract-op>Get</a>(|map|, "<code>size</code>").
     </div>
 
     The value of the [=function object=]’s <code class="idl">length</code> property is the Number value <emu-val>0</emu-val>.
@@ -12034,7 +12034,7 @@ For both of <code class="idl">get</code> and <code class="idl">has</code>, there
         1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| be the key type specified in the [=maplike declaration=].
-        1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing |name| and |map| as arguments.
+        1.  Let |function| be [=!=] <a abstract-op>Get</a>(|map|, |name|).
         1.  Let |keyArg| be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
         1.  Let |keyIDL| be the result of [=converted to an IDL value|converting=] |keyArg| to an IDL value of type |keyType|.
         1.  Let |key| be the result of [=converted to ECMAScript values|converting=] |keyIDL| to an ECMAScript value.
@@ -12086,7 +12086,7 @@ must exist on |A|’s
         1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| be the key type specified in the [=maplike declaration=].
-        1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing "<code>delete</code>" and |map| as arguments.
+        1.  Let |function| be [=!=] <a abstract-op>Get</a>(|map|, "<code>delete</code>").
         1.  Let |keyArg| be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
         1.  Let |keyIDL| be the result of [=converted to an IDL value|converting=] |keyArg| to an IDL value of type |keyType|.
         1.  Let |key| be the result of [=converted to ECMAScript values|converting=] |keyIDL| to an ECMAScript value.
@@ -12120,7 +12120,7 @@ must exist on |A|’s [=interface prototype object=]:
         1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| and |valueType| be the key and value types specified in the [=maplike declaration=].
-        1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing "<code>set</code>" and |map| as arguments.
+        1.  Let |function| be [=!=] <a abstract-op>Get</a>(|map|, "<code>set</code>").
         1.  Let |keyArg| be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
         1.  Let |valueArg| be the second argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
         1.  Let |keyIDL| be the result of [=converted to an IDL value|converting=] |keyArg| to an IDL value of type |keyType|.
@@ -12168,9 +12168,8 @@ These additional properties are described in the sub-sections below.
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |set| be the {{ECMAScript/Set}} object that is
         the value of |O|’s \[[BackingSet]] [=internal slot=].
-    1.  Let |function| be the result of calling the \[[Get]] internal method of |set|
-        passing |name| and |set| as arguments.
-    1.  If <a abstract-op>IsCallable</a>(|function|) is <emu-val>false</emu-val>,
+    1.  Let |function| be [=?=] <a abstract-op>GetMethod</a>(|set|, |name|).
+    1.  If |function| is <emu-val>undefined</emu-val>,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return <a abstract-op>Call</a>(|function|, |set|, |arguments|).
 </div>
@@ -12250,7 +12249,7 @@ with the following characteristics:
         1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |set| be the {{ECMAScript/Set}} object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
         1.  Let |type| be the value type specified in the [=setlike declaration=].
-        1.  Let |function| be the result of calling the \[[Get]] internal method of |set| passing "<code>has</code>" and |set| as arguments.
+        1.  Let |function| be [=!=] <a abstract-op>Get</a>(|set|, "<code>has</code>").
         1.  Let |arg| be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
         1.  Let |idlValue| be the result of [=converted to an IDL value|converting=] |arg| to an IDL value of type |type|.
         1.  Let |value| be the result of [=converted to ECMAScript values|converting=] |idlValue| to an ECMAScript value.
@@ -12287,7 +12286,7 @@ must exist on |A|’s [=interface prototype object=]:
         1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |set| be the {{ECMAScript/Set}} object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
         1.  Let |type| be the value type specified in the [=setlike declaration=].
-        1.  Let |function| be the result of calling the \[[Get]] internal method of |set| passing |name| and |set| as arguments.
+        1.  Let |function| be [=!=] <a abstract-op>Get</a>(|set|, |name|).
         1.  Let |arg| be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
         1.  Let |idlValue| be the result of [=converted to an IDL value|converting=] |arg| to an IDL value of type |type|.
         1.  Let |value| be the result of [=converted to ECMAScript values|converting=] |idlValue| to an ECMAScript value.
@@ -12328,15 +12327,15 @@ object is associated with.
 
 The <dfn id="dfn-primary-interface" export>primary interface</dfn> of a platform object
 that implements one or more interfaces is the most-derived [=interface=]
-that it implements.  The value of the internal \[[Prototype]]
-property of the platform object is the [=interface prototype object=]
+that it implements.  The value of the \[[Prototype]] [=internal slot=]
+of the platform object is the [=interface prototype object=]
 of the [=primary interface=]
 from the [=platform object=]’s associated global environment.
 
 The global environment that a given [=platform object=]
 is associated with can <dfn id="dfn-change-global-environment" for="global environment" export>change</dfn> after it has been created.  When
-the global environment associated with a platform object is changed, its internal
-\[[Prototype]] property must be immediately
+the global environment associated with a platform object is changed, its
+\[[Prototype]] [=internal slot=] must be immediately
 updated to be the [=interface prototype object=]
 of the [=primary interface=]
 from the [=platform object=]’s newly associated global environment.
@@ -12404,9 +12403,9 @@ and [[#legacy-platform-object-set]].
 
 <h4 id="legacy-platform-object-getownproperty" dfn oldids="getownproperty" lt=GetOwnProperty for="legacy platform object">\[[GetOwnProperty]]</h4>
 
-<div algorithm="to invoke the internal [[GetOwnProperty]] method of platform objects">
+<div algorithm="to invoke the [[GetOwnProperty]] internal method of legacy platform objects">
 
-    The internal \[[GetOwnProperty]] method of every [=legacy platform object=] |O|
+    The \[[GetOwnProperty]] internal method of every [=legacy platform object=] |O|
     must behave as follows when called with property name |P|:
 
     1. Return <a abstract-op>LegacyPlatformObjectGetOwnProperty</a>(|O|, |P|, <emu-val>false</emu-val>).
@@ -12415,9 +12414,9 @@ and [[#legacy-platform-object-set]].
 
 <h4 id="legacy-platform-object-set" oldids="platformobjectset">\[[Set]]</h4>
 
-<div algorithm="to invoke the internal [[Set]] method of legacy platform objects">
+<div algorithm="to invoke the [[Set]] internal method of legacy platform objects">
 
-    The internal \[[Set]] method of every [=legacy platform object=] |O|
+    The \[[Set]] internal method of every [=legacy platform object=] |O|
     must behave as follows when called with
     property name |P|, value |V|, and ECMAScript language value |Receiver|:
 
@@ -12437,9 +12436,9 @@ and [[#legacy-platform-object-set]].
 
 <h4 id="legacy-platform-object-defineownproperty" oldids="defineownproperty">\[[DefineOwnProperty]]</h4>
 
-<div algorithm="to invoke the internal [[DefineOwnProperty]] method of legacy platform objects">
+<div algorithm="to invoke the [[DefineOwnProperty]] internal method of legacy platform objects">
 
-    When the internal \[[DefineOwnProperty]] method of a [=legacy platform object=] |O|
+    When the \[[DefineOwnProperty]] internal method of a [=legacy platform object=] |O|
     is called with property key |P| and [=Property Descriptor=] |Desc|,
     the following steps must be taken:
 
@@ -12484,9 +12483,9 @@ and [[#legacy-platform-object-set]].
 
 <h4 id="legacy-platform-object-delete" oldids="delete">\[[Delete]]</h4>
 
-<div algorithm="to invoke the internal [[Delete]] method of legacy platform objects">
+<div algorithm="to invoke the [[Delete]] internal method of legacy platform objects">
 
-    The internal \[[Delete]] method of every [=legacy platform object=] |O|
+    The \[[Delete]] internal method of every [=legacy platform object=] |O|
     must behave as follows when called with property name |P|.
 
     1.  If |O| [=support indexed properties|supports indexed properties=] and
@@ -12598,11 +12597,11 @@ internal method as follows.
 
     1.  If |O| implements an interface that has the [{{OverrideBuiltins}}]
         [=extended attribute=], then return true.
-    1.  Initialize |prototype| to be the value of the internal \[[Prototype]] property of |O|.
+    1.  Let |prototype| be |O|.\[[GetPrototypeOf]]().
     1.  While |prototype| is not null:
         1.  If |prototype| is not a [=named properties object=],
             and |prototype| has an own property named |P|, then return false.
-        1.  Set |prototype| to be the value of the internal \[[Prototype]] property of |prototype|.
+        1.  Set |prototype| to |prototype|.\[[GetPrototypeOf]]().
     1.  Return true.
 </div>
 
@@ -13040,7 +13039,7 @@ The characteristics of a namespace object are described in [[#namespace-object]]
 In the ECMAScript binding, the {{DOMException}} type has some additional requirements:
 
 *   Unlike normal [=interface types=], the [=interface prototype object=] for {{DOMException}} must
-    have as its \[[Prototype]] the intrinsic object {{%ErrorPrototype%}}.
+    have as its \[[Prototype]] [=internal slot=] the intrinsic object {{%ErrorPrototype%}}.
 
 *   If an implementation gives native {{ECMAScript/Error}} objects special powers or
     nonstandard properties (such as a <code>stack</code> property), it should also expose those on

--- a/index.bs
+++ b/index.bs
@@ -608,7 +608,7 @@ is the value of the <emu-t class="regex"><a href="#prod-identifier">identifier</
 <span class="char">U+005F LOW LINE ("_")</span> character (underscore) removed.
 
 Note: A leading <span class="char">"_"</span> is used to escape an identifier from looking
-like a reserved word so that, for example, an interface named “interface” can be
+like a reserved word so that, for example, an interface named "<code>interface</code>" can be
 defined.  The leading <span class="char">"_"</span> is dropped to unescape the
 identifier.
 
@@ -659,12 +659,12 @@ keyword token is used, then the [=identifier=] of the operation argument
 is simply that token.
 
 The [=identifier=] of any of the abovementioned
-IDL constructs must not be “constructor”,
-“toString”,
+IDL constructs must not be "<code>constructor</code>",
+"<code>toString</code>",
 or begin with a <span class="char">U+005F LOW LINE ("_")</span> character.  These
 are known as <dfn id="dfn-reserved-identifier" export>reserved identifiers</dfn>.
 
-Although the “toJSON” [=identifier=] is not a [=reserved identifier=],
+Although the "<code>toJSON</code>" [=identifier=] is not a [=reserved identifier=],
 it must only be used for [=regular operations=]
 that convert objects to [=JSON types=],
 as described in [[#idl-tojson-operation]].
@@ -748,7 +748,7 @@ across [=IDL fragments=].
 
     Note that while the second [=attribute=]
     on the <code class="idl">TextField</code> [=interface=]
-    need not have been escaped with an underscore (because “value” is
+    need not have been escaped with an underscore (because "<code>value</code>" is
     not a keyword in the IDL grammar), it is still unescaped
     to obtain the attribute’s [=identifier=].
 
@@ -918,7 +918,7 @@ be defined on a [=callback interface=].
     [=callback interface=]
     is an example of an existing API that needs to allow
     [=user objects=] with a
-    given property (in this case “handleEvent”) to be considered to implement the interface.
+    given property (in this case <code class="idl">handleEvent</code>) to be considered to implement the interface.
     For new APIs, and those for which there are no compatibility concerns,
     using a [=callback function=] will allow
     only a [=function object=] (in the ECMAScript
@@ -1336,7 +1336,7 @@ No [=extended attributes=] defined in this specification are applicable to [=inc
         Entry includes Observable;
     </pre>
 
-    An ECMAScript implementation would thus have an “addEventListener”
+    An ECMAScript implementation would thus have an <code class="idl">addEventListener</code>
     property in the prototype chain of every <code class="idl">Entry</code>:
 
     <pre highlight="js">
@@ -1549,7 +1549,7 @@ must not be the same as the identifier
 of another [=interface member=]
 defined on the same interface.
 The identifier also must not
-be “length”, “name” or “prototype”.
+be "<code>length</code>", "<code>name</code>" or "<code>prototype</code>".
 
 Note: These three names are the names of properties that may exist on
 [=function objects=] at the time the [=function object=] is created in the ECMAScript language binding.
@@ -1795,7 +1795,7 @@ must not be the same as the identifier
 of another [=interface member=]
 defined on the same [=interface=].
 The identifier of a static attribute must not
-be “prototype”.
+be "<code>prototype</code>".
 
 The type of the attribute is given by the type (matching <emu-nt><a href="#prod-Type">Type</a></emu-nt>)
 that appears after the <emu-t>attribute</emu-t> keyword.
@@ -2022,7 +2022,7 @@ The identifier of a [=regular operation=] or [=static operation=]
 must not be the same as the identifier
 of a [=constant=] or [=attribute=]
 defined on the same [=interface=].
-The identifier of a static operation must not be “prototype”.
+The identifier of a static operation must not be "<code>prototype</code>".
 
 Note: The identifier can be the same
 as that of another operation on the interface, however.
@@ -2744,7 +2744,7 @@ a [=static attribute=].
 
     In the ECMAScript binding, using a <code class="idl">Student</code>
     object in a context where a string is expected will result in the
-    value of the object’s “name” property being
+    value of the object’s <code class="idl">name</code> property being
     used:
 
     <pre highlight="js">
@@ -2816,7 +2816,7 @@ a description of what indices the object can be indexed with at
 any given time. These indices are called the <dfn id="dfn-supported-property-indices" export>supported property indices</dfn>.
 
 Interfaces that [=support indexed properties=] must define
-an [=integer types|integer-typed=] [=attribute=] named “length”.
+an [=integer types|integer-typed=] [=attribute=] named "<code>length</code>".
 
 Indexed property getters must
 be declared to take a single {{unsigned long}} argument.
@@ -3925,7 +3925,8 @@ Objects implementing an interface that is declared to be iterable
 support being iterated over to obtain a sequence of values.
 
 Note: In the ECMAScript language binding, an interface that is iterable
-will have “entries”, “forEach”, “keys”, “values” and {{@@iterator}}
+will have <code class="idl">entries</code>, <code class="idl">forEach</code>,
+<code class="idl">keys</code>, <code class="idl">values</code>, and {{@@iterator}}
 properties on its [=interface prototype object=].
 
 If a single type parameter is given, then the interface has a
@@ -3978,12 +3979,14 @@ is.
 
 Note: This is how [=array iterator objects=] work.
 For interfaces that [=support indexed properties=],
-the iterator objects returned by “entries”, “keys”, “values” and {{@@iterator}} are
+the iterator objects returned by <code class="idl">entries</code>,
+<code class="idl">keys</code>, <code class="idl">values</code>, and {{@@iterator}} are
 actual [=array iterator objects=].
 
 Interfaces with iterable declarations must not
 have any [=interface members=]
-named “entries”, “forEach”, “keys” or “values”,
+named "<code>entries</code>", "<code>forEach</code>",
+"<code>keys</code>", or "<code>values</code>",
 or have any [=inherited interfaces=]
 that have [=members=] with these names.
 
@@ -4121,23 +4124,31 @@ the map entries.
 Note: In the ECMAScript language binding, the API for interacting
 with the map entries is similar to that available on ECMAScript
 {{ECMAScript/Map}} objects.  If the <emu-t>readonly</emu-t>
-keyword is used, this includes “entries”, “forEach”, “get”, “has”,
-“keys”, “values”, {{@@iterator}} methods and a “size” getter.
-For read–write maplikes, it also includes “clear”, “delete” and
-“set” methods.
+keyword is used, this includes <code class="idl">entries</code>,
+<code class="idl">forEach</code>, <code class="idl">get</code>,
+<code class="idl">has</code>, <code class="idl">keys</code>,
+<code class="idl">values</code>, {{@@iterator}} methods, and a
+<code class="idl">size</code> getter.
+For read–write maplikes, it also includes <code class="idl">clear</code>,
+<code class="idl">delete</code>, and <code class="idl">set</code> methods.
 
 Maplike interfaces must not
 have any [=interface members=]
-named “entries”, “forEach”, “get”, “has”, “keys”, “size”, or “values”,
+named "<code>entries</code>", "<code>forEach</code>",
+"<code>get</code>", "<code>has</code>",
+"<code>keys</code>", "<code>size</code>", or
+"<code>values</code>",
 or have any [=inherited interfaces=]
 that have [=members=] with these names.
 Read–write maplike interfaces must not
 have any [=attributes=]
 or [=constants=] named
-“clear”, “delete”, or “set”, or have any [=inherited interfaces=]
+"<code>clear</code>", "<code>delete</code>",
+or "<code>set</code>", or have any [=inherited interfaces=]
 that have [=attributes=] or [=constants=] with these names.
 
-Note: Operations named “clear”, “delete”, or “set” are allowed on read–write maplike
+Note: Operations named "<code>clear</code>", "<code>delete</code>",
+or "<code>set</code>" are allowed on read–write maplike
 interfaces and will prevent the default implementation of these methods being
 added to the interface prototype object in the ECMAScript language binding.
 This allows the default behavior of these operations to be overridden.
@@ -4207,22 +4218,29 @@ the set entries.
 Note: In the ECMAScript language binding, the API for interacting
 with the set entries is similar to that available on ECMAScript
 {{ECMAScript/Set}} objects.  If the <emu-t>readonly</emu-t>
-keyword is used, this includes “entries”, “forEach”, “has”,
-“keys”, “values”, {{@@iterator}} methods and a “size” getter.
-For read–write setlikes, it also includes “add”, “clear”, and “delete” methods.
+keyword is used, this includes <code class="idl">entries</code>,
+<code class="idl">forEach</code>, <code class="idl">has</code>,
+<code class="idl">keys</code>, <code class="idl">values</code>,
+{{@@iterator}} methods, and a <code class="idl">size</code> getter.
+For read–write setlikes, it also includes <code class="idl">add</code>,
+<code class="idl">clear</code>, and <code class="idl">delete</code> methods.
 
 Setlike interfaces must not
 have any [=interface members=]
-named “entries”, “forEach”, “has”, “keys”, “size”, or “values”,
+named "<code>entries</code>", "<code>forEach</code>",
+"<code>has</code>", "<code>keys</code>",
+"<code>size</code>", or "<code>values</code>",
 or have any [=inherited interfaces=]
 that have [=members=] with these names.
 Read–write setlike interfaces must not
 have any [=attributes=]
 or [=constants=] named
-“add”, “clear”, or “delete”, or have any [=inherited interfaces=]
+"<code>add</code>", "<code>clear</code>",
+or "<code>delete</code>", or have any [=inherited interfaces=]
 that have [=attributes=] or [=constants=] with these names.
 
-Note: Operations named “add”, “clear”, or “delete” are allowed on read–write setlike
+Note: Operations named "<code>add</code>", "<code>clear</code>",
+or "<code>delete</code>" are allowed on read–write setlike
 interfaces and will prevent the default implementation of these methods being
 added to the interface prototype object in the ECMAScript language binding.
 This allows the default behavior of these operations to be overridden.
@@ -4339,8 +4357,8 @@ namespaces.
         };
     </pre>
 
-    An ECMAScript implementation would then expose a global property named
-    <code>VectorUtils</code> which was a simple object (with prototype
+    An ECMAScript implementation would then expose a global <code class="idl">VectorUtils</code>
+    data property which was a simple object (with prototype
     {{%ObjectPrototype%}}) with enumerable data properties for each declared operation, and
     enumerable get-only accessors for each declared attribute:
 
@@ -4511,7 +4529,7 @@ if at least one of the following is true:
     includes |D|
 *   the type is a dictionary, one of whose members or inherited members has
     a type that includes |D|
-*   the type is <code>[=record=]&lt;|K|, |V|></code> where |V| includes |D|
+*   the type is <code class="idl">[=record=]&lt;|K|, |V|></code> where |V| includes |D|
 
 As with interfaces, the IDL for dictionaries can be split into multiple parts
 by using <dfn id="dfn-partial-dictionary" export>partial dictionary</dfn> definitions
@@ -5017,7 +5035,7 @@ must not include duplicates.
     separated at all, unless there is a specific reason to use another
     value naming scheme.  For example, an enumeration value that
     indicates an object should be created could be named
-    <code>"createobject"</code> or <code>"create-object"</code>.
+    "<code>createobject</code>" or "<code>create-object</code>".
     Consider related uses of enumeration values when deciding whether
     to dash-separate or not separate enumeration value words so that
     similar APIs are consistent.
@@ -5446,7 +5464,7 @@ type.
 
 The {{any}} type is the union of all other possible
 non-[=union type|union=] types.
-Its [=type name=] is “Any”.
+Its [=type name=] is "<code>Any</code>".
 
 The {{any}} type is like
 a discriminated union type, in that each of its values has a
@@ -5473,7 +5491,7 @@ represented with the <emu-t>true</emu-t> and
 <emu-t>false</emu-t> tokens.
 
 The [=type name=] of the
-{{boolean}} type is “Boolean”.
+{{boolean}} type is "<code>Boolean</code>".
 
 
 <h4 oldids="dom-byte" id="idl-byte" interface>byte</h4>
@@ -5486,7 +5504,7 @@ represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t
 tokens.
 
 The [=type name=] of the
-{{byte}} type is “Byte”.
+{{byte}} type is "<code>Byte</code>".
 
 
 <h4 oldids="dom-octet" id="idl-octet" interface>octet</h4>
@@ -5499,7 +5517,7 @@ represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t
 tokens.
 
 The [=type name=] of the
-{{octet}} type is “Octet”.
+{{octet}} type is "<code>Octet</code>".
 
 
 <h4 oldids="dom-short" id="idl-short" interface>short</h4>
@@ -5512,7 +5530,7 @@ represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t
 tokens.
 
 The [=type name=] of the
-{{short}} type is “Short”.
+{{short}} type is "<code>Short</code>".
 
 
 <h4 oldids="dom-unsignedshort" id="idl-unsigned-short" interface>unsigned short</h4>
@@ -5525,7 +5543,7 @@ represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t
 tokens.
 
 The [=type name=] of the
-{{unsigned short}} type is “UnsignedShort”.
+{{unsigned short}} type is "<code>UnsignedShort</code>".
 
 
 <h4 oldids="dom-long" id="idl-long" interface>long</h4>
@@ -5538,7 +5556,7 @@ represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t
 tokens.
 
 The [=type name=] of the
-{{long}} type is “Long”.
+{{long}} type is "<code>Long</code>".
 
 
 <h4 oldids="dom-unsignedlong" id="idl-unsigned-long" interface>unsigned long</h4>
@@ -5551,7 +5569,7 @@ represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t
 tokens.
 
 The [=type name=] of the
-{{unsigned long}} type is “UnsignedLong”.
+{{unsigned long}} type is "<code>UnsignedLong</code>".
 
 
 <h4 oldids="dom-longlong" id="idl-long-long" interface>long long</h4>
@@ -5564,7 +5582,7 @@ represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t
 tokens.
 
 The [=type name=] of the
-{{long long}} type is “LongLong”.
+{{long long}} type is "<code>LongLong</code>".
 
 
 <h4 oldids="dom-unsignedlonglong" id="idl-unsigned-long-long" interface>unsigned long long</h4>
@@ -5577,7 +5595,7 @@ represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t
 tokens.
 
 The [=type name=] of the
-{{unsigned long long}} type is “UnsignedLongLong”.
+{{unsigned long long}} type is "<code>UnsignedLongLong</code>".
 
 
 <h4 oldids="dom-float" id="idl-float" interface>float</h4>
@@ -5591,7 +5609,7 @@ represented with <emu-t class="regex"><a href="#prod-float">float</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{float}} type is “Float”.
+{{float}} type is "<code>Float</code>".
 
 <p class="advisement">
     Unless there are specific reasons to use a 32 bit floating point type,
@@ -5613,7 +5631,7 @@ represented with <emu-t class="regex"><a href="#prod-float">float</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{unrestricted float}} type is “UnrestrictedFloat”.
+{{unrestricted float}} type is "<code>UnrestrictedFloat</code>".
 
 
 <h4 oldids="dom-double" id="idl-double" interface>double</h4>
@@ -5627,7 +5645,7 @@ represented with <emu-t class="regex"><a href="#prod-float">float</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{double}} type is “Double”.
+{{double}} type is "<code>Double</code>".
 
 
 <h4 oldids="dom-unrestricteddouble" id="idl-unrestricted-double" interface>unrestricted double</h4>
@@ -5641,7 +5659,7 @@ represented with <emu-t class="regex"><a href="#prod-float">float</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{unrestricted double}} type is “UnrestrictedDouble”.
+{{unrestricted double}} type is "<code>UnrestrictedDouble</code>".
 
 
 <h4 oldids="dom-DOMString" id="idl-DOMString" interface>DOMString</h4>
@@ -5713,7 +5731,7 @@ and [=optional argument|operation optional argument=] default values
 can be specified using a <emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.
 
 The [=type name=] of the
-{{DOMString}} type is “String”.
+{{DOMString}} type is "<code>String</code>".
 
 
 <h4 oldids="dom-ByteString" id="idl-ByteString" interface>ByteString</h4>
@@ -5729,7 +5747,7 @@ and [=optional argument|operation optional argument=] default values
 can be specified using a <emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.
 
 The [=type name=] of the
-{{ByteString}} type is “ByteString”.
+{{ByteString}} type is "<code>ByteString</code>".
 
 <p class="advisement">
     Specifications should only use
@@ -5759,7 +5777,7 @@ and [=optional argument|operation optional argument=] default values
 can be specified using a <emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.
 
 The [=type name=] of the
-{{USVString}} type is “USVString”.
+{{USVString}} type is "<code>USVString</code>".
 
 <p class="advisement">
     Specifications should only use
@@ -5785,7 +5803,7 @@ To denote a type that includes all possible object references plus the
 <code class="idl">object?</code>.
 
 The [=type name=] of the
-{{object}} type is “Object”.
+{{object}} type is "<code>Object</code>".
 
 <h4 id="idl-symbol" interface>symbol</h4>
 
@@ -5794,7 +5812,7 @@ non-{{object}} values which nevertheless have identity (i.e., are only equal to 
 
 There is no way to represent a constant {{symbol}} value in IDL.
 
-The [=type name=] of the {{symbol}} type is “Symbol”.
+The [=type name=] of the {{symbol}} type is "<code>Symbol</code>".
 
 
 <h4 id="idl-interface" dfn>Interface types</h4>
@@ -5905,7 +5923,7 @@ would be represented, or with the <emu-t>null</emu-t> token.
 
 The [=type name=] of a nullable type
 is the concatenation of the type name of the [=nullable types/inner type=] |T| and
-the string “OrNull”.
+the string "<code>OrNull</code>".
 
 <div class="example">
 
@@ -5965,7 +5983,7 @@ sequence is used.
 
 The [=type name=] of a sequence type
 is the concatenation of the type name for |T| and
-the string “Sequence”.
+the string "<code>Sequence</code>".
 
 Any [=list=] can be implicitly treated as a <code>sequence&lt;|T|&gt;</code>, as long as it contains
 only [=list/items=] that are of type |T|.
@@ -5992,7 +6010,7 @@ Records must not be used as the type of an [=attribute=] or
 [=constant=].
 
 The [=type name=] of a record type is the concatenation of the type
-name for |K|, the type name for |V| and the string “Record”.
+name for |K|, the type name for |V| and the string "<code>Record</code>".
 
 Any [=ordered map=] can be implicitly treated as a <code>record&lt;|K|, |V|&gt;</code>, as long as
 it contains only [=map/entries=] whose [=map/keys=] are all of of type |K| and whose [=map/values=]
@@ -6014,7 +6032,7 @@ There is no way to represent a promise value in IDL.
 
 The [=type name=] of a promise type
 is the concatenation of the type name for |T| and
-the string “Promise”.
+the string "<code>Promise</code>".
 
 
 <h4 id="idl-union">Union types</h4>
@@ -6122,7 +6140,7 @@ represented.
 
 The [=type name=] of a union
 type is formed by taking the type names of each member type, in order,
-and joining them with the string “Or”.
+and joining them with the string "<code>Or</code>".
 
 <div data-fill-with="grammar-UnionType"></div>
 
@@ -6254,7 +6272,7 @@ There is no way to represent a constant {{Error!!interface}}
 value in IDL.
 
 The [=type name=] of the
-{{Error!!interface}} type is “Error”.
+{{Error!!interface}} type is "<code>Error</code>".
 
 
 <h4 id="idl-buffer-source-types">Buffer source types</h4>
@@ -6368,7 +6386,7 @@ There is no way to represent a constant frozen array value in IDL.
 
 The [=type name=] of a frozen array
 type is the concatenation of the type name for |T| and the string
-“Array”.
+"<code>Array</code>".
 
 
 <h3 id="idl-extended-attributes">Extended attributes</h3>
@@ -6862,7 +6880,7 @@ In effect, where <var ignore>x</var> is a Number value,
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL {{byte}} value by running the following algorithm:
 
-    1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 8, "signed").
+    1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 8, "<code>signed</code>").
     1.  Return the IDL {{byte}} value that represents the same numeric value as |x|.
 </div>
 
@@ -6882,7 +6900,7 @@ In effect, where <var ignore>x</var> is a Number value,
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL {{octet}} value by running the following algorithm:
 
-    1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 8, "unsigned").
+    1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 8, "<code>unsigned</code>").
     1.  Return the IDL {{octet}} value that represents the same numeric value as |x|.
 </div>
 
@@ -6903,7 +6921,7 @@ In effect, where <var ignore>x</var> is a Number value,
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL {{short}} value by running the following algorithm:
 
-    1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 16, "signed").
+    1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 16, "<code>signed</code>").
     1.  Return the IDL {{short}} value that represents the same numeric value as |x|.
 
 </div>
@@ -6925,7 +6943,7 @@ In effect, where <var ignore>x</var> is a Number value,
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL {{unsigned short}} value by running the following algorithm:
 
-    1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 16, "unsigned").
+    1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 16, "<code>unsigned</code>").
     1.  Return the IDL {{short}} value that represents the same numeric value as |x|.
 </div>
 
@@ -6946,7 +6964,7 @@ In effect, where <var ignore>x</var> is a Number value,
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL {{long}} value by running the following algorithm:
 
-    1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 32, "signed").
+    1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 32, "<code>signed</code>").
     1.  Return the IDL {{long}} value that represents the same numeric value as |x|.
 </div>
 
@@ -6967,7 +6985,7 @@ In effect, where <var ignore>x</var> is a Number value,
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL {{unsigned long}} value  by running the following algorithm:
 
-    1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 32, "unsigned").
+    1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 32, "<code>unsigned</code>").
     1.  Return the IDL {{long}} value that represents the same numeric value as |x|.
 </div>
 
@@ -6988,7 +7006,7 @@ In effect, where <var ignore>x</var> is a Number value,
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL {{long long}} value by running the following algorithm:
 
-    1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 64, "signed").
+    1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 64, "<code>signed</code>").
     1.  Return the IDL {{long}} value that represents the same numeric value as |x|.
 </div>
 
@@ -7013,7 +7031,7 @@ In effect, where <var ignore>x</var> is a Number value,
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL {{unsigned long long}} value by running the following algorithm:
 
-    1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 64, "unsigned").
+    1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 64, "<code>unsigned</code>").
     1.  Return the IDL {{long}} value that represents the same numeric value as |x|.
 </div>
 
@@ -7047,7 +7065,7 @@ In effect, where <var ignore>x</var> is a Number value,
 
     1.  If |bitLength| is 64, then:
         1.  Let |upperBound| be 2<sup>53</sup> − 1.
-        1.  If |signedness| is "unsigned", then let |lowerBound| be 0.
+        1.  If |signedness| is "<code>unsigned</code>", then let |lowerBound| be 0.
         1.  Otherwise let |lowerBound| be −2<sup>53</sup> + 1.
 
             Note: this ensures {{long long}} types
@@ -7055,7 +7073,7 @@ In effect, where <var ignore>x</var> is a Number value,
             [{{Clamp}}] [=extended attributes=] are representable in ECMAScript's [=Number type=]
             as unambiguous integers.
 
-    1.  Otherwise, if |signedness| is "unsigned", then:
+    1.  Otherwise, if |signedness| is "<code>unsigned</code>", then:
         1.  Let |lowerBound| be 0.
         1.  Let |upperBound| be 2<sup>|bitLength|</sup> − 1.
     1.  Otherwise:
@@ -7082,7 +7100,7 @@ In effect, where <var ignore>x</var> is a Number value,
         then return +0.
     1.  Set |x| to [=!=] <a abstract-op>IntegerPart</a>(|x|).
     1.  Set |x| to |x| [=modulo=] 2<sup>|bitLength|</sup>.
-    1.  If |signedness| is "signed" and |x| ≥ 2<sup>|bitLength| − 1</sup>,
+    1.  If |signedness| is "<code>signed</code>" and |x| ≥ 2<sup>|bitLength| − 1</sup>,
         then return |x| − 2<sup>|bitLength|</sup>.
     1.  Otherwise, return |x|.
 </div>
@@ -7710,7 +7728,7 @@ ECMAScript Object values.
 
     Passing the ECMAScript value <code>{b: 3, a: 4}</code> as a
     <code>[=record=]&lt;DOMString, double></code> argument
-    would result in the IDL value «[ "b" → 3, "a" → 4 ]».
+    would result in the IDL value «[ "<code>b</code>" → 3, "<code>a</code>" → 4 ]».
 
     Records only consider [=own property|own=] [=enumerable=]
     properties, so given an IDL operation
@@ -7746,12 +7764,12 @@ ECMAScript Object values.
         <tr>
             <td><code>{"\uD83D": 1}</code></td>
             <td><code>[=record=]&lt;USVString, double></code></td>
-            <td>«[ "\uFFFD" → 1 ]»</td>
+            <td>«[ "<code>\uFFFD</code>" → 1 ]»</td>
         </tr>
         <tr>
             <td><code>{"\uD83D": {hello: "world"}}</code></td>
             <td><code>[=record=]&lt;DOMString, double></code></td>
-            <td>«[ "\uD83D" → 0 ]»</td>
+            <td>«[ "<code>\uD83D</code>" → 0 ]»</td>
         </tr>
     </table>
 </div>
@@ -7810,7 +7828,7 @@ objects.
             return <emu-val>undefined</emu-val>.
         1.  Otherwise, return the result of performing any steps that were required to be run if the promise was rejected,
             with |reason| as the rejection reason.
-    1.  Let |then| be the result of calling the internal \[[Get]] method of |promise| with property name “then”.
+    1.  Let |then| be the result of calling the internal \[[Get]] method of |promise| with property name "<code>then</code>".
     1.  If <a abstract-op>IsCallable</a>(|then|) is <emu-val>false</emu-val>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return the result of calling |then| with |promise| as the <emu-val>this</emu-val> value and |onFulfilled| and |onRejected|
         as its two arguments.
@@ -8128,7 +8146,7 @@ Array object references.
     1.  Let |array| be the result of
         [=converted to an ECMAScript value|converting=]
         the sequence of values of type |T| to an ECMAScript value.
-    1.  Perform <a abstract-op>SetIntegrityLevel</a>(|array|, <code>"frozen"</code>).
+    1.  Perform <a abstract-op>SetIntegrityLevel</a>(|array|, "<code>frozen</code>").
     1.  Return |array|.
 </div>
 
@@ -8887,7 +8905,7 @@ It must not be used on an interface that
 has any [=inherited interfaces=].
 
 Note: Interfaces using [{{LegacyArrayClass}}] will
-need to define a “length” [=attribute=]
+need to define a <code class="idl">length</code> [=attribute=]
 of type {{unsigned long}} that exposes the length
 of the array-like object, in order for the inherited Array
 methods to operate correctly.  Such interfaces would typically also
@@ -9742,7 +9760,7 @@ is to be implemented.
     </pre>
 
     In the ECMAScript binding, this would allow assignments to the
-    “name” property:
+    <code class="idl">name</code> property:
 
     <pre highlight="js">
         var p = getPerson();           // Obtain an instance of Person.
@@ -9807,7 +9825,7 @@ for the specific requirements that the use of
         };
     </pre>
 
-    Assigning to the “value” property
+    Assigning to the <code class="idl">value</code> property
     on a [=platform object=] implementing <code class="idl">Counter</code>
     will shadow the property that corresponds to the
     [=attribute=]:
@@ -10102,7 +10120,7 @@ for the specific requirements that the use of
 If the [{{TreatNullAs}}] [=extended attribute=] appears on the {{DOMString}} type, it creates a new
 IDL type such that that when an ECMAScript <emu-val>null</emu-val> is converted to the IDL type, it
 will be handled differently from its default handling. Instead of being stringified to
-<code>"null"</code>, which is the default, it will be converted to the empty string.
+"<code>null</code>", which is the default, it will be converted to the empty string.
 
 The [{{TreatNullAs}}] extended attribute must [=takes an identifier|take the identifier=]
 <code>EmptyString</code>.
@@ -10132,7 +10150,7 @@ See [[#es-DOMString]] for the specific requirements that the use of [{{TreatNull
     interface would convert a <emu-val>null</emu-val> value
     assigned to the <code>owner</code> property or passed as the
     argument to the <code>isMemberOfBreed</code> function
-    to the empty string rather than <code>"null"</code>:
+    to the empty string rather than "<code>null</code>":
 
     <pre highlight="js">
         var d = getDog();         // Assume d is a platform object implementing the Dog
@@ -10301,8 +10319,8 @@ for the specific requirements that the use of
         };
     </pre>
 
-    the “f” property an be referenced with a bare identifier
-    in a <code>with</code> statement but the “g” property cannot:
+    the <code class="idl">f</code> property can be referenced with a bare identifier
+    in a <code>with</code> statement but the <code class="idl">g</code> property cannot:
 
     <pre highlight="js">
         var thing = getThing();  // An instance of Thing
@@ -10328,8 +10346,8 @@ allowed.  The security check takes the following three inputs:
 1.  the [=identifier=]
     of the operation or attribute, and
 1.  the type of the [=function object=] –
-    “method” (when it corresponds to an IDL operation), or
-    “getter” or “setter” (when it corresponds to the
+    "<code>method</code>" (when it corresponds to an IDL operation), or
+    "<code>getter</code>" or "<code>setter</code>" (when it corresponds to the
     getter or setter function of an IDL attribute).
 
 Note: The HTML Standard defines how a security check is performed. [[!HTML]]
@@ -10735,10 +10753,10 @@ the <code>typeof</code> operator will return "function" when applied to an inter
             with argument count 0.
         1.  Set |length| to the length of the
             shortest argument list of the entries in |S|.
-    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "length",
+    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "<code>length</code>",
         PropertyDescriptor{\[[Value]]: |length|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
     1.  Let |proto| be the [=interface prototype object=] of [=interface=] |I|.
-    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "prototype",
+    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "<code>prototype</code>",
         PropertyDescriptor{\[[Value]]: |proto|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>false</emu-val>}).
 </div>
 
@@ -10781,10 +10799,10 @@ This object's relevant [=Realm=] must be the same as that of the [=named constru
         for constructors with identifier |id| on [=interface=] |I|
         and with argument count 0.
     1.  Let |length| be the length of the shortest argument list of the entries in |S|.
-    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "length",
+    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "<code>length</code>",
         PropertyDescriptor{\[[Value]]: |length|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
     1.  Let |proto| be the [=interface prototype object=] of [=interface=] |I|.
-    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "prototype",
+    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "<code>prototype</code>",
         PropertyDescriptor{\[[Value]]: |proto|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>false</emu-val>}).
 </div>
 
@@ -10808,7 +10826,7 @@ described in [[#es-constants]].
 
 If the [{{NoInterfaceObject}}] extended attribute was not specified on the interface,
 then the [=interface prototype object=] must also
-have a property named “constructor” with attributes
+have a <code class="idl">constructor</code> data property with attributes
 { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 whose value is a reference to the [=interface object=] for the interface.
 
@@ -10889,7 +10907,7 @@ other interface that is declared with one of these attributes, then the [=interf
 must be an [=immutable prototype exotic object=].
 
 The [=class string=] of an [=interface prototype object=] is the concatenation of
-the [=interface=]’s [=identifier=] and the string “Prototype”.
+the [=interface=]’s [=identifier=] and the string "<code>Prototype</code>".
 
 
 <h4 id="legacy-callback-interface-object">Legacy callback interface object</h4>
@@ -10922,7 +10940,7 @@ when applied to a [=legacy callback interface object=].
         1.  [=ECMAScript/Throw=] a {{ECMAScript/TypeError}}.
     1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|realm|, |steps|, the {{%FunctionPrototype%}} of |realm|).
     1.  Perform [=!=] <a abstract-op>SetFunctionName</a>(|F|, |id|).
-    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "length",
+    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "<code>length</code>",
         PropertyDescriptor{\[[Value]]: 0, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
 </div>
 
@@ -10953,7 +10971,7 @@ for that interface on which named properties are exposed.
 
 The [=class string=] of a [=named properties object=]
 is the concatenation of the [=interface=]’s
-[=identifier=] and the string “Properties”.
+[=identifier=] and the string "<code>Properties</code>".
 
 
 <h5 id="named-properties-object-getownproperty">\[[GetOwnProperty]]</h5>
@@ -11121,9 +11139,9 @@ The characteristics of this property are as follows:
         1.  Otherwise, end these steps and allow the exception to propagate.
     1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|realm|,
         |steps|, the {{%FunctionPrototype%}} of |realm|).
-    1.  Let |name| be the string "get " prepended to |attribute|'s [=identifier=].
+    1.  Let |name| be the string "<code>get </code>" prepended to |attribute|'s [=identifier=].
     1.  Perform [=!=] <a abstract-op>SetFunctionName</a>(|F|, |name|).
-    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "length",
+    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "<code>length</code>",
         PropertyDescriptor{\[[Value]]: 0, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
     1. Return |F|.
 
@@ -11194,9 +11212,9 @@ The characteristics of this property are as follows:
         1.  Return <emu-val>undefined</emu-val>
     1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|realm|,
         |steps|, the {{%FunctionPrototype%}} of |realm|).
-    1.  Let |name| be the string "set " prepended to |id|.
+    1.  Let |name| be the string "<code>set </code>" prepended to |id|.
     1.  Perform [=!=] <a abstract-op>SetFunctionName</a>(|F|, |name|).
-    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "length",
+    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "<code>length</code>",
         PropertyDescriptor{\[[Value]]: 1, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
     1. Return |F|.
 </div>
@@ -11306,7 +11324,7 @@ property-installation style as namespaces.)
         operation) or for [=static operations=] (if |op| is a static operation) with [=identifier=] |id|
         on |target| and with argument count 0.
     1.  Let |length| be the length of the shortest argument list in the entries in |S|.
-    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "length",
+    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "<code>length</code>",
         PropertyDescriptor{\[[Value]]: |length|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
     1.  Return |F|.
 </div>
@@ -11471,7 +11489,7 @@ The [=return type=] of the [=default toJSON operation=] must be {{object}}.
 If the [=interface=] has an [=exposed=] [=stringifier=],
 then there must exist a property with the following characteristics:
 
-*   The name of the property is “toString”.
+*   The name of the property is "<code>toString</code>".
 *   If the [=stringifier=] is [=unforgeable=] on the interface
     or if the interface was declared with the [{{Global}}] or [{{PrimaryGlobal}}] extended attribute,
     then the property exists on every object that implements the interface.
@@ -11489,7 +11507,7 @@ then there must exist a property with the following characteristics:
             then [=perform a security check=], passing:
             *   the platform object |O|,
             *   the [=identifier=] of the [=stringifier=], and
-            *   the type “method”.
+            *   the type "<code>method</code>".
         1.  If |O| is not an object that implements the [=interface=]
             on which the stringifier was declared, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |V| be an uninitialized variable.
@@ -11510,10 +11528,10 @@ then there must exist a property with the following characteristics:
             </dl>
         1.  Return the result of [=converted to an ECMAScript value|converting=] |V| to a String value.
     </div>
-*   The value of the [=function object=]’s “length”
+*   The value of the [=function object=]’s <code class="idl">length</code>
     property is the Number value <emu-val>0</emu-val>.
-*   The value of the [=function object=]’s “name”
-    property is the String value “toString”.
+*   The value of the [=function object=]’s <code class="idl">name</code>
+    property is the String value "<code>toString</code>".
 
 
 <h4 id="es-iterators">Common iterator behavior</h4>
@@ -11525,7 +11543,7 @@ If the [=interface=] has any of the following:
 
 *   an [=iterable declaration=]
 *   an [=indexed property getter=] and
-    an [=integer types|integer-typed=] [=attribute=] named “length”
+    an [=integer types|integer-typed=] <code class="idl">length</code> [=attribute=]
 *   a [=maplike declaration=]
 *   a [=setlike declaration=]
 
@@ -11552,14 +11570,14 @@ then the [=function object=] is {{%ArrayProto_values%}}.
     1.  If |object| is a [=platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
-        *   the identifier “@@iterator”, and
-        *   the type “method”.
+        *   the identifier "<code>@@iterator</code>", and
+        *   the type "<code>method</code>".
     1.  Let |interface| be the [=interface=]
         the [=iterable declaration=] is on.
     1.  If |object| is not a [=platform object=] that implements |interface|,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |iterator| be a newly created [=default iterator object=]
-        for |interface| with |object| as its target and iterator kind “key+value”.
+        for |interface| with |object| as its target and iterator kind "<code>key+value</code>".
     1.  Return |iterator|.
 </div>
 
@@ -11573,8 +11591,8 @@ then the [=function object=] is {{%ArrayProto_values%}}.
     1.  If |object| is a [=platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
-        *   the identifier “@@iterator”, and
-        *   the type “method”.
+        *   the identifier "<code>@@iterator</code>", and
+        *   the type "<code>method</code>".
     1.  If |object| is not a [=platform object=]
         that implements the [=interface=]
         on which the [=maplike declaration=]
@@ -11582,19 +11600,19 @@ then the [=function object=] is {{%ArrayProto_values%}}.
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  If the interface has a [=maplike declaration=], then:
         1.  Let |backing| be the value of the \[[BackingMap]] [=internal slot=] of |object|.
-        1.  Return <a abstract-op>CreateMapIterator</a>(|backing|, <code>"key+value"</code>).
+        1.  Return <a abstract-op>CreateMapIterator</a>(|backing|, "<code>key+value</code>").
     1.  Otherwise:
         1.  Let |backing| be the value of the \[[BackingSet]] [=internal slot=] of |object|.
-        1.  Return <a abstract-op>CreateSetIterator</a>(|backing|, <code>"value"</code>).
+        1.  Return <a abstract-op>CreateSetIterator</a>(|backing|, "<code>value</code>").
 </div>
 
-The value of the {{@@iterator}} [=function object=]’s “length”
+The value of the {{@@iterator}} [=function object=]’s <code class="idl">length</code>
 property is the Number value <emu-val>0</emu-val>.
 
-The value of the {{@@iterator}} [=function object=]’s “name” property
-is the String value “entries”
+The value of the {{@@iterator}} [=function object=]’s <code class="idl">name</code> property
+is the String value "<code>entries</code>"
 if the interface has a [=pair iterator=] or a [=maplike declaration=]
-and the String “values”
+and the String "<code>values</code>"
 if the interface has a [=setlike declaration=].
 
 
@@ -11606,7 +11624,7 @@ If the [=interface=] has any of the following:
 *   a [=maplike declaration=]
 *   a [=setlike declaration=]
 
-then a property named “forEach” must exist with attributes
+then a <code class="idl">forEach</code> data property must exist with attributes
 { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 and whose value is a [=function object=].
 
@@ -11659,8 +11677,8 @@ then the [=function object=] is {{%ArrayProto_forEach%}}.
     1.  If |object| is a [=platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
-        *   the identifier “forEach”, and
-        *   the type “method”.
+        *   the identifier "<code>forEach</code>", and
+        *   the type "<code>method</code>".
     1.  Let |interface| be the [=interface=]
         on which the [=maplike declaration=]
         or [=setlike declaration=] is declared.
@@ -11687,17 +11705,17 @@ then the [=function object=] is {{%ArrayProto_forEach%}}.
             one function that has captured an environment?
         </p>
     1.  Let |forEach| be the result of calling the \[[Get]] internal method of
-        |backing| with “forEach” and |backing| as arguments.
+        |backing| with "<code>forEach</code>" and |backing| as arguments.
     1.  If <a abstract-op>IsCallable</a>(|forEach|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  <a abstract-op>Call</a>(|forEach|, |backing|, «|callbackWrapper|, |thisArg|»).
     1.  Return <emu-val>undefined</emu-val>.
 </div>
 
-The value of the [=function object=]’s “length”
+The value of the [=function object=]’s <code class="idl">length</code>
 property is the Number value <emu-val>1</emu-val>.
 
-The value of the [=function object=]’s “name”
-property is the String value “forEach”.
+The value of the [=function object=]’s <code class="idl">name</code>
+property is the String value "<code>forEach</code>".
 
 
 <h4 id="es-iterable">Iterable declarations</h4>
@@ -11706,7 +11724,7 @@ property is the String value “forEach”.
 <h5 id="es-iterable-entries">entries</h5>
 
 If the [=interface=] has an [=iterable declaration=],
-then a property named “entries” must exist with attributes
+then an <code class="idl">entries</code> data property must exist with attributes
 { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 and whose value is a [=function object=].
 
@@ -11727,7 +11745,7 @@ the value of the {{@@iterator}} property.
 <h5 id="es-iterable-keys">keys</h5>
 
 If the [=interface=] has an [=iterable declaration=],
-then a property named “keys” must exist with attributes
+then a <code class="idl">keys</code> data property must exist with attributes
 { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 and whose value is a [=function object=].
 
@@ -11749,28 +11767,28 @@ then the [=function object=] is {{%ArrayProto_keys%}}.
     1.  If |object| is a [=platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
-        *   the identifier “keys”, and
-        *   the type “method”.
+        *   the identifier "<code>keys</code>", and
+        *   the type "<code>method</code>".
     1.  Let |interface| be the [=interface=]
         on which the [=iterable declaration=] is declared on.
     1.  If |object| is not a [=platform object=]
         that implements |interface|,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |iterator| be a newly created [=default iterator object=]
-        for |interface| with |object| as its target and iterator kind “key”.
+        for |interface| with |object| as its target and iterator kind "<code>key</code>".
     1.  Return |iterator|.
 </div>
 
-The value of the [=function object=]’s “length” property is the Number value <emu-val>0</emu-val>.
+The value of the [=function object=]’s <code class="idl">length</code> property is the Number value <emu-val>0</emu-val>.
 
-The value of the [=function object=]’s “name” property is the String value “keys”.
+The value of the [=function object=]’s <code class="idl">name</code> property is the String value "<code>keys</code>".
 
 
 <h5 id="es-iterable-values">values</h5>
 
 If the [=interface=] has an
 [=iterable declaration=],
-then a property named “values” must exist
+then a <code class="idl">values</code> data property must exist
 with attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 and whose value is a [=function object=].
 
@@ -11793,21 +11811,21 @@ the value of the {{@@iterator}} property.
     1.  If |object| is a [=platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
-        *   the identifier “entries”, and
-        *   the type “method”.
+        *   the identifier "<code>entries</code>", and
+        *   the type "<code>method</code>".
     1.  Let |interface| be the [=interface=]
         on which the [=iterable declaration=] is declared on.
     1.  If |object| is not a [=platform object=]
         that implements |interface|,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |iterator| be a newly created [=default iterator object=]
-        for |interface| with |object| as its target and iterator kind “value”.
+        for |interface| with |object| as its target and iterator kind "<code>value</code>".
     1.  Return |iterator|.
 </div>
 
-The value of the [=function object=]’s “length” property is the Number value <emu-val>0</emu-val>.
+The value of the [=function object=]’s <code class="idl">length</code> property is the Number value <emu-val>0</emu-val>.
 
-The value of the [=function object=]’s “name” property is the String value “values”.
+The value of the [=function object=]’s <code class="idl">name</code> property is the String value "<code>values</code>".
 
 
 <h5 id="es-default-iterator-object">Default iterator objects</h5>
@@ -11836,7 +11854,7 @@ its index is set to 0.
 
 The [=class string=] of a [=default iterator object=] for a given [=interface=]
 is the result of concatenating the [=identifier=] of the [=interface=]
-and the string “Iterator”.
+and the string "<code>Iterator</code>".
 
 
 <h5 id="es-iterator-prototype-object">Iterator prototype object</h5>
@@ -11853,7 +11871,7 @@ must be {{%IteratorPrototype%}}.
 
 <div algorithm="to invoke the next property of iterators">
 
-    An [=iterator prototype object=] must have a property named “next” with attributes
+    An [=iterator prototype object=] must have a <code class="idl">next</code> data property with attributes
     { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
     and whose value is a [=built-in function object=] that behaves as follows:
 
@@ -11863,8 +11881,8 @@ must be {{%IteratorPrototype%}}.
     1.  If |object| is a [=platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
-        *   the identifier “next”, and
-        *   the type “method”.
+        *   the identifier "<code>next</code>", and
+        *   the type "<code>method</code>".
     1.  If |object| is not a [=default iterator object=] for |interface|,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |index| be |object|’s index.
@@ -11877,22 +11895,22 @@ must be {{%IteratorPrototype%}}.
     1.  Set |object|’s index to |index| + 1.
     1.  Let |result| be a value determined by the value of |kind|:
         <dl class="switch">
-             :  key
+             :  "<code>key</code>"
              :: 1.  Let |idlKey| be |pair|’s key.
                 1.  Let |key| be the result of [=converted to an ECMAScript value|converting=] |idlKey| to an ECMAScript value.
                 1.  |result| is |key|.
-             :  value
+             :  "<code>value</code>"
              :: 1.  Let |idlValue| be |pair|’s value.
                 1.  Let |value| be the result of [=converted to an ECMAScript value|converting=] |idlValue| to an ECMAScript value.
                 1.  |result| is |value|.
-             :  key+value
+             :  "<code>key+value</code>"
              :: 1.  Let |idlKey| be |pair|’s key.
                 1.  Let |idlValue| be |pair|’s value.
                 1.  Let |key| be the result of [=converted to an ECMAScript value|converting=] |idlKey| to an ECMAScript value.
                 1.  Let |value| be the result of [=converted to an ECMAScript value|converting=] |idlValue| to an ECMAScript value.
                 1.  Let |array| be the result of performing <a abstract-op>ArrayCreate</a>(2).
-                1.  Call <a abstract-op>CreateDataProperty</a>(|array|, "0", |key|).
-                1.  Call <a abstract-op>CreateDataProperty</a>(|array|, "1", |value|).
+                1.  Call <a abstract-op>CreateDataProperty</a>(|array|, "<code>0</code>", |key|).
+                1.  Call <a abstract-op>CreateDataProperty</a>(|array|, "<code>1</code>", |value|).
                 1.  |result| is |array|.
         </dl>
     1.  Return <a abstract-op>CreateIterResultObject</a>(|result|, <emu-val>false</emu-val>).
@@ -11900,7 +11918,7 @@ must be {{%IteratorPrototype%}}.
 
 The [=class string=] of an [=iterator prototype object=] for a given [=interface=]
 is the result of concatenating the [=identifier=] of the [=interface=]
-and the string “Iterator”.
+and the string "<code>Iterator</code>".
 
 
 <h4 id="es-maplike">Maplike declarations</h4>
@@ -11931,7 +11949,7 @@ These additional properties are described in the sub-sections below.
         then [=perform a security check=], passing:
         *   the platform object |O|,
         *   an identifier equal to |name|, and
-        *   the type “method”.
+        *   the type "<code>method</code>".
     1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
     1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing |name| and |map| as arguments.
@@ -11942,7 +11960,7 @@ These additional properties are described in the sub-sections below.
 
 <h5 id="es-map-size">size</h5>
 
-There must exist a property named “size” on
+There must exist a <code class="idl">size</code> property on
 |A|’s [=interface prototype object=]
 with the following characteristics:
 
@@ -11959,21 +11977,21 @@ with the following characteristics:
         1.  If |O| is a [=platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
-            *   the identifier “size”, and
-            *   the type “getter”.
+            *   the identifier "<code>size</code>", and
+            *   the type "<code>getter</code>".
         1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
-        1.  Return the result of calling the \[[Get]] internal method of |map| passing “size” and |map| as arguments.
+        1.  Return the result of calling the \[[Get]] internal method of |map| passing "<code>size</code>" and |map| as arguments.
     </div>
 
-    The value of the [=function object=]’s “length” property is the Number value <emu-val>0</emu-val>.
+    The value of the [=function object=]’s <code class="idl">length</code> property is the Number value <emu-val>0</emu-val>.
 
-    The value of the [=function object=]’s “name” property is the String value “size”.
+    The value of the [=function object=]’s <code class="idl">name</code> property is the String value "<code>size</code>".
 
 
 <h5 id="es-map-entries">entries</h5>
 
-A property named “entries” must exist on
+An <code class="idl">entries</code> data property must exist on
 |A|’s [=interface prototype object=]
 with attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 and whose value is the [=function object=] that is the value of
@@ -11982,21 +12000,21 @@ the {{@@iterator}} property.
 
 <h5 id="es-map-keys-values">keys and values</h5>
 
-For both of “keys” and “values”, there must exist a property with that name on
+For both of <code class="idl">keys</code> and <code class="idl">values</code>, there must exist a data property with that name on
 |A|’s [=interface prototype object=]
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
 *   The value of the property is a [=built-in function object=] that [=forwards to the internal map object|forwards that name to the internal map object=].
 
-The value of the [=function objects=]’ “length” properties is the Number value <emu-val>0</emu-val>.
+The value of the [=function objects=]’ <code class="idl">length</code> properties is the Number value <emu-val>0</emu-val>.
 
-The value of the [=function object=]’s “name” property is the String value “keys” or “values”, correspondingly.
+The value of the [=function object=]’s <code class="idl">name</code> property is the String value "<code>keys</code>" or "<code>values</code>", correspondingly.
 
 
 <h5 id="es-map-get-has">get and has</h5>
 
-For both of “get” and “has”, there must exist a property with that name on
+For both of <code class="idl">get</code> and <code class="idl">has</code>, there must exist a data property with that name on
 |A|’s [=interface prototype object=] with the following characteristics:
 
 *   The property has attributes
@@ -12007,12 +12025,12 @@ For both of “get” and “has”, there must exist a property with that name 
         that behaves as follows when invoked:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
-        1.  Let |name| be the name of the property – “get” or “has”.
+        1.  Let |name| be the name of the property – "<code>get</code>" or "<code>has</code>".
         1.  If |O| is a [=platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
             *   an identifier equal to |name|, and
-            *   the type “method”.
+            *   the type "<code>method</code>".
         1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| be the key type specified in the [=maplike declaration=].
@@ -12023,34 +12041,34 @@ For both of “get” and “has”, there must exist a property with that name 
         1.  Return <a abstract-op>Call</a>(|function|, |map|, «|key|»).
     </div>
 
-The value of the [=function object=]’s “length” properties is the Number value <emu-val>1</emu-val>.
+The value of the [=function object=]’s <code class="idl">length</code> properties is the Number value <emu-val>1</emu-val>.
 
-The value of the [=function object=]’s “name” property is the String value “get” or “has”, correspondingly.
+The value of the [=function object=]’s <code class="idl">name</code> property is the String value "<code>get</code>" or "<code>has</code>", correspondingly.
 
 
 <h5 id="es-map-clear">clear</h5>
 
 If |A| does not declare a [=member=]
-with identifier “clear”, and
+with identifier "<code>clear</code>", and
 |A| was declared with a read–write maplike declaration,
-then a property named “clear” and the following characteristics
+then a <code class="idl">clear</code> data property with the following characteristics
 must exist on |A|’s
 [=interface prototype object=]:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=built-in function object=] that [=forwards to the internal map object|forwards “clear” to the internal map object=].
+*   The value of the property is a [=built-in function object=] that <a lt="forwards to the internal map object">forwards <code class="idl">clear</code> to the internal map object</a>.
 
-The value of the [=function object=]’s “length” property is the Number value <emu-val>0</emu-val>.
+The value of the [=function object=]’s <code class="idl">length</code> property is the Number value <emu-val>0</emu-val>.
 
-The value of the [=function object=]’s “name” property is the String value “clear”.
+The value of the [=function object=]’s <code class="idl">name</code> property is the String value "<code>clear</code>".
 
 
 <h5 id="es-map-delete">delete</h5>
 
 If |A| does not declare a [=member=]
-with identifier “delete”, and
+with identifier "<code>delete</code>", and
 |A| was declared with a read–write maplike declaration,
-then a property named “delete” and the following characteristics
+then a <code class="idl">delete</code> data property with the following characteristics
 must exist on |A|’s
 [=interface prototype object=]:
 
@@ -12063,28 +12081,28 @@ must exist on |A|’s
         1.  If |O| is a [=platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
-            *   the identifier “delete”, and
-            *   the type “method”.
+            *   the identifier "<code>delete</code>", and
+            *   the type "<code>method</code>".
         1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| be the key type specified in the [=maplike declaration=].
-        1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing “delete” and |map| as arguments.
+        1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing "<code>delete</code>" and |map| as arguments.
         1.  Let |keyArg| be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
         1.  Let |keyIDL| be the result of [=converted to an IDL value|converting=] |keyArg| to an IDL value of type |keyType|.
         1.  Let |key| be the result of [=converted to ECMAScript values|converting=] |keyIDL| to an ECMAScript value.
         1.  Return <a abstract-op>Call</a>(|function|, |map|, «|key|»).
     </div>
 
-The value of the [=function object=]’s “length” property is the Number value <emu-val>1</emu-val>.
+The value of the [=function object=]’s <code class="idl">length</code> property is the Number value <emu-val>1</emu-val>.
 
-The value of the [=function object=]’s “name” property is the String value “delete”.
+The value of the [=function object=]’s <code class="idl">name</code> property is the String value "<code>delete</code>".
 
 
 <h5 id="es-map-set">set</h5>
 
-If |A| does not declare a [=member=] with identifier “set”,
+If |A| does not declare a [=member=] with identifier "<code>set</code>",
 and |A| was declared with a read–write maplike declaration,
-then a property named “set” and the following characteristics
+then a <code class="idl">set</code> data property with the following characteristics
 must exist on |A|’s [=interface prototype object=]:
 
 *   The property has attributes
@@ -12097,12 +12115,12 @@ must exist on |A|’s [=interface prototype object=]:
         1.  If |O| is a [=platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
-            *   the identifier “set”, and
-            *   the type “method”.
+            *   the identifier "<code>set</code>", and
+            *   the type "<code>method</code>".
         1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| and |valueType| be the key and value types specified in the [=maplike declaration=].
-        1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing “set” and |map| as arguments.
+        1.  Let |function| be the result of calling the \[[Get]] internal method of |map| passing "<code>set</code>" and |map| as arguments.
         1.  Let |keyArg| be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
         1.  Let |valueArg| be the second argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
         1.  Let |keyIDL| be the result of [=converted to an IDL value|converting=] |keyArg| to an IDL value of type |keyType|.
@@ -12113,9 +12131,9 @@ must exist on |A|’s [=interface prototype object=]:
         1.  Return |O|.
     </div>
 
-The value of the [=function object=]’s “length” property is the Number value <emu-val>2</emu-val>.
+The value of the [=function object=]’s <code class="idl">length</code> property is the Number value <emu-val>2</emu-val>.
 
-The value of the [=function object=]’s “name” property is the String value “set”.
+The value of the [=function object=]’s <code class="idl">name</code> property is the String value "<code>set</code>".
 
 
 <h4 id="es-setlike">Setlike declarations</h4>
@@ -12145,7 +12163,7 @@ These additional properties are described in the sub-sections below.
         then [=perform a security check=], passing:
         *   the platform object |O|,
         *   an identifier equal to |name|, and
-        *   the type “method”.
+        *   the type "<code>method</code>".
     1.  If |O| is not an object that implements <var ignore>A</var>,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |set| be the {{ECMAScript/Set}} object that is
@@ -12160,7 +12178,7 @@ These additional properties are described in the sub-sections below.
 
 <h5 id="es-set-size">size</h5>
 
-There must exist a property named “size” on |A|’s [=interface prototype object=]
+A <code class="idl">size</code> property must exist on |A|’s [=interface prototype object=]
 with the following characteristics:
 
 *   The property has attributes { \[[Get]]: |G|, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> },
@@ -12175,21 +12193,21 @@ with the following characteristics:
         1.  If |O| is a [=platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
-            *   the identifier “size”, and
-            *   the type “getter”.
+            *   the identifier "<code>size</code>", and
+            *   the type "<code>getter</code>".
         1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |set| be the {{ECMAScript/Set}} object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
-        1.  Return the result of calling the \[[Get]] internal method of |set| passing “size” and |set| as arguments.
+        1.  Return the result of calling the \[[Get]] internal method of |set| passing "<code>size</code>" and |set| as arguments.
     </div>
 
-    The value of the [=function object=]’s “length” property is the Number value <emu-val>0</emu-val>.
+    The value of the [=function object=]’s <code class="idl">length</code> property is the Number value <emu-val>0</emu-val>.
 
-    The value of the [=function object=]’s “name” property is the String value “size”.
+    The value of the [=function object=]’s <code class="idl">name</code> property is the String value "<code>size</code>".
 
 
 <h5 id="es-set-values">values</h5>
 
-A property named “values” must exist on |A|’s [=interface prototype object=]
+A <code class="idl">values</code> data property must exist on |A|’s [=interface prototype object=]
 with attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
 and whose value is the [=function object=] that is the value of
 the {{@@iterator}} property.
@@ -12197,7 +12215,7 @@ the {{@@iterator}} property.
 
 <h5 id="es-set-entries-keys">entries and keys</h5>
 
-For both of “entries” and “keys”, there must exist a property with that name on
+For both of <code class="idl">entries</code> and <code class="idl">keys</code>, there must exist a data property with that name on
 |A|’s [=interface prototype object=] with the following characteristics:
 
 *   The property has attributes
@@ -12205,16 +12223,16 @@ For both of “entries” and “keys”, there must exist a property with that 
 *   The value of the property is a [=built-in function object=] that
     [=forwards to the internal set object|forwards that name to the internal set object=].
 
-The value of the [=function object=]’s “length” properties is
+The value of the [=function object=]’s <code class="idl">length</code> properties is
 the Number value <emu-val>0</emu-val>.
 
-The value of the [=function object=]’s “name” property is
-the String value “entries” or “keys”, correspondingly.
+The value of the [=function object=]’s <code class="idl">name</code> property is
+the String value "<code>entries</code>" or "<code>keys</code>", correspondingly.
 
 
 <h5 id="es-set-has">has</h5>
 
-There must exist a property with named “has” on |A|’s [=interface prototype object=]
+There must exist a <code class="idl">has</code> data property on |A|’s [=interface prototype object=]
 with the following characteristics:
 
 *   The property has attributes
@@ -12227,31 +12245,31 @@ with the following characteristics:
         1.  If |O| is a [=platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
-            *   the identifier “has”, and
-            *   the type “method”.
+            *   the identifier "<code>has</code>", and
+            *   the type "<code>method</code>".
         1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |set| be the {{ECMAScript/Set}} object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
         1.  Let |type| be the value type specified in the [=setlike declaration=].
-        1.  Let |function| be the result of calling the \[[Get]] internal method of |set| passing “has” and |set| as arguments.
+        1.  Let |function| be the result of calling the \[[Get]] internal method of |set| passing "<code>has</code>" and |set| as arguments.
         1.  Let |arg| be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
         1.  Let |idlValue| be the result of [=converted to an IDL value|converting=] |arg| to an IDL value of type |type|.
         1.  Let |value| be the result of [=converted to ECMAScript values|converting=] |idlValue| to an ECMAScript value.
         1.  <a abstract-op>Call</a>(|function|, |set|, «|value|»).
     </div>
 
-The value of the [=function object=]’s “length” property is a Number value <emu-val>1</emu-val>.
+The value of the [=function object=]’s <code class="idl">length</code> property is a Number value <emu-val>1</emu-val>.
 
-The value of the [=function object=]’s “name” property is the String value “has”.
+The value of the [=function object=]’s <code class="idl">name</code> property is the String value "<code>has</code>".
 
 
 <h5 id="es-add-delete">add and delete</h5>
 
-For both of “add” and “delete”, if:
+For both of <code class="idl">add</code> and <code class="idl">delete</code>, if:
 
 *   |A| does not declare an [=member=] with a matching identifier, and
 *   |A| was declared with a read–write setlike declaration,
 
-then a property with that name and the following characteristics
+then a data property with that name and the following characteristics
 must exist on |A|’s [=interface prototype object=]:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
@@ -12260,12 +12278,12 @@ must exist on |A|’s [=interface prototype object=]:
         The value of the property is a [=built-in function object=] that behaves as follows when invoked:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
-        1.  Let |name| be the name of the property – “add” or “delete”.
+        1.  Let |name| be the name of the property – "<code>add</code>" or "<code>delete</code>".
         1.  If |O| is a [=platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
             *   an identifier equal to |name|, and
-            *   the type “method”.
+            *   the type "<code>method</code>".
         1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |set| be the {{ECMAScript/Set}} object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
         1.  Let |type| be the value type specified in the [=setlike declaration=].
@@ -12278,9 +12296,9 @@ must exist on |A|’s [=interface prototype object=]:
         1.  Otherwise, return |O|.
     </div>
 
-The value of the [=function object=]’s “length” property is the Number value <emu-val>1</emu-val>.
+The value of the [=function object=]’s <code class="idl">length</code> property is the Number value <emu-val>1</emu-val>.
 
-The value of the [=function object=]’s “name” property is the String value “add” or “delete”, correspondingly.
+The value of the [=function object=]’s <code class="idl">name</code> property is the String value "<code>add</code>" or "<code>delete</code>", correspondingly.
 
 
 <h5 id="es-set-clear">clear</h5>
@@ -12288,16 +12306,16 @@ The value of the [=function object=]’s “name” property is the String value
 If |A| does not declare a [=member=]
 with a matching identifier, and
 |A| was declared with a read–write setlike declaration,
-then a property named “clear” and the following characteristics
+then a <code class="idl">clear</code> data property with the following characteristics
 must exist on |A|’s
 [=interface prototype object=]:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=built-in function object=] that [=forwards to the internal set object|forwards “clear” to the internal set object=].
+*   The value of the property is a [=built-in function object=] that <a lt="forwards to the internal set object">forwards <code class="idl">clear</code> to the internal map object</a>.
 
-The value of the [=function object=]’s “length” property is the Number value <emu-val>0</emu-val>.
+The value of the [=function object=]’s <code class="idl">length</code> property is the Number value <emu-val>0</emu-val>.
 
-The value of the [=function object=]’s “name” property is the String value “clear”.
+The value of the [=function object=]’s <code class="idl">name</code> property is the String value "<code>clear</code>".
 
 
 <h3 id="es-platform-objects">Platform objects implementing interfaces</h3>
@@ -13507,7 +13525,7 @@ and not as a separate <emu-t class="regex"><a href="#prod-identifier">identifier
 If the longest possible match could match one of the above named terminal symbols or
 one of the other terminal symbols from the grammar, it must be tokenized as the latter.
 Thus, the input text “<span class="input">long</span>” is tokenized as the quoted terminal symbol
-<emu-t>long</emu-t> rather than an <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> called “long”,
+<emu-t>long</emu-t> rather than an <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> called "<code>long</code>",
 and “<span class="input">.</span>” is tokenized as the quoted terminal symbol
 <emu-t>.</emu-t> rather than an <emu-t class="regex"><a href="#prod-other">other</a></emu-t>.
 
@@ -13519,7 +13537,7 @@ an <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> rather
 terminal symbol <emu-t>const</emu-t>, an
 [=interface=] with
 [=identifier=]
-“A” is distinct from one named “a”, and an
+"<code>A</code>" is distinct from one named "<code>a</code>", and an
 [=extended attribute=]
 [<code class="idl">constructor</code>] will not be recognized as
 the [{{Constructor}}]


### PR DESCRIPTION
The first commit changes the notation of strings within Web IDL to Infra-mandated "`string`". This helps prevent errors like #419 to exist in the first place, as it can be difficult to tell the difference between " Iterator" and "Iterator" without monospace styling.

The second commit fixes a Bikeshed linking error.

The third commit is a normative change that actually fixes #419, by incorporating the consensus reached in https://github.com/heycam/webidl/issues/419#issuecomment-323790991.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TimothyGu/webidl/pull/483.html" title="Last updated on Dec 7, 2017, 11:40 AM GMT (c596cef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/483/2394cc9...TimothyGu:c596cef.html" title="Last updated on Dec 7, 2017, 11:40 AM GMT (c596cef)">Diff</a>