### PR TITLE
Improve the definition of the void type.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2073,7 +2073,7 @@ defined on the same [=interface=].
 The <dfn id="dfn-return-type" export>return type</dfn> of the operation is given
 by the type (matching <emu-nt><a href="#prod-ReturnType">ReturnType</a></emu-nt>)
 that appears before the operation’s optional [=identifier=].
-A return type of <dfn id="idl-void" interface>void</dfn> indicates that the operation returns no value.
+A return type of {{void}} indicates that the operation returns no value.
 If the return type is an
 [=identifier=] followed by <emu-t>?</emu-t>,
 then the identifier must
@@ -5536,6 +5536,15 @@ value is known as its <dfn id="dfn-specific-type" export>specific type</dfn>.
 (Values of [=union types=] also have
 [=specific types=].)
 
+<h4 id="idl-void" interface>void</h4>
+
+The {{void}} type has a unique value.
+
+It can only be used as the [=return type=] of an [=operation=] or the parameter of a
+[=promise type=].
+
+The [=type name=] of the {{void}} type is "<code>Void</code>".
+
 
 <h4 oldids="dom-boolean" id="idl-boolean" interface>boolean</h4>
 
@@ -6892,16 +6901,15 @@ ECMAScript value type.
 
 <h4 id="es-void">void</h4>
 
-The only place that the {{void}} type may appear
-in IDL is as the [=return type=] of an
-[=operation=].  Functions on [=platform objects=]
-that implement an operation whose IDL specifies a
-{{void}} return type must return the
-<emu-val>undefined</emu-val> value.
+<p id="es-to-void">
+    An ECMAScript value |V| is [=converted to an IDL value|converted=] to an IDL {{void}} value by
+    returning the unique {{void}} value, ignoring |V|.
+</p>
 
-ECMAScript functions that implement an operation whose IDL
-specifies a {{void}} return type
-may return any value, which will be discarded.
+<p id="void-to-es">
+    The unique IDL {{void}} value is [=converted to an ECMAScript value|converted=] to the
+    ECMAScript <emu-val>undefined</emu-val> value.
+</p>
 
 
 <h4 id="es-boolean">boolean</h4>


### PR DESCRIPTION
In particular, this acknowledges that `Promise<void>` exists.

This also ensures that the handling of `void` return types is defined fully.

Fixes #737.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/757.html" title="Last updated on Jul 2, 2019, 1:47 PM UTC (bb451af)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/757/15563ce...bb451af.html" title="Last updated on Jul 2, 2019, 1:47 PM UTC (bb451af)">Diff</a>