### PR TITLE
Include the legacy namespace identifier in both interface prototype objects and platform objects.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10878,7 +10878,7 @@ Issue: Define those properties imperatively instead.
 </div>
 
 The [=class string=] of an [=interface prototype object=] is the concatenation of
-the [=interface=]’s [=identifier=] and the string "<code>Prototype</code>".
+the [=interface=]’s [=qualified name=] and the string "<code>Prototype</code>".
 
 
 <h4 id="legacy-callback-interface-object">Legacy callback interface object</h4>

--- a/index.bs
+++ b/index.bs
@@ -6716,7 +6716,7 @@ of objects defined in this section is {{%ObjectPrototype%}}.
 Some objects described in this section are defined to have a <dfn id="dfn-class-string" export>class string</dfn>,
 which is the string to include in the string returned from Object.prototype.toString.
 
-If an object has a class string |classString|, then the object must,
+If an object has a [=class string=] |classString|, then the object must,
 at the time it is created, have a property whose name is the {{@@toStringTag}} symbol
 with PropertyDescriptor{\[[Writable]]: <emu-val>false</emu-val>,
 \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>,

--- a/index.bs
+++ b/index.bs
@@ -1076,6 +1076,20 @@ with a [{{NoInterfaceObject}}] [=extended attribute=],
 and [=callback interfaces=] which declare [=constants=]
 must be annotated with an [{{Exposed}}] [=extended attribute=].
 
+<div algorithm>
+
+The <dfn>qualified name</dfn> of an [=interface=] |interface| is defined as follows:
+
+1.  Let |identifier| be the [=identifier=] of |interface|.
+1.  If |interface| has a [{{LegacyNamespace}}] [=extended attribute=], then:
+    1.  Let |namespace| be the identifier argument of the [{{LegacyNamespace}}]
+        [=extended attribute=].
+    1.  Return the [=concatenation=] of « |namespace|, |identifier| » with
+        separator <span class="char">U+002E FULL STOP (".")</span>.
+1. Return |identifier|.
+
+</div>
+
 <pre class="grammar" id="prod-CallbackOrInterfaceOrMixin">
     CallbackOrInterfaceOrMixin :
         "callback" CallbackRestOrInterface
@@ -12346,14 +12360,9 @@ from the [=platform object=]’s newly associated global environment.
 
 The [=class string=] of
 a platform object that implements one or more interfaces
-must be the [=identifier=] of
+must be the [=qualified name=] of
 the [=primary interface=]
 of the platform object.
-
-The [=class string=] of an interface with the [{{LegacyNamespace}}] extended
-attribute is the concatenation of the class string of the namespace, ".",
-and the class string that the interface would otherwise have without this
-extended attribute.
 
 [=Platform objects=] have an internal \[[SetPrototypeOf]] method
 as defined in [[#platform-object-setprototypeof]].


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Ms2ger/webidl/pull/577.html" title="Last updated on Sep 20, 2018, 8:59 AM GMT (4ad138f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/577/4afb5e8...Ms2ger:4ad138f.html" title="Last updated on Sep 20, 2018, 8:59 AM GMT (4ad138f)">Diff</a>