### PR TITLE
Forbid overloading operations with Promise and non-Promise return types.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3216,6 +3216,11 @@ that overloaded operations and constructors can be
 specified to take, and in order to describe these restrictions,
 the notion of an <em>effective overload set</em> is used.
 
+A set of overloaded [=operations=] must either:
+
+* contain no [=operations=] whose [=return type=] is a [=promise type=];
+* only contain [=operations=] whose [=return type=] is a [=promise type=].
+
 [=Operations=] must not be overloaded across
 [=interface=],
 [=partial interface=],


### PR DESCRIPTION
Fixes <https://www.w3.org/Bugs/Public/show_bug.cgi?id=25051>.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/776.html" title="Last updated on Aug 23, 2019, 3:38 PM UTC (5ab5e9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/776/34ef605...5ab5e9a.html" title="Last updated on Aug 23, 2019, 3:38 PM UTC (5ab5e9a)">Diff</a>