### PR TITLE
Editorial: Revert "add DOMRectList to the legacy [NoInterfaceObject] list"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9512,7 +9512,6 @@ a [=promise type=].
         {{DeviceAcceleration}},
         {{DeviceRotationRate}},
         {{ConstrainablePattern}},
-        {{DOMRectList}},
         {{WEBGL_compressed_texture_astc}},
         {{WEBGL_compressed_texture_s3tc_srgb}},
         {{WEBGL_draw_buffers}},
@@ -9526,7 +9525,6 @@ a [=promise type=].
         [[GEOLOCATION-API]]
         [[ORIENTATION-EVENT]]
         [[MEDIACAPTURE-STREAMS]]
-        [[GEOMETRY]]
         (various [[WEBGL]] extension specifications)
     </small>
 


### PR DESCRIPTION
Reverts heycam/webidl#502.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/503.html" title="Last updated on Dec 29, 2017, 1:20 PM GMT (c6febf0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/503/884623d...c6febf0.html" title="Last updated on Dec 29, 2017, 1:20 PM GMT (c6febf0)">Diff</a>