### PR TITLE
Meta: fix and prevent Bikeshed warnings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -423,7 +423,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
 
 <p>
     This document is governed by the
-    <a id="w3c_process_revision" href="https://www.w3.org/2017/Process-20170301/">1 March 2017
+    <a href="https://www.w3.org/2017/Process-20170301/">1 March 2017
     <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
 
 <p>
@@ -14635,31 +14635,7 @@ The following conventions are used in the algorithms in this document:
 Everything in this specification is normative except for diagrams,
 examples, notes and sections marked as being informative.
 
-The keywords “must”,
-“must not”,
-“required”,
-“shall”,
-“shall not”,
-“should”,
-“should not”,
-“recommended”,
-“may” and
-“optional” in this document are to be
-interpreted as described in
-<cite><a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to
-Indicate Requirement Levels</a></cite>
-[[!RFC2119]].
-
-Requirements phrased in the imperative as part of algorithms (such as
-“strip any leading space characters” or “return false and abort these
-steps”) are to be interpreted with the meaning of the key word (“must”,
-“should”, “may”, etc) used in introducing the algorithm.
-
-Conformance requirements phrased as algorithms or specific steps can be
-implemented in any manner, so long as the end result is <dfn lt="processing equivalence" id="dfn-processing-equivalence">equivalent</dfn>. In
-particular, the algorithms defined in this specification are intended to
-be easy to understand and are not intended to be performant. Implementers
-are encouraged to optimize.
+This specification depends on the Infra Standard. [[!INFRA]]
 
 The following conformance classes are defined by this specification:
 


### PR DESCRIPTION
* Make builds fail on Bikeshed warnings, and display them, instead of silently proceeding.
* Remove duplicate w3c_process_revision ID to work around https://github.com/tabatkins/bikeshed/issues/1503.
* Depend on Infra explicitly to get some conformance stuff, instead of saying it again here. This removes the un-exported "processing equivalence" definition.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/807.html" title="Last updated on Sep 27, 2019, 6:22 AM UTC (bc17c83)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/807/3f89daf...bc17c83.html" title="Last updated on Sep 27, 2019, 6:22 AM UTC (bc17c83)">Diff</a>