### PR TITLE
Define "implements" checks using internal slots

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7442,7 +7442,7 @@ values are represented by ECMAScript Object values (including [=function objects
     to an IDL [=interface type=] value by running the following algorithm (where |I| is the [=interface=]):
 
     1.  If <a abstract-op>Type</a>(|V|) is not Object, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
-    1.  If |V| is a [=platform object=] that implements |I|, then return the IDL [=interface type=] value that represents a reference to that platform object.
+    1.  If |V| [=implements=] |I|, then return the IDL [=interface type=] value that represents a reference to that platform object.
     1.  If |V| is a [=user object=]
         that is considered to implement |I| according to the rules in [[#es-user-objects]], then return the IDL [=interface type=] value that represents a reference to that
         user object, with the [=incumbent settings object=] as the [=callback context=].
@@ -7939,9 +7939,9 @@ that correspond to the union’s [=member types=].
     1.  If |V| is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, then:
         1.  If |types| includes a [=dictionary type=], then return the
             result of [=converted to an IDL value|converting=] |V| to that dictionary type.
-    1.  If |V| is a [=platform object=], then:
+    1.  If |V| [=is a platform object=], then:
         1.  If |types| includes an [=interface type=] that |V|
-            implements, then return the IDL value that is a reference to the object |V|.
+            [=implements=], then return the IDL value that is a reference to the object |V|.
         1.  If |types| includes {{object}}, then return the IDL value
             that is a reference to the object |V|.
     1.  If |V| is a {{DOMException}} platform object, then:
@@ -8363,7 +8363,7 @@ extended attribute must either
 The bare form, <code>[Constructor]</code>, has the same meaning as
 using an empty argument list, <code>[Constructor()]</code>.  For each
 [{{Constructor}}] extended attribute
-on the interface, there will be a way to construct an object that implements
+on the interface, there will be a way to construct an object that [=implements=]
 the interface by passing the specified arguments.
 
 The prose definition of a constructor must
@@ -8408,7 +8408,7 @@ for an interface is to be implemented.
     An ECMAScript implementation supporting these interfaces would
     have a \[[Construct]] property on the
     <code class="idl">Circle</code> interface object which would
-    return a new object that implements the interface.  It would take
+    return a new object that [=implements=] the interface.  It would take
     either zero or one argument.  The
     <code class="idl">NodeList</code> interface object would not
     have a \[[Construct]] property.
@@ -8852,7 +8852,7 @@ or more than one [=iterable declaration=],
 across those interfaces.
 
 Note: This is because all of the [=members=] of the interface
-get flattened down on to the object that implements the interface.
+get flattened down on to the object that [=implements=] the interface.
 
 The [{{Global}}] extended attribute
 can also be used to give a name to one or more global interfaces,
@@ -9226,7 +9226,7 @@ If the [{{LenientThis}}]
 appears on a [=regular attribute=],
 it indicates that invocations of the attribute’s getter or setter
 with a <emu-val>this</emu-val> value that is not an
-object that implements the [=interface=]
+object that [=implements=] the [=interface=]
 on which the attribute appears will be ignored.
 
 The [{{LenientThis}}] extended attribute
@@ -9321,7 +9321,7 @@ has the same meaning as using an empty argument list,
 <code>[NamedConstructor=<emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t>()]</code>.
 For each [{{NamedConstructor}}] extended attribute on the interface,
 there will be a way to construct an object that
-implements the interface by passing the specified arguments to the [=constructor=]
+[=implements=] the interface by passing the specified arguments to the [=constructor=]
 that is the value of the aforementioned property.
 
 The [=NamedConstructor identifier|identifier=] used for the named constructor must not
@@ -10266,7 +10266,7 @@ If the [{{Unscopable}}]
 [=extended attribute=]
 appears on a [=regular attribute=]
 or [=regular operation=], it
-indicates that an object that implements an interface with the given
+indicates that an object that [=implements=] an interface with the given
 interface member will not include its property name in any object
 environment record with it as its base object.  The result of this is
 that bare identifiers matching the property name will not resolve to
@@ -10394,9 +10394,9 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
 
             then remove from |S| all other entries.
 
-        1.  Otherwise: if |V| is a [=platform object=], and
+        1.  Otherwise: if |V| [=is a platform object=], and
             there is an entry in |S| that has one of the following types at position |i| of its type list,
-            *   an [=interface type=] that |V| implements
+            *   an [=interface type=] that |V| [=implements=]
             *   {{object}}
             *   a [=nullable type|nullable=] version of any of the above types
             *   an [=annotated type=] whose [=annotated types/inner type=] is one of the above types
@@ -10682,7 +10682,7 @@ as described in sections [[#es-constants]] and [[#es-operations]].
 
 If the [=interface=] is declared with a [{{Constructor}}] [=extended attribute=],
 then the [=interface object=] can be called as a [=constructor=]
-to create an object that implements that interface.
+to create an object that [=implements=] that interface.
 Calling that interface as a function will throw an exception.
 
 [=Interface objects=] whose [=interfaces=] are not declared
@@ -10726,7 +10726,7 @@ the <code>typeof</code> operator will return "function" when applied to an inter
             and |object| as the <emu-val>this</emu-val> value.
         1.  Let |O| be the result of [=converted to an ECMAScript value|converting=] |object|
             to an ECMAScript [=interface type=] value |I|.
-        1.  Assert: |O| is an object that implements |I|.
+        1.  Assert: |O| is an object that [=implements=] |I|.
         1.  Assert: |O|.\[[Realm]] is |realm|.
         1.  Return |O|.
     1.  Let |constructorProto| be |realm|.\[[Intrinsics]].[[{{%FunctionPrototype%}}]].
@@ -10786,7 +10786,7 @@ implement the interface on which the
             and |object| as the <emu-val>this</emu-val> value.
         1.  Let |O| be the result of [=converted to an ECMAScript value|converting=] |object|
             to an ECMAScript [=interface type=] value |I|.
-        1.  Assert: |O| is an object that implements |I|.
+        1.  Assert: |O| is an object that [=implements=] |I|.
         1.  Assert: |O|.\[[Realm]] is |realm|.
         1.  Return |O|.
     1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
@@ -10982,7 +10982,7 @@ is the concatenation of the [=interface=]’s
     is called with property key |P|, the following steps are taken:
 
     1.  Let |A| be the [=interface=] for the [=named properties object=] |O|.
-    1.  Let |object| be the sole object from |O|’s ECMAScript global environment that implements |A|.
+    1.  Let |object| be the sole object from |O|’s ECMAScript global environment that [=implements=] |A|.
 
         Note: For example, if the [=interface=] is the {{Window}} interface,
         then the sole object will be this global environment’s window object.
@@ -10999,7 +10999,7 @@ is the concatenation of the [=interface=]’s
         1.  Let |desc| be a newly created [=Property Descriptor=] with no fields.
         1.  Set |desc|.\[[Value]] to the result of [=converted to an ECMAScript value|converting=]
             |value| to an ECMAScript value.
-        1.  If |A| implements an interface with the
+        1.  If |A| [=implements=] an interface with the
             [{{LegacyUnenumerableNamedProperties}}]
             [=extended attribute=],
             then set |desc|.\[[Enumerable]] to <emu-val>false</emu-val>,
@@ -11063,7 +11063,7 @@ is the concatenation of the [=interface=]’s
 [=Constants=] are exposed on [=interface objects=],
 [=legacy callback interface objects=],
 [=interface prototype objects=], and
-on the single object that implements the interface,
+on the single object that [=implements=] the interface,
 when an interface is declared with the [{{Global}}] [=extended attribute=].
 
 <div algorithm>
@@ -11088,7 +11088,7 @@ when an interface is declared with the [{{Global}}] [=extended attribute=].
 [=Regular attributes=] are exposed on the [=interface prototype object=],
 unless the attribute is [=unforgeable=] or
 if the interface was declared with the [{{Global}}] [=extended attribute=],
-in which case they are exposed on every object that implements the interface.
+in which case they are exposed on every object that [=implements=] the interface.
 
 <div algorithm>
     To <dfn>define the regular attributes</dfn> of [=interface=] or [=namespace=] |definition| on |target|,
@@ -11153,10 +11153,9 @@ in which case they are exposed on every object that implements the interface.
                     specified.)
                     <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
                 1.  Otherwise, set |O| to the <emu-val>this</emu-val> value.
-                1.  If |O| is a [=platform object=], then [=perform a security check=], passing |O|,
+                1.  If |O| [=is a platform object=], then [=perform a security check=], passing |O|,
                     |attribute|'s [=identifier=], and "getter".
-                1.  If |O| is not a [=platform object=] that implements the interface |target|,
-                    then:
+                1.  If |O| does not [=implement=] the interface |target|, then:
                     1.  If |attribute| was specified with the [{{LenientThis}}]
                         [=extended attribute=], then return <emu-val>undefined</emu-val>.
                     1. Otherwise, [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
@@ -11203,9 +11202,9 @@ in which case they are exposed on every object that implements the interface.
                 specified.)
                 <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
             1.  Otherwise, set |O| to the <emu-val>this</emu-val> value.
-            1.  If |O| is a [=platform object=], then [=perform a security check=], passing |O|,
+            1.  If |O| [=is a platform object=], then [=perform a security check=], passing |O|,
                 |id|, and "setter".
-            1.  Let |validThis| be true if |O| is a [=platform object=] that implements the
+            1.  Let |validThis| be true if |O| [=implements=] the
                 interface |target|, or false otherwise.
             1.  If |validThis| is false and |attribute| was not specified with the [{{LenientThis}}]
                 [=extended attribute=], then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
@@ -11271,7 +11270,7 @@ there exist a corresponding property.
 [=Regular operations=] are exposed on the [=interface prototype object=],
 unless the operation is [=unforgeable=] or
 the interface was declared with the [{{Global}}] [=extended attribute=],
-in which case they are exposed on every object that implements the interface.
+in which case they are exposed on every object that [=implements=] the interface.
 
 <div algorithm>
     To <dfn>define the regular operations</dfn> of [=interface=] or [=namespace=] |definition| on |target|, given [=Realm=] |realm|,
@@ -11331,9 +11330,9 @@ in which case they are exposed on every object that implements the interface.
                     object does not implement |target|.)
                     <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
                 1.  Otherwise, set |O| to the <emu-val>this</emu-val> value.
-                1.  If |O| is a [=platform object=], then [=perform a security check=], passing |O|,
+                1.  If |O| [=is a platform object=], then [=perform a security check=], passing |O|,
                     |id|, and "method".
-                1.  If |O| is not a [=platform object=] that implements the interface |target|,
+                1.  If |O| does not [=implement=] the interface |target|,
                     [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
             1.  Let |n| be the [=list/size=] of |args|.
             1.  Let |S| be the [=effective overload set=] for [=regular operations=] (if |op| is a
@@ -11536,7 +11535,7 @@ then there must exist a property with the following characteristics:
 *   The name of the property is "<code>toString</code>".
 *   If the [=stringifier=] is [=unforgeable=] on the interface
     or if the interface was declared with the [{{Global}}] [=extended attribute=],
-    then the property exists on every object that implements the interface.
+    then the property exists on every object that [=implements=] the interface.
     Otherwise, the property exists on the [=interface prototype object=].
 *   The property has attributes
     { \[[Writable]]: |B|, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: |B| },
@@ -11547,12 +11546,12 @@ then there must exist a property with the following characteristics:
         The value of the property is a [=built-in function object=], which behaves as follows:
 
         1.  Let |O| be the result of calling <a abstract-op>ToObject</a> on the <emu-val>this</emu-val> value.
-        1.  If |O| is a [=platform object=],
+        1.  If |O| [=is a platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
             *   the [=identifier=] of the [=stringifier=], and
             *   the type "<code>method</code>".
-        1.  If |O| is not an object that implements the [=interface=]
+        1.  If |O| does not [=implement=] the [=interface=]
             on which the stringifier was declared, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |V| be an uninitialized variable.
         1.  Depending on where <code>stringifier</code> was specified:
@@ -11599,7 +11598,7 @@ and whose value is a [=function object=].
 The location of the property is determined as follows:
 
 *   If the interface was declared with the [{{Global}}] [=extended attribute=],
-    then the property exists on the single object that implements the interface.
+    then the property exists on the single object that [=implements=] the interface.
 *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 
 If the interface defines an [=indexed property getter=],
@@ -11611,14 +11610,14 @@ then the [=function object=] is {{%ArrayProto_values%}}.
     when invoked, must behave as follows:
 
     1.  Let |object| be the result of calling <a abstract-op>ToObject</a> on the <emu-val>this</emu-val> value.
-    1.  If |object| is a [=platform object=],
+    1.  If |object| [=is a platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
         *   the identifier "<code>@@iterator</code>", and
         *   the type "<code>method</code>".
     1.  Let |interface| be the [=interface=]
         the [=iterable declaration=] is on.
-    1.  If |object| is not a [=platform object=] that implements |interface|,
+    1.  If |object| does not [=implement=] |interface|,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |iterator| be a newly created [=default iterator object=]
         for |interface| with |object| as its target and iterator kind "<code>key+value</code>".
@@ -11632,13 +11631,12 @@ then the [=function object=] is {{%ArrayProto_values%}}.
     when invoked, must behave as follows:
 
     1.  Let |object| be the result of calling <a abstract-op>ToObject</a> on the <emu-val>this</emu-val> value.
-    1.  If |object| is a [=platform object=],
+    1.  If |object| [=is a platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
         *   the identifier "<code>@@iterator</code>", and
         *   the type "<code>method</code>".
-    1.  If |object| is not a [=platform object=]
-        that implements the [=interface=]
+    1.  If |object| does not [=implement=] the [=interface=]
         on which the [=maplike declaration=]
         or [=setlike declaration=] is defined,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
@@ -11675,7 +11673,7 @@ and whose value is a [=function object=].
 The location of the property is determined as follows:
 
 *   If the interface was declared with the [{{Global}}] [=extended attribute=],
-    then the property exists on the single object that implements the interface.
+    then the property exists on the single object that [=implements=] the interface.
 *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 
 If the interface defines an [=indexed property getter=],
@@ -11719,7 +11717,7 @@ then the [=function object=] is {{%ArrayProto_forEach%}}.
     the method, when invoked, must behave as follows:
 
     1.  Let |object| be the result of calling <a abstract-op>ToObject</a> on the <emu-val>this</emu-val> value.
-    1.  If |object| is a [=platform object=],
+    1.  If |object| [=is a platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
         *   the identifier "<code>forEach</code>", and
@@ -11727,8 +11725,7 @@ then the [=function object=] is {{%ArrayProto_forEach%}}.
     1.  Let |interface| be the [=interface=]
         on which the [=maplike declaration=]
         or [=setlike declaration=] is declared.
-    1.  If |object| is not a [=platform object=]
-        that implements |interface|,
+    1.  If |object| does not [=implement=] |interface|,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |callbackFn| be the value of the first argument passed to the function, or <emu-val>undefined</emu-val> if the argument was not supplied.
     1.  If <a abstract-op>IsCallable</a>(|callbackFn|) is <emu-val>false</emu-val>, [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
@@ -11775,7 +11772,7 @@ and whose value is a [=function object=].
 The location of the property is determined as follows:
 
 *   If the interface was declared with the [{{Global}}] [=extended attribute=],
-    then the property exists on the single object that implements the interface.
+    then the property exists on the single object that [=implements=] the interface.
 *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 
 If the interface has a [=value iterator=],
@@ -11796,7 +11793,7 @@ and whose value is a [=function object=].
 The location of the property is determined as follows:
 
 *   If the interface was declared with the [{{Global}}] [=extended attribute=],
-    then the property exists on the single object that implements the interface.
+    then the property exists on the single object that [=implements=] the interface.
 *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 
 If the interface has a [=value iterator=],
@@ -11808,15 +11805,14 @@ then the [=function object=] is {{%ArrayProto_keys%}}.
     then the method, when invoked, must behave as follows:
 
     1.  Let |object| be the result of calling <a abstract-op>ToObject</a> on the <emu-val>this</emu-val> value.
-    1.  If |object| is a [=platform object=],
+    1.  If |object| [=is a platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
         *   the identifier "<code>keys</code>", and
         *   the type "<code>method</code>".
     1.  Let |interface| be the [=interface=]
         on which the [=iterable declaration=] is declared on.
-    1.  If |object| is not a [=platform object=]
-        that implements |interface|,
+    1.  If |object| does not [=implement=] |interface|,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |iterator| be a newly created [=default iterator object=]
         for |interface| with |object| as its target and iterator kind "<code>key</code>".
@@ -11839,7 +11835,7 @@ and whose value is a [=function object=].
 The location of the property is determined as follows:
 
 *   If the interface was declared with the [{{Global}}] [=extended attribute=],
-    then the property exists on the single object that implements the interface.
+    then the property exists on the single object that [=implements=] the interface.
 *   Otherwise, the property exists solely on the interface’s [=interface prototype object=].
 
 If the interface has a [=value iterator=],
@@ -11852,15 +11848,14 @@ the value of the {{@@iterator}} property.
     then the method, when invoked, must behave as follows:
 
     1.  Let |object| be the result of calling <a abstract-op>ToObject</a> on the <emu-val>this</emu-val> value.
-    1.  If |object| is a [=platform object=],
+    1.  If |object| [=is a platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
         *   the identifier "<code>entries</code>", and
         *   the type "<code>method</code>".
     1.  Let |interface| be the [=interface=]
         on which the [=iterable declaration=] is declared on.
-    1.  If |object| is not a [=platform object=]
-        that implements |interface|,
+    1.  If |object| does not [=implement=] |interface|,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |iterator| be a newly created [=default iterator object=]
         for |interface| with |object| as its target and iterator kind "<code>value</code>".
@@ -11923,7 +11918,7 @@ must be {{%IteratorPrototype%}}.
     1.  Let |interface| be the [=interface=] for which the
         [=iterator prototype object=] exists.
     1.  Let |object| be the result of calling <a abstract-op>ToObject</a> on the <emu-val>this</emu-val> value.
-    1.  If |object| is a [=platform object=],
+    1.  If |object| [=is a platform object=],
         then [=perform a security check=], passing:
         *   the platform object |object|,
         *   the identifier "<code>next</code>", and
@@ -11968,7 +11963,7 @@ and the string "<code> Iterator</code>".
 
 <h4 id="es-maplike">Maplike declarations</h4>
 
-Any object that implements an [=interface=]
+Any object that [=implements=] an [=interface=]
 that has a [=maplike declaration=]
 must have a \[[BackingMap]] [=internal slot=], which is
 initially set to a newly created {{ECMAScript/Map}} object.
@@ -11990,12 +11985,12 @@ These additional properties are described in the sub-sections below.
     1.  Let |O| be the <emu-val>this</emu-val> value.
     1.  Let |arguments| be the list of arguments passed to this function.
     1.  Let |name| be the function name.
-    1.  If |O| is a [=platform object=],
+    1.  If |O| [=is a platform object=],
         then [=perform a security check=], passing:
         *   the platform object |O|,
         *   an identifier equal to |name|, and
         *   the type "<code>method</code>".
-    1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+    1.  If |O| does not [=implement=] <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
     1.  Let |function| be [=?=] <a abstract-op>GetMethod</a>(|map|, |name|).
     1.  If |function| is <emu-val>undefined</emu-val>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
@@ -12019,12 +12014,12 @@ with the following characteristics:
         whose behavior when invoked is as follows:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
-        1.  If |O| is a [=platform object=],
+        1.  If |O| [=is a platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
             *   the identifier "<code>size</code>", and
             *   the type "<code>getter</code>".
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        1.  If |O| does not [=implement=] <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Return <a abstract-op>Get</a>(|map|, "<code>size</code>").
     </div>
@@ -12071,12 +12066,12 @@ For both of <code class="idl">get</code> and <code class="idl">has</code>, there
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
         1.  Let |name| be the name of the property – "<code>get</code>" or "<code>has</code>".
-        1.  If |O| is a [=platform object=],
+        1.  If |O| [=is a platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
             *   an identifier equal to |name|, and
             *   the type "<code>method</code>".
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        1.  If |O| does not [=implement=] <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| be the key type specified in the [=maplike declaration=].
         1.  Let |function| be [=!=] <a abstract-op>Get</a>(|map|, |name|).
@@ -12123,12 +12118,12 @@ must exist on |A|’s
         The value of the property is a [=built-in function object=] that behaves as follows when invoked:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
-        1.  If |O| is a [=platform object=],
+        1.  If |O| [=is a platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
             *   the identifier "<code>delete</code>", and
             *   the type "<code>method</code>".
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        1.  If |O| does not [=implement=] <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| be the key type specified in the [=maplike declaration=].
         1.  Let |function| be [=!=] <a abstract-op>Get</a>(|map|, "<code>delete</code>").
@@ -12157,12 +12152,12 @@ must exist on |A|’s [=interface prototype object=]:
         The value of the property is a [=built-in function object=] that behaves as follows when invoked:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
-        1.  If |O| is a [=platform object=],
+        1.  If |O| [=is a platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
             *   the identifier "<code>set</code>", and
             *   the type "<code>method</code>".
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        1.  If |O| does not [=implement=] <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |map| be the {{ECMAScript/Map}} object that is the value of |O|’s \[[BackingMap]] [=internal slot=].
         1.  Let |keyType| and |valueType| be the key and value types specified in the [=maplike declaration=].
         1.  Let |function| be [=!=] <a abstract-op>Get</a>(|map|, "<code>set</code>").
@@ -12183,7 +12178,7 @@ The value of the [=function object=]’s <code class="idl">name</code> property 
 
 <h4 id="es-setlike">Setlike declarations</h4>
 
-Any object that implements an [=interface=]
+Any object that [=implements=] an [=interface=]
 that has a [=setlike declaration=]
 must have a \[[BackingSet]] [=internal slot=], which is
 initially set to a newly created {{ECMAScript/Set}} object.
@@ -12204,12 +12199,12 @@ These additional properties are described in the sub-sections below.
     1.  Let |O| be the <emu-val>this</emu-val> value.
     1.  Let |arguments| be the list of arguments passed to this function.
     1.  Let |name| be the function name.
-    1.  If |O| is a [=platform object=],
+    1.  If |O| [=is a platform object=],
         then [=perform a security check=], passing:
         *   the platform object |O|,
         *   an identifier equal to |name|, and
         *   the type "<code>method</code>".
-    1.  If |O| is not an object that implements <var ignore>A</var>,
+    1.  If |O| does not [=implement=] <var ignore>A</var>,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |set| be the {{ECMAScript/Set}} object that is
         the value of |O|’s \[[BackingSet]] [=internal slot=].
@@ -12234,12 +12229,12 @@ with the following characteristics:
         whose behavior when invoked is as follows:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
-        1.  If |O| is a [=platform object=],
+        1.  If |O| [=is a platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
             *   the identifier "<code>size</code>", and
             *   the type "<code>getter</code>".
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        1.  If |O| does not [=implement=] <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |set| be the {{ECMAScript/Set}} object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
         1.  Return the result of calling the \[[Get]] internal method of |set| passing "<code>size</code>" and |set| as arguments.
     </div>
@@ -12286,12 +12281,12 @@ with the following characteristics:
         The value of the property is a [=built-in function object=] that behaves as follows when invoked:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
-        1.  If |O| is a [=platform object=],
+        1.  If |O| [=is a platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
             *   the identifier "<code>has</code>", and
             *   the type "<code>method</code>".
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        1.  If |O| does not [=implement=] <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |set| be the {{ECMAScript/Set}} object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
         1.  Let |type| be the value type specified in the [=setlike declaration=].
         1.  Let |function| be [=!=] <a abstract-op>Get</a>(|set|, "<code>has</code>").
@@ -12323,12 +12318,12 @@ must exist on |A|’s [=interface prototype object=]:
 
         1.  Let |O| be the <emu-val>this</emu-val> value.
         1.  Let |name| be the name of the property – "<code>add</code>" or "<code>delete</code>".
-        1.  If |O| is a [=platform object=],
+        1.  If |O| [=is a platform object=],
             then [=perform a security check=], passing:
             *   the platform object |O|,
             *   an identifier equal to |name|, and
             *   the type "<code>method</code>".
-        1.  If |O| is not an object that implements <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+        1.  If |O| does not [=implement=] <var ignore>A</var>, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |set| be the {{ECMAScript/Set}} object that is the value of |O|’s \[[BackingSet]] [=internal slot=].
         1.  Let |type| be the value type specified in the [=setlike declaration=].
         1.  Let |function| be [=?=] <a abstract-op>Get</a>(|set|, |name|).
@@ -12364,6 +12359,20 @@ The value of the [=function object=]’s <code class="idl">name</code> property 
 
 <h3 id="es-platform-objects">Platform objects implementing interfaces</h3>
 
+<div algorithm>
+    An ECMAScript value |value| <dfn>is a platform object</dfn> if [$Type$](|value|) is Object and
+    if |value| has a \[[PrimaryInterface]] internal slot.
+</div>
+
+<div algorithm>
+    An ECMAScript value |value| <dfn export>implements</dfn> an [=interface=] |interface|
+    if |value| [=is a platform object=] and the [=inclusive inherited interfaces=] of
+    |value|.\[[PrimaryInterface]] [=list/contains=] |interface|.
+
+    Specifications may reference the concept "|object| implements |interface|"
+    in various ways, including "|object| is an |interface| object".
+</div>
+
 Every [=platform object=] is associated with a global environment, just
 as the [=initial objects=] are.
 It is the responsibility of specifications using Web IDL to state
@@ -12394,7 +12403,10 @@ object is associated with.
             1.  Let |targetRealm| be [$GetFunctionRealm$](|newTarget|).
             1.  Set |prototype| to the [=interface prototype object=] for |interface| in
                 |targetRealm|.
-    1.  Let |instance| be a newly created [=ECMAScript/object=] in |realm|.
+    1.  Let |slots| be « \[[PrimaryInterface]] ».
+    1.  Let |instance| be a newly created [=ECMAScript/object=] in |realm|
+        with an internal slot for each name in |slots|.
+    1.  Set |instance|.\[[PrimaryInterface]] to |interface|.
     1.  Set |instance|.\[[Prototype]] to |prototype|.
     1.  Set |instance|'s essential internal methods to the definitions specified in
         [=ECMA-262 Ordinary object internal methods and internal slots=].
@@ -12426,9 +12438,28 @@ object is associated with.
     1.  Return |instance|.
 </div>
 
-The <dfn id="dfn-primary-interface" export>primary interface</dfn> of a platform object
-that implements one or more interfaces is the most-derived [=interface=]
-that it implements.
+<div class="note">
+  The set of interfaces that a [=platform object=] [=implements=] does not change over
+  the lifetime of the object.
+
+  Multiple [=platform objects=] with different [=Realm/global objects=] will share
+  a reference to the same [=interface=] in their \[[PrimaryInterface]] internal
+  slots. For example, a page may contain a same-origin iframe, with the iframe's
+  method being called on the main page's element of the same kind, with no exception
+  thrown.
+
+  [=Interface mixins=] do not participate directly in the evaluation of the [=implements=]
+  algorithm. Instead, each [=interface=] that the [=interface mixin=] is [=included=] in
+  has its own "copy" of each [=member=] of the [=interface mixin=], and the corresponding
+  [=creating an operation function|operation function=] checks that the receiver [=implements=]
+  the particular [=interface=] which [=includes=] the [=interface mixin=].
+</div>
+
+<div algorithm>
+  The <dfn id="dfn-primary-interface" export>primary interface</dfn> of a [=platform object=] is
+  the value of the object's \[[PrimaryInterface]] internal slot, which is is the most-derived
+  [=interface=] that it [=implements=].
+</div>
 
 The global environment that a given [=platform object=]
 is associated with can <dfn id="dfn-change-global-environment" for="global environment" export>change</dfn> after it has been created.  When
@@ -12532,12 +12563,12 @@ Additionally, [=legacy platform objects=] have internal methods as defined in:
     property name |P|, value |V|, and ECMAScript language value |Receiver|:
 
     1.  If |O| and |Receiver| are the same object, then:
-        1.  If |O| [=support indexed properties|supports indexed properties=], |P| [=is an array index=], and |O| implements an interface with an [=indexed property setter=], then:
+        1.  If |O| [=support indexed properties|supports indexed properties=], |P| [=is an array index=], and |O| [=implements=] an interface with an [=indexed property setter=], then:
             1.  [=Invoke the indexed property setter=] with |P| and |V|.
             1.  Return <emu-val>true</emu-val>.
         1.  If |O| [=support named properties|supports named properties=], <a abstract-op>Type</a>(|P|) is String,
             |P| [=is not an array index=],
-            and |O| implements an interface with a [=named property setter=], then:
+            and |O| [=implements=] an interface with a [=named property setter=], then:
             1.  [=Invoke the named property setter=] with |P| and |V|.
             1.  Return <emu-val>true</emu-val>.
     1.  Let |ownDesc| be <a abstract-op>LegacyPlatformObjectGetOwnProperty</a>(|O|, |P|, <emu-val>true</emu-val>).
@@ -12568,12 +12599,12 @@ Additionally, [=legacy platform objects=] have internal methods as defined in:
         and |P| is not an [=unforgeable property name=]
         of |O|, then:
         1.  Let |creating| be true if |P| is not a [=supported property name=], and false otherwise.
-        1.  If |O| implements an interface with the [{{OverrideBuiltins}}]
+        1.  If |O| [=implements=] an interface with the [{{OverrideBuiltins}}]
             [=extended attribute=] or |O| does not have an own property
             named |P|, then:
             1.  If |creating| is false and |O| does not implement an
                 interface with a [=named property setter=], then return <emu-val>false</emu-val>.
-            1.  If |O| implements an interface with a
+            1.  If |O| [=implements=] an interface with a
                 [=named property setter=], then:
                 1.  If the result of calling <a abstract-op>IsDataDescriptor</a>(|Desc|) is
                     <emu-val>false</emu-val>, then return
@@ -12701,7 +12732,7 @@ internal method as follows.
           because in practice those are always set up before objects have any supported property names,
           and once set up will make the corresponding named properties invisible.
 
-    1.  If |O| implements an interface that has the [{{OverrideBuiltins}}]
+    1.  If |O| [=implements=] an interface that has the [{{OverrideBuiltins}}]
         [=extended attribute=], then return true.
     1.  Let |prototype| be |O|.\[[GetPrototypeOf]]().
     1.  While |prototype| is not null:
@@ -12788,7 +12819,7 @@ internal method as follows.
             1.  Let |desc| be a newly created [=Property Descriptor=] with no fields.
             1.  Set |desc|.\[[Value]] to the result of [=converted to an ECMAScript value|converting=]
                 |value| to an ECMAScript value.
-            1.  If |O| implements an interface with an [=indexed property setter=], then set
+            1.  If |O| [=implements=] an interface with an [=indexed property setter=], then set
                 |desc|.\[[Writable]] to <emu-val>true</emu-val>, otherwise set it to
                 <emu-val>false</emu-val>.
             1.  Set |desc|.\[[Enumerable]] and |desc|.\[[Configurable]] to <emu-val>true</emu-val>.
@@ -12809,10 +12840,10 @@ internal method as follows.
             1.  Let |desc| be a newly created [=Property Descriptor=] with no fields.
             1.  Set |desc|.\[[Value]] to the result of [=converted to an ECMAScript value|converting=]
                 |value| to an ECMAScript value.
-            1.  If |O| implements an interface with a [=named property setter=], then set
+            1.  If |O| [=implements=] an interface with a [=named property setter=], then set
                 |desc|.\[[Writable]] to <emu-val>true</emu-val>, otherwise set it to
                 <emu-val>false</emu-val>.
-            1.  If |O| implements an interface with the
+            1.  If |O| [=implements=] an interface with the
                 [{{LegacyUnenumerableNamedProperties}}]
                 [=extended attribute=],
                 then set |desc|.\[[Enumerable]] to <emu-val>false</emu-val>,


### PR DESCRIPTION
- Update the steps for instantiating a platform object, which everything
  theoretically calls into, and which sets the primary interface into a new
  internal slot [[PrimaryInterface]].
- Define the "implements" algorithm as checking the [[PrimaryInterface]]
  internal slot.

The algorithm here is roughly in correspondence with the V8 implementation,
where operation functions are allocated with a reference to a
FunctionTemplate object (which is in corresondence with WebIDL interfaces).
When checking the receiver of a method that came from WebIDL, the original
prototype chain is traversed by looking at the FunctionTemplate's parent.
The same FunctionTemplate is used in multiple JavaScript realms.

Fixes #97.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Ms2ger/webidl/pull/654.html" title="Last updated on Feb 25, 2019, 4:24 PM UTC (1f1c78f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/654/c9246d4...Ms2ger:1f1c78f.html" title="Last updated on Feb 25, 2019, 4:24 PM UTC (1f1c78f)">Diff</a>