### PR TITLE
Fix "this" typo in constructor operations example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2656,7 +2656,7 @@ See [[#interface-object]] for details on how a [=constructor operation=] is to b
     constructor will cause a {{TypeError}} to be thrown.
 
     <pre highlight="js">
-        var x = new Circle();      // The uses the zero-argument constructor to create a
+        var x = new Circle();      // This uses the zero-argument constructor to create a
                                    // reference to a platform object that implements the
                                    // Circle interface.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shvaikalesh/webidl/pull/830.html" title="Last updated on Dec 24, 2019, 1:48 AM UTC (f10d1e7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/830/28fadc2...shvaikalesh:f10d1e7.html" title="Last updated on Dec 24, 2019, 1:48 AM UTC (f10d1e7)">Diff</a>