### PR TITLE
Add [AllowShared] in the list of applicable-to-types

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6214,8 +6214,9 @@ annotate are called <dfn export for="annotated types" lt="inner type">inner type
 
 The following extended attributes are <dfn for="extended attributes">applicable to types</dfn>:
 [{{Clamp}}],
-[{{EnforceRange}}], and
-[{{TreatNullAs}}].
+[{{EnforceRange}}],
+[{{TreatNullAs}}], and
+[{{AllowShared}}].
 
 <div algorithm>
     The <dfn for="IDL type" lt="extended attribute associated with|extended attributes associated with">extended attributes associated with</dfn>

--- a/index.bs
+++ b/index.bs
@@ -6213,10 +6213,10 @@ annotate are called <dfn export for="annotated types" lt="inner type">inner type
 </div>
 
 The following extended attributes are <dfn for="extended attributes">applicable to types</dfn>:
+[{{AllowShared}}],
 [{{Clamp}}],
-[{{EnforceRange}}],
-[{{TreatNullAs}}], and
-[{{AllowShared}}].
+[{{EnforceRange}}], and
+[{{TreatNullAs}}].
 
 <div algorithm>
     The <dfn for="IDL type" lt="extended attribute associated with|extended attributes associated with">extended attributes associated with</dfn>


### PR DESCRIPTION
Annotated types lists 3 extended attributes as applicable-to-type attributes, and [AllowShared] is not in the list.
On the other hand, [AllowShared] is explained to appear on one of the buffer source type, and it means [AllowShared] is applicable to types.

This PR adds [AllowShared] in the list of applicable to types extended attributes, so that it fixes the ambiguity.

Fixes #687.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/peria/webidl/pull/695.html" title="Last updated on Apr 4, 2019, 8:12 AM UTC (5e8329e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/695/b47c90c...peria:5e8329e.html" title="Last updated on Apr 4, 2019, 8:12 AM UTC (5e8329e)">Diff</a>