### PR TITLE
Fix one inconsistent use of [] in examples (editorial)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -13390,11 +13390,9 @@ The {{DOMException}} type is an [=interface type=] defined by the following IDL
 fragment:
 
 <pre class="idl">
-[
- Exposed=(Window,Worker),
+[Exposed=(Window,Worker),
  Constructor(optional DOMString message = "", optional DOMString name = "Error"),
- Serializable
-]
+ Serializable]
 interface DOMException { // but see below note about ECMAScript binding
   readonly attribute DOMString name;
   readonly attribute DOMString message;


### PR DESCRIPTION
I'd like to refer to the WebIDL examples as the de facto style guide for WebIDL.

To that end, I'd like to fix an inconsistency in one example's use of `[]` that I found. From:
```js
[
 Exposed=(Window,Worker),
 Constructor(optional DOMString message = "", optional DOMString name = "Error"),
 Serializable
]
interface DOMException {
```
to
```js
[Exposed=(Window,Worker),
 Constructor(optional DOMString message = "", optional DOMString name = "Error"),
 Serializable]
interface DOMException {
```
The latter appears to be the predominant style in this document as well as in [HTML](https://html.spec.whatwg.org/#htmlallcollection) and [DOM](https://dom.spec.whatwg.org/#interface-event).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webidl/pull/759.html" title="Last updated on Jul 17, 2019, 7:36 PM UTC (3a4f1d6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/759/f23ef42...jan-ivar:3a4f1d6.html" title="Last updated on Jul 17, 2019, 7:36 PM UTC (3a4f1d6)">Diff</a>