### PR TITLE
Disallow combining an indexed getter with a maplike/setlike

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4233,8 +4233,9 @@ of a maplike interface must not
 also have a [=maplike declaration=].
 A maplike interface and its [=inherited interfaces=]
 must not have an
-[=iterable declaration=] or
-[=setlike declaration=].
+[=iterable declaration=],
+a [=setlike declaration=], or
+an [=indexed getter=].
 
 <div data-fill-with="grammar-ReadOnlyMember"></div>
 
@@ -4325,8 +4326,9 @@ of a setlike interface must not
 also have a [=setlike declaration=].
 A setlike interface and its [=inherited interfaces=]
 must not have an
-[=iterable declaration=] or
-[=maplike declaration=].
+[=iterable declaration=],
+a [=maplike declaration=], or
+an [=indexed getter=].
 
 <div data-fill-with="grammar-ReadOnlyMember"></div>
 


### PR DESCRIPTION
This avoids the ambiguity around which `@@iterator` to use. This combination is
not currently used; if a use case comes up, we can reconsider this.

Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=28592.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/671.html" title="Last updated on Mar 4, 2019, 12:15 PM UTC (95ad6ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/671/c705ce6...95ad6ba.html" title="Last updated on Mar 4, 2019, 12:15 PM UTC (95ad6ba)">Diff</a>