### PR TITLE
Only use *one* dfn type per dfn...

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9235,7 +9235,7 @@ for the specific requirements that the use of
 </div>
 
 
-<h4 oldids="PrimaryGlobal" id="Global" extended-attribute lt="Global" dfn>[Global]</h4>
+<h4 oldids="PrimaryGlobal" id="Global" extended-attribute lt="Global">[Global]</h4>
 
 If the [{{Global}}] [=extended attribute=] appears on an [=interface=],
 it indicates that objects implementing this interface can


### PR DESCRIPTION
This used to luckily work due to attribute ordering details, but on Bikeshed's py3 branch it results in Global becoming dfn-type=dfn, and all references being broken. ^_^


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: write EPROTO 140719397996416:error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version:../deps/openssl/openssl/ssl/s23_clnt.c:772:
 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 14, 2020, 6:56 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fheycam%2Fwebidl%2Fpull%2F853%2F7f3f39e.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Ftabatkins%2Fwebidl%2Fpull%2F853.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20heycam/webidl%23853.)._
</details>
