### PR TITLE
Specify that returned Promises are created in the relevant realm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7855,10 +7855,14 @@ objects.
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL <a interface lt="Promise">Promise<var ignore>T</var></a> value as follows:
 
-    1.  Let |promise| be [=!=] <a abstract-op>Call</a>({{%Promise_resolve%}}, {{%Promise%}}, «|V|»).
+    1.  Let |realm| be the [=relevant Realm=] of the |this| value that led to the execution of this algorithm.
+    1.  Let |promise| be [=!=] <a abstract-op>Call</a>(|realm|.\[[Intrinsics]].[[{{%Promise_resolve%}}]], |realm|.\[[Intrinsics]].[[{{%Promise%}}]], «|V|»).
     1.  Return the IDL [=promise type=] value that is a reference to the
         same object as |promise|.
 </div>
+
+Issue: The relevant |this| value is not always well-defined; see
+<a href="https://github.com/heycam/webidl/issues/135">#135</a> for discussion.
 
 <p id="promise-to-es">
     The result of [=converted to an ECMAScript value|converting=]


### PR DESCRIPTION
Note that these semantics differ from JavaScript async functions, which
create a Promise in the current Realm.

Verified in Chromium and Firefox that HTMLImageElement.decode and
CustomElementsRegistry.whenDefined return Promise instances from
the relevant realm.

(I'm not sure what's the preferred way to typeset "this", or if it would
be preferred to thread it explicitly through the algorithm. Also, it's
not quite necessary to use the relevant Promise.resolve function, since
resolve effectively uses the relevant realm of its receiver(!))

Resolves part of #135


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/littledan/webidl/pull/598.html" title="Last updated on Dec 12, 2018, 4:50 PM GMT (688df8c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/598/5a20e34...littledan:688df8c.html" title="Last updated on Dec 12, 2018, 4:50 PM GMT (688df8c)">Diff</a>