### PR TITLE
Correct the spelling of "additionally"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2485,7 +2485,7 @@ which returns the [=JSON type=]
 converted into an ECMAScript value
 that can be turned into a JSON string
 by the {{JSON.stringify()}} function.
-Additionaly, in the ECMAScript language binding,
+Additionally, in the ECMAScript language binding,
 the <code>toJSON</code> operation can take a [{{Default}}] [=extended attribute=],
 in which case the [=default toJSON operation=] is exposed instead.
 
@@ -12382,7 +12382,7 @@ the following steps must be run as part of |obj|'s creation:
 1.  [=Define the regular operations=] of |interface| on |obj|, given |realm|.
 1.  [=Define the regular attributes=] of |interface| on |obj|, given |realm|.
 
-Additionaly, [=platform objects=] which implement an [=interface=]
+Additionally, [=platform objects=] which implement an [=interface=]
 which has a [{{Global}}] [=extended attribute=]
 get properties declaratively from:
 
@@ -12443,7 +12443,7 @@ Support for [=getters=] is handled in [[#legacy-platform-object-getownproperty]]
 and for [=setters=] in [[#legacy-platform-object-defineownproperty]]
 and [[#legacy-platform-object-set]].
 
-Additionaly, [=legacy platform objects=] must have internal methods as defined in:
+Additionally, [=legacy platform objects=] must have internal methods as defined in:
 
 * [[#legacy-platform-object-delete]],
 * [[#legacy-platform-object-preventextensions]], and
@@ -13078,7 +13078,7 @@ In the ECMAScript binding, the [=interface prototype object=] for {{DOMException
 has its \[[Prototype]] [=internal slot=] set to the intrinsic object {{%ErrorPrototype%}},
 as defined in the [=create an interface prototype object=] abstract operation.
 
-Additionaly, if an implementation gives native {{ECMAScript/Error}} objects special powers or
+Additionally, if an implementation gives native {{ECMAScript/Error}} objects special powers or
 nonstandard properties (such as a <code>stack</code> property),
 it should also expose those on {{DOMException}} instances.
 


### PR DESCRIPTION
"Additionally" was spelt "additionaly" in a number of places. Fix it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ricea/webidl/pull/590.html" title="Last updated on Nov 30, 2018, 6:41 AM GMT (9c3bcf9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/590/b0aa0b7...ricea:9c3bcf9.html" title="Last updated on Nov 30, 2018, 6:41 AM GMT (9c3bcf9)">Diff</a>