### PR TITLE
Allow identifiers that start with a hyphen.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -13556,7 +13556,7 @@ expression syntax [[!PERLRE]]) as follows:
     <tr>
         <td id="prod-identifier"><emu-t class="regex">identifier</emu-t></td>
         <td><code>=</code></td>
-        <td><code class="regex"><span class="mute">/</span>_?[A-Za-z][0-9A-Z_a-z-]*<span class="mute">/</span></code></td>
+        <td><code class="regex"><span class="mute">/</span>_?[A-Za-z-][0-9A-Z_a-z-]*<span class="mute">/</span></code></td>
     </tr>
     <tr>
         <td id="prod-string"><emu-t class="regex">string</emu-t></td>


### PR DESCRIPTION
Fixes #564.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Ms2ger/webidl/pull/612.html" title="Last updated on Jan 15, 2019, 10:59 AM UTC (ed1765c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/612/d05c8cc...Ms2ger:ed1765c.html" title="Last updated on Jan 15, 2019, 10:59 AM UTC (ed1765c)">Diff</a>