### PR TITLE
Editorial: Don't use ReadWriteMapLike/ReadWriteSetLike after 'readonly'.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1940,8 +1940,8 @@ are applicable only to regular attributes:
 <pre class="grammar" id="prod-ReadOnlyMemberRest">
     ReadOnlyMemberRest :
         AttributeRest
-        ReadWriteMaplike
-        ReadWriteSetlike
+        MaplikeRest
+        SetlikeRest
 </pre>
 
 <pre class="grammar" id="prod-ReadWriteAttribute">


### PR DESCRIPTION
Fixes #752.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/766.html" title="Last updated on Aug 7, 2019, 8:36 AM UTC (c8b7848)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/766/13c7e8f...c8b7848.html" title="Last updated on Aug 7, 2019, 8:36 AM UTC (c8b7848)">Diff</a>