### PR TITLE
Explicitly include annotated types in the various type categories.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5313,22 +5313,28 @@ The following types are known as <dfn id="dfn-integer-type" export>integer types
 {{unsigned short}},
 {{long}},
 {{unsigned long}},
-{{long long}} and
-{{unsigned long long}}.
+{{long long}},
+{{unsigned long long}},
+and any [=annotated types=] whose [=annotated types/inner type=] is an [=integer type=].
 
 The following types are known as <dfn id="dfn-numeric-type" export>numeric types</dfn>:
 the [=integer types=],
 {{float}},
 {{unrestricted float}},
-{{double}} and
-{{unrestricted double}}.
+{{double}},
+{{unrestricted double}},
+and any [=annotated types=] whose [=annotated types/inner type=] is a [=numeric type=].
 
 The <dfn id="dfn-primitive-type" export>primitive types</dfn> are
-{{boolean}} and the [=numeric types=].
+{{boolean}},
+the [=numeric types=],
+and any [=annotated types=] whose [=annotated types/inner type=] is a [=primitive type=].
 
 The <dfn id="dfn-string-type" export>string types</dfn> are
 {{DOMString}}, all [=enumeration types=],
-{{ByteString}} and {{USVString}}.
+{{ByteString}},
+{{USVString}},
+and any [=annotated types=] whose [=annotated types/inner type=] is a [=string type=].
 
 The <dfn id="dfn-typed-array-type" export>typed array types</dfn> are
 {{Int8Array}},
@@ -5338,18 +5344,21 @@ The <dfn id="dfn-typed-array-type" export>typed array types</dfn> are
 {{Uint16Array}},
 {{Uint32Array}},
 {{Uint8ClampedArray}},
-{{Float32Array}} and
-{{Float64Array}}.
+{{Float32Array}},
+{{Float64Array}},
+and any [=annotated types=] whose [=annotated types/inner type=] is a [=typed array type=].
 
-The <dfn id="dfn-buffer-source-type" export>buffer source types</dfn>
-are {{ArrayBuffer}},
+The <dfn id="dfn-buffer-source-type" export>buffer source types</dfn> are
+{{ArrayBuffer}},
 {{DataView}},
-and the [=typed array types=].
+the [=typed array types=],
+and any [=annotated types=] whose [=annotated types/inner type=] is a [=buffer source type=].
 
-The {{object}} type,
-all [=interface types=], and
-all [=callback interface types=]
-are known as <dfn id="dfn-object-type" export>object types</dfn>.
+The <dfn id="dfn-object-type" export>object types</dfn> are
+the {{object}} type,
+all [=interface types=],
+all [=callback interface types=],
+and any [=annotated types=] whose [=annotated types/inner type=] is an [=object type=].
 
 Every type has a <dfn id="dfn-type-name" export>type name</dfn>, which
 is a string, not necessarily unique, that identifies the type.


### PR DESCRIPTION
Fixes #670.