### PR TITLE
Make the grammar check more robust

### DIFF
--- a/check-grammar.js
+++ b/check-grammar.js
@@ -31,6 +31,10 @@ let path = process.argv[2];
 let html = fs.readFileSync(path, "utf8");
 let dom = new jsdom.JSDOM(html);
 let rules = getRulesFromDOM(dom.window);
+if (!rules.length) {
+    console.log("Did not find any grammar snippets in the generated specification.");
+    process.exit(1);
+}
 let bnf = toBNF(rules);
 let data = Grammar.dataFromString(bnf, "bnf");
 let grammar = Grammar.fromData(data, { mode: "LL1" });

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,7 +5,7 @@ SOURCE_BRANCH="master"
 TARGET_BRANCH="gh-pages"
 
 function doCompile {
-  curl https://api.csswg.org/bikeshed/ -F file=@index.bs > out/index.html
+  curl https://api.csswg.org/bikeshed/ -f -F file=@index.bs > out/index.html
   node ./check-grammar.js ./out/index.html
   npm run pp-webidl -- --input ./out/index.html
 }


### PR DESCRIPTION
In particular, fail immediately if the server returns with an error, and yield
a readable error if no grammar snippets are found in the specification.