### PR TITLE
Allow "constructor" as an argument name

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -685,6 +685,7 @@ underscore.
         "attribute"
         "callback"
         "const"
+        "constructor"
         "deleter"
         "dictionary"
         "enum"

--- a/index.bs
+++ b/index.bs
@@ -715,7 +715,7 @@ keyword token is used, then the [=identifier=] of the operation argument
 is simply that token.
 
 The [=identifier=] of any of the abovementioned
-IDL constructs must not be "<code>constructor</code>",
+IDL constructs (except operation arguments) must not be "<code>constructor</code>",
 "<code>toString</code>",
 or begin with a <span class="char">U+005F LOW LINE ("_")</span> character.  These
 are known as <dfn id="dfn-reserved-identifier" export>reserved identifiers</dfn>.


### PR DESCRIPTION
Fixes #779


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Sep 2, 2019, 9:00 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsaschanaz%2Fwebidl%2F390a9dc01dc40b262f50c7972b03a3e161c5e3e8%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
WARNING: Multiple elements have the same ID 'w3c_process_revision'.
Deduping, but this ID may not be stable across revisions.
Traceback (most recent call last):
  File "/sites/api.csswg.org/bikeshed/bikeshed.py", line 5, in 
    bikeshed.main()
  File "/sites/api.csswg.org/bikeshed/bikeshed/cli.py", line 205, in main
    handleSpec(options, extras)
  File "/sites/api.csswg.org/bikeshed/bikeshed/cli.py", line 241, in handleSpec
    doc.preprocess()
  File "/sites/api.csswg.org/bikeshed/bikeshed/Spec.py", line 103, in preprocess
    self.processDocument()
  File "/sites/api.csswg.org/bikeshed/bikeshed/Spec.py", line 186, in processDocument
    idl.markupIDL(self)
  File "/sites/api.csswg.org/bikeshed/bikeshed/idl.py", line 231, in markupIDL
    replaceContents(el, parseHTML(unicode(widl.markup(marker))))
  File "/sites/api.csswg.org/bikeshed/bikeshed/widlparser/widlparser/parser.py", line 280, in markup
    return generator.markup(marker)
  File "/sites/api.csswg.org/bikeshed/bikeshed/widlparser/widlparser/markup.py", line 81, in markup
    output += u''.join([child.markup(marker, self.construct) for child in self.children])
  File "/sites/api.csswg.org/bikeshed/bikeshed/widlparser/widlparser/markup.py", line 81, in markup
    output += u''.join([child.markup(marker, self.construct) for child in self.children])
  File "/sites/api.csswg.org/bikeshed/bikeshed/widlparser/widlparser/markup.py", line 81, in markup
    output += u''.join([child.markup(marker, self.construct) for child in self.children])
  File "/sites/api.csswg.org/bikeshed/bikeshed/widlparser/widlparser/markup.py", line 81, in markup
    output += u''.join([child.markup(marker, self.construct) for child in self.children])
  File "/sites/api.csswg.org/bikeshed/bikeshed/widlparser/widlparser/markup.py", line 164, in markup
    head, tail = marker.markupName(self.text, construct) if (hasattr(marker, 'markupName')) else (None, None)
  File "/sites/api.csswg.org/bikeshed/bikeshed/idl.py", line 168, in markupName
    methodNames = ["{0}/{1}".format(interfaceName, m) for m in construct.parent.methodNames]
  File "/sites/api.csswg.org/bikeshed/bikeshed/widlparser/widlparser/productions.py", line 1799, in methodNames
    return [_name(self) + '(' + argumentName + ')' for argumentName in self.arguments.argumentNames]
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20heycam/webidl%23786.)._
</details>
