### PR TITLE
Disallow multiple keywords for SpecialOperation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2371,13 +2371,7 @@ The following extended attributes are applicable to operations:
 
 <pre class="grammar" id="prod-SpecialOperation">
     SpecialOperation :
-        Special Specials RegularOperation
-</pre>
-
-<pre class="grammar" id="prod-Specials">
-    Specials :
-        Special Specials
-        ε
+        Special RegularOperation
 </pre>
 
 <pre class="grammar" id="prod-Special">


### PR DESCRIPTION
Closes #470 

This was to allow `setter creator` but is not useful anymore.