### PR TITLE
Clarify object creation in named constructors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10759,10 +10759,6 @@ It allows constructing objects that
 implement the interface on which the
 [{{NamedConstructor}}] extended attributes appear.
 
-If the actions listed in the description of the constructor return normally,
-then those steps must return an object that implements interface |I|.
-This object's relevant [=Realm=] must be the same as that of the [=named constructor=].
-
 <div algorithm>
 
     The [=named constructor=] with [=NamedConstructor identifier|identifier=] |id|

--- a/index.bs
+++ b/index.bs
@@ -10721,11 +10721,10 @@ the <code>typeof</code> operator will return "function" when applied to an inter
         1.  Perform the actions listed in the description of |constructor|
             with |values| as the argument values
             and |object| as the <emu-val>this</emu-val> value.
-            Rethrow any exceptions.
         1.  Let |O| be the result of [=converted to an ECMAScript value|converting=] |object|
             to an ECMAScript [=interface type=] value |I|.
         1.  Assert: |O| is an object that implements |I|.
-        1.  Assert: |O|.\[[Realm]] is equal to |realm|.
+        1.  Assert: |O|.\[[Realm]] is |realm|.
         1.  Return |O|.
     1.  Let |constructorProto| be |realm|.\[[Intrinsics]].[[{{%FunctionPrototype%}}]].
     1.  If |I| inherits from some other interface |P|,
@@ -10786,11 +10785,10 @@ This object's relevant [=Realm=] must be the same as that of the [=named constru
         1.  Perform the actions listed in the description of |constructor|
             with |values| as the argument values
             and |object| as the <emu-val>this</emu-val> value.
-            Rethrow any exceptions.
         1.  Let |O| be the result of [=converted to an ECMAScript value|converting=] |object|
             to an ECMAScript [=interface type=] value |I|.
         1.  Assert: |O| is an object that implements |I|.
-        1.  Assert: |O|.\[[Realm]] is equal to |realm|.
+        1.  Assert: |O|.\[[Realm]] is |realm|.
         1.  Return |O|.
     1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
     1.  Perform [=!=] <a abstract-op>SetFunctionName</a>(|F|, |id|).

--- a/index.bs
+++ b/index.bs
@@ -10780,10 +10780,18 @@ This object's relevant [=Realm=] must be the same as that of the [=named constru
             and with argument count |n|.
         1.  Let &lt;|constructor|, |values|&gt; be the result of passing |S| and
             |args| to the [=overload resolution algorithm=].
-        1.  Let |R| be the result of performing the actions listed in the description of
-            |constructor| with |values| as the argument values.
-        1.  Return the result of [=converted to an ECMAScript value|converting=]
-            |R| to an ECMAScript [=interface type=] value |I|.
+        1.  Let |object| be the result of [=internally create a new object implementing the
+            interface|internally creating a new object implementing=] |I|, with |realm| and
+            {{NewTarget}}.
+        1.  Perform the actions listed in the description of |constructor|
+            with |values| as the argument values
+            and |object| as the <emu-val>this</emu-val> value.
+            Rethrow any exceptions.
+        1.  Let |O| be the result of [=converted to an ECMAScript value|converting=] |object|
+            to an ECMAScript [=interface type=] value |I|.
+        1.  Assert: |O| is an object that implements |I|.
+        1.  Assert: |O|.\[[Realm]] is equal to |realm|.
+        1.  Return |O|.
     1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
     1.  Perform [=!=] <a abstract-op>SetFunctionName</a>(|F|, |id|).
     1.  Initialize |S| to the [=effective overload set=]


### PR DESCRIPTION
This matches the text for normal constructors. I forgot to update this
algorithm in 8e1b52942525e9135885eba8aa68c028d2c6a5be.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/652.html" title="Last updated on Feb 25, 2019, 1:59 PM UTC (593fe84)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/652/4d049be...593fe84.html" title="Last updated on Feb 25, 2019, 1:59 PM UTC (593fe84)">Diff</a>