### PR TITLE
Rename the 'float' production to 'real'.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1606,7 +1606,7 @@ one of the two boolean literal tokens (<emu-t>true</emu-t>
 and <emu-t>false</emu-t>),
 the <emu-t>null</emu-t> token, an
 <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t> token,
-a <emu-t class="regex"><a href="#prod-float">float</a></emu-t> token,
+a <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token,
 or one of the three special floating point constant values
 (<emu-t>-Infinity</emu-t>, <emu-t>Infinity</emu-t> and <emu-t>NaN</emu-t>).
 
@@ -1647,23 +1647,23 @@ The value of the <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t
 lie outside the valid range of values for its type, as given in
 [[#idl-types]].
 
-<div id="float-token-value" algorithm="value of float tokens">
-    The value of a <emu-t class="regex"><a href="#prod-float">float</a></emu-t> token is
+<div id="decimal-token-value" algorithm="value of decimal tokens">
+    The value of a <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token is
     either an IEEE 754 single-precision floating point number or an IEEE 754
     double-precision floating point number, depending on the type of the
     constant, dictionary member or optional argument it is being used as the value for, determined as follows:
 
     1.  Let |S| be the sequence of characters matched by the
-        <emu-t class="regex"><a href="#prod-float">float</a></emu-t> token.
+        <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token.
     1.  Let |result| be the Mathematical Value that would be obtained if
         |S| were parsed as an ECMAScript <emu-nt>[=NumericLiteral=]</emu-nt>.
-    1.  If the <emu-t class="regex"><a href="#prod-float">float</a></emu-t> token is being
+    1.  If the <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token is being
         used as the value for a {{float}} or {{unrestricted float}}, then
-        the value of the <emu-t class="regex"><a href="#prod-float">float</a></emu-t> token
+        the value of the <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token
         is the IEEE 754 single-precision floating point number closest to |result|.
-    1.  Otherwise, the <emu-t class="regex"><a href="#prod-float">float</a></emu-t> token is being
+    1.  Otherwise, the <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token is being
         used as the value for a {{double}} or {{unrestricted double}}, and
-        the value of the <emu-t class="regex"><a href="#prod-float">float</a></emu-t> token
+        the value of the <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token
         is the IEEE 754 double-precision floating point number closest to |result|. [[!IEEE-754]]
 </div>
 
@@ -1689,9 +1689,9 @@ value for:
      :: The value is the IEEE 754 double-precision NaN value with the bit pattern 0x7ff8000000000000.
 </dl>
 
-The type of a <emu-t class="regex"><a href="#prod-float">float</a></emu-t> token is the same
+The type of a <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token is the same
 as the type of the constant, dictionary member or optional argument it is being used as the value of.
-The value of the <emu-t class="regex"><a href="#prod-float">float</a></emu-t> token must not
+The value of the <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token must not
 lie outside the valid range of values for its type, as given in [[#idl-types]].
 Also, <emu-t>Infinity</emu-t>, <emu-t>-Infinity</emu-t> and <emu-t>NaN</emu-t> must not
 be used as the value of a {{float}} or {{double}}.
@@ -1758,7 +1758,7 @@ The following extended attributes are applicable to constants:
 
 <pre class="grammar" id="prod-FloatLiteral">
     FloatLiteral :
-        float
+        decimal
         "-Infinity"
         "Infinity"
         "NaN"
@@ -2272,7 +2272,7 @@ dictionary, unless otherwise specified.
 When a boolean literal token (<emu-t>true</emu-t> or <emu-t>false</emu-t>),
 the <emu-t>null</emu-t> token,
 an <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t> token, a
-<emu-t class="regex"><a href="#prod-float">float</a></emu-t> token or one of
+<emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token or one of
 the three special floating point literal values (<emu-t>Infinity</emu-t>,
 <emu-t>-Infinity</emu-t> or <emu-t>NaN</emu-t>) is used as the
 [=optional argument/default value=],
@@ -4552,7 +4552,7 @@ then that gives the dictionary member its [=dictionary member/default value=].
 When a boolean literal token (<emu-t>true</emu-t> or <emu-t>false</emu-t>),
 the <emu-t>null</emu-t> token,
 an <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t> token, a
-<emu-t class="regex"><a href="#prod-float">float</a></emu-t> token,
+<emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token,
 one of the three special floating point literal values (<emu-t>Infinity</emu-t>,
 <emu-t>-Infinity</emu-t> or <emu-t>NaN</emu-t>),
 a <emu-t class="regex"><a href="#prod-string">string</a></emu-t> token or
@@ -5673,7 +5673,7 @@ type that corresponds to the set of finite single-precision 32 bit
 IEEE 754 floating point numbers. [[!IEEE-754]]
 
 {{float}} constant values in IDL are
-represented with <emu-t class="regex"><a href="#prod-float">float</a></emu-t>
+represented with <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t>
 tokens.
 
 The [=type name=] of the
@@ -5695,7 +5695,7 @@ type that corresponds to the set of all possible single-precision 32 bit
 IEEE 754 floating point numbers, finite, non-finite, and special "not a number" values (NaNs). [[!IEEE-754]]
 
 {{unrestricted float}} constant values in IDL are
-represented with <emu-t class="regex"><a href="#prod-float">float</a></emu-t>
+represented with <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t>
 tokens.
 
 The [=type name=] of the
@@ -5709,7 +5709,7 @@ type that corresponds to the set of finite double-precision 64 bit
 IEEE 754 floating point numbers. [[!IEEE-754]]
 
 {{double}} constant values in IDL are
-represented with <emu-t class="regex"><a href="#prod-float">float</a></emu-t>
+represented with <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t>
 tokens.
 
 The [=type name=] of the
@@ -5723,7 +5723,7 @@ type that corresponds to the set of all possible double-precision 64 bit
 IEEE 754 floating point numbers, finite, non-finite, and special "not a number" values (NaNs). [[!IEEE-754]]
 
 {{unrestricted double}} constant values in IDL are
-represented with <emu-t class="regex"><a href="#prod-float">float</a></emu-t>
+represented with <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t>
 tokens.
 
 The [=type name=] of the
@@ -6596,7 +6596,7 @@ five forms are allowed.
 <pre class="grammar" id="prod-Other">
     Other :
         integer
-        float
+        decimal
         identifier
         string
         other
@@ -13549,7 +13549,7 @@ expression syntax [[!PERLRE]]) as follows:
         <td><code class="regex"><span class="mute">/</span>-?([1-9][0-9]*|0[Xx][0-9A-Fa-f]+|0[0-7]*)<span class="mute">/</span></code></td>
     </tr>
     <tr>
-        <td id="prod-float"><emu-t class="regex">float</emu-t></td>
+        <td id="prod-decimal"><emu-t class="regex">decimal</emu-t></td>
         <td><code>=</code></td>
         <td><code class="regex"><span class="mute">/</span>-?(([0-9]+\.[0-9]*|[0-9]*\.[0-9]+)([Ee][+-]?[0-9]+)?|[0-9]+[Ee][+-]?[0-9]+)<span class="mute">/</span></code></td>
     </tr>
@@ -13767,7 +13767,7 @@ The following conformance classes are defined by this specification:
         [].forEach.call(document.querySelectorAll("pre.grammar"), pre => {
             var html = pre.textContent.replace(/("[^"]+")|([a-zA-Z]+)|(:)/g, m => {
                 if (/^"/.test(m)) { return "<emu-t>" + m.replace(/^"|"$/g, "") + "</emu-t>"; }
-                if (/^(integer|float|identifier|string|whitespace|comment|other)$/.test(m)) {
+                if (/^(integer|decimal|identifier|string|whitespace|comment|other)$/.test(m)) {
                   return "<emu-t class=\"regex\"><a href=\"#prod-" + m + "\">" + m + "</a></emu-t>";
                 }
                 if (m == ":") { return "::"; }


### PR DESCRIPTION
This should prevent confusion between the production and the keyword. Fixes #558.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Ms2ger/webidl/pull/616.html" title="Last updated on Jan 28, 2019, 1:31 PM UTC (c04bd6a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/616/d05c8cc...Ms2ger:c04bd6a.html" title="Last updated on Jan 28, 2019, 1:31 PM UTC (c04bd6a)">Diff</a>