### PR TITLE
Editorial: remove redundant requirement for existence of 'length'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11585,8 +11585,7 @@ then there must exist a property with the following characteristics:
 If the [=interface=] has any of the following:
 
 *   an [=iterable declaration=]
-*   an [=indexed property getter=] and
-    an [=integer types|integer-typed=] <code class="idl">length</code> [=attribute=]
+*   an [=indexed property getter=]
 *   a [=maplike declaration=]
 *   a [=setlike declaration=]
 


### PR DESCRIPTION
The spec already requires:

> Interfaces that support indexed properties must define an integer-typed
> attribute named length.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/667.html" title="Last updated on Feb 28, 2019, 2:06 PM UTC (a765ae3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/667/c705ce6...a765ae3.html" title="Last updated on Feb 28, 2019, 2:06 PM UTC (a765ae3)">Diff</a>