### PR TITLE
Specify what typeof should return for exotic objects

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6713,9 +6713,9 @@ of objects defined in this section has the value <emu-val>true</emu-val>.
 Unless otherwise specified, the \[[Prototype]] internal slot
 of objects defined in this section is {{%ObjectPrototype%}}.
 
-Unless otherwise specified, when the {{ECMAScript/typeof}} operator is called
+Unless otherwise specified, {{ECMAScript/typeof}} operator, when called
 on an exotic object that is not a [=function object=] defined in this section
-and other specifications, the string "<code>object</code>" is returned.
+and other specifications, must return the string "<code>object</code>".
 
 Some objects described in this section are defined to have a <dfn id="dfn-class-string" export>class string</dfn>,
 which is the string to include in the string returned from Object.prototype.toString.

--- a/index.bs
+++ b/index.bs
@@ -103,6 +103,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: %Promise_reject%; url: sec-promise.reject
         text: %Promise_resolve%; url: sec-promise.resolve
         text: %PromiseProto_then%; url: sec-promise.prototype.then
+        text: typeof; url: sec-typeof-operator
     type: const; for: ECMAScript
         url: sec-well-known-symbols
             text: @@iterator
@@ -6711,6 +6712,10 @@ of objects defined in this section has the value <emu-val>true</emu-val>.
 
 Unless otherwise specified, the \[[Prototype]] internal slot
 of objects defined in this section is {{%ObjectPrototype%}}.
+
+Unless otherwise specified, when the {{ECMAScript/typeof}} operator is called
+on an exotic object that is not a [=function object=] defined in this section
+and other specifications, the string "<code>object</code>" is returned.
 
 Some objects described in this section are defined to have a <dfn id="dfn-class-string" export>class string</dfn>,
 which is the string to include in the string returned from Object.prototype.toString.

--- a/index.bs
+++ b/index.bs
@@ -6713,9 +6713,9 @@ of objects defined in this section has the value <emu-val>true</emu-val>.
 Unless otherwise specified, the \[[Prototype]] internal slot
 of objects defined in this section is {{%ObjectPrototype%}}.
 
-Unless otherwise specified, {{ECMAScript/typeof}} operator, when called
-on an exotic object that is not a [=function object=] defined in this section
-and other specifications, must return the string "<code>object</code>".
+Unless otherwise specified, {{ECMAScript/typeof}} operator, when called on an
+exotic object that is not a [=function object=] defined in this section and
+other specifications, must return the string "<code>object</code>".
 
 Some objects described in this section are defined to have a <dfn id="dfn-class-string" export>class string</dfn>,
 which is the string to include in the string returned from Object.prototype.toString.


### PR DESCRIPTION
Fixes #512.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TimothyGu/webidl/pull/640.html" title="Last updated on Feb 9, 2019, 2:25 AM UTC (a6b9638)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/640/fc5da8f...TimothyGu:a6b9638.html" title="Last updated on Feb 9, 2019, 2:25 AM UTC (a6b9638)">Diff</a>