### PR TITLE
The GetIterator operation in ECMA262 now takes three arguments

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7635,7 +7635,7 @@ ECMAScript Array values.
     given an iterable |iterable| and an iterator getter |method|,
     perform the following steps:
 
-    1.  Let |iter| be [=?=] <a abstract-op>GetIterator</a>(|iterable|, |method|).
+    1.  Let |iter| be [=?=] <a abstract-op>GetIterator</a>(|iterable|, sync, |method|).
     1.  Initialize |i| to be 0.
     1.  Repeat
         1.  Let |next| be [=?=] <a abstract-op>IteratorStep</a>(|iter|).

--- a/index.bs
+++ b/index.bs
@@ -255,6 +255,9 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
             border-bottom-color: #9D937D;
         }
 
+        emu-const {
+            font-family: sans-serif;
+        }
 
         emu-val {
             font-weight: bold;
@@ -7635,7 +7638,7 @@ ECMAScript Array values.
     given an iterable |iterable| and an iterator getter |method|,
     perform the following steps:
 
-    1.  Let |iter| be [=?=] <a abstract-op>GetIterator</a>(|iterable|, sync, |method|).
+    1.  Let |iter| be [=?=] <a abstract-op>GetIterator</a>(|iterable|, <emu-const>sync</emu-const>, |method|).
     1.  Initialize |i| to be 0.
     1.  Repeat
         1.  Let |next| be [=?=] <a abstract-op>IteratorStep</a>(|iter|).


### PR DESCRIPTION
The signature changed from (obj, method) to (obj, hint, method) when @@asyncIterator was introduced. Because the method is already known to be defined at this point, I don’t believe the hint argument will actually be used, but the argument still seems to be needed to put the method arg in the right position.

I was unsure what formatting "sync" should get here. It’s a constant symbolic value rather than a variable or a string. I didn’t see any pre-existing examples in the IDL spec, so it may need additional markup.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bathos/webidl/pull/731.html" title="Last updated on May 29, 2019, 10:04 AM UTC (14536c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/731/4ef3509...bathos:14536c1.html" title="Last updated on May 29, 2019, 10:04 AM UTC (14536c1)">Diff</a>