### PR TITLE
Editorial: run platform algorithms on IDL objects

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11110,23 +11110,25 @@ in which case they are exposed on every object that [=implements=] the interface
 
     1.  Let |steps| be the following series of steps:
         1.  Try running the following steps:
-            1.  Let |O| be <emu-val>null</emu-val>.
+            1.  Let |idlObject| be null.
             1.  If |target| is an [=interface=], and |attribute| is a [=regular attribute=]:
-                1.  If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or
-                    <emu-val>undefined</emu-val>, set |O| to |realm|'s [=Realm/global object=].
+                1.  Let |esValue| be the <emu-val>this</emu-val> value, if it is not
+                    <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, or |realm|'s
+                    [=Realm/global object=] otherwise.
                     (This will subsequently cause a {{ECMAScript/TypeError}} in a few steps, if
                     the global object does not implement |target| and [{{LenientThis}}] is not
                     specified.)
                     <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
-                1.  Otherwise, set |O| to the <emu-val>this</emu-val> value.
-                1.  If |O| [=is a platform object=], then [=perform a security check=], passing |O|,
-                    |attribute|'s [=identifier=], and "getter".
-                1.  If |O| does not [=implement=] the interface |target|, then:
+                1.  If |esValue| [=is a platform object=], then [=perform a security check=],
+                    passing |esValue|, |attribute|'s [=identifier=], and "getter".
+                1.  If |esValue| does not [=implement=] |target|, then:
                     1.  If |attribute| was specified with the [{{LenientThis}}]
                         [=extended attribute=], then return <emu-val>undefined</emu-val>.
