### PR TITLE
[LegacyArrayClass] is gone from CSSOM.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8923,11 +8923,7 @@ corresponding to [=interface members=].
 
     <small class="non-normative">
         The [{{LegacyArrayClass}}] [=extended attribute=] appears on
-        the following [=interfaces=]:
-        {{DOMRectList}},
-        {{MediaList}},
-        {{StyleSheetList}}, and
-        {{CSSRuleList}}. [[GEOMETRY]] [[CSSOM]]
+        the {{DOMRectList}} [=interface=]. [[GEOMETRY]]
     </small>
 
 </div>


### PR DESCRIPTION
As of:

  https://github.com/w3c/csswg-drafts/commit/b05eb1b9c05c22f771aff6a3ae7cdbb4a925522e

The spec references to [LegacyArrayClass] are gone from CSSOM.

See https://github.com/w3c/csswg-drafts/issues/2601.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/emilio/webidl/pull/550.html" title="Last updated on Apr 24, 2018, 5:13 AM GMT (f5667f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/550/aecffc4...emilio:f5667f1.html" title="Last updated on Apr 24, 2018, 5:13 AM GMT (f5667f1)">Diff</a>