### PR TITLE
Editorial: add DOMRectList to the legacy [NoInterfaceObject] list

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9512,6 +9512,7 @@ a [=promise type=].
         {{DeviceAcceleration}},
         {{DeviceRotationRate}},
         {{ConstrainablePattern}},
+        {{DOMRectList}},
         {{WEBGL_compressed_texture_astc}},
         {{WEBGL_compressed_texture_s3tc_srgb}},
         {{WEBGL_draw_buffers}},
@@ -9525,6 +9526,7 @@ a [=promise type=].
         [[GEOLOCATION-API]]
         [[ORIENTATION-EVENT]]
         [[MEDIACAPTURE-STREAMS]]
+        [[GEOMETRY]]
         (various [[WEBGL]] extension specifications)
     </small>
 


### PR DESCRIPTION
Closes w3c/fxtf-drafts#233.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/502.html" title="Last updated on Dec 28, 2017, 11:35 PM GMT (7bce4f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/502/09d8f54...7bce4f1.html" title="Last updated on Dec 28, 2017, 11:35 PM GMT (7bce4f1)">Diff</a>