### PR TITLE
Adds [CatchTypeErrors] extended type attribute to stop TypeErrors from propagating during conversions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7475,6 +7475,8 @@ the object (or its prototype chain) correspond to [=dictionary members=].
                 </dl>
             1.  If |esMemberValue| is not <emu-val>undefined</emu-val>, then:
                 1.  Let |idlMemberValue| be the result of [=converted to an IDL value|converting=] |esMemberValue| to an IDL value whose type is the type |member| is declared to be of.
+                1.  If, during the previous step, <a lt="an exception was thrown">an exception |E| was thrown</a>, |E| is a {{TypeError}}, and |member| is declared to be of a type
+                    annotated with [{{CatchTypeErrors}}], let |idlMemberValue| be |member|’s default value, and do not allow the exception to propagate.
                 1.  Set the dictionary member on |idlDict| with key name |key| to the value |idlMemberValue|.  This dictionary member is considered to be [=present=].
             1.  Otherwise, if |esMemberValue| is <emu-val>undefined</emu-val> but |member| has a [=dictionary member/default value=], then:
                 1.  Let |idlMemberValue| be |member|’s default value.
@@ -7591,7 +7593,12 @@ the ECMAScript <emu-val>null</emu-val> value.
         value <emu-val>null</emu-val>.
     1.  Otherwise, return the result of
         [=converted to an IDL value|converting=] |V|
-        using the rules for the [=nullable types/inner type|inner IDL type=] <code class="idl">T</code>.
+        using the rules for the [=nullable types/inner type|inner IDL type=] <code
+        class="idl">|T|</code>.
+    1.  If, during the previous step, <a lt="an exception was thrown">an exception |E| was
+        thrown</a>, |E| is a {{TypeError}}, and <code class="idl">|T|</code> is annotated with
+        [{{CatchTypeErrors}}], return the IDL [=nullable type=] <code class="idl">|T|?</code> value
+        <emu-val>null</emu-val>, instead of allowing the exception to propagate.
 </div>
 
 <div id="nullable-to-es" algorithm="convert a nullable to an ECMAScript value">
@@ -7671,6 +7678,10 @@ ECMAScript Array values.
         1.  Initialize |S|<sub>|i|</sub> to the result of
             [=converted to an IDL value|converting=]
             |nextItem| to an IDL value of type |T|.
+        1.  If, during the previous step, <a lt="an exception was thrown">an exception |E| was
+            thrown</a>, |E| is a {{TypeError}}, and <code class="idl">|T|</code> is annotated with
+            [{{CatchTypeErrors}}], [=iteration/continue=], instead of allowing the exception to
+            propagate.
         1.  Set |i| to |i| + 1.
 </div>
 
@@ -7772,6 +7783,10 @@ ECMAScript Object values.
             1.  Let |typedKey| be |key| [=converted to an IDL value=] of type |K|.
             1.  Let |value| be [=?=] <a abstract-op>Get</a>(|O|, |key|).
             1.  Let |typedValue| be |value| [=converted to an IDL value=] of type |V|.
+            1.  If, during the previous step, <a lt="an exception was thrown">an exception |E| was
+                thrown</a>, |E| is a {{TypeError}}, and <code class="idl">|V|</code> is annotated
+                with [{{CatchTypeErrors}}], [=iteration/continue=], instead of allowing the
+                exception to propagate.
             1.  [=map/Set=] |result|[|typedKey|] to |typedValue|.
 
                 Note: it's possible that |typedKey| is already in |result|, if |O| is a proxy
@@ -8303,6 +8318,9 @@ A dictionary member that does not have a [=dictionary member/default value=] mus
 attributes associated with|associated with=] the [{{CatchTypeErrors}}] extended attribute.  A type
 that is not in one of the above contexts must not be [=extended attributes associated
 with|associated with=] the [{{CatchTypeErrors}}] extended attribute.
