### PR TITLE
Add bigint type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -165,6 +165,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: ToBigInt; url: #sec-tobigint
         text: ToInt32; url: sec-toint32
         text: ToNumber; url: sec-tonumber
+        text: ToNumeric; url: sec-tonumeric
         text: ToObject; url: sec-toobject
         text: ToString; url: sec-tostring
         text: ToUint16; url: sec-touint16
@@ -7678,6 +7679,18 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
         value.
 </div>
 
+<div id="es-to-bigint" algorithm="convert an ECMAScript value to a numeric type or a bigint">
+
+    An ECMAScript value |V| is <dfn lt="converted to a numeric type or bigint">converted</dfn>
+    to an IDL [=numeric type=] |T| or {{bigint}} value by running the following algorithm:
+
+    1.  Let |x| be [=?=] [$ToNumeric$](|V|).
+    1.  If [$Type$](|x|) is BigInt, then
+        1.  Return the IDL {{bigint}} value that represents the same numeric value as |x|.
+    1.  Assert: [$Type$](|x|) is Number.
+    1.  Return the result of [=converted to an ECMAScript value|converting=] |x| to |T|.
+</div>
+
 
 <h4 id="es-DOMString">DOMString</h4>
 
@@ -8722,6 +8735,9 @@ that correspond to the union’s [=member types=].
         then return the result of
         [=converted to an IDL value|converting=]
         |V| to that type.
+    1.  If |types| includes a [=numeric type=] and {{bigint}},
+        then return the result of [=converted to a numeric type or bigint|converting=]
+        |V| to either that [=numeric type=] or {{bigint}}.
     1.  If |types| includes a [=numeric type=],
         then return the result of [=converted to an IDL value|converting=]
         |V| to that [=numeric type=].

--- a/index.bs
+++ b/index.bs
@@ -5924,14 +5924,12 @@ The [=type name=] of the
 
 <h4 id="idl-bigint" interface>bigint</h4>
 
-The {{bigint}} type is an arbitrary integer, unrestricted in range.
+The {{bigint}} type is an arbitrary integer type, unrestricted in range.
 
-{{bigint}} constant values in IDL are
-represented with <emu-t class="regex"><a href="#prod-bigint">bigint</a></emu-t>
-tokens.
+{{bigint}} constant values in IDL are represented with
+<emu-t class="regex"><a href="#prod-bigint">bigint</a></emu-t> tokens.
 
-The [=type name=] of the
-{{bigint}} type is “BigInt”.
+The [=type name=] of the {{bigint}} type is “<code>BigInt</code>”.
 
 
 <h4 oldids="dom-short" id="idl-short" interface>short</h4>
@@ -7228,9 +7226,9 @@ ECMAScript value type.
     1.  If <a abstract-op>Type</a>(|V|) is Number, then
         return the result of <a href="#es-to-unrestricted-double">converting</a> |V|
         to an {{unrestricted double}}.
-    1.  If <a abstract-op>Type</a>(|V|) is [=BigInt=], then
+    1.  If <a abstract-op>Type</a>(|V|) is BigInt, then
         return the result of <a href="#es-to-bigint">converting</a> |V|
-        to an {{bigint}}.
+        to a {{bigint}}.
     1.  If <a abstract-op>Type</a>(|V|) is String, then
         return the result of <a href="#es-DOMString">converting</a> |V|
         to a {{DOMString}}.
@@ -7667,18 +7665,17 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL {{bigint}} value by running the following algorithm:
 
-    1.  Let |x| be [=?=] <a abstract-op>ToBigInt</a>(|V|).
-    1.  Return the IDL {{bigint}} value that represents the same numeric
-        value as |x|.
+    1.  Let |x| be [=?=] [$ToBigInt$](|V|).
+    1.  Return the IDL {{bigint}} value that represents the same numeric value as |x|.
 </div>
 
 <div id="bigint-to-es" algorithm="convert a bigint to an ECMAScript value">
 
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{bigint}} value to an ECMAScript value is a [=BigInt=]:
+    an IDL {{bigint}} value to an ECMAScript value is a BigInt:
 
-    1.  Return the [=BigInt=] value that represents the same numeric value
-        as the IDL {{bigint}} value.
+    1.  Return the [=BigInt=] value that represents the same numeric value as the IDL {{bigint}}
+        value.
 </div>
 
 
