### PR TITLE
Correct the effective overload set use for named constructors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10743,7 +10743,7 @@ implement the interface on which the
         1.  Let |args| be the passed arguments.
         1.  Let |n| be the [=list/size=] of |args|.
         1.  Initialize |S| to the  [=effective overload set=]
-            for constructors with [=identifier=] |id| on [=interface=] |I|
+            for named constructors with [=identifier=] |id| on [=interface=] |I|
             and with argument count |n|.
         1.  Let &lt;|constructor|, |values|&gt; be the result of passing |S| and
             |args| to the [=overload resolution algorithm=].
@@ -10760,7 +10760,7 @@ implement the interface on which the
     1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
     1.  Perform [=!=] <a abstract-op>SetFunctionName</a>(|F|, |id|).
     1.  Initialize |S| to the [=effective overload set=]
-        for constructors with identifier |id| on [=interface=] |I|
+        for named constructors with identifier |id| on [=interface=] |I|
         and with argument count 0.
     1.  Let |length| be the length of the shortest argument list of the entries in |S|.
     1.  Perform [=!=] <a abstract-op>SetFunctionLength</a>(|F|, |length|).


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/699.html" title="Last updated on Mar 29, 2019, 11:16 AM UTC (e0a3316)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/699/b47c90c...e0a3316.html" title="Last updated on Mar 29, 2019, 11:16 AM UTC (e0a3316)">Diff</a>