### PR TITLE
Remove use of [Constructor] extended attribute

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2910,8 +2910,9 @@ a [=static attribute=].
     <code class="idl">name</code> attribute:
 
     <pre highlight="webidl">
-        [Exposed=Window, Constructor]
+        [Exposed=Window]
         interface Student {
+          constructor();
           attribute unsigned long id;
           stringifier attribute DOMString name;
         };
@@ -2935,8 +2936,9 @@ a [=static attribute=].
     not specified in the IDL itself.
 
     <pre highlight="webidl">
-        [Exposed=Window, Constructor]
+        [Exposed=Window]
         interface Student {
+          constructor();
           attribute unsigned long id;
           attribute DOMString? familyName;
           attribute DOMString givenName;
@@ -5026,8 +5028,9 @@ No [=extended attributes=] are applicable to dictionaries.
     consider the following [=IDL fragment=]:
 
     <pre highlight="webidl">
-        [Exposed=Window, Constructor]
+        [Exposed=Window]
         interface Point {
+          constructor();
           attribute double x;
           attribute double y;
         };
@@ -6799,7 +6802,7 @@ which form (or forms) it is in:
             <dfn id="dfn-xattr-argument-list" for="extended attribute" export>takes an argument list</dfn>
         </td>
         <td>
-            <code>[Constructor(double x, double y)]</code>
+            Not currently used; previously used by <code>[Constructor(double x, double y)]</code>
         </td>
     </tr>
     <tr>
@@ -9193,8 +9196,9 @@ for the specific requirements that the use of
         };
 
         // Dimensions is available for use in workers and on the main thread.
-        [Exposed=(Window,Worker), Constructor(double width, double height)]
+        [Exposed=(Window,Worker)]
         interface Dimensions {
+          constructor(double width, double height);
           readonly attribute double width;
           readonly attribute double height;
         };
@@ -9435,8 +9439,10 @@ See [[#namespace-object]] for details on how an interface is exposed on a namesp
     <pre highlight="webidl">
         namespace Foo { };
 
-        [LegacyNamespace=Foo, Constructor]
-        interface Bar { };
+        [LegacyNamespace=Foo]
+        interface Bar {
+          constructor();
+        };
     </pre>
 
     In an ECMAScript implementation of the above namespace and interface, the
@@ -9562,7 +9568,6 @@ are to be implemented.
 
     <pre highlight="webidl">
         [Exposed=Window,
-         Constructor,
          LegacyWindowAlias=WebKitCSSMatrix]
         interface DOMMatrix : DOMMatrixReadOnly {
           // ...
@@ -14149,9 +14154,9 @@ fragment:
 
 <pre class="idl">
 [Exposed=(Window,Worker),
- Constructor(optional DOMString message = "", optional DOMString name = "Error"),
  Serializable]
 interface DOMException { // but see below note about ECMAScript binding
+  constructor(optional DOMString message = "", optional DOMString name = "Error");
   readonly attribute DOMString name;
   readonly attribute DOMString message;
   readonly attribute unsigned short code;


### PR DESCRIPTION
This removes [Constructor] from DOMException and from examples, replacing
it as necessary with constructor operations.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/clelland/webidl/pull/798.html" title="Last updated on Sep 23, 2019, 2:42 PM UTC (2a37a9b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/798/db74ef4...clelland:2a37a9b.html" title="Last updated on Sep 23, 2019, 2:42 PM UTC (2a37a9b)">Diff</a>