### PR TITLE
docs(`callback interface`): Make `EventListener` into reference

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1446,7 +1446,7 @@ Note: See also the similarly named [=callback function=] definition.
     unless required to describe the requirements of existing APIs.
     Instead, a [=callback function=] should be used.
 
-    The definition of <code class="idl">EventListener</code> as a
+    The definition of {{EventListener}} as a
     [=callback interface=]
     is an example of an existing API that needs to allow
     objects with a
@@ -5637,7 +5637,7 @@ will not be treated as platform objects that implement <code class="idl">Node</c
 [=Callback interfaces=], on the other hand, can be implemented by any ECMAScript object. This
 allows Web APIs to invoke author-defined operations. For example, the DOM Events implementation
 allows authors to register callbacks by providing objects that implement the
-<code class="idl">EventListener</code> interface.
+{{EventListener}} interface.
 
 
 <h3 id="idl-types">Types</h3>


### PR DESCRIPTION
The&nbsp;definition of&nbsp;`callback interface` lists&nbsp;[`EventListener`](https://dom.spec.whatwg.org/#callbackdef-eventlistener) as&nbsp;what needs&nbsp;it for&nbsp;legacy&nbsp;reasons.

This&nbsp;makes it&nbsp;into a&nbsp;reference, like&nbsp;what&nbsp;other legacy&nbsp;**WebIDL**&nbsp;features do&nbsp;with&nbsp;definitions that&nbsp;need&nbsp;them.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/EB-Forks/webidl/pull/826.html" title="Last updated on Dec 12, 2019, 12:58 AM UTC (2119792)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/826/513c5ea...EB-Forks:2119792.html" title="Last updated on Dec 12, 2019, 12:58 AM UTC (2119792)">Diff</a>