### PR TITLE
Editorial: Add an example of using ordered map syntax for dictionaries.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4676,6 +4676,20 @@ specific dictionary |D| if all of its [=map/entries=] correspond to [=dictionary
 correct order and with the correct types, and with appropriate [=map/entries=] for any required
 dictionary members.
 
+<div class="example">
+    <pre highlight="webidl">
+    dictionary Descriptor {
+      DOMString name;
+      sequence&lt;unsigned long> serviceIdentifiers;
+    };
+    </pre>
+
+    A <code>Descriptor</code> dictionary could be created as in the following steps:
+
+    1.  Let |identifiers| be « 1, 3, 7 ».
+    1.  Return «[ "name" → "test", "serviceIdentifiers" → |identifiers| ]».
+</div>
+
 <p class="advisement">
     As with [=optional argument/default value|operation argument default values=],
     it is strongly suggested not to use <emu-val>true</emu-val> as the


### PR DESCRIPTION
Ref. #142.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/775.html" title="Last updated on Aug 23, 2019, 2:51 PM UTC (b3450e1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/775/34ef605...b3450e1.html" title="Last updated on Aug 23, 2019, 2:51 PM UTC (b3450e1)">Diff</a>