+
+See the rules for converting ECMAScript values to the various IDL types mentioned above in
+[[#es-type-mapping]] for the specific requirements that the use of [{{CatchTypeErrors}}] entails.
 
 <div class="example">
 

--- a/index.bs
+++ b/index.bs
@@ -6232,6 +6232,7 @@ annotate are called <dfn export for="annotated types" lt="inner type">inner type
 </div>
 
 The following extended attributes are <dfn for="extended attributes">applicable to types</dfn>:
+[{{CatchTypeErrors}}],
 [{{Clamp}}],
 [{{EnforceRange}}], and
 [{{TreatNullAs}}].
@@ -8276,6 +8277,71 @@ See the rules for converting ECMAScript values to IDL [=buffer source types=] in
     objects as input.
 </div>
 
+
+<h4 id="CatchTypeErrors" extended-attribute lt="CatchTypeErrors">[CatchTypeErrors]</h4>
+
+If the [{{CatchTypeErrors}}] [=extended attribute=] appears on the type of an optional [=dictionary
+member=], the [=nullable types/inner type=] of a [=nullable type=], or the value type of a
+[=sequence=], [=record=] or <a interface lt="FrozenArray">FrozenArray</a>, it creates a new IDL type
+such that when an ECMAScript value is converted to the IDL type, any type errors during the
+conversion result in the omission of that value in its container, rather than further propagation of
+the error. How this omission happens depends on the container type:
+
+*   On an optional [=dictionary member=], a type error while converting the member's value results
+    in that member taking its [=dictionary member/default value=].
+*   On the [=nullable types/inner type=] of a [=nullable type=], a type error while converting the
+    inner type results in <emu-val>null</emu-val>.
+*   On the value type of a [=sequence=], [=record=] or <a interface
+    lt="FrozenArray">FrozenArray</a>, a type error while converting one of the values results in
+    that value being omitted from the resulting object.
+
+The [{{CatchTypeErrors}}]
+extended attribute must
+[=takes no arguments|take no arguments=].
+
+A dictionary member that does not have a [=dictionary member/default value=] must not be [=extended
+attributes associated with|associated with=] the [{{CatchTypeErrors}}] extended attribute.  A type
+that is not in one of the above contexts must not be [=extended attributes associated
+with|associated with=] the [{{CatchTypeErrors}}] extended attribute.
+
+<div class="example">
+
+    In the following [=IDL fragment=], four [=operations=] are declared that take various objects
+    that use the [{{CatchTypeErrors}}] [=extended attribute=]:
+
+    <pre highlight="webidl">
+        dictionary ExampleDict {
+          required double a;
+          [CatchTypeErrors] double b = -1.0;
+        };
+
+        interface CatchTypeErrorsExample {
+          void processDictionary(ExampleDict d);
+          void processNullable(([CatchTypeErrors] double)? n);
+          void processSequence(sequence&lt;[CatchTypeErrors] double&gt; s);
+          void processRecord(record&lt;DOMString, [CatchTypeErrors] double&gt; r);
+        };
+    </pre>
+
+    Calling these with invalid {{double}} values results in those invalid values being omitted,
+    rather than a {{ECMAScript/TypeError}} being thrown:
+
+    <pre highlight="js">
+        // Throws a TypeError, since a does not use [CatchTypeErrors].
+        example.processDictionary({a: "bad", b: 1.2});
+        // Treats input as {a: 1.2, b: -1.0}.
+        example.processDictionary({a: 1.2, b: "bad"});
+
+        // Treats input as null.
+        example.processNullable("bad");
+
+        // Treats input as [1.2, 3.4].
+        example.processSequence([1.2, "bad", 3.4]);
+
+        // Treats input as {a: 1.2, c: 3.4}.
+        example.processRecord({a: 1.2, b: "bad", c: 3.4});
+    </pre>
+</div>
 
 <h4 id="Clamp" extended-attribute lt="Clamp">[Clamp]</h4>
 


### PR DESCRIPTION
DO NOT REVIEW YET. Just posting this for comments on the Manifest spec. See w3c/manifest#611


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/webidl/pull/597.html" title="Last updated on Dec 10, 2018, 4:56 AM GMT (792260c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/597/5a20e34...mgiuca:792260c.html" title="Last updated on Dec 10, 2018, 4:56 AM GMT (792260c)">Diff</a>