### PR TITLE
Correct the 'indexed getter' cross-reference

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4205,7 +4205,7 @@ A maplike interface and its [=inherited interfaces=]
 must not have an
 [=iterable declaration=],
 a [=setlike declaration=], or
-an [=indexed getter=].
+an [=indexed property getter=].
 
 <div data-fill-with="grammar-ReadOnlyMember"></div>
 
@@ -4298,7 +4298,7 @@ A setlike interface and its [=inherited interfaces=]
 must not have an
 [=iterable declaration=],
 a [=maplike declaration=], or
-an [=indexed getter=].
+an [=indexed property getter=].
 
 <div data-fill-with="grammar-ReadOnlyMember"></div>
 
@@ -13630,6 +13630,7 @@ Jungkee Song,
 Josh Soref,
 Maciej Stachowiak,
 Anton Tayanovskyy,
+triple-underscore,
 Peter Van der Beken,
 Jeff Walden,
 Allen Wirfs-Brock,


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/679.html" title="Last updated on Mar 7, 2019, 2:23 PM UTC (b549ba8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/679/a94e4b4...b549ba8.html" title="Last updated on Mar 7, 2019, 2:23 PM UTC (b549ba8)">Diff</a>