### PR TITLE
Fix "overriden" typo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11148,7 +11148,7 @@ default interfaces do not have such steps.
     with [=identifier=] |id| and in [=Realm=] |realm|
     is <dfn lt="create an interface object">created</dfn> as follows:
 
-    1.  Let |steps| be |I|'s [=overriden constructor steps=] if they exist, or
+    1.  Let |steps| be |I|'s [=overridden constructor steps=] if they exist, or
         the following steps otherwise:
         1.  If |I| was not declared with a [=constructor operation=],
             then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TimothyGu/webidl/pull/806.html" title="Last updated on Sep 26, 2019, 5:46 AM UTC (5604396)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/806/8450ca2...TimothyGu:5604396.html" title="Last updated on Sep 26, 2019, 5:46 AM UTC (5604396)">Diff</a>