### PR TITLE
Update the requirement about the definition of a constructor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8330,10 +8330,8 @@ using an empty argument list, <code>[Constructor()]</code>.  For each
 on the interface, there will be a way to construct an object that [=implements=]
 the interface by passing the specified arguments.
 
-The prose definition of a constructor must
-either return an IDL value of a type corresponding to the interface
-the [{{Constructor}}]
-extended attribute appears on, or throw an exception.
+The prose definition of a constructor must either initialize the value passed as <b>[=this=]</b>,
+or throw an exception.
 
 The [{{Constructor}}] and
 [{{NoInterfaceObject}}]


### PR DESCRIPTION
I didn't notice this paragraph in 8e1b52942525e9135885eba8aa68c028d2c6a5be,
where it should have been updated.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/697.html" title="Last updated on Mar 26, 2019, 2:38 PM UTC (21c1a17)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/697/b47c90c...21c1a17.html" title="Last updated on Mar 26, 2019, 2:38 PM UTC (21c1a17)">Diff</a>