### PR TITLE
[[ViewedArrayBuffer]] cannot be undefined during usage

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2047,7 +2047,7 @@ There are three kinds of operation:
 
 If an operation has an identifier but no <emu-t>static</emu-t>
 keyword, then it declares a <dfn id="dfn-regular-operation" export>regular operation</dfn>.
-If the operation has a 
+If the operation has a
 [=special keyword=]
 used in its declaration (that is, any keyword matching
 <emu-nt><a href="#prod-Special">Special</a></emu-nt>, or
@@ -8166,8 +8166,6 @@ a reference to the same object that the IDL value represents.
     1.  Initialize |length| to 0.
     1.  If |O| has a \[[ViewedArrayBuffer]] [=internal slot=], then:
         1.  Set |arrayBuffer| to the value of |O|’s \[[ViewedArrayBuffer]] [=internal slot=].
-        1.  If |arrayBuffer| is <emu-val>undefined</emu-val>, then
-            [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Set |offset| to the value of |O|’s \[[ByteOffset]] [=internal slot=].
         1.  Set |length| to the value of |O|’s \[[ByteLength]] [=internal slot=].
     1.  Otherwise, set |length| to the value of |O|’s \[[ArrayBufferByteLength]] [=internal slot=].


### PR DESCRIPTION
As far as I can tell there's no way for a %TypedArray%'s [[ViewedArrayBuffer]] internal slot to be undefined. I'm pretty sure this has to be the case as implementations assume this algorithm to never throw (the detached issue is tracked separately by #151).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/604.html" title="Last updated on Jan 9, 2019, 2:44 PM UTC (3391298)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/604/8f48c5a...3391298.html" title="Last updated on Jan 9, 2019, 2:44 PM UTC (3391298)">Diff</a>