### PR TITLE
Remove a check for array index in [[Set]]

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12527,7 +12527,6 @@ Additionally, [=legacy platform objects=] have internal methods as defined in:
             1.  [=Invoke the indexed property setter=] with |P| and |V|.
             1.  Return <emu-val>true</emu-val>.
         1.  If |O| [=support named properties|supports named properties=], <a abstract-op>Type</a>(|P|) is String,
-            |P| [=is not an array index=],
             and |O| [=implements=] an interface with a [=named property setter=], then:
             1.  [=Invoke the named property setter=] with |P| and |V|.
             1.  Return <emu-val>true</emu-val>.


### PR DESCRIPTION
Array index properties are not special on objects with named setters. Note
that the corresponding step in [[DefineOwnProperty]] does not have this
condition.

This change does not affect normal usage; it is only detectable by messing with
the prototype of the object.

Gecko and WebKit already handle array indexes the same way as other properties;
Chrome does for DOMStringMap but does not for Storage. (In the Storage case, it
does the exact opposite of the current specification.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/706.html" title="Last updated on Apr 4, 2019, 2:58 PM UTC (53097fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/706/0b75c48...53097fb.html" title="Last updated on Apr 4, 2019, 2:58 PM UTC (53097fb)">Diff</a>