### PR TITLE
Editorial: correctly reference ES bindings section on constants

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10342,7 +10342,7 @@ in sections [[#es-attributes]] and [[#es-operations]].
 As with the [=interface object=],
 the [=interface prototype object=] also has properties that
 correspond to the [=constants=] defined on that interface,
-described in [[#es-operations]].
+described in [[#es-constants]].
 
 If the [{{NoInterfaceObject}}] extended attribute was not specified on the interface,
 then the [=interface prototype object=] must also


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/531.html" title="Last updated on Mar 4, 2018, 8:10 AM GMT (b0e7199)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/531/93dc13d...b0e7199.html" title="Last updated on Mar 4, 2018, 8:10 AM GMT (b0e7199)">Diff</a>