### PR TITLE
Fix grammar reference in the definition of callback interfaces.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1393,7 +1393,10 @@ you can extend the {{WindowOrWorkerGlobalScope}} [=interface mixin=] using a [=p
 <h3 id="idl-callback-interfaces">Callback interfaces</h3>
 
 A <dfn id="dfn-callback-interface" export>callback interface</dfn> is a [=definition=] matching
-<emu-t>callback</emu-t> <emu-t>interface</emu-t> <emu-nt><a href="#prod-InterfaceRest">InterfaceRest</a></emu-nt>.
+<emu-t>callback</emu-t> <emu-t>interface</emu-t>
+<emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> <emu-t>{</emu-t>
+<emu-nt><a href="#prod-CallbackInterfaceMembers">CallbackInterfaceMembers</a></emu-nt>
+<emu-t>}</emu-t> <emu-t>;</emu-t>.
 It can be implemented by any object, as described in [[#idl-objects]].
 
 Note: A [=callback interface=] is not an [=interface=]. The name and syntax are left over from


### PR DESCRIPTION
They no longer use InterfaceRest.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/765.html" title="Last updated on Aug 6, 2019, 3:36 PM UTC (cd93b7f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/765/13c7e8f...cd93b7f.html" title="Last updated on Aug 6, 2019, 3:36 PM UTC (cd93b7f)">Diff</a>