### PR TITLE
Only [Global] platform objects are immutable prototype

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12364,7 +12364,8 @@ must be the [=qualified name=] of
 the [=primary interface=]
 of the platform object.
 
-[=Platform objects=] have an internal \[[SetPrototypeOf]] method
+[=Platform objects=] which implement an [=interface=] which has a [{{Global}}]
+[=extended attribute=] have an internal \[[SetPrototypeOf]] method
 as defined in [[#platform-object-setprototypeof]].
 
 Within a [=Realm=] |realm|,


### PR DESCRIPTION
Fixing a typo introduced in #494

cc @tobie


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/littledan/webidl/pull/596.html" title="Last updated on Dec 10, 2018, 7:16 AM GMT (e94abc8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/596/5a20e34...littledan:e94abc8.html" title="Last updated on Dec 10, 2018, 7:16 AM GMT (e94abc8)">Diff</a>