### PR TITLE
Disallow underscore-and-hyphen only identifiers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -13557,7 +13557,7 @@ expression syntax [[!PERLRE]]) as follows:
     <tr>
         <td id="prod-identifier"><emu-t class="regex">identifier</emu-t></td>
         <td><code>=</code></td>
-        <td><code class="regex"><span class="mute">/</span>_?[A-Za-z-][0-9A-Z_a-z-]*<span class="mute">/</span></code></td>
+        <td><code class="regex"><span class="mute">/</span>[_-]?[A-Za-z][0-9A-Z_a-z-]*<span class="mute">/</span></code></td>
     </tr>
     <tr>
         <td id="prod-string"><emu-t class="regex">string</emu-t></td>


### PR DESCRIPTION
This works for #632.
The previous regular expression accepts strange tokens, i.e. `_-` or `-123`, as identifier tokens. The new expression does not accept them.