### PR TITLE
Editorial: Shorten the conditions in the [[Set]] algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12529,11 +12529,12 @@ Additionally, [=legacy platform objects=] have internal methods as defined in:
     property name |P|, value |V|, and ECMAScript language value |Receiver|:
 
     1.  If |O| and |Receiver| are the same object, then:
-        1.  If |O| [=support indexed properties|supports indexed properties=], |P| [=is an array index=], and |O| [=implements=] an interface with an [=indexed property setter=], then:
+        1.  If |O| [=implements=] an interface with an [=indexed property setter=]
+            and |P| [=is an array index=], then:
             1.  [=Invoke the indexed property setter=] with |P| and |V|.
             1.  Return <emu-val>true</emu-val>.
-        1.  If |O| [=support named properties|supports named properties=], <a abstract-op>Type</a>(|P|) is String,
-            and |O| [=implements=] an interface with a [=named property setter=], then:
+        1.  If |O| [=implements=] an interface with a [=named property setter=]
+            and <a abstract-op>Type</a>(|P|) is String, then:
             1.  [=Invoke the named property setter=] with |P| and |V|.
             1.  Return <emu-val>true</emu-val>.
     1.  Let |ownDesc| be <a abstract-op>LegacyPlatformObjectGetOwnProperty</a>(|O|, |P|, <emu-val>true</emu-val>).


### PR DESCRIPTION
An interface can only have a (named or indexed) setter if it also has the
corresponding getter, so checking for both is unnecessary.