### PR TITLE
Clarify the restrictions on SecureContext combinations.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9862,19 +9862,14 @@ If [{{SecureContext}}] appears on an [=overloaded=] [=operation=],
 then it must appear on all overloads.
 
 The [{{SecureContext}}] [=extended attribute=] must not be specified both on
-an [=interface member|interface=], [=interface mixin member|mixin=], or [=namespace member=], and on
-the [=partial interface=], [=partial interface mixin=], or [=partial namespace=] definition
-the [=member=] is declared on.
 
-Note: This is because adding a [{{SecureContext}}] [=extended attribute=] on a
-[=partial interface=], [=partial interface mixin=], or [=partial namespace=]
-is shorthand for annotating each of its [=members=].
+* an [=interface member=] and its [=interface=] or [=partial interface=];
+* an [=interface mixin member=] and its [=interface mixin=] or [=partial interface mixin=];
+* a [=namespace member=] and its [=namespace=] or [=partial namespace=].
 
-The [{{SecureContext}}] [=extended attribute=]
-must not be specified on both an [=interface member=] and
-the [=interface=] or [=partial interface=] definition the [=interface member=] is declared on.
-It must also not be specified on both a [=namespace member=] and
-the [=namespace=] or [=partial namespace=] definition the [=namespace member=] is declared on.
+Note: This is because adding the [{{SecureContext}}] [=extended attribute=] on a [=member=] when
+its containing definition is also annotated with the [{{SecureContext}}] [=extended attribute=]
+does not further restrict the exposure of the [=member=].
 
 An [=interface=] without the [{{SecureContext}}] [=extended attribute=]
 must not [=interface/inherit=] from another interface


### PR DESCRIPTION
Fixes #762.