### PR TITLE
Editorial: Stop using markdown for bold

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2477,7 +2477,7 @@ in which case the [=default toJSON operation=] is exposed instead.
         1.  [=list/For each=] attribute [=identifier=] |attr| in « "from", "to", "amount", "description" »:
             1.  Let |value| be result of [=get the underlying value|getting the underlying value=]
                 of the [=attribute=] identified by |attr|,
-                given **this**.
+                given <b>this</b>.
             1.  Set |json|[|attr|] to |value|.
         1.  Return |json|.
     </div>
@@ -11310,7 +11310,7 @@ The [=return type=] of the [=default toJSON operation=] must be {{object}}.
     1.  Let |map| be a new [=ordered map=].
     1.  Let |stack| be the result of [=create an inheritance stack|creating an inheritance stack=]
         for [=interface=] |I|.
-    1.  Invoke [=collect attribute values of an inheritance stack=] on **this**,
+    1.  Invoke [=collect attribute values of an inheritance stack=] on <b>this</b>,
         passing it |stack| and |map| as arguments.
     1.  Let |result| be [=!=] <a abstract-op>ObjectCreate</a>({{%ObjectPrototype%}}).
     1.  [=map/For each=] |key| → |value| of |map|,
@@ -11327,10 +11327,10 @@ The [=return type=] of the [=default toJSON operation=] must be {{object}}.
     run the the following steps:
 
     1.  Let |I| be the result of [=stack/pop|popping=] from |stack|.
-    1.  Invoke [=collect attribute values=] on **this**,
+    1.  Invoke [=collect attribute values=] on <b>this</b>,
         passing it |I| and |map| as arguments.
     1.  If |stack| [=stack/is not empty=],
-        then invoke [=collect attribute values of an inheritance stack=] on **this**,
+        then invoke [=collect attribute values of an inheritance stack=] on <b>this</b>,
         passing it |stack| and |map| as arguments.
 </div>
 
@@ -11345,7 +11345,7 @@ The [=return type=] of the [=default toJSON operation=] must be {{object}}.
         that is an [=interface member=] of |I|, in order:
         1.  Let |id| be the [=identifier=] of |attr|.
         1.  Let |value| be the result of [=get the underlying value|getting the underlying value=]
-            of |attr| given **this**.
+            of |attr| given <b>this</b>.
         1.  If |value| is a [=JSON type=], then [=map/set=] |map|[|id|] to |value|.
 
 </div>
@@ -13323,8 +13323,8 @@ Each {{DOMException}} object has an associated <dfn for="DOMException">name</dfn
 The <dfn constructor for="DOMException"><code>DOMException(|message|, |name|)</code></dfn>
 constructor, when invoked, must run these steps:
 
-1. Set **this**'s [=DOMException/name=] to |name|.
-1. Set **this**'s [=DOMException/message=] to |message|.
+1. Set <b>this</b>'s [=DOMException/name=] to |name|.
+1. Set <b>this</b>'s [=DOMException/message=] to |message|.
 
 The <dfn attribute for="DOMException"><code>name</code></dfn> attribute's getter must return this
 {{DOMException}} object's [=DOMException/name=].


### PR DESCRIPTION
This seems to be broken in bikshed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/721.html" title="Last updated on May 7, 2019, 1:54 PM UTC (fce7187)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/721/059491b...fce7187.html" title="Last updated on May 7, 2019, 1:54 PM UTC (fce7187)">Diff</a>