### PR TITLE
A dictionary inheriting from a non-JSON type can't be a JSON type.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2460,7 +2460,7 @@ The <dfn id="dfn-json-types" export lt="JSON type">JSON types</dfn> are:
 *   [=typedefs=] whose [=type being given a new name=] is a [=JSON type=],
 *   [=sequence types=] whose parameterized type is a [=JSON type=],
 *   [=frozen array types=] whose parameterized type is a [=JSON type=],
-*   [=dictionaries=] where all of their [=dictionary members|members=] are [=JSON types=],
+*   [=dictionary types=] where the types of all [=dictionary members|members=] declared on the dictionary and all its [=inherited dictionaries=] are [=JSON types=],
 *   [=records=] where all of their [=map/values=] are [=JSON types=],
 *   {{object}},
 *   [=interface types=] that have a <code>toJSON</code> operation declared on themselves or


### PR DESCRIPTION
Fixes https://github.com/heycam/webidl/issues/555


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bzbarsky/webidl/pull/571.html" title="Last updated on Jul 16, 2018, 11:31 PM GMT (ec1f2c9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/571/ebdaa2b...bzbarsky:ec1f2c9.html" title="Last updated on Jul 16, 2018, 11:31 PM GMT (ec1f2c9)">Diff</a>