### PR TITLE
Clarify note about enum conversion exceptions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5125,7 +5125,7 @@ whose type is the enumeration, is language binding specific.
 
 Note: In the ECMAScript binding, assignment of an invalid string value to an
 [=attribute=] is ignored, while
-passing such a value as an [=operation=] argument
+passing such a value in other contexts (for example as an [=operation=] argument)
 results in an exception being thrown.
 
 No [=extended attributes=]


### PR DESCRIPTION
Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=25050.
Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=26767.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/673.html" title="Last updated on Mar 1, 2019, 1:35 PM UTC (3608f4c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/673/c705ce6...3608f4c.html" title="Last updated on Mar 1, 2019, 1:35 PM UTC (3608f4c)">Diff</a>