### PR TITLE
Use %PromiseProto_then% to 'perform some steps once a promise is settled'.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -102,6 +102,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: %ObjProto_toString%; url: sec-object.prototype.tostring
         text: %Promise_reject%; url: sec-promise.reject
         text: %Promise_resolve%; url: sec-promise.resolve
+        text: %PromiseProto_then%; url: sec-promise.prototype.then
     type: const; for: ECMAScript
         url: sec-well-known-symbols
             text: @@iterator
@@ -7899,9 +7900,7 @@ objects.
             return <emu-val>undefined</emu-val>.
         1.  Otherwise, return the result of performing any steps that were required to be run if the promise was rejected,
             with |reason| as the rejection reason.
-    1.  Let |then| be [=?=] <a abstract-op>GetMethod</a>(|promise|, "<code>then</code>").
-    1.  If |then| is <emu-val>undefined</emu-val>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
-    1.  Return <a abstract-op>Call</a>(|then|, |promise|, «|onFulfilled|, |onRejected|»).
+    1.  Return <a abstract-op>Call</a>({{%PromiseProto_then%}}, |promise|, «|onFulfilled|, |onRejected|»).
 </div>
 
 <p class="issue">


### PR DESCRIPTION
Fixes #583.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Ms2ger/webidl/pull/611.html" title="Last updated on Jan 15, 2019, 10:27 AM UTC (e79feeb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/611/d05c8cc...Ms2ger:e79feeb.html" title="Last updated on Jan 15, 2019, 10:27 AM UTC (e79feeb)">Diff</a>