### PR TITLE
Editorial: Better explanation of the TreatNonObjectAsNull extended attribute.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6241,6 +6241,9 @@ An [=identifier=] that identifies
 a [=callback function=] is used to refer to
 a type whose values are references to objects that are functions with the given signature.
 
+Note: If the [{{TreatNonObjectAsNull}}] [=extended attribute=] is specified on the [=definition=] of
+the [=callback function=], the values can be references to objects that are not functions.
+
 An IDL value of the callback function type is represented by a tuple of an object
 reference and a [=callback context=].
 
@@ -10485,16 +10488,13 @@ that does specify [{{SecureContext}}].
 
 </div>
 
-If the [{{TreatNonObjectAsNull}}]
-[=extended attribute=]
-appears on a [=callback function=],
-then it indicates that any value assigned to an [=attribute=]
-whose type is a [=nullable type|nullable=]
-[=callback function=]
-that is not an object will be converted to
-the <emu-val>null</emu-val> value.
+If the [{{TreatNonObjectAsNull}}] [=extended attribute=] appears on a [=callback function=], then
+it indicates that any value assigned to an [=attribute=] whose type is a [=nullable type|nullable=]
+[=callback function=] will be converted more loosely: if the value is not an object, it will be
+converted to null, and if the value is not [=ECMAScript/callable=], it will be converted to a
+[=callback function=] value that does nothing when called.
 
-See [[#es-nullable-type]]
+See [[#es-nullable-type]], [[#es-callback-function]] and [[#es-invoking-callback-functions]]
 for the specific requirements that the use of
 [{{TreatNonObjectAsNull}}] entails.
 
@@ -10519,7 +10519,7 @@ for the specific requirements that the use of
     </pre>
 
     In an ECMAScript implementation, assigning a value that is not
-    an object (such as a Number value)
+    an object (such as a Number value), or that is not [=ECMAScript/callable=]
     to handler1 will have different behavior from that when assigning
     to handler2:
 
@@ -10534,11 +10534,19 @@ for the specific requirements that the use of
         } catch (e) {
         }
 
+        try {
+          manager.handler1 = {};     // Throws a TypeError.
+        } catch (e) {
+        }
+
         manager.handler2 = function() { };
         manager.handler2;            // Evaluates to the function.
 
         manager.handler2 = 123;
         manager.handler2;            // Evaluates to null.
+
+        manager.handler2 = {};
+        manager.handler2;            // Evaluates to the object.
     </pre>
 </div>
 
@@ -13744,11 +13752,9 @@ described in the previous section).
     1.  If |thisArg| was not given, let |thisArg| be <emu-val>undefined</emu-val>.
     1.  Let |F| be the ECMAScript object corresponding to |callable|.
     1.  If [=!=] <a abstract-op>IsCallable</a>(|F|) is <emu-val>false</emu-val>:
-        1.  If the callback function's return type is {{void}}, return.
-
-            Note: This is only possible when the callback function came from an attribute
+        1.  Note: This is only possible when the [=callback function=] came from an attribute
             marked with [{{TreatNonObjectAsNull}}].
-
+        1.  If the callback function's return type is {{void}}, return.
         1.  Return the result of [=converted to an IDL value|converting=]
             <emu-val>undefined</emu-val> to the callback function's return type.
     1.  Let |realm| be |F|'s [=associated Realm=].


### PR DESCRIPTION
When the name and behaviour of the extended attribute were changed back in
4043b051d492d4a2f21064f0edf91e642c5a6249, various prose around the
specification became somewhat unclear. This tries to make everything agree on
what happens.