### PR TITLE
Check ignoreNamedProps before the named property visibility algorithm.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12741,30 +12741,31 @@ internal method as follows.
             1.  Set |desc|.\[[Enumerable]] and |desc|.\[[Configurable]] to <emu-val>true</emu-val>.
             1.  Return |desc|.
         1.  Set |ignoreNamedProps| to true.
-    1.  If |O| [=support named properties|supports named properties=],
-        the result of running the [=named property visibility algorithm=] with
-        property name |P| and object |O| is true, and |ignoreNamedProps| is false, then:
-        1.  Let |operation| be the operation used to declare the named property getter.
-        1.  Let |value| be an uninitialized variable.
-        1.  If |operation| was defined without an [=identifier=], then
-            set |value| to the result of performing the steps listed in the interface description to
-            [=determine the value of a named property=]
-            with |P| as the name.
-        1.  Otherwise, |operation| was defined with an identifier.  Set |value| to the result
-            of performing the steps listed in the description of |operation| with |P| as the only argument value.
-        1.  Let |desc| be a newly created [=Property Descriptor=] with no fields.
-        1.  Set |desc|.\[[Value]] to the result of [=converted to an ECMAScript value|converting=]
-            |value| to an ECMAScript value.
-        1.  If |O| implements an interface with a [=named property setter=], then set
-            |desc|.\[[Writable]] to <emu-val>true</emu-val>, otherwise set it to
-            <emu-val>false</emu-val>.
-        1.  If |O| implements an interface with the
-            [{{LegacyUnenumerableNamedProperties}}]
-            [=extended attribute=],
-            then set |desc|.\[[Enumerable]] to <emu-val>false</emu-val>,
-            otherwise set it to <emu-val>true</emu-val>.
-        1.  Set |desc|.\[[Configurable]] to <emu-val>true</emu-val>.
-        1.  Return |desc|.
+    1.  If |O| [=support named properties|supports named properties=] and
+        |ignoreNamedProps| is false, then:
+        1.  If the result of running the [=named property visibility algorithm=] with
+            property name |P| and object |O| is true, then:
+            1.  Let |operation| be the operation used to declare the named property getter.
+            1.  Let |value| be an uninitialized variable.
+            1.  If |operation| was defined without an [=identifier=], then
+                set |value| to the result of performing the steps listed in the interface description to
+                [=determine the value of a named property=]
+                with |P| as the name.
+            1.  Otherwise, |operation| was defined with an identifier.  Set |value| to the result
+                of performing the steps listed in the description of |operation| with |P| as the only argument value.
+            1.  Let |desc| be a newly created [=Property Descriptor=] with no fields.
+            1.  Set |desc|.\[[Value]] to the result of [=converted to an ECMAScript value|converting=]
+                |value| to an ECMAScript value.
+            1.  If |O| implements an interface with a [=named property setter=], then set
+                |desc|.\[[Writable]] to <emu-val>true</emu-val>, otherwise set it to
+                <emu-val>false</emu-val>.
+            1.  If |O| implements an interface with the
+                [{{LegacyUnenumerableNamedProperties}}]
+                [=extended attribute=],
+                then set |desc|.\[[Enumerable]] to <emu-val>false</emu-val>,
+                otherwise set it to <emu-val>true</emu-val>.
+            1.  Set |desc|.\[[Configurable]] to <emu-val>true</emu-val>.
+            1.  Return |desc|.
     1.  Return <a abstract-op>OrdinaryGetOwnProperty</a>(|O|, |P|).
 </div>
 


### PR DESCRIPTION
Running the named property visibility algorithm is (or should be) observable
by inserting a proxy in the prototype chain. This changes the spec to match
Gecko's behavior.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Ms2ger/webidl/pull/625.html" title="Last updated on Jan 31, 2019, 8:21 AM UTC (4f60f42)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/625/45438a1...Ms2ger:4f60f42.html" title="Last updated on Jan 31, 2019, 8:21 AM UTC (4f60f42)">Diff</a>