### PR TITLE
Ensure that interface objects aren't used before they exist

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12415,8 +12415,11 @@ the Realm given as an argument.
   To <dfn>define the global property references</dfn> on |target|, given [=Realm=] |realm|,
   perform the following steps:
 
-    1.  [=list/iterate|For every=] non-callback [=interface=] |interface| that is [=exposed=] in
-        |realm|:
+    1.  Let |interfaces| be a [=list=] that contains every non-callback [=interface=] that is
+        [=exposed=] in |realm|.
+    1.  Sort |interfaces| in such a way that if |A| and |B| are [=list/items=] of |interfaces|,
+        and |A| [=interface/inherits=] from |B|, |A| has a higher index in |interfaces| than |B|.
+    1.  [=list/iterate|For every=] |interface| of |interfaces|:
         1.  If |interface| is not declared with the [{{NoInterfaceObject}}] or
             [{{LegacyNamespace}}] [=extended attributes=], then:
             1.  Let |id| be |interface|'s [=identifier=].


### PR DESCRIPTION
We use the interface object of the inherited interface in the 'create an
interface object' algorithm, so this ensures it already exists at that point.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/682.html" title="Last updated on Mar 8, 2019, 5:02 PM UTC (73e145a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/682/b4f9467...73e145a.html" title="Last updated on Mar 8, 2019, 5:02 PM UTC (73e145a)">Diff</a>