### PR TITLE
Mark DOMException as serializable

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -13352,7 +13352,8 @@ fragment:
 <pre class="idl">
 [
  Exposed=(Window,Worker),
- Constructor(optional DOMString message = "", optional DOMString name = "Error")
+ Constructor(optional DOMString message = "", optional DOMString name = "Error"),
+ Serializable
 ]
 interface DOMException { // but see below note about ECMAScript binding
   readonly attribute DOMString name;
@@ -13409,6 +13410,20 @@ The <dfn attribute for="DOMException"><code>code</code></dfn> attribute's getter
 legacy code indicated in the [=error names table=] for this {{DOMException}} object's
 [=DOMException/name=], or 0 if no such entry exists in the table.
 
+DOMException objects are [=serializable objects=].
+
+Their [=serialization steps=], given <var>value</var> and <var>serialized</var>, are:
+<ol>
+    <li>Set <var>serialized</var>.\[[Name]] to <var>value</var>'s [=DOMException/name=].</li>
+    <li>Set <var>serialized</var>.\[[Message]] to <var>value</var>'s [=DOMException/message=].</li>
+</ol>
+
+Their [=deserialization steps=], given <var>value</var> and <var>serialized</var>, are:
+
+<ol>
+    <li><Set <var>value</var>'s [=DOMException/name=] to <var>serialized</var>.\[[Name]].</li>
+    <li><Set <var>value</var>'s [=DOMException/message=] to <var>serialized</var>.\[[Message]].</li>
+</ol>
 
 <h3 id="DOMTimeStamp" typedef oldids="common-DOMTimeStamp">DOMTimeStamp</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -13397,7 +13397,7 @@ Each {{DOMException}} object has an associated <dfn for="DOMException">name</dfn
 The <dfn constructor for="DOMException"><code>DOMException(|message|, |name|)</code></dfn>
 constructor, when invoked, must run these steps:
 
-1. Set <b>this</b>'s [=DOMExcep tion/name=] to |name|.
+1. Set <b>this</b>'s [=DOMException/name=] to |name|.
 1. Set <b>this</b>'s [=DOMException/message=] to |message|.
 
 The <dfn attribute for="DOMException"><code>name</code></dfn> attribute's getter must return this

--- a/index.bs
+++ b/index.bs
@@ -13413,6 +13413,7 @@ legacy code indicated in the [=error names table=] for this {{DOMException}} obj
 {{DOMException}} objects are [=serializable objects=].
 
 Their [=serialization steps=], given <var>value</var> and <var>serialized</var>, are:
+
 <ol>
     <li>Set <var>serialized</var>.\[[Name]] to <var>value</var>'s [=DOMException/name=].</li>
     <li>Set <var>serialized</var>.\[[Message]] to <var>value</var>'s [=DOMException/message=].</li>

--- a/index.bs
+++ b/index.bs
@@ -13397,7 +13397,7 @@ Each {{DOMException}} object has an associated <dfn for="DOMException">name</dfn
 The <dfn constructor for="DOMException"><code>DOMException(|message|, |name|)</code></dfn>
 constructor, when invoked, must run these steps:
 
-1. Set <b>this</b>'s [=DOMException/name=] to |name|.
+1. Set <b>this</b>'s [=DOMExcep tion/name=] to |name|.
 1. Set <b>this</b>'s [=DOMException/message=] to |message|.
 
 The <dfn attribute for="DOMException"><code>name</code></dfn> attribute's getter must return this
@@ -13416,6 +13416,8 @@ Their [=serialization steps=], given <var>value</var> and <var>serialized</var>,
 <ol>
     <li>Set <var>serialized</var>.\[[Name]] to <var>value</var>'s [=DOMException/name=].</li>
     <li>Set <var>serialized</var>.\[[Message]] to <var>value</var>'s [=DOMException/message=].</li>
+    <li>User agents attach should a serialized representation of any interesting accompanying data
+    which are not yet specified, notably the {{stack}} property, to <var>serialized</var>.</li>
 </ol>
 
 Their [=deserialization steps=], given <var>value</var> and <var>serialized</var>, are:
@@ -13423,6 +13425,8 @@ Their [=deserialization steps=], given <var>value</var> and <var>serialized</var
 <ol>
     <li><Set <var>value</var>'s [=DOMException/name=] to <var>serialized</var>.\[[Name]].</li>
     <li><Set <var>value</var>'s [=DOMException/message=] to <var>serialized</var>.\[[Message]].</li>
+    <li>If any other data is attached to <var>serialized</var>, then deserialize and attach it to
+    <var>value</var>.</li>
 </ol>
 
 <h3 id="DOMTimeStamp" typedef oldids="common-DOMTimeStamp">DOMTimeStamp</h3>

--- a/index.bs
+++ b/index.bs
@@ -13410,7 +13410,7 @@ The <dfn attribute for="DOMException"><code>code</code></dfn> attribute's getter
 legacy code indicated in the [=error names table=] for this {{DOMException}} object's
 [=DOMException/name=], or 0 if no such entry exists in the table.
 
-DOMException objects are [=serializable objects=].
+{{DOMException}} objects are [=serializable objects=].
 
 Their [=serialization steps=], given <var>value</var> and <var>serialized</var>, are:
 <ol>

--- a/index.bs
+++ b/index.bs
@@ -13416,7 +13416,7 @@ Their [=serialization steps=], given <var>value</var> and <var>serialized</var>,
 <ol>
     <li>Set <var>serialized</var>.\[[Name]] to <var>value</var>'s [=DOMException/name=].</li>
     <li>Set <var>serialized</var>.\[[Message]] to <var>value</var>'s [=DOMException/message=].</li>
-    <li>User agents attach should a serialized representation of any interesting accompanying data
+    <li>User agents should attach a serialized representation of any interesting accompanying data
     which are not yet specified, notably the <code>stack</code> property, to
     <var>serialized</var>.</li>
 </ol>

--- a/index.bs
+++ b/index.bs
@@ -13417,7 +13417,8 @@ Their [=serialization steps=], given <var>value</var> and <var>serialized</var>,
     <li>Set <var>serialized</var>.\[[Name]] to <var>value</var>'s [=DOMException/name=].</li>
     <li>Set <var>serialized</var>.\[[Message]] to <var>value</var>'s [=DOMException/message=].</li>
     <li>User agents attach should a serialized representation of any interesting accompanying data
-    which are not yet specified, notably the {{stack}} property, to <var>serialized</var>.</li>
+    which are not yet specified, notably the <code>stack</code> property, to
+    <var>serialized</var>.</li>
 </ol>
 
 Their [=deserialization steps=], given <var>value</var> and <var>serialized</var>, are:


### PR DESCRIPTION
Mark DOMException as serialiable

Also define serialization and deserialization steps.
tests: https://github.com/web-platform-tests/wpt/pull/17095

Fixes #729


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yutakahirano/webidl/pull/732.html" title="Last updated on Jun 7, 2019, 7:51 AM UTC (0017a1d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/732/4ef3509...yutakahirano:0017a1d.html" title="Last updated on Jun 7, 2019, 7:51 AM UTC (0017a1d)">Diff</a>