### PR TITLE
Add cross-reference to 'exposed' in the [SecureContext] definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9870,7 +9870,7 @@ If the [{{SecureContext}}] [=extended attribute=] appears on an
 [=interface member=],
 [=interface mixin member=], or
 [=namespace member=],
-it indicates that the construct is exposed
+it indicates that the construct is [=exposed=]
 only within a [=secure context=].
 The [{{SecureContext}}] extended attribute must not be used
 on any other construct.


### PR DESCRIPTION
Fixes #119.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/637.html" title="Last updated on Feb 5, 2019, 10:07 AM UTC (be59c93)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/637/f733024...be59c93.html" title="Last updated on Feb 5, 2019, 10:07 AM UTC (be59c93)">Diff</a>