### PR TITLE
Formally define a [[Realm]] slot on platform objects

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12378,11 +12378,14 @@ The value of the [=function object=]’s <code class="idl">name</code> property 
     in various ways, including "|object| is an |interface| object".
 </div>
 
-Every [=platform object=] is associated with a global environment, just
+Every [=platform object=] is associated with a [=Realm=], just
 as the [=initial objects=] are.
+This Realm is stored in the [=platform object=]'s \[[Realm]] slot.
 It is the responsibility of specifications using Web IDL to state
-which global environment (or, by proxy, which global object) each platform
+which Realm (or, by proxy, which global object) each platform
 object is associated with.
+In particular, the algorithms below associate the new [=platform object=] with
+the Realm given as an argument.
 
 <div algorithm>
   To <dfn export lt=new>create a new object implementing the interface</dfn> |interface|, with a
@@ -12408,9 +12411,10 @@ object is associated with.
             1.  Let |targetRealm| be [$GetFunctionRealm$](|newTarget|).
             1.  Set |prototype| to the [=interface prototype object=] for |interface| in
                 |targetRealm|.
-    1.  Let |slots| be « \[[PrimaryInterface]] ».
+    1.  Let |slots| be « \[[Realm]], \[[PrimaryInterface]] ».
     1.  Let |instance| be a newly created [=ECMAScript/object=] in |realm|
         with an internal slot for each name in |slots|.
+    1.  Set |instance|.\[[Realm]] to |realm|.
     1.  Set |instance|.\[[PrimaryInterface]] to |interface|.
     1.  Set |instance|.\[[Prototype]] to |prototype|.
     1.  Set |instance|'s essential internal methods to the definitions specified in


### PR DESCRIPTION
Note that this slot was already used in assertions for the result of the
[Constructor] and [NamedConstructor] implementation algorithms.

Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=24652.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/658.html" title="Last updated on Feb 25, 2019, 4:47 PM UTC (7f9d3c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/658/d534bbe...7f9d3c4.html" title="Last updated on Feb 25, 2019, 4:47 PM UTC (7f9d3c4)">Diff</a>