### PR TITLE
Editorial: Add min-width to distinguishable-table's cells

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -316,6 +316,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         .csstransforms #distinguishable-table td {
           text-align: center;
           width: 30px;
+          min-width: 30px;
           padding: 10px 5px;
           height: 19px
         }


### PR DESCRIPTION
Fixes #723.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/725.html" title="Last updated on May 10, 2019, 7:54 AM UTC (477bd48)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/725/059491b...477bd48.html" title="Last updated on May 10, 2019, 7:54 AM UTC (477bd48)">Diff</a>