### PR TITLE
Editorial: minor copy editing

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1255,7 +1255,7 @@ or [=partial interface mixins=] can be found in [[#using-mixins-and-partials]].
 An [=interface mixin=] is a specification of a set of <dfn export lt="interface mixin member">interface mixin members</dfn>
 (matching <emu-nt><a href="#prod-MixinMembers">MixinMembers</a></emu-nt>),
 which are the [=constants=], [=regular operations=], [=regular attributes=], and [=stringifiers=]
-that appear between the braces in the [=interface mixin=] [=declaration=].
+that appear between the braces in the [=interface mixin=] declaration.
 
 These [=constants=], [=regular operations=], [=regular attributes=], and [=stringifiers=]
 describe the behaviors that can be implemented by an object,
@@ -1263,7 +1263,7 @@ as if they were specified on the [=interface=] that [=includes=] them.
 
 [=Static attributes=], [=static operations=], [=special operations=] except for [=stringifiers=], and
 [=iterable declaration|iterable=], [=maplike declaration|maplike=], and [=setlike declarations=]
-cannot appear in [=interface mixin=] [=declarations=].
+cannot appear in [=interface mixin=] declarations.
 
 As with interfaces, the IDL for [=interface mixins=] can be split into multiple parts by using
 <dfn export>partial interface mixin</dfn> definitions
@@ -1297,7 +1297,7 @@ An <dfn>includes statement</dfn> is a definition
 (matching <emu-nt><a href="#prod-IncludesStatement">IncludesStatement</a></emu-nt>)
 used to declare that all objects implementing an [=interface=] |I|
 (identified by the first [=identifier=])
-must additionally include the [=interface mixin member|members] of [=interface mixin=] |M|
+must additionally include the [=interface mixin member|members=] of [=interface mixin=] |M|
 (identified by the second identifier).
 [=Interface=] |I| is said to <dfn id="include" for="interface" export>include</dfn>
 [=interface mixin=] |M|.
@@ -4897,12 +4897,12 @@ over just using {{SyntaxError!!exception}} to refer to the {{DOMException}}. [[D
         </tr>
         <tr>
             <td>"<dfn id="hierarchyrequesterror" exception export><code>HierarchyRequestError</code></dfn>"</td>
-            <td>The operation would yield an incorrect <a href="https://dom.spec.whatwg.org/#concept-node-tree" title="concept-node-tree">node tree</a>.</td>
+            <td>The operation would yield an incorrect [=node tree=]. [[!DOM]]</td>
             <td><dfn id="dom-domexception-hierarchy_request_err" for="DOMException" const export><code>HIERARCHY_REQUEST_ERR</code></dfn>&nbsp;(3)</td>
         </tr>
         <tr>
             <td>"<dfn id="wrongdocumenterror" exception export><code>WrongDocumentError</code></dfn>"</td>
-            <td>The object is in the wrong <a href="https://dom.spec.whatwg.org/#concept-document" title="concept-document">document</a>.</td>
+            <td>The object is in the wrong [=document=]. [[!DOM]]</td>
             <td><dfn id="dom-domexception-wrong_document_err" for="DOMException" const export><code>WRONG_DOCUMENT_ERR</code></dfn>&nbsp;(4)</td>
         </tr>
         <tr>
@@ -9473,11 +9473,9 @@ a [=promise type=].
 <div class="example">
 
     As an example, this extended attribute is suitable for use on
-    the <a href="http://dom.spec.whatwg.org/#dom-document-createelement">createElement</a>
-    operation on the <a href="http://dom.spec.whatwg.org/#document"><code class="idl">Document</code></a>
-    interface ([[DOM]], section 6.5),
+    the {{Document/createElement()}} operation on the {{Document}} interface,
     since a new object should always be returned when
-    it is called.
+    it is called. [[DOM]]
 
     <pre highlight="webidl">
         [Exposed=Window]
@@ -9931,11 +9929,9 @@ or {{object}}.
 <div class="example">
 
     As an example, this extended attribute is suitable for use on
-    the <a href="http://dom.spec.whatwg.org/#dom-document-implementation">implementation</a>
-    attribute on the <a href="http://dom.spec.whatwg.org/#document"><code class="idl">Document</code></a>
-    interface ([[DOM]], section 6.5),
+    the {{Document/implementation}} attribute on the {{Document}} interface
     since the same object is always returned for a given
-    <code class="idl">Document</code> object.
+    {{Document}} object. [[DOM]]
 
     <pre highlight="webidl">
         [Exposed=Window]


### PR DESCRIPTION
"declaration" was linked to the definition in [CSS-SYNTAX-3].

Use/fix Bikeshed autolinking.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TimothyGu/webidl/pull/538.html" title="Last updated on Mar 24, 2018, 7:10 PM GMT (f317fc8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/538/3ef2ba7...TimothyGu:f317fc8.html" title="Last updated on Mar 24, 2018, 7:10 PM GMT (f317fc8)">Diff</a>