### PR TITLE
Editorial: Correct assertion

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10801,7 +10801,7 @@ the <code>typeof</code> operator will return "function" when applied to an inter
         1.  Let |O| be the result of [=converted to an ECMAScript value|converting=] |R|
             to an ECMAScript [=interface type=] value |I|.
         1.  Assert: |O| is an object that implements |I|.
-        1.  Assert: |O|.\[[Realm]] is equal to |F|.\[[Realm]].
+        1.  Assert: |O|.\[[Realm]] is equal to |realm|.
         1.  Return |O|.
     1.  Let |constructorProto| be the {{%FunctionPrototype%}} of |realm|.
     1.  If |I| inherits from some other interface |P|,


### PR DESCRIPTION
|F| is not defined until later. Use an equivalent check instead.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TimothyGu/webidl/pull/500.html" title="Last updated on Dec 20, 2017, 4:35 AM GMT (0cc44fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/500/02e998a...TimothyGu:0cc44fd.html" title="Last updated on Dec 20, 2017, 4:35 AM GMT (0cc44fd)">Diff</a>