### PR TITLE
Limit the special case in the [[Set]] algorithm to [OverrideBuiltins] interfaces

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12534,6 +12534,7 @@ Additionally, [=legacy platform objects=] have internal methods as defined in:
             1.  [=Invoke the indexed property setter=] with |P| and |V|.
             1.  Return <emu-val>true</emu-val>.
         1.  If |O| [=implements=] an interface with a [=named property setter=]
+            and the [{{OverrideBuiltins}}] [=extended attribute=],
             and <a abstract-op>Type</a>(|P|) is String, then:
             1.  [=Invoke the named property setter=] with |P| and |V|.
             1.  Return <emu-val>true</emu-val>.


### PR DESCRIPTION
This is the case where it makes most sense, since the prototype chain can't
shadow any properties.

This change does not affect normal usage; it is only detectable by messing with
the prototype of the object.

The majority of implementations (Gecko and Chrome) already follow the proposed
change; WebKit follows the existing spec.

Fixes #630.