### PR TITLE
Remove definition of class strings of default iterator objects

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11915,9 +11915,10 @@ use standard ECMAScript Array iterator objects.
 When a [=default iterator object=] is first created,
 its index is set to 0.
 
-The [=class string=] of a [=default iterator object=] for a given [=interface=]
-is the result of concatenating the [=identifier=] of the [=interface=]
-and the string "<code> Iterator</code>".
+[=Default iterator objects=] do not have [=class strings=]; when <code
+class="idl">Object.prototype.toString()</code> is called on a [=default
+iterator object=] of a given [=interface=], the [=class string=] of the
+[=iterator prototype object=] of that [=interface=] is used.
 
 
 <h5 id="es-iterator-prototype-object">Iterator prototype object</h5>


### PR DESCRIPTION
Per consensus reached in #483, class strings should only exist on iterator prototype objects.

Tests: https://github.com/w3c/web-platform-tests/pull/8796


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TimothyGu/webidl/pull/501.html" title="Last updated on Dec 25, 2017, 2:09 AM GMT (513317f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/501/02e998a...TimothyGu:513317f.html" title="Last updated on Dec 25, 2017, 2:09 AM GMT (513317f)">Diff</a>