### PR TITLE
Use "react" for the spec promise.then() analog

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8230,8 +8230,8 @@ IDL [=promise type=] values are represented by ECMAScript [=PromiseCapability=] 
 
 <div algorithm>
 
-    To <dfn id="dfn-perform-steps-once-promise-is-settled" export lt="upon settling">perform some steps once a promise is settled</dfn>,
-    given a <code><a interface>Promise</a>&lt;|T|&gt;</code> |promise| and one or two sets of steps
+    To <dfn id="dfn-perform-steps-once-promise-is-settled" export lt="react|reacting" for="promise">react</dfn>
+    to a <code><a interface>Promise</a>&lt;|T|&gt;</code> |promise|, given one or two sets of steps
     to perform, covering when the promise is fulfilled, rejected, or both, perform the following
     steps:
 
@@ -8274,7 +8274,7 @@ IDL [=promise type=] values are represented by ECMAScript [=PromiseCapability=] 
     <code><a interface>Promise</a>&lt;|T|&gt;</code> |promise| given some steps |steps| taking a
     value of type |T|, perform the following steps:
 
-    1.  [=Upon settling=] of |promise|:
+    1.  [=promise/React=] to |promise|:
         *   If |promise| was fulfilled with value |v|, then:
             1.  Perform |steps| with |v|.
 </div>
@@ -8285,7 +8285,7 @@ IDL [=promise type=] values are represented by ECMAScript [=PromiseCapability=] 
     <code><a interface>Promise</a>&lt;<var ignore>T</var>&gt;</code> |promise| given some steps
     |steps| taking an ECMAScript value, perform the following steps:
 
-    1.  [=Upon settling=] of |promise|:
+    1.  [=promise/React=] to |promise|:
         *   If |promise| was rejected with reason |r|, then:
             1.  Perform |steps| with |r|.
 </div>
@@ -8418,7 +8418,7 @@ JavaScript code.
     1.  Let |realm| be <b>this</b>'s [=relevant Realm=].
     1.  If |ms| is NaN, let |ms| be +0; otherwise let |ms| be the maximum of |ms| and +0.
     1.  Let |p| be [=a new promise=] in |realm|.
-    1.  [=Upon settling=] of |promise|:
+    1.  [=promise/React=] to |promise|:
         *   If |promise| was fulfilled with value |v|, then:
             1.  Run the following steps [=in parallel=]:
                 1.  Wait |ms| milliseconds.


### PR DESCRIPTION
Closes #783.

/cc @jakearchibald


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/792.html" title="Last updated on Sep 3, 2019, 7:36 PM UTC (1f89230)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/792/182b487...1f89230.html" title="Last updated on Sep 3, 2019, 7:36 PM UTC (1f89230)">Diff</a>