### PR TITLE
Include typedefs in the JSON type definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2456,6 +2456,7 @@ The <dfn id="dfn-json-types" export lt="JSON type">JSON types</dfn> are:
 *   [=nullable types=] whose [=nullable types/inner type=] is a [=JSON type=],
 *   [=annotated types=] whose [=annotated types/inner type=] is a [=JSON type=],
 *   [=union types=] whose [=member types=] are [=JSON types=],
+*   [=typedefs=] whose [=type being given a new name=] is a [=JSON type=],
 *   [=sequence types=] whose parameterized type is a [=JSON type=],
 *   [=frozen array types=] whose parameterized type is a [=JSON type=],
 *   [=dictionaries=] where all of their [=dictionary members|members=] are [=JSON types=],


### PR DESCRIPTION
Closes #504.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tobie/webidl/pull/505.html" title="Last updated on Jan 2, 2018, 11:04 PM GMT (9ec9589)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/505/f6d726e...tobie:9ec9589.html" title="Last updated on Jan 2, 2018, 11:04 PM GMT (9ec9589)">Diff</a>