### PR TITLE
Editorial: fix language in nullable types section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5980,7 +5980,7 @@ The [=nullable types/inner type=] must not be:
 *   {{any}},
 *   a [=Promise type=],
 *   another nullable type, or
-*   a [=union type=] that itself has [=includes a nullable type=]
+*   a [=union type=] that itself [=includes a nullable type=]
     or has a dictionary type as one of its [=flattened member types=].
 
 Note: Although dictionary types can in general be nullable,


### PR DESCRIPTION
This PR fixes the following sentence:

```diff
- The inner type must not be […] a union type that itself has includes a nullable type 
+ The inner type must not be […] a union type that itself includes a nullable type 
```

cf. section https://heycam.github.io/webidl/#idl-nullable-type


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/vhf/webidl/pull/628.html" title="Last updated on Jan 21, 2019, 2:59 PM UTC (339f954)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/628/45438a1...vhf:339f954.html" title="Last updated on Jan 21, 2019, 2:59 PM UTC (339f954)">Diff</a>