### PR TITLE
Fix typo in example in Namespaces section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4408,7 +4408,7 @@ Of the extended attributes defined in this specification, only the [{{Exposed}}]
 
 <div class="example" id="example-namespace">
 
-    The following [=IDL fragment=] defines an
+    The following [=IDL fragment=] defines a
     [=namespace=].
 
     <pre highlight="webidl">


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sideshowbarker/webidl/pull/593.html" title="Last updated on Dec 7, 2018, 11:17 AM GMT (d6cbaf3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/593/822328f...sideshowbarker:d6cbaf3.html" title="Last updated on Dec 7, 2018, 11:17 AM GMT (d6cbaf3)">Diff</a>