### PR TITLE
Use new syntax for DOMException.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14129,9 +14129,10 @@ fragment:
 
 <pre class="idl">
 [Exposed=(Window,Worker),
- Constructor(optional DOMString message = "", optional DOMString name = "Error"),
  Serializable]
 interface DOMException { // but see below note about ECMAScript binding
+  constructor(optional DOMString message = "", optional DOMString name = "Error");
+
   readonly attribute DOMString name;
   readonly attribute DOMString message;
   readonly attribute unsigned short code;


### PR DESCRIPTION
See https://github.com/heycam/webidl/issues/778.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 29, 2019, 9:04 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fheycam%2Fwebidl%2F035c1568f6e19d1f2386b91492b9b8cc8318c1cf%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
WARNING: Multiple elements have the same ID 'w3c_process_revision'.
Deduping, but this ID may not be stable across revisions.
Traceback (most recent call last):
  File "/sites/api.csswg.org/bikeshed/bikeshed.py", line 5, in 
    bikeshed.main()
  File "/sites/api.csswg.org/bikeshed/bikeshed/cli.py", line 205, in main
    handleSpec(options, extras)
  File "/sites/api.csswg.org/bikeshed/bikeshed/cli.py", line 241, in handleSpec
    doc.preprocess()
  File "/sites/api.csswg.org/bikeshed/bikeshed/Spec.py", line 103, in preprocess
    self.processDocument()
  File "/sites/api.csswg.org/bikeshed/bikeshed/Spec.py", line 186, in processDocument
    idl.markupIDL(self)
  File "/sites/api.csswg.org/bikeshed/bikeshed/idl.py", line 231, in markupIDL
    replaceContents(el, parseHTML(unicode(widl.markup(marker))))
  File "/sites/api.csswg.org/bikeshed/bikeshed/widlparser/widlparser/parser.py", line 280, in markup
    return generator.markup(marker)
  File "/sites/api.csswg.org/bikeshed/bikeshed/widlparser/widlparser/markup.py", line 81, in markup
    output += u''.join([child.markup(marker, self.construct) for child in self.children])
  File "/sites/api.csswg.org/bikeshed/bikeshed/widlparser/widlparser/markup.py", line 81, in markup
    output += u''.join([child.markup(marker, self.construct) for child in self.children])
  File "/sites/api.csswg.org/bikeshed/bikeshed/widlparser/widlparser/markup.py", line 81, in markup
    output += u''.join([child.markup(marker, self.construct) for child in self.children])
  File "/sites/api.csswg.org/bikeshed/bikeshed/widlparser/widlparser/markup.py", line 81, in markup
    output += u''.join([child.markup(marker, self.construct) for child in self.children])
  File "/sites/api.csswg.org/bikeshed/bikeshed/widlparser/widlparser/markup.py", line 164, in markup
    head, tail = marker.markupName(self.text, construct) if (hasattr(marker, 'markupName')) else (None, None)
  File "/sites/api.csswg.org/bikeshed/bikeshed/idl.py", line 168, in markupName
    methodNames = ["{0}/{1}".format(interfaceName, m) for m in construct.parent.methodNames]
  File "/sites/api.csswg.org/bikeshed/bikeshed/widlparser/widlparser/productions.py", line 1799, in methodNames
    return [_name(self) + '(' + argumentName + ')' for argumentName in self.arguments.argumentNames]
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20heycam/webidl%23780.)._
</details>
