### PR TITLE
Fix example for 'upon settling'.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8416,17 +8416,20 @@ JavaScript code.
     The <code>addDelay(|ms|, |promise|)</code> method steps are:
 
     1.  Let |realm| be <b>this</b>'s [=relevant Realm=].
+    1.  Let |taskSource| be some appropriate [=task source=].
     1.  If |ms| is NaN, let |ms| be +0; otherwise let |ms| be the maximum of |ms| and +0.
     1.  Let |p| be [=a new promise=] in |realm|.
     1.  [=Upon settling=] of |promise|:
         *   If |promise| was fulfilled with value |v|, then:
             1.  Run the following steps [=in parallel=]:
                 1.  Wait |ms| milliseconds.
-                1.  [=Resolve=] |promise| with |v|.
+                1.  [=Queue a task=] to run the following steps on |taskSource|:
+                    1.  [=Resolve=] |p| with |v|.
         *   If |promise| was rejected with reason |r|, then:
             1.  Run the following steps [=in parallel=]:
                 1.  Wait |ms| milliseconds.
-                1.  [=Reject=] |promise| with |r|.
+                1.  [=Queue a task=] to run the following steps on |taskSource|:
+                    1.  [=Reject=] |p| with |r|.
     1.  Return |p|.
 </div>
 </div>
@@ -14351,6 +14354,7 @@ The editor would like to thank the following people for contributing
 to this specification:
 Glenn Adams,
 David Andersson,
+Jake Archibald,
 L. David Baron,
 Art Barstow,
 Nils Barth,


### PR DESCRIPTION
Fixes #788.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/790.html" title="Last updated on Sep 4, 2019, 8:02 AM UTC (bd8283f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/790/182b487...bd8283f.html" title="Last updated on Sep 4, 2019, 8:02 AM UTC (bd8283f)">Diff</a>