### PR TITLE
Fix a grammar mistake in the 'partial interface' definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1023,7 +1023,8 @@ be defined on a [=callback interface=].
 
 The IDL for interfaces can be split into multiple parts by using
 <dfn id="dfn-partial-interface" export>partial interface</dfn> definitions
-(matching <emu-t>partial</emu-t> <emu-nt><a href="#prod-PartialInterfaceRest">PartialInterfaceRest</a></emu-nt>).
+(matching <emu-t>partial</emu-t> <emu-t>interface</emu-t>
+<emu-nt><a href="#prod-PartialInterfaceRest">PartialInterfaceRest</a></emu-nt>).
 The [=identifier=] of a partial
 interface definition must be the same
 as the identifier of an interface definition.  All of


### PR DESCRIPTION
PartialInterfaceRest does not include the 'interface' keyword.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/693.html" title="Last updated on Mar 20, 2019, 3:32 PM UTC (ce45f11)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/693/b0621a8...ce45f11.html" title="Last updated on Mar 20, 2019, 3:32 PM UTC (ce45f11)">Diff</a>