### PR TITLE
Tighten the grammar for the 'inherit' keyword

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1745,10 +1745,11 @@ The following extended attributes are applicable to constants:
 
 An <dfn id="dfn-attribute" export>attribute</dfn> is an [=interface member=] or [=namespace member=]
 (matching
-<emu-t>inherit</emu-t> <emu-nt><a href="#prod-ReadOnly">ReadOnly</a></emu-nt> <emu-nt><a href="#prod-AttributeRest">AttributeRest</a></emu-nt>,
+<emu-t>inherit</emu-t> <emu-nt><emu-nt><a href="#prod-AttributeRest">AttributeRest</a></emu-nt>,
 <emu-t>static</emu-t> <emu-nt><a href="#prod-ReadOnly">ReadOnly</a></emu-nt> <emu-nt><a href="#prod-AttributeRest">AttributeRest</a></emu-nt>,
 <emu-t>stringifier</emu-t> <emu-nt><a href="#prod-ReadOnly">ReadOnly</a></emu-nt> <emu-nt><a href="#prod-AttributeRest">AttributeRest</a></emu-nt>,
-or <emu-nt><a href="#prod-ReadOnly">ReadOnly</a></emu-nt> <emu-nt><a href="#prod-AttributeRest">AttributeRest</a></emu-nt>)
+<emu-nt><a href="#prod-ReadOnly">ReadOnly</a></emu-nt> <emu-nt><a href="#prod-AttributeRest">AttributeRest</a></emu-nt>,
+or <emu-nt><a href="#prod-AttributeRest">AttributeRest</a></emu-nt>)
 that is used to declare data fields with a given type and
 [=identifier=] whose value can
 be retrieved and (in some cases) changed.  There are two kinds of attributes:
@@ -1837,9 +1838,10 @@ The read only attribute from which the attribute inherits its getter
 is the attribute with the same identifier on the closest ancestor interface
 of the one on which the inheriting attribute is defined.  The attribute
 whose getter is being inherited must be
-of the same type as the inheriting attribute, and <emu-t>inherit</emu-t>
-must not appear on a [=read only=]
-attribute or a [=static attribute=].
+of the same type as the inheriting attribute.
+
+Note: The grammar ensures that <emu-t>inherit</emu-t> does not appear on a [=read only=] attribute
+or a [=static attribute=].
 
 <pre highlight="webidl" class="syntax">
     [Exposed=Window]
@@ -1893,7 +1895,7 @@ are applicable only to regular attributes:
 
 <pre class="grammar" id="prod-ReadWriteAttribute">
     ReadWriteAttribute :
-        "inherit" ReadOnly AttributeRest
+        "inherit" AttributeRest
         AttributeRest
 </pre>
 


### PR DESCRIPTION
We do not allow read-only attributes to be annotated with it, so we might as
well prevent it in the grammar. This is already done for static attributes.

Fixes #703.