### PR TITLE
Editorial: Note that interface mixins' elements are included among interface elements

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1483,6 +1483,15 @@ and [=operations=] describe the behaviors that can be invoked on the object.
 [=Constants=] declare named constant values
 that are exposed as a convenience to users of objects in the system.
 
+<div class="note">
+
+    When an [=interface=] [=includes=] an [=interface mixin=], each [=member=]
+    of the interface mixin is also considered a member of the interface, but
+    [=interface/inherit|inherited=] interface members are not considered members
+    of the interface.
+
+</div>
+
 [=Interfaces=], [=interface mixins=], and [=namespaces=] each support a different set of [=members=],
 which are specified in [[#idl-interfaces]], [[#idl-interface-mixins]], and [[#idl-namespaces]],
 and summarized in the following informative table:

--- a/index.bs
+++ b/index.bs
@@ -1486,7 +1486,7 @@ that are exposed as a convenience to users of objects in the system.
 <div class="note">
 
     When an [=interface=] [=includes=] an [=interface mixin=], each [=member=]
-    of the interface mixin is also considered a member of the interface, but
+    of the interface mixin is also considered a member of the interface. In contrast,
     [=interface/inherit|inherited=] interface members are not considered members
     of the interface.
 


### PR DESCRIPTION
This was a bit confusing to me when reading the definition of operations
and attributes in the ECMAScript binding--there is a link from that definition to
"member", but no explicit definition of which members are included there (you
have to go check the definition of interface mixin).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/littledan/webidl/pull/594.html" title="Last updated on Jan 28, 2019, 10:28 PM UTC (860e1c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/594/5a20e34...littledan:860e1c6.html" title="Last updated on Jan 28, 2019, 10:28 PM UTC (860e1c6)">Diff</a>