### PR TITLE
Remove support for overloading callbacks

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3215,7 +3215,7 @@ constructor (specified with [{{Constructor}}]
 or [{{NamedConstructor}}]), or
 [=callback function=].
 The algorithm to compute an [=effective overload set=]
-operates on one of the following six types of IDL constructs, and listed with them below are
+operates on one of the following four types of IDL constructs, and listed with them below are
 the inputs to the algorithm needed to compute the set.
 
  :  For regular operations
@@ -3230,9 +3230,6 @@ the inputs to the algorithm needed to compute the set.
  :: *   the [=interface=] on which the [{{NamedConstructor}}] [=extended attributes=] are to be found
     *   the [=identifier=] of the named constructors
     *   the number of arguments to be passed
- :  For callback functions
- :: *   the [=callback function=]
-    *   the number of arguments to be passed
 
 An effective overload set is used, among other things, to determine whether there are ambiguities in the
 overloaded operations and constructors specified on an interface.
@@ -3242,9 +3239,8 @@ The [=set/items=] of an [=effective overload set=] are [=tuples=] of the form
 whose [=tuple/items=] are described below:
 
 *   A <dfn for="effective overload set tuple">callable</dfn> is an [=operation=]
-    if the [=effective overload set=] is for [=regular operations=] or [=static operations=];
-    it is an [=extended attribute=] if the [=effective overload set=] is for constructors or [=named constructors=];
-    and it is the [=callback function=] itself if the [=effective overload set=] is for [=callback functions=].
+    if the [=effective overload set=] is for [=regular operations=] or [=static operations=]; and
+    it is an [=extended attribute=] if the [=effective overload set=] is for constructors or [=named constructors=].
 *   A <dfn>type list</dfn> is a [=list=] of IDL types.
 *   An <dfn>optionality list</dfn> is a [=list=] of
     three possible <dfn id="dfn-optionality-value" export>optionality values</dfn>
@@ -3267,7 +3263,6 @@ the same operation or constructor.
     *   the identifier of the operation or named constructor is |A|
     *   the argument count is |N|
     *   the interface is |I|
-    *   the callback function is |C|
 
     Whenever an argument of an extended attribute is mentioned,
     it is referring to an argument of the extended attribute’s
@@ -3293,8 +3288,6 @@ the same operation or constructor.
                 [=extended attributes=] on interface |I| whose
                 [=takes a named argument list|named argument lists’=]
                 identifiers are |A|.
-             :  For callback functions
-             :: The single element of |F| is the callback function itself, |C|.
         </dl>
 
     1.  Let |maxarg| be the maximum number of arguments the operations,
@@ -3304,7 +3297,7 @@ the same operation or constructor.
 
         Note: So <code>void f(long x, long... y);</code> is considered to be declared to take two arguments.
     1.  Let |max| be <a abstract-op>max</a>(|maxarg|, |N|).
-    1.  [=set/For each=] operation, extended attribute, or callback function |X| in |F|:
+    1.  [=set/For each=] operation or extended attribute |X| in |F|:
         1.  Let |arguments| be the [=list=] of arguments |X| is declared to take.
         1.  Let |n| be the [=list/size=] of |arguments|.
         1.  Let |types| be a [=type list=].


### PR DESCRIPTION
This was only supported in the definition of the effective overload set, but
this wasn't actually used anywhere, and there is no syntax to overload a
callback anyway.

The six types of IDL constructs are the five that were in the specification
before this change, and legacycallers. The count was not updated when these
were removed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/690.html" title="Last updated on Mar 19, 2019, 10:21 AM UTC (404e94f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/690/b0621a8...404e94f.html" title="Last updated on Mar 19, 2019, 10:21 AM UTC (404e94f)">Diff</a>