### PR TITLE
Fix a wrong description `[LenientThis]`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9131,7 +9131,7 @@ it indicates that a no-op setter will be generated for the attribute’s
 accessor property.  This results in erroneous assignments to the property
 in strict mode to be ignored rather than causing an exception to be thrown.
 
-The [{{LenientThis}}] extended attribute
+The [{{LenientSetter}}] extended attribute
 must [=takes no arguments|take no arguments=].
 It must not be used on anything other than
 a [=read only=] [=regular attribute=].


### PR DESCRIPTION
In the section of `[LenientSetter]`, a sentence commented on `[LenientThis]` by mistake.