### PR TITLE
Correct requirement to define Global properties on the object itself

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12382,8 +12382,7 @@ the following steps must be run as part of |obj|'s creation:
 1.  [=Define the unforgeable regular attributes=] of |interface| on |obj|, given |realm|.
 
 If within a [=Realm=] |realm| a [=platform object=] |obj| implements
-an interface which is declared with the [{{Global}}] [=extended attribute=], then
-for each [=interface=] |interface| implemented by |obj|,
+an interface |interface| which is declared with the [{{Global}}] [=extended attribute=], then
 the following steps must be run as part of |obj|'s creation:
 
 1.  [=Define the regular operations=] of |interface| on |obj|, given |realm|.


### PR DESCRIPTION
The specification required defining the operations and attributes for the Global
interface itself as well as its inherited interfaces on the object itself.

This is not implemented in Gecko, Chrome or WebKit: none of these engines
defines, for example, the `addEventListener` method on the window object.

I suspect this text was meant to refer to mixin interfaces rather than
inherited interfaces, but these are already covered by a catch-all statement.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/639.html" title="Last updated on Feb 6, 2019, 4:05 PM UTC (db1a9fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/639/fa21124...db1a9fc.html" title="Last updated on Feb 6, 2019, 4:05 PM UTC (db1a9fc)">Diff</a>