### PR TITLE
Call Set with Throw=false for [PutForwards]

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11667,7 +11667,7 @@ in which case they are exposed on every object that [=implements=] the interface
                     {{ECMAScript/TypeError}}.
                 1.  Let |forwardId| be the identifier argument of the [{{PutForwards}}] extended
                     attribute.
-                1.  Perform [=?=] <a abstract-op>Set</a>(|Q|, |forwardId|, |V|, <emu-val>true</emu-val>).
+                1.  Perform [=?=] <a abstract-op>Set</a>(|Q|, |forwardId|, |V|, <emu-val>false</emu-val>).
                 1.  Return <emu-val>undefined</emu-val>.
             1.  Set |idlObject| to the IDL [=interface type=] value that represents a reference
                 to |esValue|.


### PR DESCRIPTION
This is what browsers actually implement. Tested by https://github.com/web-platform-tests/wpt/pull/21039.

----

Apparently, I didn't quite test what browsers actually do when I added _Throw_ = true in #406. This further illustrates the importance of having tests accompany each spec change.

https://github.com/web-platform-tests/wpt/pull/21039 currently actually tests the spec'd semantics. But I'll fix the PR once this gets LGTM'd.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TimothyGu/webidl/pull/832.html" title="Last updated on Jan 14, 2020, 7:49 PM UTC (bd48fcd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/832/ce149d1...TimothyGu:bd48fcd.html" title="Last updated on Jan 14, 2020, 7:49 PM UTC (bd48fcd)">Diff</a>