### PR TITLE
Restrict the extended attributes for partial interfaces.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1037,28 +1037,6 @@ Note: A partial interface definition cannot specify that the interface
 Inheritance must be specified on the original [=interface=]
 definition.
 
-[=Extended attributes=] can be specified on
-[=partial interface=] definitions, with some
-limitations.  The following extended attributes must not
-be specified on partial interface definitions:
-[{{Constructor}}],
-[{{LegacyWindowAlias}}],
-[{{NamedConstructor}}],
-[{{NoInterfaceObject}}].
-
-Note: The above list of [=extended attributes=]
-is all of those defined in this document that are applicable to
-[=interfaces=] except for
-[{{Exposed}}],
-[{{Global}}],
-[{{OverrideBuiltins}}], and
-[{{SecureContext}}].
-
-Any [=extended attribute=] specified
-on a [=partial interface=] definition
-is considered to appear on the [=interface=]
-itself.
-
 The relevant language binding determines how interfaces correspond to constructs
 in the language.
 
@@ -1069,6 +1047,11 @@ The following extended attributes are applicable to interfaces:
 [{{LegacyWindowAlias}}],
 [{{NamedConstructor}}],
 [{{NoInterfaceObject}}],
+[{{OverrideBuiltins}}], and
+[{{SecureContext}}].
+
+The following extended attributes are applicable to [=partial interfaces=]:
+[{{Exposed}}],
 [{{OverrideBuiltins}}], and
 [{{SecureContext}}].
 
@@ -9562,6 +9545,10 @@ a [=partial interface=]
 definition, then that partial interface definition must
 be the part of the interface definition that defines
 the [=named property getter=].
+
+If the [{{OverrideBuiltins}}] extended attribute is specified on a
+[=partial interface=] definition, it is considered to appear on the
+[=interface=] itself.
 
 See [[#es-legacy-platform-objects]]
 and [[#legacy-platform-object-defineownproperty]]


### PR DESCRIPTION
It seems like a bad idea to allow [Global] on a partial interface.

The behavior of [Exposed] and [SecureContext] on partial interfaces is already
defined in the relevant algorithms.

The behavior of [OverrideBuiltins] is defined here with the same vague wording
used before. It might be better to disentangle the concept of an interface and
its syntactical structure.

Fixes #154.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Ms2ger/webidl/pull/620.html" title="Last updated on Jan 16, 2019, 1:12 PM UTC (c0d8b12)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/620/ce7b02c...Ms2ger:c0d8b12.html" title="Last updated on Jan 16, 2019, 1:12 PM UTC (c0d8b12)">Diff</a>