### PR TITLE
Detached ArrayBuffer objects should not throw

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8171,8 +8171,8 @@ a reference to the same object that the IDL value represents.
         1.  Set |offset| to the value of |O|’s \[[ByteOffset]] [=internal slot=].
         1.  Set |length| to the value of |O|’s \[[ByteLength]] [=internal slot=].
     1.  Otherwise, set |length| to the value of |O|’s \[[ArrayBufferByteLength]] [=internal slot=].
-    1.  If <a abstract-op>IsDetachedBuffer</a>(|arrayBuffer|), then return a reference to or a copy
-        of (as required) the empty byte sequence.
+    1.  If <a abstract-op>IsDetachedBuffer</a>(|arrayBuffer|) is <emu-val>true</emu-val>, then
+        return a reference to or a copy of (as required) the empty byte sequence.
     1.  Let |data| be the value of |O|’s \[[ArrayBufferData]] [=internal slot=].
     1.  Return a reference to or copy of (as required) the |length| bytes in |data|
         starting at byte offset |offset|.

--- a/index.bs
+++ b/index.bs
@@ -8172,7 +8172,7 @@ a reference to the same object that the IDL value represents.
         1.  Set |length| to the value of |O|’s \[[ByteLength]] [=internal slot=].
     1.  Otherwise, set |length| to the value of |O|’s \[[ArrayBufferByteLength]] [=internal slot=].
     1.  If <a abstract-op>IsDetachedBuffer</a>(|arrayBuffer|) is <emu-val>true</emu-val>, then
-        return a reference to or a copy of (as required) the empty byte sequence.
+        return the empty byte sequence.
     1.  Let |data| be the value of |O|’s \[[ArrayBufferData]] [=internal slot=].
     1.  Return a reference to or copy of (as required) the |length| bytes in |data|
         starting at byte offset |offset|.

--- a/index.bs
+++ b/index.bs
@@ -2047,7 +2047,7 @@ There are three kinds of operation:
 
 If an operation has an identifier but no <emu-t>static</emu-t>
 keyword, then it declares a <dfn id="dfn-regular-operation" export>regular operation</dfn>.
-If the operation has a 
+If the operation has a
 [=special keyword=]
 used in its declaration (that is, any keyword matching
 <emu-nt><a href="#prod-Special">Special</a></emu-nt>, or
@@ -8171,8 +8171,8 @@ a reference to the same object that the IDL value represents.
         1.  Set |offset| to the value of |O|’s \[[ByteOffset]] [=internal slot=].
         1.  Set |length| to the value of |O|’s \[[ByteLength]] [=internal slot=].
     1.  Otherwise, set |length| to the value of |O|’s \[[ArrayBufferByteLength]] [=internal slot=].
-    1.  If <a abstract-op>IsDetachedBuffer</a>(|O|), then
-        [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+    1.  If <a abstract-op>IsDetachedBuffer</a>(|arrayBuffer|), then return a reference to or a copy
+        of (as required) the empty byte sequence.
     1.  Let |data| be the value of |O|’s \[[ArrayBufferData]] [=internal slot=].
     1.  Return a reference to or copy of (as required) the |length| bytes in |data|
         starting at byte offset |offset|.


### PR DESCRIPTION
Instead treat them the same as the empty byte sequence as implementations have been doing since forever.

This also performs the IsDetachedBuffer abstract operation on the correct object.

Fixes #151.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/605.html" title="Last updated on Jan 10, 2019, 8:57 AM UTC (19fa3e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/605/8f48c5a...19fa3e2.html" title="Last updated on Jan 10, 2019, 8:57 AM UTC (19fa3e2)">Diff</a>