### PR TITLE
Allow `async` and `includes` as member names

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1976,6 +1976,7 @@ are applicable only to regular attributes:
 
 <pre class="grammar" id="prod-AttributeNameKeyword">
     AttributeNameKeyword :
+        "async"
         "required"
 </pre>
 
@@ -2425,8 +2426,19 @@ The following extended attributes are applicable to operations:
 
 <pre class="grammar" id="prod-OptionalIdentifier">
     OptionalIdentifier :
-        identifier
+        OperationName
         ε
+</pre>
+
+<pre class="grammar" id="prod-OperationName">
+    OperationName :
+        OperationNameKeyword
+        identifier
+</pre>
+
+<pre class="grammar" id="prod-OperationNameKeyword">
+    OperationNameKeyword :
+        "includes"
 </pre>
 
 <pre class="grammar" id="prod-ArgumentList">

--- a/index.bs
+++ b/index.bs
@@ -677,6 +677,7 @@ underscore.
 
 <pre class="grammar" id="prod-ArgumentNameKeyword">
     ArgumentNameKeyword :
+        "async"
         "attribute"
         "callback"
         "const"

--- a/index.bs
+++ b/index.bs
@@ -640,7 +640,7 @@ in the declaration:
 *   For [=operations=], the
     <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> token that appears
     after the return type but before the opening parenthesis (that is,
-    one that is matched as part of the <emu-nt><a href="#prod-OptionalIdentifier">OptionalIdentifier</a></emu-nt>
+    one that is matched as part of the <emu-nt><a href="#prod-OptionalOperationName">OptionalOperationName</a></emu-nt>
     grammar symbol in an <emu-nt><a href="#prod-OperationRest">OperationRest</a></emu-nt>) determines the identifier of the operation.  If
     there is no such <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> token,
     then the operation does not have an identifier.
@@ -2422,11 +2422,11 @@ The following extended attributes are applicable to operations:
 
 <pre class="grammar" id="prod-OperationRest">
     OperationRest :
-        OptionalIdentifier "(" ArgumentList ")" ";"
+        OptionalOperationName "(" ArgumentList ")" ";"
 </pre>
 
-<pre class="grammar" id="prod-OptionalIdentifier">
-    OptionalIdentifier :
+<pre class="grammar" id="prod-OptionalOperationName">
+    OptionalOperationName :
         OperationName
         ε
 </pre>


### PR DESCRIPTION
Closes #767 
Closes #768
Fixes https://github.com/whatwg/xhr/issues/251


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/webidl/pull/769.html" title="Last updated on Aug 14, 2019, 3:42 AM UTC (68aa41d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/769/a08d398...saschanaz:68aa41d.html" title="Last updated on Aug 14, 2019, 3:42 AM UTC (68aa41d)">Diff</a>