### PR TITLE
Disallow combining Global with Constructor/NamedConstructor.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8276,6 +8276,9 @@ The [{{Constructor}}] and
 [{{NoInterfaceObject}}]
 extended attributes must not be specified on the same interface.
 
+The [{{Constructor}}] and [{{Global}}] [=extended attributes=] must not be specified on the same
+[=interface=].
+
 See [[#interface-object]] for details on how a constructor
 for an interface is to be implemented.
 
@@ -9228,6 +9231,9 @@ must not be the same as an [=identifier=] of an interface
 that has an [=interface object=],
 and must not be one of the
 [=reserved identifiers=].
+
+The [{{NamedConstructor}}] and [{{Global}}] [=extended attributes=] must not be specified on the
+same [=interface=].
 
 See [[#named-constructors]] for details on how named constructors
 are to be implemented.


### PR DESCRIPTION
Fixes #744.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/745.html" title="Last updated on Jun 27, 2019, 12:11 PM UTC (a9537fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/745/c0d927a...a9537fb.html" title="Last updated on Jun 27, 2019, 12:11 PM UTC (a9537fb)">Diff</a>