@@ -8717,7 +8714,7 @@ that correspond to the union’s [=member types=].
         1.  If |types| includes a [=numeric type=],
             then return the result of [=converted to an IDL value|converting=]
             |V| to that [=numeric type=].
-    1.  If <a abstract-op>Type</a>(|V|) is [=BigInt=], then:
+    1.  If <a abstract-op>Type</a>(|V|) is BigInt, then:
         1.  If |types| includes {{bigint}},
             then return the result of [=converted to an IDL value|converting=]
             |V| to {{bigint}}
@@ -8725,15 +8722,13 @@ that correspond to the union’s [=member types=].
         then return the result of
         [=converted to an IDL value|converting=]
         |V| to that type.
-    1.  If |types| includes a [=numeric type=], then:
-        1.  If |types| includes {{bigint}},
-            [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
-        1.  Return the result of [=converted to an IDL value|converting=]
-            |V| to that [=numeric type=].
+    1.  If |types| includes a [=numeric type=],
+        then return the result of [=converted to an IDL value|converting=]
+        |V| to that [=numeric type=].
     1.  If |types| includes {{boolean}},
         then return the result of [=converted to an IDL value|converting=]
         |V| to {{boolean}}.
-    1.  If |types| includes a {{bigint}},
+    1.  If |types| includes {{bigint}},
         then return the result of [=converted to an IDL value|converting=]
         |V| to {{bigint}}.
     1.  [=ECMAScript/Throw=] a {{ECMAScript/TypeError}}.
@@ -11065,7 +11060,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
 
             then remove from |S| all other entries.
 
-        1.  Otherwise: if <a abstract-op>Type</a>(|V|) is [=BigInt=]
+        1.  Otherwise: if <a abstract-op>Type</a>(|V|) is BigInt
             and there is an entry in |S| that has one of the following types at position |i| of its type list,
             *   {{bigint}}
             *   a [=nullable type|nullable=] {{bigint}}

--- a/index.bs
+++ b/index.bs
@@ -5932,16 +5932,6 @@ The [=type name=] of the
 {{octet}} type is "<code>Octet</code>".
 
 
-<h4 id="idl-bigint" interface>bigint</h4>
-
-The {{bigint}} type is an arbitrary integer type, unrestricted in range.
-
-{{bigint}} constant values in IDL are represented with
-<emu-t class="regex"><a href="#prod-bigint">bigint</a></emu-t> tokens.
-
-The [=type name=] of the {{bigint}} type is “<code>BigInt</code>”.
-
-
 <h4 oldids="dom-short" id="idl-short" interface>short</h4>
 
 The {{short}} type is a signed integer
@@ -6082,6 +6072,16 @@ tokens.
 
 The [=type name=] of the
 {{unrestricted double}} type is "<code>UnrestrictedDouble</code>".
+
+
+<h4 id="idl-bigint" interface>bigint</h4>
+
+The {{bigint}} type is an arbitrary integer type, unrestricted in range.
+
+{{bigint}} constant values in IDL are represented with
+<emu-t class="regex"><a href="#prod-bigint">bigint</a></emu-t> tokens.
+
+The [=type name=] of the {{bigint}} type is “<code>BigInt</code>”.
 
 
 <h4 oldids="dom-DOMString" id="idl-DOMString" interface>DOMString</h4>

--- a/index.bs
+++ b/index.bs
@@ -7701,7 +7701,7 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
         value.
 </div>
 
-<div id="es-to-bigint" algorithm="convert an ECMAScript value to a numeric type or a bigint">
+<div id="es-to-bigint-or-numeric" algorithm="convert an ECMAScript value to a numeric type or a bigint">
 
     An ECMAScript value |V| is <dfn lt="converted to a numeric type or bigint">converted</dfn>
     to an IDL [=numeric type=] |T| or {{bigint}} value by running the following algorithm:

--- a/index.bs
+++ b/index.bs
@@ -3655,7 +3655,7 @@ the following algorithm returns <i>true</i>.
             <th>bigint</th>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
-            <td></td>
+            <td>(b)</td>
             <td>●</td>
             <td>●</td>
             <td>●</td>
@@ -3761,6 +3761,10 @@ the following algorithm returns <i>true</i>.
         1.  The two identified interface-like types are
             not the same, and no single [=platform object=] implements both
             interface-like types.
+        1.  The types are distinguishable, but there is
+            <a href="#limit-bigint-numeric-overloading">a separate restriction on their use in
+            overloading</a> below. Please also note <a href="#limit-bigint-numeric-unions">the
+            advice about using unions of these types</a>.
     </ol>
 
     <div class="example" id="example-distinguishability-diff-types">
@@ -3810,6 +3814,11 @@ then for those items there must be an index |i| such that
 for each pair of items the types at index |i| are [=distinguishable=].
 The lowest such index is termed the <dfn id="dfn-distinguishing-argument-index" export>distinguishing argument index</dfn>
 for the items of the [=effective overload set=] with the given type list size.
+
+<p id="limit-bigint-numeric-overloading">An [=effective overload set=] must not contain more than
+one [=list/item=] with the same [=type list=] [=list/size=], where one [=list/item=] has a
+{{bigint}} argument at the [=distinguishing argument index=] and another has a [=numeric type=]
+argument at the [=distinguishing argument index=].
 
 <div class="example">
 
@@ -6569,6 +6578,19 @@ A type <dfn id="dfn-includes-a-nullable-type" export>includes a nullable type</d
 Each pair of [=flattened member types=]
 in a [=union type=], <var ignore>T</var> and <var ignore>U</var>,
 must be [=distinguishable=].
+
+<p class="advisement" id="limit-bigint-numeric-unions">
+It is possible to create a union of {{bigint}} and a [=numeric type=].
+However, this is generally only supposed to be used for interfaces such as
+[[ECMA-402#numberformat-objects|NumberFormat]], which formats the values rather than using them in
+calculations.
+It would not be appropriate to accept such a union, only to then convert values of the
+[=numeric type=] to a {{bigint}} for further processing, as this runs the risk of introducing
+precision errors.
+Please
+<a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20bigint/numeric union">file an issue</a>
+to discuss before using this feature.
+</p>
 
 [=Union type=] constant values
 in IDL are represented in the same way that constant values of their

--- a/index.bs
+++ b/index.bs
@@ -161,8 +161,8 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: SetFunctionName; url: sec-setfunctionname
         text: SetImmutablePrototype; url: sec-set-immutable-prototype
         text: SetIntegrityLevel; url: sec-setintegritylevel
-        text: ToBoolean; url: sec-toboolean
         text: ToBigInt; url: #sec-tobigint
+        text: ToBoolean; url: sec-toboolean
         text: ToInt32; url: sec-toint32
         text: ToNumber; url: sec-tonumber
         text: ToNumeric; url: sec-tonumeric
@@ -5701,7 +5701,7 @@ the [=integer types=],
 {{unrestricted double}}.
 
 The <dfn id="dfn-primitive-type" export>primitive types</dfn> are
-{{boolean}}, {{bigint}} and the [=numeric types=].
+{{bigint}}, {{boolean}} and the [=numeric types=].
 
 The <dfn id="dfn-string-type" export>string types</dfn> are
 {{DOMString}}, all [=enumeration types=],

--- a/index.bs
+++ b/index.bs
@@ -1646,7 +1646,6 @@ constant declaration gives the value of the constant, which can be
 one of the two boolean literal tokens (<emu-t>true</emu-t>
 and <emu-t>false</emu-t>), an
 <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t> token,
-a <emu-t class="regex"><a href="#prod-bigint">bigint</a></emu-t> token,
 a <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token,
 or one of the three special floating point constant values
 (<emu-t>-Infinity</emu-t>, <emu-t>Infinity</emu-t> and <emu-t>NaN</emu-t>).
@@ -1788,7 +1787,6 @@ The following extended attributes are applicable to constants:
         BooleanLiteral
         FloatLiteral
         integer
-        bigint
 </pre>
 
 <pre class="grammar" id="prod-BooleanLiteral">
@@ -6079,7 +6077,7 @@ The [=type name=] of the
 The {{bigint}} type is an arbitrary integer type, unrestricted in range.
 
 {{bigint}} constant values in IDL are represented with
-<emu-t class="regex"><a href="#prod-bigint">bigint</a></emu-t> tokens.
+<emu-t class="regex"><a href="#prod-integer">integer</a></emu-t> tokens.
 
 The [=type name=] of the {{bigint}} type is “<code>BigInt</code>”.
 
@@ -14681,11 +14679,6 @@ expression syntax [[!PERLRE]]) as follows:
         <td id="prod-decimal"><emu-t class="regex">decimal</emu-t></td>
         <td><code>=</code></td>
         <td><code class="regex"><span class="mute">/</span>-?(([0-9]+\.[0-9]*|[0-9]*\.[0-9]+)([Ee][+-]?[0-9]+)?|[0-9]+[Ee][+-]?[0-9]+)<span class="mute">/</span></code></td>
-    </tr>
-    <tr>
-        <td id="prod-bigint"><emu-t class="regex">bigint</emu-t></td>
-        <td><code>=</code></td>
-        <td><code class="regex"><span class="mute">/</span>-?([1-9][0-9]*|0[Xx][0-9A-Fa-f]+|0[0-7]*)n<span class="mute">/</span></code></td>
     </tr>
     <tr>
         <td id="prod-identifier"><emu-t class="regex">identifier</emu-t></td>

--- a/index.bs
+++ b/index.bs
@@ -162,6 +162,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: SetImmutablePrototype; url: sec-set-immutable-prototype
         text: SetIntegrityLevel; url: sec-setintegritylevel
         text: ToBoolean; url: sec-toboolean
+        text: ToBigInt; url: #sec-tobigint
         text: ToInt32; url: sec-toint32
         text: ToNumber; url: sec-tonumber
         text: ToObject; url: sec-toobject
@@ -187,6 +188,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: array index; url: array-index
         text: array iterator object; url: sec-array-iterator-objects
         text: built-in function object; url: sec-built-in-function-objects
+        text: BigInt; url: #sec-ecmascript-language-types-bigint-type
         text: callable; for: ECMAScript; url: sec-iscallable
         text: Completion Record; url: sec-completion-record-specification-type
         text: constructor; url: constructor
@@ -1643,6 +1645,7 @@ constant declaration gives the value of the constant, which can be
 one of the two boolean literal tokens (<emu-t>true</emu-t>
 and <emu-t>false</emu-t>), an
 <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t> token,
+a <emu-t class="regex"><a href="#prod-bigint">bigint</a></emu-t> token,
 a <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token,
 or one of the three special floating point constant values
 (<emu-t>-Infinity</emu-t>, <emu-t>Infinity</emu-t> and <emu-t>NaN</emu-t>).
@@ -1784,6 +1787,7 @@ The following extended attributes are applicable to constants:
         BooleanLiteral
         FloatLiteral
         integer
+        bigint
 </pre>
 
 <pre class="grammar" id="prod-BooleanLiteral">
@@ -3596,6 +3600,9 @@ the following algorithm returns <i>true</i>.
                     <span>numeric types</span>
             </div></th>
                 <th><div>
+                    <span>bigint</span>
+            </div></th>
+                <th><div>
                     <span>string types</span>
             </div></th>
                 <th><div>
@@ -3628,9 +3635,24 @@ the following algorithm returns <i>true</i>.
             <td>●</td>
             <td>●</td>
             <td>●</td>
+            <td>●</td>
         </tr>
         <tr>
             <th>numeric types</th>
+            <td class="belowdiagonal"></td>
+            <td></td>
+            <td></td>
+            <td>●</td>
+            <td>●</td>
+            <td>●</td>
+            <td>●</td>
+            <td>●</td>
+            <td>●</td>
+            <td>●</td>
+        </tr>
+        <tr>
+            <th>bigint</th>
+            <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td></td>
             <td>●</td>
@@ -3643,6 +3665,7 @@ the following algorithm returns <i>true</i>.
         </tr>
         <tr>
             <th>string types</th>
+            <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td></td>
@@ -3658,6 +3681,7 @@ the following algorithm returns <i>true</i>.
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
+            <td class="belowdiagonal"></td>
             <td></td>
             <td>●</td>
             <td></td>
@@ -3667,6 +3691,7 @@ the following algorithm returns <i>true</i>.
         </tr>
         <tr>
             <th>symbol</th>
+            <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
@@ -3684,6 +3709,7 @@ the following algorithm returns <i>true</i>.
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
+            <td class="belowdiagonal"></td>
             <td>(a)</td>
             <td>●</td>
             <td>●</td>
@@ -3691,6 +3717,7 @@ the following algorithm returns <i>true</i>.
         </tr>
         <tr>
             <th>callback function</th>
+            <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
@@ -3710,11 +3737,13 @@ the following algorithm returns <i>true</i>.
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
+            <td class="belowdiagonal"></td>
             <td></td>
             <td>●</td>
         </tr>
         <tr>
             <th>sequence-like</th>
+            <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
             <td class="belowdiagonal"></td>
@@ -5664,7 +5693,7 @@ the [=integer types=],
 {{unrestricted double}}.
 
 The <dfn id="dfn-primitive-type" export>primitive types</dfn> are
-{{boolean}} and the [=numeric types=].
+{{boolean}}, {{bigint}} and the [=numeric types=].
 
 The <dfn id="dfn-string-type" export>string types</dfn> are
 {{DOMString}}, all [=enumeration types=],
@@ -5768,6 +5797,7 @@ type.
         "boolean"
         "byte"
         "octet"
+        "bigint"
 </pre>
 
 <pre class="grammar" id="prod-UnrestrictedFloatType">
@@ -5890,6 +5920,18 @@ tokens.
 
 The [=type name=] of the
 {{octet}} type is "<code>Octet</code>".
+
+
+<h4 id="idl-bigint" interface>bigint</h4>
+
+The {{bigint}} type is an arbitrary integer, unrestricted in range.
+
+{{bigint}} constant values in IDL are
+represented with <emu-t class="regex"><a href="#prod-bigint">bigint</a></emu-t>
+tokens.
+
+The [=type name=] of the
+{{bigint}} type is “BigInt”.
 
 
 <h4 oldids="dom-short" id="idl-short" interface>short</h4>
@@ -7186,6 +7228,9 @@ ECMAScript value type.
     1.  If <a abstract-op>Type</a>(|V|) is Number, then
         return the result of <a href="#es-to-unrestricted-double">converting</a> |V|
         to an {{unrestricted double}}.
+    1.  If <a abstract-op>Type</a>(|V|) is [=BigInt=], then
+        return the result of <a href="#es-to-bigint">converting</a> |V|
+        to an {{bigint}}.
     1.  If <a abstract-op>Type</a>(|V|) is String, then
         return the result of <a href="#es-DOMString">converting</a> |V|
         to a {{DOMString}}.
@@ -7613,6 +7658,27 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
     1.  Otherwise, the Number value is
         the one that represents the same numeric value as the IDL
         {{unrestricted double}} value.
+</div>
+
+<h4 id="es-bigint">bigint</h4>
+
+<div id="es-to-bigint" algorithm="convert an ECMAScript value to a bigint">
+
+    An ECMAScript value |V| is [=converted to an IDL value|converted=]
+    to an IDL {{bigint}} value by running the following algorithm:
+
+    1.  Let |x| be [=?=] <a abstract-op>ToBigInt</a>(|V|).
+    1.  Return the IDL {{bigint}} value that represents the same numeric
+        value as |x|.
+</div>
+
+<div id="bigint-to-es" algorithm="convert a bigint to an ECMAScript value">
+
+    The result of [=converted to an ECMAScript value|converting=]
+    an IDL {{bigint}} value to an ECMAScript value is a [=BigInt=]:
+
+    1.  Return the [=BigInt=] value that represents the same numeric value
+        as the IDL {{bigint}} value.
 </div>
 
 
@@ -8644,23 +8710,32 @@ that correspond to the union’s [=member types=].
         1.  If |types| includes {{object}}, then return the IDL value
             that is a reference to the object |V|.
     1.  If <a abstract-op>Type</a>(|V|) is Boolean, then:
-        1.  If |types| includes a {{boolean}},
+        1.  If |types| includes {{boolean}},
             then return the result of [=converted to an IDL value|converting=]
             |V| to {{boolean}}.
     1.  If <a abstract-op>Type</a>(|V|) is Number, then:
         1.  If |types| includes a [=numeric type=],
             then return the result of [=converted to an IDL value|converting=]
             |V| to that [=numeric type=].
+    1.  If <a abstract-op>Type</a>(|V|) is [=BigInt=], then:
+        1.  If |types| includes {{bigint}},
+            then return the result of [=converted to an IDL value|converting=]
+            |V| to {{bigint}}
     1.  If |types| includes a [=string type=],
         then return the result of
         [=converted to an IDL value|converting=]
         |V| to that type.
-    1.  If |types| includes a [=numeric type=],
-        then return the result of [=converted to an IDL value|converting=]
-        |V| to that [=numeric type=].
-    1.  If |types| includes a {{boolean}},
+    1.  If |types| includes a [=numeric type=], then:
+        1.  If |types| includes {{bigint}},
+            [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        1.  Return the result of [=converted to an IDL value|converting=]
+            |V| to that [=numeric type=].
+    1.  If |types| includes {{boolean}},
         then return the result of [=converted to an IDL value|converting=]
         |V| to {{boolean}}.
+    1.  If |types| includes a {{bigint}},
+        then return the result of [=converted to an IDL value|converting=]
+        |V| to {{bigint}}.
     1.  [=ECMAScript/Throw=] a {{ECMAScript/TypeError}}.
 </div>
 
@@ -10990,6 +11065,16 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
 
             then remove from |S| all other entries.
 
+        1.  Otherwise: if <a abstract-op>Type</a>(|V|) is [=BigInt=]
+            and there is an entry in |S| that has one of the following types at position |i| of its type list,
+            *   {{bigint}}
+            *   a [=nullable type|nullable=] {{bigint}}
+            *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
+            *   a [=union type=], [=nullable type|nullable=] union type, or [=annotated type|annotated=] union type
+                that has one of the above types in its [=flattened member types=]
+
+            then remove from |S| all other entries.
+
         1.  Otherwise: if there is an entry in |S| that has one of the following types at position |i| of its type list,
             *   a [=string type=]
             *   a [=nullable type|nullable=] version of any of the above types
@@ -11011,6 +11096,15 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
         1.  Otherwise: if there is an entry in |S| that has one of the following types at position |i| of its type list,
             *   {{boolean}}
             *   a [=nullable type|nullable=] {{boolean}}
+            *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
+            *   a [=union type=], [=nullable type|nullable=] union type, or [=annotated type|annotated=] union type
+                that has one of the above types in its [=flattened member types=]
+
+            then remove from |S| all other entries.
+
+        1.  Otherwise: if there is an entry in |S| that has one of the following types at position |i| of its type list,
+            *   {{bigint}}
+            *   a [=nullable type|nullable=] {{bigint}}
             *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
             *   a [=union type=], [=nullable type|nullable=] union type, or [=annotated type|annotated=] union type
                 that has one of the above types in its [=flattened member types=]
@@ -14554,6 +14648,11 @@ expression syntax [[!PERLRE]]) as follows:
         <td id="prod-decimal"><emu-t class="regex">decimal</emu-t></td>
         <td><code>=</code></td>
         <td><code class="regex"><span class="mute">/</span>-?(([0-9]+\.[0-9]*|[0-9]*\.[0-9]+)([Ee][+-]?[0-9]+)?|[0-9]+[Ee][+-]?[0-9]+)<span class="mute">/</span></code></td>
+    </tr>
+    <tr>
+        <td id="prod-bigint"><emu-t class="regex">bigint</emu-t></td>
+        <td><code>=</code></td>
+        <td><code class="regex"><span class="mute">/</span>-?([1-9][0-9]*|0[Xx][0-9A-Fa-f]+|0[0-7]*)n<span class="mute">/</span></code></td>
     </tr>
     <tr>
         <td id="prod-identifier"><emu-t class="regex">identifier</emu-t></td>

--- a/index.bs
+++ b/index.bs
@@ -6994,6 +6994,7 @@ five forms are allowed.
         "Promise"
         "USVString"
         "any"
+        "bigint"
         "boolean"
         "byte"
         "double"

--- a/index.bs
+++ b/index.bs
@@ -6587,7 +6587,7 @@ It would not be appropriate to accept such a union, only to then convert values 
 precision errors.
 Please
 <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20bigint/numeric union">file an issue</a>
-to discuss before using this feature.
+before using this feature.
 </p>
 
 [=Union type=] constant values


### PR DESCRIPTION
This patch adds a bigint type to WebIDL with the following properties:
- bigint corresponds directly to BigInt
- The conversion from JS is based on ToBigInt, namely it throws on Number.
- bigint is not grouped as a "numeric" type, as this category is often
  used to refer to types which have a JavaScript representation of Number.
- bigint is included in the overloading resolution algorithm, and it's
  possible to overload a function for BigInt and numeric arguments.

Although it may be on the early side for such a change, the lack of
BigInt WebIDL integration is already coming up in some designs for integrating
BigInt with the Web Platform, such as https://github.com/w3c/IndexedDB/pull/231


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/littledan/webidl/pull/525.html" title="Last updated on Nov 5, 2020, 4:57 PM UTC (4f8357a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/525/d87d389...littledan:4f8357a.html" title="Last updated on Nov 5, 2020, 4:57 PM UTC (4f8357a)">Diff</a>