### PR TITLE
Editorial: Use some more abstract operations.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -138,6 +138,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: NormalCompletion; url: sec-normalcompletion
         text: ObjectCreate; url: sec-objectcreate
         text: OrdinaryDefineOwnProperty; url: sec-ordinarydefineownproperty
+        text: OrdinaryDelete; url: sec-ordinarydelete
         text: OrdinaryGetOwnProperty; url: sec-ordinarygetownproperty
         text: OrdinaryPreventExtensions; url: sec-ordinarypreventextensions
         text: OrdinarySetWithOwnDescriptor; url: sec-ordinarysetwithowndescriptor
@@ -12553,9 +12554,9 @@ Issue: Define those internal methods imperatively instead.
             1.  If |operation| was declared with a [=return type=] of {{boolean}}
                 and the steps returned <emu-val>false</emu-val>, then return <emu-val>false</emu-val>.
         1.  Return <emu-val>true</emu-val>.
-    1.  If |O| has an own property with name |P|, then:
+    1.  If <a abstract-op>OrdinaryGetOwnProperty</a>(|O|, |P|) is not <emu-val>undefined</emu-val>, then:
         1.  If the property is not configurable, then return <emu-val>false</emu-val>.
-        1.  Otherwise, remove the property from |O|.
+        1.  Remove the own property with name |P| from |O|.
     1.  Return <emu-val>true</emu-val>.
 </div>
 
@@ -12634,7 +12635,7 @@ internal method as follows.
     The algorithm operates as follows, with property name |P| and object |O|:
 
     1.  If |P| is not a [=supported property name=] of |O|, then return false.
-    1.  If |O| has an own property named |P|, then return false.
+    1.  If <a abstract-op>OrdinaryGetOwnProperty</a>(|O|, |P|) is not <emu-val>undefined</emu-val>, then return false.
 
           Note: This will include cases in which |O| has unforgeable properties,
           because in practice those are always set up before objects have any supported property names,


### PR DESCRIPTION
Notably, this removes the vague 'has an own property' language and fixes #42.

Only in the case of the prototype in the named property visibility algorithm
is this change potentially observable.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Ms2ger/webidl/pull/601.html" title="Last updated on Jan 16, 2019, 9:42 AM UTC (e843626)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/601/6ec828c...Ms2ger:e843626.html" title="Last updated on Jan 16, 2019, 9:42 AM UTC (e843626)">Diff</a>