### PR TITLE
"creating a frozen array" as link text

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8766,7 +8766,7 @@ Array object references.
 
 <div algorithm>
 
-    To <dfn id="dfn-create-frozen-array" export>create a frozen array</dfn>
+    To <dfn id="dfn-create-frozen-array" lt="create a frozen array|creating a frozen array" export>create a frozen array</dfn>
     from a sequence of values of type |T|, follow these steps:
 
     1.  Let |array| be the result of


### PR DESCRIPTION
Allows "Let |array| be the result of [=creating a frozen array=] with…".

I guess the wrapping is wrong, but I'm not sure what the rules are in this spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jakearchibald/webidl/pull/851.html" title="Last updated on Mar 11, 2020, 11:10 AM UTC (d0edb65)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/851/6844bc4...jakearchibald:d0edb65.html" title="Last updated on Mar 11, 2020, 11:10 AM UTC (d0edb65)">Diff</a>