### PR TITLE
Clarify the interpretation of string literal tokens.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5796,8 +5796,8 @@ of specifications using Web IDL might want to obtain a sequence of
 </div>
 
 There is no way to represent a constant {{DOMString}}
-value in IDL, although {{DOMString}} [=dictionary member=]
-and [=optional argument|operation optional argument=] default values
+value in IDL, although {{DOMString}} [=dictionary member=] [=dictionary member/default values=]
+and [=optional argument|operation optional argument=] [=optional argument/default values=]
 can be set to [=value of string literal tokens|the value=] of a
 <emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.
 
@@ -5813,8 +5813,8 @@ Such sequences might be interpreted as UTF-8 encoded strings [[!RFC3629]]
 or strings in some other 8-bit-per-code-unit encoding, although this is not required.
 
 There is no way to represent a constant {{ByteString}}
-value in IDL, although {{ByteString}} [=dictionary member=]
-and [=optional argument|operation optional argument=] default values
+value in IDL, although {{ByteString}} [=dictionary member=] [=dictionary member/default values=]
+and [=optional argument|operation optional argument=] [=optional argument/default values=]
 can be set to [=value of string literal tokens|the value=] of a
 <emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.
 
@@ -5844,8 +5844,8 @@ which are all of the Unicode code points apart from the
 surrogate code points.
 
 There is no way to represent a constant {{USVString}}
-value in IDL, although {{USVString}} [=dictionary member=]
-and [=optional argument|operation optional argument=] default values
+value in IDL, although {{USVString}} [=dictionary member=] [=dictionary member/default values=]
+and [=optional argument|operation optional argument=] [=optional argument/default values=]
 can be set to [=value of string literal tokens|the value=] of a
 <emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.
 
@@ -5942,8 +5942,8 @@ refer to a type whose values are the set of strings (sequences of
 [=enumeration values|enumeration’s values=].
 
 Like {{DOMString}}, there is no way to represent a constant [=enumeration=]
-value in IDL, although enumeration-typed [=dictionary member=]
-and [=optional argument|operation optional argument=] default values
+value in IDL, although enumeration-typed [=dictionary member=] [=dictionary member/default values=]
+and [=optional argument|operation optional argument=] [=optional argument/default values=]
 can be set to [=value of string literal tokens|the value=] of a
 <emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.
 

--- a/index.bs
+++ b/index.bs
@@ -2282,7 +2282,8 @@ it is interpreted in the same way as for a [=constant=].
 <div id="string-literal" algorithm="value of string literal tokens">
     Optional argument default values can also be specified using a
     <emu-t class="regex"><a href="#prod-string">string</a></emu-t>
-    token, whose value is a [=string type=] determined as follows:
+    token, whose <dfn lt="value of string literal tokens">value</dfn> is a
+    [=string type=] determined as follows:
 
     1.  Let |S| be the sequence of [=Unicode scalar values=] matched by
         the <emu-t class="regex"><a href="#prod-string">string</a></emu-t> token
@@ -5797,7 +5798,8 @@ of specifications using Web IDL might want to obtain a sequence of
 There is no way to represent a constant {{DOMString}}
 value in IDL, although {{DOMString}} [=dictionary member=]
 and [=optional argument|operation optional argument=] default values
-can be specified using a <emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.
+can be set to [=value of string literal tokens|the value=] of a
+<emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.
 
 The [=type name=] of the
 {{DOMString}} type is "<code>String</code>".
@@ -5813,7 +5815,8 @@ or strings in some other 8-bit-per-code-unit encoding, although this is not requ
 There is no way to represent a constant {{ByteString}}
 value in IDL, although {{ByteString}} [=dictionary member=]
 and [=optional argument|operation optional argument=] default values
-can be specified using a <emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.
+can be set to [=value of string literal tokens|the value=] of a
+<emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.
 
 The [=type name=] of the
 {{ByteString}} type is "<code>ByteString</code>".
@@ -5843,7 +5846,8 @@ surrogate code points.
 There is no way to represent a constant {{USVString}}
 value in IDL, although {{USVString}} [=dictionary member=]
 and [=optional argument|operation optional argument=] default values
-can be specified using a <emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.
+can be set to [=value of string literal tokens|the value=] of a
+<emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.
 
 The [=type name=] of the
 {{USVString}} type is "<code>USVString</code>".
@@ -5939,7 +5943,8 @@ refer to a type whose values are the set of strings (sequences of
 
 Like {{DOMString}}, there is no way to represent a constant [=enumeration=]
 value in IDL, although enumeration-typed [=dictionary member=]
-[=dictionary member/default values=] can be specified using a
+and [=optional argument|operation optional argument=] default values
+can be set to [=value of string literal tokens|the value=] of a
 <emu-t class="regex"><a href="#prod-string">string</a></emu-t> literal.
 
 The [=type name=] of an enumeration type


### PR DESCRIPTION
Fixes #141.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Ms2ger/webidl/pull/621.html" title="Last updated on Jan 30, 2019, 9:09 AM UTC (cfd45ff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/621/ce7b02c...Ms2ger:cfd45ff.html" title="Last updated on Jan 30, 2019, 9:09 AM UTC (cfd45ff)">Diff</a>