### PR TITLE
Editorial: improve language around conversions to JS

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10725,8 +10725,7 @@ the <code>typeof</code> operator will return "function" when applied to an inter
         1.  Perform the actions listed in the description of |constructor|
             with |values| as the argument values
             and |object| as the <emu-val>this</emu-val> value.
-        1.  Let |O| be the result of [=converted to an ECMAScript value|converting=] |object|
-            to an ECMAScript [=interface type=] value |I|.
+        1.  Let |O| be |object|, [=converted to an ECMAScript value=].
         1.  Assert: |O| is an object that [=implements=] |I|.
         1.  Assert: |O|.\[[Realm]] is |realm|.
         1.  Return |O|.
@@ -10785,8 +10784,7 @@ implement the interface on which the
         1.  Perform the actions listed in the description of |constructor|
             with |values| as the argument values
             and |object| as the <emu-val>this</emu-val> value.
-        1.  Let |O| be the result of [=converted to an ECMAScript value|converting=] |object|
-            to an ECMAScript [=interface type=] value |I|.
+        1.  Let |O| be |object|, [=converted to an ECMAScript value=].
         1.  Assert: |O| is an object that [=implements=] |I|.
         1.  Assert: |O|.\[[Realm]] is |realm|.
         1.  Return |O|.
@@ -11343,15 +11341,16 @@ in which case they are exposed on every object that [=implements=] the interface
             1.  Let |R| be <emu-val>null</emu-val>.
             1.  If |operation| is declared with a [{{Default}}] [=extended attribute=],
                 then:
-                1.  Set |R| be the result of performing the actions listed in
+                1.  Set |R| to the result of performing the actions listed in
                     |operation|'s [=corresponding default operation=] on |O|,
                     with |values| as the argument values.
             1.  Otherwise:
-                1.  Set |R| be the result of performing the actions listed in the
+                1.  Set |R| to the result of performing the actions listed in the
                     description of |operation|, on |O| if |O| is not <emu-val>null</emu-val>, with |values|
                     as the argument values.
-                1.  Return the result of [=converted to an ECMAScript value|converting=] |R| to
-                    an ECMAScript value of the type |op| is declared to return.
+            1.  Return |R|, [=converted to an ECMAScript value=].
+
+                Issue(heycam/webidl#674): |R| is assumed to be an IDL value of the type |op| is declared to return.
 
         And then, if <a lt="an exception was thrown">an exception |E| was thrown</a>:
 


### PR DESCRIPTION
This prose is converting IDL values to JS values, so they should not try to
convert to IDL types.

Separately, fix some grammar nits.

Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=20455.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/664.html" title="Last updated on Mar 1, 2019, 4:28 PM UTC (e325ade)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/664/c705ce6...e325ade.html" title="Last updated on Mar 1, 2019, 4:28 PM UTC (e325ade)">Diff</a>