### PR TITLE
Define "implements" checks using internal slots

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7427,7 +7427,7 @@ values are represented by ECMAScript Object values (including [=function objects
     to an IDL [=interface type=] value by running the following algorithm (where |I| is the [=interface=]):
 
     1.  If <a abstract-op>Type</a>(|V|) is not Object, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
-    1.  If |V| is a [=platform object=] that implements |I|, then return the IDL [=interface type=] value that represents a reference to that platform object.
+    1.  If |V| [=implements=] |I|, then return the IDL [=interface type=] value that represents a reference to that platform object.
     1.  If |V| is a [=user object=]
         that is considered to implement |I| according to the rules in [[#es-user-objects]], then return the IDL [=interface type=] value that represents a reference to that
         user object, with the [=incumbent settings object=] as the [=callback context=].
@@ -7441,7 +7441,6 @@ values are represented by ECMAScript Object values (including [=function objects
     value that represents a reference to the same object that the IDL
     [=interface type=] value represents.
 </p>
-
 
 <h4 id="es-dictionary">Dictionary types</h4>
 
@@ -7926,9 +7925,9 @@ that correspond to the union’s [=member types=].
     1.  If |V| is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, then:
         1.  If |types| includes a [=dictionary type=], then return the
             result of [=converted to an IDL value|converting=] |V| to that dictionary type.
-    1.  If |V| is a [=platform object=], then:
+    1.  If |V| [=is a platform object=], then:
         1.  If |types| includes an [=interface type=] that |V|
-            implements, then return the IDL value that is a reference to the object |V|.
+            [=implements=], then return the IDL value that is a reference to the object |V|.
         1.  If |types| includes {{object}}, then return the IDL value
             that is a reference to the object |V|.
     1.  If |V| is a {{DOMException}} platform object, then:
@@ -8352,7 +8351,7 @@ extended attribute must either
 The bare form, <code>[Constructor]</code>, has the same meaning as
 using an empty argument list, <code>[Constructor()]</code>.  For each
 [{{Constructor}}] extended attribute
-on the interface, there will be a way to construct an object that implements
+on the interface, there will be a way to construct an object that [=implements=]
 the interface by passing the specified arguments.
 
 The prose definition of a constructor must
@@ -8397,7 +8396,7 @@ for an interface is to be implemented.
     An ECMAScript implementation supporting these interfaces would
     have a \[[Construct]] property on the
     <code class="idl">Circle</code> interface object which would
-    return a new object that implements the interface.  It would take
+    return a new object that [=implements=] the interface.  It would take
     either zero or one argument.  The
     <code class="idl">NodeList</code> interface object would not
     have a \[[Construct]] property.
@@ -9212,7 +9211,7 @@ If the [{{LenientThis}}]
 appears on a [=regular attribute=],
 it indicates that invocations of the attribute’s getter or setter
 with a <emu-val>this</emu-val> value that is not an
-object that implements the [=interface=]
+object that [=implements=] the [=interface=]
 on which the attribute appears will be ignored.
 
 The [{{LenientThis}}] extended attribute
@@ -9307,7 +9306,7 @@ has the same meaning as using an empty argument list,
 <code>[NamedConstructor=<emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t>()]</code>.
 For each [{{NamedConstructor}}] extended attribute on the interface,
 there will be a way to construct an object that
-implements the interface by passing the specified arguments to the [=constructor=]
+[=implements=] the interface by passing the specified arguments to the [=constructor=]
 that is the value of the aforementioned property.
 
 The [=NamedConstructor identifier|identifier=] used for the named constructor must not
@@ -10244,7 +10243,7 @@ If the [{{Unscopable}}]
 [=extended attribute=]
 appears on a [=regular attribute=]
 or [=regular operation=], it
-indicates that an object that implements an interface with the given
+indicates that an object that [=implements=] an interface with the given
 interface member will not include its property name in any object
 environment record with it as its base object.  The result of this is
 that bare identifiers matching the property name will not resolve to
@@ -10372,9 +10371,9 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
 
             then remove from |S| all other entries.
 
-        1.  Otherwise: if |V| is a [=platform object=], and
+        1.  Otherwise: if |V| [=is a platform object=], and
             there is an entry in |S| that has one of the following types at position |i| of its type list,
-            *   an [=interface type=] that |V| implements
+            *   an [=interface type=] that |V| [=implements=]
             *   {{object}}
             *   a [=nullable type|nullable=] version of any of the above types
             *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
@@ -10660,7 +10659,7 @@ as described in sections [[#es-constants]] and [[#es-operations]].
 
 If the [=interface=] is declared with a [{{Constructor}}] [=extended attribute=],
 then the [=interface object=] can be called as a [=constructor=]
-to create an object that implements that interface.
+to create an object that [=implements=] that interface.
 Calling that interface as a function will throw an exception.
 
 [=Interface objects=] whose [=interfaces=] are not declared
@@ -10702,7 +10701,7 @@ the <code>typeof</code> operator will return "function" when applied to an inter
             Rethrow any exceptions.
         1.  Let |O| be the result of [=converted to an ECMAScript value|converting=] |R|
             to an ECMAScript [=interface type=] value |I|.
-        1.  Assert: |O| is an object that implements |I|.
+        1.  Assert: |O| is an object that [=implements=] |I|.
         1.  Assert: |O|.\[[Realm]] is equal to |realm|.
         1.  Return |O|.
     1.  Let |constructorProto| be |realm|.\[[Intrinsics]].[[{{%FunctionPrototype%}}]].
@@ -10738,7 +10737,7 @@ implement the interface on which the
 [{{NamedConstructor}}] extended attributes appear.
 
 If the actions listed in the description of the constructor return normally,
-then those steps must return an object that implements interface |I|.
+then those steps must return an object that [=implements=] interface |I|.
 This object's relevant [=Realm=] must be the same as that of the [=named constructor=].
 
 <div algorithm>
@@ -10955,7 +10954,7 @@ is the concatenation of the [=interface=]’s
     is called with property key |P|, the following steps are taken:
 
     1.  Let |A| be the [=interface=] for the [=named properties object=] |O|.
-    1.  Let |object| be the sole object from |O|’s ECMAScript global environment that implements |A|.
+    1.  Let |object| be the sole object from |O|’s ECMAScript global environment that [=implements=] |A|.
 
         Note: For example, if the [=interface=] is the {{Window}} interface,
         then the sole object will be this global environment’s window object.
@@ -10972,7 +10971,7 @@ is the concatenation of the [=interface=]’s
         1.  Let |desc| be a newly created [=Property Descriptor=] with no fields.
         1.  Set |desc|.\[[Value]] to the result of [=converted to an ECMAScript value|converting=]
             |value| to an ECMAScript value.
-        1.  If |A| implements an interface with the
+        1.  If |A| [=implements=] an interface with the
             [{{LegacyUnenumerableNamedProperties}}]
             [=extended attribute=],
             then set |desc|.\[[Enumerable]] to <emu-val>false</emu-val>,
@@ -11036,7 +11035,7 @@ is the concatenation of the [=interface=]’s
 [=Constants=] are exposed on [=interface objects=],
 [=legacy callback interface objects=],
 [=interface prototype objects=], and
-on the single object that implements the interface,
+on the single object that [=implements=] the interface,
 when an interface is declared with the [{{Global}}] [=extended attribute=].
 
 <div algorithm>
@@ -11061,7 +11060,7 @@ when an interface is declared with the [{{Global}}] [=extended attribute=].
 [=Regular attributes=] are exposed on the [=interface prototype object=],
 unless the attribute is [=unforgeable=] or
 if the interface was declared with the [{{Global}}] [=extended attribute=],
-in which case they are exposed on every object that implements the interface.
+in which case they are exposed on every object that [=implements=] the interface.
 
 <div algorithm>
     To <dfn>define the regular attributes</dfn> of [=interface=] or [=namespace=] |definition| on |target|,
@@ -11126,9 +11125,9 @@ in which case they are exposed on every object that implements the interface.
                     specified.)
                     <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
                 1.  Otherwise, set |O| to the <emu-val>this</emu-val> value.
-                1.  If |O| is a [=platform object=], then [=perform a security check=], passing |O|,
+                1.  If |O| [=is a platform object=], then [=perform a security check=], passing |O|,
                     |attribute|'s [=identifier=], and "getter".
-                1.  If |O| is not a [=platform object=] that implements the interface |target|,
+                1.  If |O| is not a [=platform object=] that [=implements=] the interface |target|,
                     then:
                     1.  If |attribute| was specified with the [{{LenientThis}}]
                         [=extended attribute=], then return <emu-val>undefined</emu-val>.
@@ -11174,9 +11173,9 @@ in which case they are exposed on every object that implements the interface.
                 specified.)
                 <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
             1.  Otherwise, set |O| to the <emu-val>this</emu-val> value.
-            1.  If |O| is a [=platform object=], then [=perform a security check=], passing |O|,
+            1.  If |O| [=is a platform object=], then [=perform a security check=], passing |O|,
                 |id|, and "setter".
-            1.  Let |validThis| be true if |O| is a [=platform object=] that implements the
+            1.  Let |validThis| be true if |O| [=implements=] the
                 interface |target|, or false otherwise.
             1.  If |validThis| is false and |attribute| was not specified with the [{{LenientThis}}]
                 [=extended attribute=], then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
@@ -11243,7 +11242,7 @@ there exist a corresponding property.
 [=Regular operations=] are exposed on the [=interface prototype object=],
 unless the operation is [=unforgeable=] or
 the interface was declared with the [{{Global}}] [=extended attribute=],
-in which case they are exposed on every object that implements the interface.
+in which case they are exposed on every object that [=implements=] the interface.
 
 <div algorithm>
     To <dfn>define the regular operations</dfn> of [=interface=] or [=namespace=] |definition| on |target|, given [=Realm=] |realm|,
@@ -11303,9 +11302,9 @@ in which case they are exposed on every object that implements the interface.
                     object does not implement |target|.)
                     <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
                 1.  Otherwise, set |O| to the <emu-val>this</emu-val> value.
-                1.  If |O| is a [=platform object=], then [=perform a security check=], passing |O|,
+                1.  If |O| [=is a platform object=], then [=perform a security check=], passing |O|,
                     |id|, and "method".
-                1.  If |O| is not a [=platform object=] that implements the interface |target|,
+                1.  If |O| is not a [=platform object=] that [=implements=] the interface |target|,
                     [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
             1.  Let |n| be the [=list/size=] of |args|.
             1.  Let |S| be the [=effective overload set=] for [=regular operations=] (if |op| is a
@@ -11509,7 +11508,7 @@ then there must exist a property with the following characteristics:
 *   The name of the property is "<code>toString</code>".
 *   If the [=stringifier=] is [=unforgeable=] on the interface
     or if the interface was declared with the [{{Global}}] [=extended attribute=],
-    then the property exists on every object that implements the interface.
+    then the property exists on every object that [=implements=] the interface.
     Otherwise, the property exists on the [=interface prototype object=].
 *   The property has attributes
     { \[[Writable]]: |B|, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: |B| },
@@ -11520,12 +11519,12 @@ then there must exist a property with the following characteristics:
         The value of the property is a [=built-in function object=], which behaves as follows:
 
         1.  Let |O| be the result of calling <a abstract-op>ToObject</a> on the <emu-val>this</emu-val> value.
-        1.  If |O| is a [=platform object=],
+        1.  If |O| [=is a platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
             *   the [=identifier=] of the [=stringifier=], and
             *   the type "<code>method</code>".
-        1.  If |O| is not an object that implements the [=interface=]
+        1.  If |O| is not an object that [=implements=] the [=interface=]
             on which the stringifier was declared, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |V| be an uninitialized variable.
         1.  Depending on where <code>stringifier</code> was specified:
@@ -11572,7 +11571,7 @@ and whose value is a [=function object=].
 The location of the property is determined as follows:
 
 *   If the interface was declared with the [{{Global}}] [=extended attribute=],
-    then the property exists on the single object that implements the interface.
+    then the property exists on the single object that [=implements=] the interface.
 *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 
 If the interface defines an [=indexed property getter=],
@@ -11584,14 +11583,14 @@ then the [=function object=] is {{%ArrayProto_values%}}.
     when invoked, must behave as follows:
 
     1.  Let |object| be the result of calling <a abstract-op>ToObject</a> on the <emu-val>this</emu-val> value.
-    1.  If |object| is a [=platform object=],
+    1.  If |object| [=is a platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
         *   the identifier "<code>@@iterator</code>", and
         *   the type "<code>method</code>".
     1.  Let |interface| be the [=interface=]
         the [=iterable declaration=] is on.
-    1.  If |object| is not a [=platform object=] that implements |interface|,
+    1.  If |object| is not a [=platform object=] that [=implements=] |interface|,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |iterator| be a newly created [=default iterator object=]
         for |interface| with |object| as its target and iterator kind "<code>key+value</code>".
@@ -11605,13 +11604,13 @@ then the [=function object=] is {{%ArrayProto_values%}}.
     when invoked, must behave as follows:
 
     1.  Let |object| be the result of calling <a abstract-op>ToObject</a> on the <emu-val>this</emu-val> value.
-    1.  If |object| is a [=platform object=],
+    1.  If |object| [=is a platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
         *   the identifier "<code>@@iterator</code>", and
         *   the type "<code>method</code>".
     1.  If |object| is not a [=platform object=]
-        that implements the [=interface=]
+        that [=implements=] the [=interface=]
         on which the [=maplike declaration=]
         or [=setlike declaration=] is defined,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
@@ -11648,7 +11647,7 @@ and whose value is a [=function object=].
 The location of the property is determined as follows:
 
 *   If the interface was declared with the [{{Global}}] [=extended attribute=],
-    then the property exists on the single object that implements the interface.
+    then the property exists on the single object that [=implements=] the interface.
 *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 
 If the interface defines an [=indexed property getter=],
@@ -11692,7 +11691,7 @@ then the [=function object=] is {{%ArrayProto_forEach%}}.
     the method, when invoked, must behave as follows:
 
     1.  Let |object| be the result of calling <a abstract-op>ToObject</a> on the <emu-val>this</emu-val> value.
-    1.  If |object| is a [=platform object=],
+    1.  If |object| [=is a platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
         *   the identifier "<code>forEach</code>", and
@@ -11701,7 +11700,7 @@ then the [=function object=] is {{%ArrayProto_forEach%}}.
         on which the [=maplike declaration=]
         or [=setlike declaration=] is declared.
     1.  If |object| is not a [=platform object=]
-        that implements |interface|,
+        that [=implements=] |interface|,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |callbackFn| be the value of the first argument passed to the function, or <emu-val>undefined</emu-val> if the argument was not supplied.
     1.  If <a abstract-op>IsCallable</a>(|callbackFn|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
@@ -11748,7 +11747,7 @@ and whose value is a [=function object=].
 The location of the property is determined as follows:
 
 *   If the interface was declared with the [{{Global}}] [=extended attribute=],
-    then the property exists on the single object that implements the interface.
+    then the property exists on the single object that [=implements=] the interface.
 *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 
 If the interface has a [=value iterator=],
@@ -11769,7 +11768,7 @@ and whose value is a [=function object=].
 The location of the property is determined as follows:
 
 *   If the interface was declared with the [{{Global}}] [=extended attribute=],
-    then the property exists on the single object that implements the interface.
+    then the property exists on the single object that [=implements=] the interface.
 *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 
 If the interface has a [=value iterator=],
@@ -11781,7 +11780,7 @@ then the [=function object=] is {{%ArrayProto_keys%}}.
     then the method, when invoked, must behave as follows:
 
     1.  Let |object| be the result of calling <a abstract-op>ToObject</a> on the <emu-val>this</emu-val> value.
-    1.  If |object| is a [=platform object=],
+    1.  If |object| [=is a platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
         *   the identifier "<code>keys</code>", and
@@ -11789,7 +11788,7 @@ then the [=function object=] is {{%ArrayProto_keys%}}.
     1.  Let |interface| be the [=interface=]
         on which the [=iterable declaration=] is declared on.
     1.  If |object| is not a [=platform object=]
-        that implements |interface|,
+        that [=implements=] |interface|,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |iterator| be a newly created [=default iterator object=]
         for |interface| with |object| as its target and iterator kind "<code>key</code>".
@@ -11812,7 +11811,7 @@ and whose value is a [=function object=].
 The location of the property is determined as follows:
 
 *   If the interface was declared with the [{{Global}}] [=extended attribute=],
-    then the property exists on the single object that implements the interface.
+    then the property exists on the single object that [=implements=] the interface.
 *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 
 If the interface has a [=value iterator=],
@@ -11825,7 +11824,7 @@ the value of the {{@@iterator}} property.
     then the method, when invoked, must behave as follows:
 
     1.  Let |object| be the result of calling <a abstract-op>ToObject</a> on the <emu-val>this</emu-val> value.
-    1.  If |object| is a [=platform object=],
+    1.  If |object| [=is a platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
         *   the identifier "<code>entries</code>", and
@@ -11833,7 +11832,7 @@ the value of the {{@@iterator}} property.
     1.  Let |interface| be the [=interface=]
         on which the [=iterable declaration=] is declared on.
     1.  If |object| is not a [=platform object=]
-        that implements |interface|,
+        that [=implements=] |interface|,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |iterator| be a newly created [=default iterator object=]
         for |interface| with |object| as its target and iterator kind "<code>value</code>".
@@ -11896,7 +11895,7 @@ must be {{%IteratorPrototype%}}.
     1.  Let |interface| be the [=interface=] for which the
         [=iterator prototype object=] exists.
     1.  Let |object| be the result of calling <a abstract-op>ToObject</a> on the <emu-val>this</emu-val> value.
-    1.  If |object| is a [=platform object=],
+    1.  If |object| [=is a platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
         *   the identifier "<code>next</code>", and
@@ -11941,7 +11940,7 @@ and the string "<code> Iterator</code>".
 
 <h4 id="es-maplike">Maplike declarations</h4>
 
-Any object that implements an [=interface=]
+Any object that [=implements=] an [=interface=]
 that has a [=maplike declaration=]
 must have a \[[BackingMap]] [=internal slot=], which is
 initially set to a newly created {{ECMAScript/Map}} object.
@@ -11963,12 +11962,12 @@ These additional properties are described in the sub-sections below.
     1.  Let |O| be the <emu-val>this</emu-val> value.
     1.  Let |arguments| be the list of arguments passed to this function.
     1.  Let |name| be the function name.
-    1.  If |O| is a [=platform object=],
+    1.  If |O| [=is a platform object=],
         then [=perform a security check=], passing:
         *   the platform object |O|,
         *   an identifier equal to |name|, and
         *   the type "<code>method</code>".
-    1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+    1.  If |O| is not an object that [=implements=] <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
     1.  Let |function| be [=?=] <a abstract-op>GetMethod</a>(|map|, |name|).
     1.  If |function| is <emu-val>undefined</emu-val>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
@@ -11992,12 +11991,12 @@ with the following characteristics:
         whose behavior when invoked is as follows:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
-        1.  If |O| is a [=platform object=],
+        1.  If |O| [=is a platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
             *   the identifier "<code>size</code>", and
             *   the type "<code>getter</code>".
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        1.  If |O| is not an object that [=implements=] <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Return <a abstract-op>Get</a>(|map|, "<code>size</code>").
     </div>
@@ -12044,12 +12043,12 @@ For both of <code class="idl">get</code> and <code class="idl">has</code>, there
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
         1.  Let |name| be the name of the property – "<code>get</code>" or "<code>has</code>".
-        1.  If |O| is a [=platform object=],
+        1.  If |O| [=is a platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
             *   an identifier equal to |name|, and
             *   the type "<code>method</code>".
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        1.  If |O| is not an object that [=implements=] <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| be the key type specified in the [=maplike declaration=].
         1.  Let |function| be [=!=] <a abstract-op>Get</a>(|map|, |name|).
@@ -12096,12 +12095,12 @@ must exist on |A|’s
         The value of the property is a [=built-in function object=] that behaves as follows when invoked:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
-        1.  If |O| is a [=platform object=],
+        1.  If |O| [=is a platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
             *   the identifier "<code>delete</code>", and
             *   the type "<code>method</code>".
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        1.  If |O| is not an object that [=implements=] <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| be the key type specified in the [=maplike declaration=].
         1.  Let |function| be [=!=] <a abstract-op>Get</a>(|map|, "<code>delete</code>").
@@ -12130,12 +12129,12 @@ must exist on |A|’s [=interface prototype object=]:
         The value of the property is a [=built-in function object=] that behaves as follows when invoked:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
-        1.  If |O| is a [=platform object=],
+        1.  If |O| [=is a platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
             *   the identifier "<code>set</code>", and
             *   the type "<code>method</code>".
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        1.  If |O| is not an object that [=implements=] <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| and |valueType| be the key and value types specified in the [=maplike declaration=].
         1.  Let |function| be [=!=] <a abstract-op>Get</a>(|map|, "<code>set</code>").
@@ -12156,7 +12155,7 @@ The value of the [=function object=]’s <code class="idl">name</code> property 
 
 <h4 id="es-setlike">Setlike declarations</h4>
 
-Any object that implements an [=interface=]
+Any object that [=implements=] an [=interface=]
 that has a [=setlike declaration=]
 must have a \[[BackingSet]] [=internal slot=], which is
 initially set to a newly created {{ECMAScript/Set}} object.
@@ -12177,12 +12176,12 @@ These additional properties are described in the sub-sections below.
     1.  Let |O| be the <emu-val>this</emu-val> value.
     1.  Let |arguments| be the list of arguments passed to this function.
     1.  Let |name| be the function name.
-    1.  If |O| is a [=platform object=],
+    1.  If |O| [=is a platform object=],
         then [=perform a security check=], passing:
         *   the platform object |O|,
         *   an identifier equal to |name|, and
         *   the type "<code>method</code>".
-    1.  If |O| is not an object that implements <var ignore>A</var>,
+    1.  If |O| is not an object that [=implements=] <var ignore>A</var>,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |set| be the {{ECMAScript/Set}} object that is
         the value of |O|’s \[[BackingSet]] [=internal slot=].
@@ -12207,12 +12206,12 @@ with the following characteristics:
         whose behavior when invoked is as follows:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
-        1.  If |O| is a [=platform object=],
+        1.  If |O| [=is a platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
             *   the identifier "<code>size</code>", and
             *   the type "<code>getter</code>".
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        1.  If |O| is not an object that [=implements=] <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |set| be the {{ECMAScript/Set}} object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
         1.  Return the result of calling the \[[Get]] internal method of |set| passing "<code>size</code>" and |set| as arguments.
     </div>
@@ -12259,12 +12258,12 @@ with the following characteristics:
         The value of the property is a [=built-in function object=] that behaves as follows when invoked:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
-        1.  If |O| is a [=platform object=],
+        1.  If |O| [=is a platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
             *   the identifier "<code>has</code>", and
             *   the type "<code>method</code>".
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        1.  If |O| is not an object that [=implements=] <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |set| be the {{ECMAScript/Set}} object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
         1.  Let |type| be the value type specified in the [=setlike declaration=].
         1.  Let |function| be [=!=] <a abstract-op>Get</a>(|set|, "<code>has</code>").
@@ -12296,12 +12295,12 @@ must exist on |A|’s [=interface prototype object=]:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
         1.  Let |name| be the name of the property – "<code>add</code>" or "<code>delete</code>".
-        1.  If |O| is a [=platform object=],
+        1.  If |O| [=is a platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
             *   an identifier equal to |name|, and
             *   the type "<code>method</code>".
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        1.  If |O| is not an object that [=implements=] <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |set| be the {{ECMAScript/Set}} object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
         1.  Let |type| be the value type specified in the [=setlike declaration=].
         1.  Let |function| be [=!=] <a abstract-op>Get</a>(|set|, |name|).
@@ -12337,18 +12336,73 @@ The value of the [=function object=]’s <code class="idl">name</code> property 
 
 <h3 id="es-platform-objects">Platform objects implementing interfaces</h3>
 
+<div algorithm>
+    An ECMAScript value |value| <dfn id="es-is-platform-object">is a platform object</dfn>
+    if [$Type$](|value|) is Object and if |value| has a \[[PrimaryInterface]] internal slot.
+</div>
+
+<div algorithm>
+    An ECMAScript value |value| <dfn export>implements</dfn> an [=interface=] |interface|
+    if |value| [=is a platform object=] and one of the following is true:
+    <ul>
+        <li>|value|.\[[PrimaryInterface]] is |interface|.</li>
+        <li>The set of [=inherited interfaces=] of |value|.\[[PrimaryInterface]] contains |interface|.</li>
+    </ul>
+
+</div>
+
 Every [=platform object=] is associated with a global environment, just
 as the [=initial objects=] are.
 It is the responsibility of specifications using Web IDL to state
 which global environment (or, by proxy, which global object) each platform
 object is associated with.
 
+<div algorithm>
+    To <dfn>create an object implementing the interface</dfn> |interface|, with optional
+    intenal slots |slots|, for an interface which is not declared with the
+    [{{Global}}] [=extended attribute=], perform the following steps:
+
+    1. If |slots| is provided, append \[[PrimaryInterface]] to |slots|.
+    1. Otherwise, let |slots| be &laquo; \[[PrimaryInterface]] &raquo;.
+    1. Let |proto| be the [=interface prototype object=] of |interface|.
+    1. Let |instance| be [$ObjectCreate$](|proto|, |slots|).
+    1. Set |instance|.\[[PrimaryInterface]] to |interface|.
+    1. Let |realm| be the current [=Realm=].
+    1. [=Define the unforgeable regular operations=] of |interface| on |instance|, given |realm|.
+    1. [=Define the unforgeable regular attributes=] of |interface| on |instance|, given |realm|.
+    1. Return |instance|.
+</div>
+
+<div class="note">
+    Specifications use various wordings to reference the "[=create an object implementing
+    the interface=]" algorithm, such as "a new |interface| object".
+</div>
+
+<div class="note">
+
+    The set of interfaces that a [=platform object=] [=implements=] does not change over
+    the lifetime of the object.
+
+    Multiple [=interface objects=] associated with different [=Realm/global objects=]
+    will allocate [=platform objects=] which have \[[PrimaryInterface]] internal
+    slots referencing the same underlying [=interface=]. For example, a page may
+    contain a same-origin iframe, with the iframe's method being called on the
+    main page's element of the same kind, with no exception thrown.
+
+    [=Interface mixins=] do not participate directly in the evaluation of the [=implements=]
+    algorithm. Instead, each [=interface=] that the [=interface mixin=] is [=included=] in
+    has its own "copy" of each [=member=] of the [=interface mixin=], and the corresponding
+    [=creating an operation function|operation function=] checks that the receiver [=implements=]
+    the particular [=interface=] which [=includes=] the [=interface mixin=].
+
+</div>
+
 The <dfn id="dfn-primary-interface" export>primary interface</dfn> of a platform object
-that implements one or more interfaces is the most-derived [=interface=]
-that it implements.  The value of the \[[Prototype]] [=internal slot=]
+that [=implements=] one or more interfaces is the value of the object's
+\[[PrimaryInterface]] internal slot, which is is the most-derived [=interface=]
+that it [=implements=].  The value of the \[[Prototype]] [=internal slot=]
 of the platform object is the [=interface prototype object=]
-of the [=primary interface=]
-from the [=platform object=]’s associated global environment.
+of the [=primary interface=] from the [=platform object=]’s associated global environment.
 
 The global environment that a given [=platform object=]
 is associated with can <dfn id="dfn-change-global-environment" for="global environment" export>change</dfn> after it has been created.  When
@@ -12366,13 +12420,6 @@ of the platform object.
 
 [=Platform objects=] have an internal \[[SetPrototypeOf]] method
 as defined in [[#platform-object-setprototypeof]].
-
-Within a [=Realm=] |realm|,
-for each [=interface=] |interface| implemented by a [=platform object=] |obj|,
-the following steps must be run as part of |obj|'s creation:
-
-1.  [=Define the unforgeable regular operations=] of |interface| on |obj|, given |realm|.
-1.  [=Define the unforgeable regular attributes=] of |interface| on |obj|, given |realm|.
 
 If within a [=Realm=] |realm| a [=platform object=] |obj| implements
 an interface which is declared with the [{{Global}}] [=extended attribute=], then


### PR DESCRIPTION
- Define an imperative algorithm for instantiating a platform object,
  which everything theoretically calls into, and which sets the primary
  interface into a new internal slot [[PrimaryInterface]].
- Define the "implements" algorithm as checking the [[PrimaryInterface]]
  internal slot.

The algorithm here is roughly in correspondence with the V8 implementation,
where operation functions are allocated with a reference to a
FunctionTemplate object (which is in corresondence with WebIDL interfaces).
When checking the receiver of a method that came from WebIDL, the original
prototype chain is traversed by looking at the FunctionTemplate's parent.
The same FunctionTemplate is used in multiple JavaScript realms.

This PR procrastinates on defining an imperative algorithm for [Global]
interfaces, which would be a bit more text. It also doesn't define which
global object is associated with platform objects, or how this association
is represented.

Fixes #97