### PR TITLE
Editorial: Remove section numbers from ES references.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -164,10 +164,10 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         url: sec-returnifabrupt-shorthands
             text: !
             text: ?
-        text: ECMA-262 §5.2; url: sec-algorithm-conventions
-        text: ECMA-262 §9.1; url: sec-ordinary-object-internal-methods-and-internal-slots
-        text: ECMA-262 §9.3; url: sec-built-in-function-objects
-        text: ECMA-262 §9.4.7; url: sec-immutable-prototype-exotic-objects
+        text: ECMA-262 Algorithm Conventions; url: sec-algorithm-conventions
+        text: ECMA-262 Ordinary Object Internal Methods and Internal Slots; url: sec-ordinary-object-internal-methods-and-internal-slots
+        text: ECMA-262 Built-in Function Objects; url: sec-built-in-function-objects
+        text: ECMA-262 Immutable Prototype Exotic Objects; url: sec-immutable-prototype-exotic-objects
         text: abrupt completion; url: sec-completion-record-specification-type
         text: array index; url: array-index
         text: array iterator object; url: sec-array-iterator-objects
@@ -6688,8 +6688,8 @@ in ECMAScript, as defined by the <cite>ECMAScript Language Specification</cite>
 [[!ECMA-262]].
 
 Unless otherwise specified, objects defined in this section are ordinary objects as described in
-[=ECMA-262 §9.1|ECMA-262 §9.1 Ordinary object internal methods and internal slots=], and if the
-object is a [=function object=], [=ECMA-262 §9.3|§9.3 Built-in function objects=].
+[=ECMA-262 Ordinary object internal methods and internal slots=], and if the
+object is a [=function object=], [=ECMA-262 Built-in function objects=].
 
 This section may redefine certain internal methods and/or internal slots of objects. Other
 specifications may also override the definitions of any internal method and/or internal slots of a
@@ -6725,7 +6725,7 @@ with PropertyDescriptor{\[[Writable]]: <emu-val>false</emu-val>,
 \[[Value]]: |classString|}.
 
 <p id="ecmascript-abstractop">
-    Algorithms in this section use the conventions described in [=ECMA-262 §5.2|ECMA-262 §5.2
+    Algorithms in this section use the conventions described in [=ECMA-262
     Algorithm conventions=], such as the use of steps and substeps, the use of mathematical
     operations, and so on.  This section may also reference abstract operations
     and notations defined in other parts of ECMA-262.
@@ -6935,7 +6935,7 @@ may return any value, which will be discarded.
 <h4 id="es-integer-types">Integer types</h4>
 
 Mathematical operations used in this section,
-including those defined in [=ECMA-262 §5.2|ECMA-262 §5.2 Algorithm conventions=],
+including those defined in [=ECMA-262 Algorithm conventions=],
 are to be understood as computing exact mathematical results
 on mathematical real numbers.
 
@@ -10823,7 +10823,7 @@ with the [{{NoInterfaceObject}}] [=extended attribute=].
         1.  Set the internal methods of |interfaceProtoObj|
             which are specific to [=immutable prototype exotic objects=]
             to the definitions specified in
-            [=ECMA-262 §9.4.7|ECMA-262 §9.4.7 Immutable prototype exotic objects=].
+            [=ECMA-262 Immutable prototype exotic objects=].
     1.  If |interface| is not declared with the [{{Global}}] [=extended attribute=], then:
         1.  [=Define the regular attributes=] of |interface| on |interfaceProtoObj| given |realm|.
         1.  [=Define the regular operations=] of |interface| on |interfaceProtoObj| given |realm|.
@@ -10934,7 +10934,7 @@ for that interface on which named properties are exposed.
     1.  Otherwise, set |proto| to |realm|.\[[Intrinsics]].[[{{%ObjectPrototype%}}]].
     1.  Let |obj| be a newly created object.
     1.  Set |obj|'s internal methods to the definitions specified in
-        [=ECMA-262 §9.1|ECMA-262 §9.1 Ordinary object internal methods and internal slots=],
+        [=ECMA-262 Ordinary object internal methods and internal slots=],
         unless they are specified in the the rest of [[#named-properties-object]].
     1.  Set |obj|'s remaining internal methods to the definitions specified below.
     1.  Set |obj|.\[[Prototype]] to |proto|.


### PR DESCRIPTION
Fixes #542.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Ms2ger/webidl/pull/617.html" title="Last updated on Jan 16, 2019, 9:47 AM UTC (54c60d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/617/d05c8cc...Ms2ger:54c60d1.html" title="Last updated on Jan 16, 2019, 9:47 AM UTC (54c60d1)">Diff</a>