### PR TITLE
Disallow combining LegacyWindowAlias and LegacyNamespace

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9072,6 +9072,9 @@ and must not be one of the [=reserved identifiers=].
 The [{{LegacyWindowAlias}}] and [{{NoInterfaceObject}}]
 extended attributes must not be specified on the same interface.
 
+The [{{LegacyWindowAlias}}] and [{{LegacyNamespace}}]
+extended attributes must not be specified on the same interface.
+
 The [{{LegacyWindowAlias}}] extended attribute must not be specified
 on an interface that does not include the {{Window}} [=interface=]
 in its [=exposure set=].


### PR DESCRIPTION
This doesn't currently happen, and we don't expect it to happen in the future.

Fixes #645.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/651.html" title="Last updated on Feb 25, 2019, 11:18 AM UTC (5da20cf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/651/4d049be...5da20cf.html" title="Last updated on Feb 25, 2019, 11:18 AM UTC (5da20cf)">Diff</a>