### PR TITLE
Align a bit with Infra

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6060,43 +6060,6 @@ of specifications using Web IDL might want to obtain a sequence of
 [=Unicode scalar values=] given a particular sequence of
 [=code units=].
 
-<div algorithm>
-
-    The following algorithm defines a way to
-    <dfn id="dfn-obtain-unicode" export lt="obtain Unicode|convert to a sequence of Unicode scalar values">convert a DOMString to a sequence of Unicode scalar values</dfn>:
-
-    1.  Let |S| be the {{DOMString}} value.
-    1.  Let |n| be the length of |S|.
-    1.  Initialize |i| to 0.
-    1.  Initialize |U| to be an empty sequence of Unicode characters.
-    1.  While |i| &lt; |n|:
-        1.  Let |c| be the [=code unit=] in |S| at index |i|.
-        1.  Depending on the value of |c|:
-            <dl class="switch">
-                 :  |c| &lt; 0xD800 or |c| &gt; 0xDFFF
-                 :: Append to |U| the Unicode character with code point |c|.
-                 :  0xDC00 ≤ |c| ≤ 0xDFFF
-                 :: Append to |U| a <span class="char">U+FFFD REPLACEMENT CHARACTER</span>.
-                 :  0xD800 ≤ |c| ≤ 0xDBFF
-                 :: <ol class="only">
-                        1.  If |i| = |n|−1, then append to |U| a <span class="char">U+FFFD REPLACEMENT CHARACTER</span>.
-                        1.  Otherwise, |i| &lt; |n|−1:
-                            1.  Let |d| be the code unit in |S| at index
-                                |i|+1.
-                            1.  If 0xDC00 ≤ |d| ≤ 0xDFFF, then:
-                                1.  Let |a| be |c| &amp; 0x3FF.
-                                1.  Let |b| be |d| &amp; 0x3FF.
-                                1.  Append to |U| the Unicode character with
-                                    code point 2<sup>16</sup>+2<sup>10</sup>|a|+|b|.
-                                1.  Set |i| to |i|+1.
-                            1.  Otherwise, |d| &lt; 0xDC00 or |d| &gt; 0xDFFF.
-                                Append to |U| a <span class="char">U+FFFD REPLACEMENT CHARACTER</span>.
-                    </ol>
-            </dl>
-        1.  Set |i| to |i|+1.
-    1.  Return |U|.
-</div>
-
 There is no way to represent a constant {{DOMString}}
 value in IDL, although {{DOMString}} [=dictionary member=] [=dictionary member/default values=]
 and [=optional argument|operation optional argument=] [=optional argument/default values=]
@@ -7674,7 +7637,7 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
     1.  Let |string| be the result of [=converted to an IDL value|converting=] |V|
         to a {{DOMString}}.
     1.  Return an IDL {{USVString}} value that is the result of
-        [=obtain Unicode|converting=] |string| to a sequence of [=Unicode scalar values=].
+        [=string/convert|converting=] |string| to a sequence of [=Unicode scalar values=].
 </div>
 
 <div id="USVString-to-es" algorithm="convert an USVString to an ECMAScript value">
@@ -14286,7 +14249,7 @@ Note: as discussed in [[#es-DOMException-specialness]], the ECMAScript binding i
 requirements beyond the normal ones for [=interface types=].
 
 Each {{DOMException}} object has an associated <dfn for="DOMException">name</dfn> and
-<dfn for="DOMException">message</dfn>, both [=JavaScript strings=].
+<dfn for="DOMException">message</dfn>, both [=strings=].
 
 The <dfn constructor for="DOMException"><code>DOMException(|message|, |name|)</code></dfn>
 constructor, when invoked, must run these steps:


### PR DESCRIPTION
This will make IDL adopt https://infra.spec.whatwg.org/#javascript-string-convert rather than have its own algorithm.

Depends on https://github.com/whatwg/infra/pull/292.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/848.html" title="Last updated on Mar 9, 2020, 12:23 PM UTC (b85f284)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/848/225a115...b85f284.html" title="Last updated on Mar 9, 2020, 12:23 PM UTC (b85f284)">Diff</a>