-                    1. Otherwise, [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+                    1.  Otherwise, [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+                1.  Set |idlObject| to the IDL [=interface type=] value that represents a reference
+                    to |esValue|.
             1.  Let |R| be the result of [=get the underlying value|getting the underlying value=]
-                of |attribute| given |O|.
+                of |attribute| given |idlObject|.
             1.  Return the result of [=converted to an ECMAScript value|converting=] |R| to an
                 ECMAScript value of the type |attribute| is declared as.
 
@@ -11159,35 +11161,36 @@ in which case they are exposed on every object that [=implements=] the interface
         1.  If no arguments were passed, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |V| be the value of the first argument passed.
         1.  Let |id| be |attribute|'s [=identifier=].
-        1.  Let |O| be <emu-val>null</emu-val>.
+        1.  Let |idlObject| be null.
         1.  If |attribute| is a [=regular attribute=]:
-            1.  If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or
-                <emu-val>undefined</emu-val>, set |O| to |realm|'s [=Realm/global object=].
+            1.  Let |esValue| be the <emu-val>this</emu-val> value, if it is not
+                <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, or |realm|'s
+                [=Realm/global object=] otherwise.
                 (This will subsequently cause a {{ECMAScript/TypeError}} in a few steps, if
                 the global object does not implement |target| and [{{LenientThis}}] is not
                 specified.)
                 <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
-            1.  Otherwise, set |O| to the <emu-val>this</emu-val> value.
-            1.  If |O| [=is a platform object=], then [=perform a security check=], passing |O|,
-                |id|, and "setter".
-            1.  Let |validThis| be true if |O| [=implements=] the
-                interface |target|, or false otherwise.
+            1.  If |esValue| [=is a platform object=], then [=perform a security check=], passing
+                |esValue|, |id|, and "setter".
+            1.  Let |validThis| be true if |esValue| [=implements=] |target|, or false otherwise.
             1.  If |validThis| is false and |attribute| was not specified with the [{{LenientThis}}]
                 [=extended attribute=], then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
             1.  If |attribute| is declared with the [{{Replaceable}}] extended attribute, then:
-                1.  Perform [=?=] <a abstract-op>CreateDataProperty</a>(|O|, |id|, |V|).
+                1.  Perform [=?=] <a abstract-op>CreateDataProperty</a>(|esValue|, |id|, |V|).
                 1.  Return <emu-val>undefined</emu-val>.
             1.  If |validThis| is false, then return <emu-val>undefined</emu-val>.
             1.  If |attribute| is declared with a [{{LenientSetter}}] extended attribute, then
                 return <emu-val>undefined</emu-val>.
             1.  If |attribute| is declared with a [{{PutForwards}}] extended attribute, then:
-                1.  Let |Q| be [=?=] <a abstract-op>Get</a>(|O|, |id|).
+                1.  Let |Q| be [=?=] <a abstract-op>Get</a>(|esValue|, |id|).
                 1.  If <a abstract-op>Type</a>(|Q|) is not Object, then [=ECMAScript/throw=] a
                     {{ECMAScript/TypeError}}.
                 1.  Let |forwardId| be the identifier argument of the [{{PutForwards}}] extended
                     attribute.
                 1.  Perform [=?=] <a abstract-op>Set</a>(|Q|, |forwardId|, |V|, <emu-val>true</emu-val>).
                 1.  Return <emu-val>undefined</emu-val>.
+            1.  Set |idlObject| to the IDL [=interface type=] value that represents a reference
+                to |esValue|.
         1.  Let |idlValue| be determined as follows:
 
             <dl class="switch">
@@ -11207,7 +11210,7 @@ in which case they are exposed on every object that [=implements=] the interface
             </dl>
 
         1.  Perform the actions listed in the description of |attribute| that occur on setting, on
-            |O| if |O| is not <emu-val>null</emu-val>.
+            |idlObject| if it is not null.
         1.  Return <emu-val>undefined</emu-val>
     1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
     1.  Let |name| be the string "<code>set </code>" prepended to |id|.
@@ -11288,18 +11291,21 @@ in which case they are exposed on every object that [=implements=] the interface
     1.  Let |steps| be the following series of steps, given function argument
         values |args|:
         1.  Try running the following steps:
-            1.  Let |O| be <emu-val>null</emu-val>.
+            1.  Let |idlObject| be null.
             1.  If |target| is an [=interface=], and |op| is not a [=static operation=]:
-                1.  If the <emu-val>this</emu-val> value is <emu-val>null</emu-val> or
-                    <emu-val>undefined</emu-val>, set |O| to |realm|'s [=Realm/global object=]. (This
-                    will subsequently cause a {{ECMAScript/TypeError}} in a few steps, if the global
-                    object does not implement |target|.)
+                1.  Let |esValue| be the <emu-val>this</emu-val> value, if it is not
+                    <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, or |realm|'s
+                    [=Realm/global object=] otherwise.
+                    (This will subsequently cause a {{ECMAScript/TypeError}} in a few steps, if
+                    the global object does not implement |target| and [{{LenientThis}}] is not
+                    specified.)
                     <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
-                1.  Otherwise, set |O| to the <emu-val>this</emu-val> value.
-                1.  If |O| [=is a platform object=], then [=perform a security check=], passing |O|,
-                    |id|, and "method".
-                1.  If |O| does not [=implement=] the interface |target|,
+                1.  If |esValue| [=is a platform object=], then [=perform a security check=],
+                    passing |esValue|, |id|, and "method".
+                1.  If |esValue| does not [=implement=] the interface |target|,
                     [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+                1.  Set |idlObject| to the IDL [=interface type=] value that represents a reference
+                    to |esValue|.
             1.  Let |n| be the [=list/size=] of |args|.
             1.  Let |S| be the [=effective overload set=] for [=regular operations=] (if |op| is a
                 regular operation) or for [=static operations=] (if |op| is a static operation) with
@@ -11309,12 +11315,12 @@ in which case they are exposed on every object that [=implements=] the interface
             1.  Let |R| be <emu-val>null</emu-val>.
             1.  If |operation| is declared with a [{{Default}}] [=extended attribute=],
                 then:
-                1.  Set |R| to the result of performing the actions listed in
-                    |operation|'s [=corresponding default operation=] on |O|,
+                1.  Set |R| be the result of performing the actions listed in
+                    |operation|'s [=corresponding default operation=] on |idlObject|,
                     with |values| as the argument values.
             1.  Otherwise:
-                1.  Set |R| to the result of performing the actions listed in the
-                    description of |operation|, on |O| if |O| is not <emu-val>null</emu-val>, with |values|
+                1.  Set |R| be the result of performing the actions listed in the description of
+                    |operation|, on |idlObject| if it is not <emu-val>null</emu-val>, with |values|
                     as the argument values.
             1.  Return |R|, [=converted to an ECMAScript value=].
 


### PR DESCRIPTION
Currently we technically pass around JS objects to specifications
that use IDL to define their APIs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/666.html" title="Last updated on Mar 14, 2019, 2:59 PM UTC (3cfbccf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/666/ff2b414...3cfbccf.html" title="Last updated on Mar 14, 2019, 2:59 PM UTC (3cfbccf)">Diff</a>