### PR TITLE
Disallow constants to be null

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1748,7 +1748,7 @@ The following extended attributes are applicable to constants:
 
 <pre class="grammar" id="prod-Const">
     Const :
-        "const" PrimitiveType identifier "=" ConstValue ";"
+        "const" ConstType identifier "=" ConstValue ";"
 </pre>
 
 <pre class="grammar" id="prod-ConstValue">
@@ -1770,6 +1770,12 @@ The following extended attributes are applicable to constants:
         "-Infinity"
         "Infinity"
         "NaN"
+</pre>
+
+<pre class="grammar" id="prod-ConstType">
+    ConstType :
+        PrimitiveType
+        identifier
 </pre>
 
 <div class="example">

--- a/index.bs
+++ b/index.bs
@@ -1603,17 +1603,15 @@ Note: These three names are the names of properties that may exist on
 
 The type of a constant (matching <emu-nt><a href="#prod-ConstType">ConstType</a></emu-nt>)
 must not be any type other than
-a [=primitive type=]
-or a [=nullable type|nullable=] primitive type.
+a [=primitive type=].
 If an [=identifier=] is used,
 it must reference a [=typedef=]
-whose type is a primitive type or a nullable primitive type.
+whose type is a primitive type.
 
 The <emu-nt><a href="#prod-ConstValue">ConstValue</a></emu-nt> part of a
 constant declaration gives the value of the constant, which can be
 one of the two boolean literal tokens (<emu-t>true</emu-t>
-and <emu-t>false</emu-t>),
-the <emu-t>null</emu-t> token, an
+and <emu-t>false</emu-t>), an
 <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t> token,
 a <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token,
 or one of the three special floating point constant values

--- a/index.bs
+++ b/index.bs
@@ -1748,7 +1748,7 @@ The following extended attributes are applicable to constants:
 
 <pre class="grammar" id="prod-Const">
     Const :
-        "const" ConstType identifier "=" ConstValue ";"
+        "const" PrimitiveType identifier "=" ConstValue ";"
 </pre>
 
 <pre class="grammar" id="prod-ConstValue">
@@ -1756,7 +1756,6 @@ The following extended attributes are applicable to constants:
         BooleanLiteral
         FloatLiteral
         integer
-        "null"
 </pre>
 
 <pre class="grammar" id="prod-BooleanLiteral">
@@ -1771,12 +1770,6 @@ The following extended attributes are applicable to constants:
         "-Infinity"
         "Infinity"
         "NaN"
-</pre>
-
-<pre class="grammar" id="prod-ConstType">
-    ConstType :
-        PrimitiveType Null
-        identifier Null
 </pre>
 
 <div class="example">
@@ -2351,6 +2344,7 @@ The following extended attributes are applicable to operations:
         ConstValue
         string
         "[" "]"
+        "null"
 </pre>
 
 <pre class="grammar" id="prod-Operation">


### PR DESCRIPTION
Closes #448.

No known specs are using constant null, and we discourage adding new constants (with some specs as exceptions), so I think we can safely remove this.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/webidl/pull/686.html" title="Last updated on Mar 11, 2019, 11:02 AM UTC (6094723)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/686/cc2fa40...saschanaz:6094723.html" title="Last updated on Mar 11, 2019, 11:02 AM UTC (6094723)">Diff</a>