### PR TITLE
Editorial: use SetFunctionLength abstract ops

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -143,6 +143,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: OrdinaryPreventExtensions; url: sec-ordinarypreventextensions
         text: OrdinarySetWithOwnDescriptor; url: sec-ordinarysetwithowndescriptor
         text: Set; url: sec-set-o-p-v-throw
+        text: SetFunctionLength; url: sec-setfunctionlength
         text: SetFunctionName; url: sec-setfunctionname
         text: SetImmutablePrototype; url: sec-set-immutable-prototype
         text: SetIntegrityLevel; url: sec-setintegritylevel
@@ -10806,8 +10807,7 @@ the <code>typeof</code> operator will return "function" when applied to an inter
             with argument count 0.
         1.  Set |length| to the length of the
             shortest argument list of the entries in |S|.
-    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "<code>length</code>",
-        PropertyDescriptor{\[[Value]]: |length|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
+    1.  Perform [=!=] <a abstract-op>SetFunctionLength</a>(|F|, |length|).
     1.  Let |proto| be the [=interface prototype object=] of [=interface=] |I| in |realm|.
     1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "<code>prototype</code>",
         PropertyDescriptor{\[[Value]]: |proto|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>false</emu-val>}).
@@ -10858,8 +10858,7 @@ This object's relevant [=Realm=] must be the same as that of the [=named constru
         for constructors with identifier |id| on [=interface=] |I|
         and with argument count 0.
     1.  Let |length| be the length of the shortest argument list of the entries in |S|.
-    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "<code>length</code>",
-        PropertyDescriptor{\[[Value]]: |length|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
+    1.  Perform [=!=] <a abstract-op>SetFunctionLength</a>(|F|, |length|).
     1.  Let |proto| be the [=interface prototype object=] of [=interface=] |I| in |realm|.
     1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "<code>prototype</code>",
         PropertyDescriptor{\[[Value]]: |proto|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>false</emu-val>}).
@@ -11004,8 +11003,7 @@ when applied to a [=legacy callback interface object=].
         1.  [=ECMAScript/Throw=] a {{ECMAScript/TypeError}}.
     1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|realm|, |steps|, |realm|.\[[Intrinsics]].[[{{%FunctionPrototype%}}]]).
     1.  Perform [=!=] <a abstract-op>SetFunctionName</a>(|F|, |id|).
-    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "<code>length</code>",
-        PropertyDescriptor{\[[Value]]: 0, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
+    1.  Perform [=!=] <a abstract-op>SetFunctionLength</a>(|F|, 0).
     1.  [=Define the constants=] of |interface| on |F| given |realm|.
     1.  Return |F|.
 </div>
@@ -11243,9 +11241,8 @@ in which case they are exposed on every object that implements the interface.
         |steps|, |realm|.\[[Intrinsics]].[[{{%FunctionPrototype%}}]]).
     1.  Let |name| be the string "<code>get </code>" prepended to |attribute|'s [=identifier=].
     1.  Perform [=!=] <a abstract-op>SetFunctionName</a>(|F|, |name|).
-    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "<code>length</code>",
-        PropertyDescriptor{\[[Value]]: 0, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
-    1. Return |F|.
+    1.  Perform [=!=] <a abstract-op>SetFunctionLength</a>(|F|, 0).
+    1.  Return |F|.
 
 </div>
 
@@ -11316,8 +11313,7 @@ in which case they are exposed on every object that implements the interface.
         |steps|, |realm|.\[[Intrinsics]].[[{{%FunctionPrototype%}}]]).
     1.  Let |name| be the string "<code>set </code>" prepended to |id|.
     1.  Perform [=!=] <a abstract-op>SetFunctionName</a>(|F|, |name|).
-    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "<code>length</code>",
-        PropertyDescriptor{\[[Value]]: 1, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
+    1.  Perform [=!=] <a abstract-op>SetFunctionLength</a>(|F|, 1).
     1. Return |F|.
 </div>
 
@@ -11437,8 +11433,7 @@ in which case they are exposed on every object that implements the interface.
         operation) or for [=static operations=] (if |op| is a static operation) with [=identifier=] |id|
         on |target| and with argument count 0.
     1.  Let |length| be the length of the shortest argument list in the entries in |S|.
-    1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|F|, "<code>length</code>",
-        PropertyDescriptor{\[[Value]]: |length|, \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>}).
+    1.  Perform [=!=] <a abstract-op>SetFunctionLength</a>(|F|, |length|).
     1.  Return |F|.
 </div>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tobie/webidl/pull/549.html" title="Last updated on Apr 19, 2018, 9:30 PM GMT (d19974d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/549/121edc5...tobie:d19974d.html" title="Last updated on Apr 19, 2018, 9:30 PM GMT (d19974d)">Diff</a>