### PR TITLE
Define "usual constructor steps"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11130,6 +11130,13 @@ An interface may have <dfn export>overridden constructor steps</dfn>, which can
 change the behavior of the [=interface object=] when called or constructed. By
 default interfaces do not have such steps.
 
+<p class="advisement">
+    In general, constructors are described by defining a [=constructor operation=] and its behavior.
+    The [=overridden constructor steps=] are used only for more complicated situations.
+    Editors who wish to use this feature are strongly advised to discuss this by
+    <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20constructor%20steps">filing an issue</a> before proceeding.
+</p>
+
 <div algorithm>
 
     The [=interface object=] for a given [=interface=] |I|

--- a/index.bs
+++ b/index.bs
@@ -11130,7 +11130,7 @@ An interface may have <dfn export>overridden constructor steps</dfn>, which can
 change the behavior of the [=interface object=] when called or constructed. By
 default interfaces do not have such steps.
 
-<div>
+<div algorithm>
 
     The [=interface object=] for a given [=interface=] |I|
     with [=identifier=] |id| and in [=Realm=] |realm|

--- a/index.bs
+++ b/index.bs
@@ -11130,7 +11130,7 @@ An interface may have <dfn export>overridden constructor steps</dfn>, which can
 change the behavior of the [=interface object=] when called or constructed. By
 default interfaces do not have such steps.
 
-<div algorithm="create an interface object">
+<div>
 
     The [=interface object=] for a given [=interface=] |I|
     with [=identifier=] |id| and in [=Realm=] |realm|

--- a/index.bs
+++ b/index.bs
@@ -11126,13 +11126,18 @@ and is described in more detail in [[#interface-prototype-object]].
 Note: Since an [=interface object=] is a [=function object=]
 the <code>typeof</code> operator will return "function" when applied to an interface object.
 
+An interface may have <dfn export>overridden constructor steps</dfn>, which can
+change the behavior of the [=interface object=] when called or constructed. By
+default interfaces do not have such steps.
+
 <div algorithm="create an interface object">
 
     The [=interface object=] for a given [=interface=] |I|
     with [=identifier=] |id| and in [=Realm=] |realm|
     is <dfn lt="create an interface object">created</dfn> as follows:
 
-    1.  Let |steps| be the following steps, known as the <dfn export>usual constructor steps</dfn>:
+    1.  Let |steps| be |I|'s [=overriden constructor steps=] if they exist, or
+        the following steps otherwise:
         1.  If |I| was not declared with a [=constructor operation=],
             then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  If {{NewTarget}} is <emu-val>undefined</emu-val>, then
@@ -11185,9 +11190,6 @@ the <code>typeof</code> operator will return "function" when applied to an inter
     1.  [=Define the static attributes=] of [=interface=] |I| on |F| given |realm|.
     1.  [=Define the static operations=] of [=interface=] |I| on |F| given |realm|.
     1.  Return |F|.
-
-    Other specifications may require that, under certain circumstances, a different set of steps
-    replace the [=usual constructor steps=].
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -11126,13 +11126,13 @@ and is described in more detail in [[#interface-prototype-object]].
 Note: Since an [=interface object=] is a [=function object=]
 the <code>typeof</code> operator will return "function" when applied to an interface object.
 
-<div algorithm>
+<div algorithm="create an interface object">
 
     The [=interface object=] for a given [=interface=] |I|
     with [=identifier=] |id| and in [=Realm=] |realm|
     is <dfn lt="create an interface object">created</dfn> as follows:
 
-    1.  Let |steps| be the following steps:
+    1.  Let |steps| be the following steps, known as the <dfn export>usual constructor steps</dfn>:
         1.  If |I| was not declared with a [=constructor operation=],
             then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  If {{NewTarget}} is <emu-val>undefined</emu-val>, then
@@ -11185,6 +11185,9 @@ the <code>typeof</code> operator will return "function" when applied to an inter
     1.  [=Define the static attributes=] of [=interface=] |I| on |F| given |realm|.
     1.  [=Define the static operations=] of [=interface=] |I| on |F| given |realm|.
     1.  Return |F|.
+
+    Other specifications may require that, under certain circumstances, a different set of steps
+    replace the [=usual constructor steps=].
 
 </div>
 


### PR DESCRIPTION
This is for use in [HTMLConstructor] in https://github.com/whatwg/html/pull/4915.

There are alternative approaches and wordings that might be better, e.g.

- Say "perform the following steps or any others specified by specs" inline instead of allowing the usual steps to be replaced using a paragraph at the bottom
- Have an explicit "overridden constructor steps" value for each interface object, which [HTMLConstructor] sets and this algorithm consults

But I thought I'd start here to get the ball rolling, as it's the first thing that occurred to me. Happy to tweak as desired.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/797.html" title="Last updated on Sep 18, 2019, 8:36 AM UTC (4554894)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/797/db74ef4...4554894.html" title="Last updated on Sep 18, 2019, 8:36 AM UTC (4554894)">Diff</a>