### PR TITLE
JavaScript defines typeof fully now

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -103,7 +103,6 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: %Promise_reject%; url: sec-promise.reject
         text: %Promise_resolve%; url: sec-promise.resolve
         text: %PromiseProto_then%; url: sec-promise.prototype.then
-        text: typeof; url: sec-typeof-operator
     type: const; for: ECMAScript
         url: sec-well-known-symbols
             text: @@iterator
@@ -6637,10 +6636,6 @@ of objects defined in this section has the value <emu-val>true</emu-val>.
 
 Unless otherwise specified, the \[[Prototype]] internal slot
 of objects defined in this section is {{%ObjectPrototype%}}.
-
-Unless otherwise specified, {{ECMAScript/typeof}} operator, when called on an
-exotic object that is not a [=function object=] defined in this section and
-other specifications, must return the string "<code>object</code>".
 
 Some objects described in this section are defined to have a <dfn id="dfn-class-string" export>class string</dfn>,
 which is the string to include in the string returned from Object.prototype.toString.


### PR DESCRIPTION
See https://github.com/tc39/ecma262/pull/1441.

This therefore reverts 5de45d9bc817fb0ce3f498e4ca9c14adbee2d172.