### PR TITLE
Overload set tuple: callable definition out of sync with new constructor ops

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3378,9 +3378,9 @@ The [=set/items=] of an [=effective overload set=] are [=tuples=] of the form
 whose [=tuple/items=] are described below:
 
 *   A <dfn for="effective overload set tuple">callable</dfn> is an [=operation=]
-    if the [=effective overload set=] is for [=regular operations=] or
-    [=static operations=]; and it is either an [=operation=] or an [=extended attribute=]
-    if the [=effective overload set=] is for [=constructor operations=] and [=named constructors=].
+    if the [=effective overload set=] is for [=regular operations=],
+    [=static operations=], or [=constructor operations=]; and it is an [=extended attribute=]
+    if the [=effective overload set=] is for [=named constructors=].
 *   A <dfn>type list</dfn> is a [=list=] of IDL types.
 *   An <dfn>optionality list</dfn> is a [=list=] of
     three possible <dfn id="dfn-optionality-value" export>optionality values</dfn>

--- a/index.bs
+++ b/index.bs
@@ -3378,8 +3378,9 @@ The [=set/items=] of an [=effective overload set=] are [=tuples=] of the form
 whose [=tuple/items=] are described below:
 
 *   A <dfn for="effective overload set tuple">callable</dfn> is an [=operation=]
-    if the [=effective overload set=] is for [=regular operations=] or [=static operations=]; and
-    it is an [=extended attribute=] if the [=effective overload set=] is for constructors or [=named constructors=].
+    if the [=effective overload set=] is for [=regular operations=] or
+    [=static operations=]; and it is either an [=operation=] or an [=extended attribute=]
+    if the [=effective overload set=] is for [=constructor operations=] and [=named constructors=].
 *   A <dfn>type list</dfn> is a [=list=] of IDL types.
 *   An <dfn>optionality list</dfn> is a [=list=] of
     three possible <dfn id="dfn-optionality-value" export>optionality values</dfn>

--- a/index.bs
+++ b/index.bs
@@ -715,8 +715,7 @@ keyword token is used, then the [=identifier=] of the operation argument
 is simply that token.
 
 The [=identifier=] of any of the abovementioned
-IDL constructs (except operation arguments) must not be "<code>constructor</code>",
-"<code>toString</code>",
+IDL constructs (except operation arguments) must not be "<code>toString</code>",
 or begin with a <span class="char">U+005F LOW LINE ("_")</span> character.  These
 are known as <dfn id="dfn-reserved-identifier" export>reserved identifiers</dfn>.
 

--- a/index.bs
+++ b/index.bs
@@ -715,7 +715,8 @@ keyword token is used, then the [=identifier=] of the operation argument
 is simply that token.
 
 The [=identifier=] of any of the abovementioned
-IDL constructs (except operation arguments) must not be "<code>toString</code>",
+IDL constructs (except operation arguments) must not be "<code>constructor</code>",
+"<code>toString</code>",
 or begin with a <span class="char">U+005F LOW LINE ("_")</span> character.  These
 are known as <dfn id="dfn-reserved-identifier" export>reserved identifiers</dfn>.
 


### PR DESCRIPTION
I’m not confident that this attempted correction is quite right, but I figured one way to find out is to open a PR.

I think there might be another, unrelated issue in this definition. Later text implies that callback functions are also possible callable values, which don’t seem to be accounted for here.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Oct 9, 2019, 12:57 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbathos%2Fwebidl%2F1e39093274a67ca61e351389b774246db2a7083c%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
FATAL ERROR: Multiple local 'constructor' &lt;dfn>s for 'DOMException' have the same linking text 'DOMException(message, name)'.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20heycam/webidl%23811.)._
</details>
