### PR TITLE
Add informative section on legacy constructs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -13410,9 +13410,12 @@ Editors who wish to use legacy WebIDL constructs are strongly advised to discuss
 by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20a%20legacy%20WebIDL%20construct">filing an issue</a>
 before proceeding.
 
-Legacy WebIDL constructs are not deprecated unless they are specifically marked as such.
-They are, however, candidate for deprecation whenever various heuristics indicate that
-the Web platform features they help specify can be removed altogether
+Marking a construct as legacy does not, in itself,
+imply that it is about to be removed form this specification.
+It does suggest however, that it is a good candidate
+for future removal from this specification,
+whenever various heuristics indicate that
+the Web platform features it helps specify can be removed altogether
 or can be modified to rely on non-legacy WebIDL constructs instead.
 
 

--- a/index.bs
+++ b/index.bs
@@ -13411,7 +13411,7 @@ by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%
 before proceeding.
 
 Marking a construct as legacy does not, in itself,
-imply that it is about to be removed form this specification.
+imply that it is about to be removed from this specification.
 It does suggest however, that it is a good candidate
 for future removal from this specification,
 whenever various heuristics indicate that

--- a/index.bs
+++ b/index.bs
@@ -13396,6 +13396,26 @@ Extensions to any other aspect of the IDL language are
 strongly discouraged.
 
 
+<h2 id="legacy-constructs">Legacy constructs</h4>
+
+<i>This section is informative.</i>
+
+Legacy WebIDL constructs exist only so that
+legacy Web platform features can be specified.
+They are generally prefixed with the "<code>Legacy</code>" string.
+It is strongly discouraged to use legacy WebIDL constructs in specifications
+unless required to specify the behavior of legacy Web platform features,
+or for consistency with such features.
+Editors who wish to use legacy WebIDL constructs are strongly advised to discuss this
+by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20a%20legacy%20WebIDL%20construct">filing an issue</a>
+before proceeding.
+
+Legacy WebIDL constructs are not deprecated unless they are specifically marked as such.
+They are, however, candidate for deprecation whenever various heuristics indicate that
+the Web platform features they help specify can be removed altogether
+or can be modified to rely on non-legacy WebIDL constructs instead.
+
+
 <h2 id="referencing">Referencing this specification</h2>
 
 <i>This section is informative.</i>


### PR DESCRIPTION
I often see confusion about deprecation and legacy constructs. For example: https://github.com/KhronosGroup/WebGL/pull/2566#issuecomment-353656192. I was also very confused by this when I started working on WebIDL.

This is an attempt at clarifying this. I'm not sure whether all advisements should just link to this section, be completely replaced by a link to it, or should simply co-exist as in this current PR. Thoughts welcomed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tobie/webidl/pull/506.html" title="Last updated on Jan 4, 2018, 7:07 PM GMT (82550f5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/506/d28856d...tobie:82550f5.html" title="Last updated on Jan 4, 2018, 7:07 PM GMT (82550f5)">Diff</a>