### PR TITLE
Normative: Rename numeric types to match ECMAScript typed arrays

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8455,7 +8455,7 @@ JavaScript code.
 
     <pre highlight="webidl">
         interface I {
-          Promise&lt;void> delay(unrestricted f64 ms);
+          Promise&lt;void> delay(unrestricted double ms);
         };
     </pre>
 
@@ -8482,7 +8482,7 @@ JavaScript code.
 
     <pre highlight="webidl">
         interface I {
-          Promise&lt;void> validatedDelay(unrestricted f64 ms);
+          Promise&lt;void> validatedDelay(unrestricted double ms);
         };
     </pre>
 
@@ -8508,7 +8508,7 @@ JavaScript code.
 
     <pre highlight="webidl">
         interface I {
-          Promise&lt;any> addDelay(Promise&lt;any> promise, unrestricted f64 ms);
+          Promise&lt;any> addDelay(Promise&lt;any> promise, unrestricted double ms);
         };
     </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -5892,7 +5892,7 @@ The [=type name=] of the
 For legacy compatibility, <code>byte</code> is to be treated
 as an alias for {{i8}}, similar to:
 
-<pre highlight="webidl">
+<pre no-highlight>
     typedef (i8) byte;
 </pre>
 
@@ -5912,7 +5912,7 @@ The [=type name=] of the
 For legacy compatibility, <code>octet</code> is to be treated
 as an alias for {{u8}}, similar to:
 
-<pre highlight="webidl">
+<pre no-highlight>
     typedef (u8) octet;
 </pre>
 
@@ -5932,7 +5932,7 @@ The [=type name=] of the
 For legacy compatibility, <code>short</code> is to be treated
 as an alias for {{i16}}, similar to:
 
-<pre highlight="webidl">
+<pre no-highlight>
     typedef (i16) short;
 </pre>
 
@@ -5952,7 +5952,7 @@ The [=type name=] of the
 For legacy compatibility, <code>unsigned short</code> is to be treated
 as an alias for {{u16}}, similar to:
 
-<pre highlight="webidl">
+<pre no-highlight>
     typedef (u16) unsigned short;
 </pre>
 
@@ -5972,7 +5972,7 @@ The [=type name=] of the
 For legacy compatibility, <code>long</code> is to be treated
 as an alias for {{i32}}, similar to:
 
-<pre highlight="webidl">
+<pre no-highlight>
     typedef (i32) long;
 </pre>
 
@@ -5992,7 +5992,7 @@ The [=type name=] of the
 For legacy compatibility, <code>unsigned long</code> is to be treated
 as an alias for {{u32}}, similar to:
 
-<pre highlight="webidl">
+<pre no-highlight>
     typedef (u32) unsigned long;
 </pre>
 
@@ -6012,7 +6012,7 @@ The [=type name=] of the
 For legacy compatibility, <code>long long</code> is to be treated
 as an alias for {{i64}}, similar to:
 
-<pre highlight="webidl">
+<pre no-highlight>
     typedef (i64) long long;
 </pre>
 
@@ -6032,7 +6032,7 @@ The [=type name=] of the
 For legacy compatibility, <code>unsigned long long</code> is to be treated
 as an alias for {{u64}}, similar to:
 
-<pre highlight="webidl">
+<pre no-highlight>
     typedef (u64) unsigned long long;
 </pre>
 
@@ -6061,7 +6061,7 @@ The [=type name=] of the
 For legacy compatibility, <code>float</code> is to be treated
 as an alias for {{f32}}, similar to:
 
-<pre highlight="webidl">
+<pre no-highlight>
     typedef (f32) float;
 </pre>
 
@@ -6082,7 +6082,7 @@ The [=type name=] of the
 For legacy compatibility, <code>unrestricted float</code> is to be treated
 as an alias for {{unrestricted f32}}, similar to:
 
-<pre highlight="webidl">
+<pre no-highlight>
     typedef (unrestricted f32) unrestricted float;
 </pre>
 
@@ -6103,7 +6103,7 @@ The [=type name=] of the
 For legacy compatibility, <code>double</code> is to be treated
 as an alias for {{f64}}, similar to:
 
-<pre highlight="webidl">
+<pre no-highlight>
     typedef (f64) double;
 </pre>
 
@@ -6124,7 +6124,7 @@ The [=type name=] of the
 For legacy compatibility, <code>unrestricted double</code> is to be treated
 as an alias for {{unrestricted f64}}, similar to:
 
-<pre highlight="webidl">
+<pre no-highlight>
     typedef (unrestricted f64) unrestricted double;
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -7253,7 +7253,7 @@ ECMAScript value type.
     1.  If <a abstract-op>Type</a>(|V|) is Boolean, then
         return the {{boolean}} value that represents the same truth value.
     1.  If <a abstract-op>Type</a>(|V|) is Number, then
-        return the result of <a href="#es-to-unrestricted-double">converting</a> |V|
+        return the result of <a href="#es-to-unrestricted-f64">converting</a> |V|
         to an {{unrestricted f64}}.
     1.  If <a abstract-op>Type</a>(|V|) is String, then
         return the result of <a href="#es-DOMString">converting</a> |V|

--- a/index.bs
+++ b/index.bs
@@ -451,7 +451,7 @@ commonly used on the web, ECMAScript, are consistently specified with
 low enough precision as to result in interoperability issues.  In
 addition, each specification must describe the same basic information,
 such as DOM interfaces described in IDL corresponding to properties
-on the ECMAScript global object, or the {{u32}} IDL type mapping to the Number
+on the ECMAScript global object, or the {{uint32}} IDL type mapping to the Number
 type in ECMAScript.
 
 This specification defines an IDL language similar to OMG IDL
@@ -534,9 +534,9 @@ in [[#es-extended-attributes]].
 
         [Exposed=Window]
         interface SolidColor : Paint {
-          attribute f64 red;
-          attribute f64 green;
-          attribute f64 blue;
+          attribute float64 red;
+          attribute float64 green;
+          attribute float64 blue;
         };
 
         [Exposed=Window]
@@ -547,14 +547,14 @@ in [[#es-extended-attributes]].
         [Exposed=Window]
         interface GraphicalWindow {
           constructor();
-          readonly attribute u32 width;
-          readonly attribute u32 height;
+          readonly attribute uint32 width;
+          readonly attribute uint32 height;
 
           attribute Paint currentPaint;
 
-          void drawRectangle(f64 x, f64 y, f64 width, f64 height);
+          void drawRectangle(float64 x, float64 y, float64 width, float64 height);
 
-          void drawText(f64 x, f64 y, DOMString text);
+          void drawText(float64 x, float64 y, DOMString text);
         };
     </pre>
 
@@ -769,7 +769,7 @@ across [=IDL fragments=].
         interface A {
         };
 
-        typedef sequence&lt;i32&gt; SequenceOfLongs;
+        typedef sequence&lt;int32&gt; SequenceOfLongs;
     </pre>
 </div>
 
@@ -781,7 +781,7 @@ across [=IDL fragments=].
 
     <pre highlight="webidl">
         // Typedef identifier: "number"
-        typedef f64 number;
+        typedef float64 number;
 
         // Interface identifier: "System"
         [Exposed=Window]
@@ -1306,7 +1306,7 @@ No [=extended attributes=] defined in this specification are applicable to [=inc
 
     <pre highlight="webidl">
         interface Entry {
-          readonly attribute u16 entryType;
+          readonly attribute uint16 entryType;
           // ...
         };
 
@@ -1695,11 +1695,11 @@ lie outside the valid range of values for its type, as given in
     1.  Let |result| be the Mathematical Value that would be obtained if
         |S| were parsed as an ECMAScript <emu-nt>[=NumericLiteral=]</emu-nt>.
     1.  If the <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token is being
-        used as the value for a {{f32}}, then the value of the
+        used as the value for a {{float32}}, then the value of the
         <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token
         is the IEEE 754 single-precision floating point number closest to |result|.
     1.  Otherwise, the <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token is being
-        used as the value for a {{f64}}, then the value of the
+        used as the value for a {{float64}}, then the value of the
         <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token
         is the IEEE 754 double-precision floating point number closest to |result|. [[!IEEE-754]]
 </div>
@@ -1712,17 +1712,17 @@ constant, dictionary member or optional argument is is being used as the
 value for:
 
 <dl class="switch">
-     :  Type {{f32}}, constant value <emu-t>Infinity</emu-t>
+     :  Type {{float32}}, constant value <emu-t>Infinity</emu-t>
      :: The value is the IEEE 754 single-precision positive infinity value.
-     :  Type {{f64}}, constant value <emu-t>Infinity</emu-t>
+     :  Type {{float64}}, constant value <emu-t>Infinity</emu-t>
      :: The value is the IEEE 754 double-precision positive infinity value.
-     :  Type {{f32}}, constant value <emu-t>-Infinity</emu-t>
+     :  Type {{float32}}, constant value <emu-t>-Infinity</emu-t>
      :: The value is the IEEE 754 single-precision negative infinity value.
-     :  Type {{f64}}, constant value <emu-t>-Infinity</emu-t>
+     :  Type {{float64}}, constant value <emu-t>-Infinity</emu-t>
      :: The value is the IEEE 754 double-precision negative infinity value.
-     :  Type {{f32}}, constant value <emu-t>NaN</emu-t>
+     :  Type {{float32}}, constant value <emu-t>NaN</emu-t>
      :: The value is the IEEE 754 single-precision NaN value with the bit pattern 0x7fc00000.
-     :  Type {{f64}}, constant value <emu-t>NaN</emu-t>
+     :  Type {{float64}}, constant value <emu-t>NaN</emu-t>
      :: The value is the IEEE 754 double-precision NaN value with the bit pattern 0x7ff8000000000000.
 </dl>
 
@@ -1731,7 +1731,7 @@ as the type of the constant, dictionary member or optional argument it is being 
 The value of the <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token must not
 lie outside the valid range of values for its type, as given in [[#idl-types]].
 Also, <emu-t>Infinity</emu-t>, <emu-t>-Infinity</emu-t> and <emu-t>NaN</emu-t> must not
-be used as the value of a {{f32}} or {{f64}}.
+be used as the value of a {{float32}} or {{float64}}.
 
 The value of the <emu-t>null</emu-t> token is the special
 <emu-val>null</emu-val> value that is a member of the
@@ -1761,7 +1761,7 @@ on which they appear.  It is language binding specific whether
     <pre highlight="webidl">
         [Exposed=Window]
         interface A {
-          const u16 rambaldi = 47;
+          const uint16 rambaldi = 47;
         };
     </pre>
 
@@ -1816,9 +1816,9 @@ The following extended attributes are applicable to constants:
         [Exposed=Window]
         interface Util {
           const boolean DEBUG = false;
-          const u8 LF = 10;
-          const u32 BIT_MASK = 0x0000fc00;
-          const f64 AVOGADRO = 6.022e23;
+          const uint8 LF = 10;
+          const uint32 BIT_MASK = 0x0000fc00;
+          const float64 AVOGADRO = 6.022e23;
         };
     </pre>
 </div>
@@ -2019,7 +2019,7 @@ are applicable only to regular attributes:
           readonly attribute DOMString name;
 
           // An attribute whose value can be assigned to.
-          attribute u16 age;
+          attribute uint16 age;
         };
 
         [Exposed=Window]
@@ -2165,8 +2165,8 @@ language bindings.
     <pre highlight="webidl">
         [Exposed=Window]
         interface Dimensions {
-          attribute u32 width;
-          attribute u32 height;
+          attribute uint32 width;
+          attribute uint32 height;
         };
 
         [Exposed=Window]
@@ -2177,7 +2177,7 @@ language bindings.
 
           // Overloaded operations.
           void setDimensions(Dimensions size);
-          void setDimensions(u32 width, u32 height);
+          void setDimensions(uint32 width, uint32 height);
         };
     </pre>
 </div>
@@ -2215,10 +2215,10 @@ when the <emu-t>...</emu-t> token is used in their argument lists.
     <pre highlight="webidl">
         [Exposed=Window]
         interface IntegerSet {
-          readonly attribute u32 cardinality;
+          readonly attribute uint32 cardinality;
 
-          void union(i32... ints);
-          void intersection(i32... ints);
+          void union(int32... ints);
+          void intersection(int32... ints);
         };
     </pre>
 
@@ -2359,7 +2359,7 @@ type=] that has a [=dictionary type=] in its [=flattened member types=].
     <pre highlight="webidl">
         [Exposed=Window]
         interface ColorCreator {
-          object createColor(f64 v1, f64 v2, f64 v3, optional f64 alpha);
+          object createColor(float64 v1, float64 v2, float64 v3, optional float64 alpha);
         };
     </pre>
 
@@ -2370,8 +2370,8 @@ type=] that has a [=dictionary type=] in its [=flattened member types=].
     <pre highlight="webidl">
         [Exposed=Window]
         interface ColorCreator {
-          object createColor(f64 v1, f64 v2, f64 v3);
-          object createColor(f64 v1, f64 v2, f64 v3, f64 alpha);
+          object createColor(float64 v1, float64 v2, float64 v3);
+          object createColor(float64 v1, float64 v2, float64 v3, float64 alpha);
         };
     </pre>
 </div>
@@ -2553,16 +2553,16 @@ in which case the [=default toJSON operation=] is exposed instead.
         interface Transaction {
           readonly attribute DOMString from;
           readonly attribute DOMString to;
-          readonly attribute f64 amount;
+          readonly attribute float64 amount;
           readonly attribute DOMString description;
-          readonly attribute u32 number;
+          readonly attribute uint32 number;
           TransactionJSON toJSON();
         };
 
         dictionary TransactionJSON {
           Account from;
           Account to;
-          f64 amount;
+          float64 amount;
           DOMString description;
         };
     </pre>
@@ -2631,18 +2631,18 @@ See [[#interface-object]] for details on how a [=constructor operation=] is to b
     <pre highlight="webidl">
         [Exposed=Window]
         interface NodeList {
-          Node item(u32 index);
-          readonly attribute u32 length;
+          Node item(uint32 index);
+          readonly attribute uint32 length;
         };
 
         [Exposed=Window]
         interface Circle {
           constructor();
-          constructor(f64 radius);
-          attribute f64 r;
-          attribute f64 cx;
-          attribute f64 cy;
-          readonly attribute f64 circumference;
+          constructor(float64 radius);
+          attribute float64 r;
+          attribute float64 cx;
+          attribute float64 cy;
+          readonly attribute float64 circumference;
         };
     </pre>
 
@@ -2739,10 +2739,10 @@ will not be such functionality.
     <pre highlight="webidl">
         [Exposed=Window]
         interface Dictionary {
-          readonly attribute u32 propertyCount;
+          readonly attribute uint32 propertyCount;
 
-          getter f64 (DOMString propertyName);
-          setter void (DOMString propertyName, f64 propertyValue);
+          getter float64 (DOMString propertyName);
+          setter void (DOMString propertyName, float64 propertyValue);
         };
     </pre>
 
@@ -2764,22 +2764,22 @@ simplify prose descriptions of an interface’s operations.
     <pre highlight="webidl">
         [Exposed=Window]
         interface Dictionary {
-          readonly attribute u32 propertyCount;
+          readonly attribute uint32 propertyCount;
 
-          getter f64 getProperty(DOMString propertyName);
-          setter void setProperty(DOMString propertyName, f64 propertyValue);
+          getter float64 getProperty(DOMString propertyName);
+          setter void setProperty(DOMString propertyName, float64 propertyValue);
         };
     </pre>
     <pre highlight="webidl">
         [Exposed=Window]
         interface Dictionary {
-          readonly attribute u32 propertyCount;
+          readonly attribute uint32 propertyCount;
 
-          f64 getProperty(DOMString propertyName);
-          void setProperty(DOMString propertyName, f64 propertyValue);
+          float64 getProperty(DOMString propertyName);
+          void setProperty(DOMString propertyName, float64 propertyValue);
 
-          getter f64 (DOMString propertyName);
-          setter void (DOMString propertyName, f64 propertyValue);
+          getter float64 (DOMString propertyName);
+          setter void (DOMString propertyName, float64 propertyValue);
         };
     </pre>
 </div>
@@ -2792,7 +2792,7 @@ take a {{DOMString}} as a property name,
 known as
 <dfn id="dfn-named-property-getter" export lt="named property getter">named property getters</dfn> and
 <dfn id="dfn-named-property-setter" export lt="named property setter">named property setters</dfn>,
-and ones that take an {{u32}}
+and ones that take an {{uint32}}
 as a property index, known as
 <dfn id="dfn-indexed-property-getter" export lt="indexed property getter">indexed property getters</dfn> and
 <dfn id="dfn-indexed-property-setter" export lt="indexed property setter">indexed property setters</dfn>.
@@ -2915,7 +2915,7 @@ a [=static attribute=].
         [Exposed=Window]
         interface Student {
           constructor();
-          attribute u32 id;
+          attribute uint32 id;
           stringifier attribute DOMString name;
         };
     </pre>
@@ -2941,7 +2941,7 @@ a [=static attribute=].
         [Exposed=Window]
         interface Student {
           constructor();
-          attribute u32 id;
+          attribute uint32 id;
           attribute DOMString? familyName;
           attribute DOMString givenName;
 
@@ -2998,17 +2998,17 @@ Interfaces that [=support indexed properties=] must define
 an [=integer types|integer-typed=] [=attribute=] named "<code>length</code>".
 
 Indexed property getters must
-be declared to take a single {{u32}} argument.
+be declared to take a single {{uint32}} argument.
 Indexed property setters must
-be declared to take two arguments, where the first is an {{u32}}.
+be declared to take two arguments, where the first is an {{uint32}}.
 
 <pre highlight="webidl" class="syntax">
     interface interface_identifier {
-      getter type identifier(u32 identifier);
-      setter type identifier(u32 identifier, type identifier);
+      getter type identifier(uint32 identifier);
+      setter type identifier(uint32 identifier, type identifier);
 
-      getter type (u32 identifier);
-      setter type (u32 identifier, type identifier);
+      getter type (uint32 identifier);
+      setter type (uint32 identifier, type identifier);
     };
 </pre>
 
@@ -3046,7 +3046,7 @@ The following requirements apply to the definitions of indexed property getters 
     <pre highlight="webidl">
         [Exposed=Window]
         interface A {
-          getter DOMString toWord(u32 index);
+          getter DOMString toWord(uint32 index);
         };
     </pre>
 
@@ -3076,10 +3076,10 @@ The following requirements apply to the definitions of indexed property getters 
     <pre highlight="webidl">
         [Exposed=Window]
         interface OrderedMap {
-          readonly attribute u32 size;
+          readonly attribute uint32 size;
 
-          getter any getByIndex(u32 index);
-          setter void setByIndex(u32 index, any value);
+          getter any getByIndex(uint32 index);
+          setter void setByIndex(uint32 index, any value);
 
           getter any get(DOMString name);
           setter void set(DOMString name, any value);
@@ -3260,11 +3260,11 @@ to an instance of the interface.
 
         [Exposed=Window]
         interface Circle {
-          attribute f64 cx;
-          attribute f64 cy;
-          attribute f64 radius;
+          attribute float64 cx;
+          attribute float64 cy;
+          attribute float64 radius;
 
-          static readonly attribute i32 triangulationCount;
+          static readonly attribute int32 triangulationCount;
           static Point triangulate(Circle c1, Circle c2, Circle c3);
         };
     </pre>
@@ -3332,7 +3332,7 @@ definitions.
         };
 
         partial interface A {
-          void f(f64 x);
+          void f(float64 x);
           void g();
         };
 
@@ -3436,7 +3436,7 @@ the same operation or constructor.
         For [=variadic=] operations and constructor extended attributes,
         the argument on which the ellipsis appears counts as a single argument.
 
-        Note: So <code>void f(i32 x, i32... y);</code> is considered to be declared to take two arguments.
+        Note: So <code>void f(int32 x, int32... y);</code> is considered to be declared to take two arguments.
     1.  Let |max| be <a abstract-op>max</a>(|maxarg|, |N|).
     1.  [=set/For each=] operation or extended attribute |X| in |F|:
         1.  Let |arguments| be the [=list=] of arguments |X| is declared to take.
@@ -3486,9 +3486,9 @@ the same operation or constructor.
         [Exposed=Window]
         interface A {
           /* f1 */ void f(DOMString a);
-          /* f2 */ void f(Node a, DOMString b, f64... c);
+          /* f2 */ void f(Node a, DOMString b, float64... c);
           /* f3 */ void f();
-          /* f4 */ void f(Event a, DOMString b, optional DOMString c, f64... d);
+          /* f4 */ void f(Event a, DOMString b, optional DOMString c, float64... d);
         };
     </pre>
 
@@ -3502,12 +3502,12 @@ the same operation or constructor.
       «
         (f1, « DOMString »,                           « required »),
         (f2, « Node, DOMString »,                     « required, required »),
-        (f2, « Node, DOMString, f64 »,             « required, required, variadic »),
-        (f2, « Node, DOMString, f64, f64 »,     « required, required, variadic, variadic »),
+        (f2, « Node, DOMString, float64 »,             « required, required, variadic »),
+        (f2, « Node, DOMString, float64, float64 »,     « required, required, variadic, variadic »),
         (f3, « »,                                     « »),
         (f4, « Event, DOMString »,                    « required, required »),
         (f4, « Event, DOMString, DOMString »,         « required, required, optional »),
-        (f4, « Event, DOMString, DOMString, f64 », « required, required, optional, variadic »)
+        (f4, « Event, DOMString, DOMString, float64 », « required, required, optional, variadic »)
       »
     </pre>
 </div>
@@ -3527,27 +3527,27 @@ the following algorithm returns <i>true</i>.
         None of the following pairs are distinguishable:
         <ul>
             <li>
-                <code>{{f64}}?</code> and
+                <code>{{float64}}?</code> and
                 <code>Dictionary1</code>
             </li>
             <li>
-                <code>(Interface1 or {{i32}})?</code> and
+                <code>(Interface1 or {{int32}})?</code> and
                 <code>(Interface2 or {{DOMString}})?</code>
             </li>
             <li>
-                <code>(Interface1 or {{i32}}?)</code> and
+                <code>(Interface1 or {{int32}}?)</code> and
                 <code>(Interface2 or {{DOMString}})?</code>
             </li>
             <li>
-                <code>(Interface1 or {{i32}}?)</code> and
+                <code>(Interface1 or {{int32}}?)</code> and
                 <code>(Interface2 or {{DOMString}}?)</code>
             </li>
             <li>
-                <code>(Dictionary1 or {{i32}})</code> and
+                <code>(Dictionary1 or {{int32}})</code> and
                 <code>(Interface2 or {{DOMString}})?</code>
             </li>
             <li>
-                <code>(Dictionary1 or {{i32}})</code> and
+                <code>(Dictionary1 or {{int32}})</code> and
                 <code>(Interface2 or {{DOMString}}?)</code>
             </li>
         </ul>
@@ -3734,12 +3734,12 @@ the following algorithm returns <i>true</i>.
     </ol>
 
     <div class="example" id="example-distinguishability-diff-types">
-        {{f64}} and {{DOMString}} are distinguishable because
+        {{float64}} and {{DOMString}} are distinguishable because
         there is a ● at the intersection of [=numeric types=] with [=string types=].
     </div>
 
     <div class="example" id="example-distinguishability-same-category">
-        {{f64}} and {{i32}} are not distinguishable because they are both [=numeric types=],
+        {{float64}} and {{int32}} are not distinguishable because they are both [=numeric types=],
         and there is no ● or letter at the intersection of [=numeric types=] with [=numeric types=].
     </div>
 
@@ -3817,8 +3817,8 @@ be the same.
         [Exposed=Window]
         interface B {
           /* f1 */ void f(DOMString w);
-          /* f2 */ void f(i32 w, f64 x, Node y, Node z);
-          /* f3 */ void f(f64 w, f64 x, DOMString y, Node z);
+          /* f2 */ void f(int32 w, float64 x, Node y, Node z);
+          /* f3 */ void f(float64 w, float64 x, DOMString y, Node z);
         };
     </pre>
 
@@ -3827,8 +3827,8 @@ be the same.
     <pre class="set">
       «
         (f1, « DOMString »,                       « required »),
-        (f2, « i32, f64, Node, Node »,        « required, required, required, required »),
-        (f3, « f64, f64, DOMString, Node », « required, required, required, required »)
+        (f2, « int32, float64, Node, Node »,        « required, required, required, required »),
+        (f3, « float64, float64, DOMString, Node », « required, required, required, required »)
       »
     </pre>
 
@@ -3900,14 +3900,14 @@ determine what Web IDL language feature to use:
     class="note">This is almost never appropriate API design, and separate operations with distinct
     names usually are a better choice for such cases.</span>
 
-    Suppose there is an operation <code class="idl">calculate()</code> that accepts a {{i32}},
+    Suppose there is an operation <code class="idl">calculate()</code> that accepts a {{int32}},
     {{DOMString}}, or <code class="idl">CalculatableInterface</code> (an [=interface type=]) as its
     only argument, and returns a value of the same type as its argument. It would be clearer to
     write the IDL fragment using [=overloaded=] operations as
 
     <pre highlight="webidl">
         interface A {
-          i32 calculate(i32 input);
+          int32 calculate(int32 input);
           DOMString calculate(DOMString input);
           CalculatableInterface calculate(CalculatableInterface input);
         };
@@ -3916,7 +3916,7 @@ determine what Web IDL language feature to use:
     than using a [=union type=] with a [=typedef=] as
 
     <pre highlight="webidl">
-        typedef (i32 or DOMString or CalculatableInterface) Calculatable;
+        typedef (int32 or DOMString or CalculatableInterface) Calculatable;
         interface A {
           Calculatable calculate(Calculatable input);
         };
@@ -3936,7 +3936,7 @@ determine what Web IDL language feature to use:
 
     <pre highlight="webidl">
         interface A {
-          i32 calculateNumber(i32 input);
+          int32 calculateNumber(int32 input);
           DOMString calculateString(DOMString input);
           CalculatableInterface calculateCalculatableInterface(CalculatableInterface input);
         };
@@ -4019,7 +4019,7 @@ determine what Web IDL language feature to use:
     different arguments, [=union types=] can sometimes be the only viable solution.
 
     <pre highlight="webidl">
-        typedef (i64 or DOMString or CalculatableInterface) SupportedArgument;
+        typedef (int64 or DOMString or CalculatableInterface) SupportedArgument;
         interface A {
           void add(SupportedArgument operand1, SupportedArgument operand2);
         };
@@ -4030,13 +4030,13 @@ determine what Web IDL language feature to use:
 
     <pre highlight="webidl">
         interface A {
-          void add(i64 operand1, i64 operand2);
-          void add(i64 operand1, DOMString operand2);
-          void add(i64 operand1, CalculatableInterface operand2);
-          void add(DOMString operand1, i64 operand2);
+          void add(int64 operand1, int64 operand2);
+          void add(int64 operand1, DOMString operand2);
+          void add(int64 operand1, CalculatableInterface operand2);
+          void add(DOMString operand1, int64 operand2);
           void add(DOMString operand1, DOMString operand2);
           void add(DOMString operand1, CalculatableInterface operand2);
-          void add(CalculatableInterface operand1, i64 operand2);
+          void add(CalculatableInterface operand1, int64 operand2);
           void add(CalculatableInterface operand1, DOMString operand2);
           void add(CalculatableInterface operand1, CalculatableInterface operand2);
         };
@@ -4707,7 +4707,7 @@ Of the extended attributes defined in this specification, only the [{{Exposed}}]
     <pre highlight="webidl">
         namespace VectorUtils {
           readonly attribute Vector unit;
-          f64 dotProduct(Vector x, Vector y);
+          float64 dotProduct(Vector x, Vector y);
           Vector crossProduct(Vector x, Vector y);
         };
     </pre>
@@ -4800,7 +4800,7 @@ dictionary members.
     <pre highlight="webidl">
     dictionary Descriptor {
       DOMString name;
-      sequence&lt;u32> serviceIdentifiers;
+      sequence&lt;uint32> serviceIdentifiers;
     };
     </pre>
 
@@ -4938,23 +4938,23 @@ identifiers.
 
     <pre highlight="webidl">
         dictionary B : A {
-          i32 b;
-          i32 a;
+          int32 b;
+          int32 a;
         };
 
         dictionary A {
-          i32 c;
-          i32 g;
+          int32 c;
+          int32 g;
         };
 
         dictionary C : B {
-          i32 e;
-          i32 f;
+          int32 e;
+          int32 f;
         };
 
         partial dictionary A {
-          i32 h;
-          i32 d;
+          int32 h;
+          int32 d;
         };
     </pre>
 
@@ -5057,8 +5057,8 @@ No [=extended attributes=] are applicable to dictionaries.
         [Exposed=Window]
         interface Point {
           constructor();
-          attribute f64 x;
-          attribute f64 y;
+          attribute float64 x;
+          attribute float64 y;
         };
 
         dictionary PaintOptions {
@@ -5069,7 +5069,7 @@ No [=extended attributes=] are applicable to dictionaries.
 
         [Exposed=Window]
         interface GraphicsContext {
-          void drawRectangle(f64 width, f64 height, optional PaintOptions options);
+          void drawRectangle(float64 width, float64 height, optional PaintOptions options);
         };
     </pre>
 
@@ -5460,9 +5460,9 @@ defined in this specification are applicable to [=enumerations=].
         [Exposed=Window]
         interface Meal {
           attribute MealType type;
-          attribute f64 size;     // in grams
+          attribute float64 size;     // in grams
 
-          void initialize(MealType type, f64 size);
+          void initialize(MealType type, float64 size);
         };
     </pre>
 
@@ -5582,14 +5582,14 @@ defined in this specification are applicable to [=typedefs=].
     The following [=IDL fragment=]
     demonstrates the use of [=typedefs=]
     to allow the use of a short
-    [=identifier=] instead of a i32
+    [=identifier=] instead of a int32
     [=sequence type=].
 
     <pre highlight="webidl">
         [Exposed=Window]
         interface Point {
-          attribute f64 x;
-          attribute f64 y;
+          attribute float64 x;
+          attribute float64 y;
         };
 
         typedef sequence&lt;Point&gt; Points;
@@ -5647,18 +5647,18 @@ corresponding to each type, and how [=constants=]
 of that type are represented.
 
 The following types are known as <dfn id="dfn-integer-type" export>integer types</dfn>:
-{{i8}},
-{{u8}},
-{{i16}},
-{{u16}},
-{{i32}},
-{{u32}},
-{{i64}} and
-{{u64}}.
+{{int8}},
+{{uint8}},
+{{int16}},
+{{uint16}},
+{{int32}},
+{{uint32}},
+{{int64}} and
+{{uint64}}.
 
 The following types are known as <dfn id="dfn-decimal-type" export>decimal types</dfn>:
-{{f32}} and
-{{f64}}.
+{{float32}} and
+{{float64}}.
 
 The following types are known as <dfn id="dfn-numeric-type" export>numeric types</dfn>:
 the [=integer types=], and
@@ -5769,22 +5769,22 @@ type.
         "boolean"
         "byte"
         "octet"
-        "u8"
-        "u16"
-        "u32"
-        "u64"
-        "i8"
-        "i16"
-        "i32"
-        "i64"
+        "uint8"
+        "uint16"
+        "uint32"
+        "uint64"
+        "int8"
+        "int16"
+        "int32"
+        "int64"
 </pre>
 
 <pre class="grammar" oldids="prod-UnrestrictedFloatType" id="prod-FloatType">
     FloatType :
         "float"
         "double"
-        "f32"
-        "f64"
+        "float32"
+        "float64"
 </pre>
 
 <pre class="grammar" id="prod-UnsignedIntegerType">
@@ -5839,8 +5839,8 @@ a discriminated union type, in that each of its values has a
 specific non-{{any}} type
 associated with it.  For example, one value of the
 {{any}} type is the
-{{u32}}
-150, while another is the {{i32}} 150.
+{{uint32}}
+150, while another is the {{int32}} 150.
 These are distinct values.
 
 The particular type of an {{any}}
@@ -5871,219 +5871,219 @@ The [=type name=] of the
 {{boolean}} type is "<code>Boolean</code>".
 
 
-<h4 oldids="dom-byte idl-byte" id="idl-i8" interface>i8</h4>
+<h4 oldids="dom-byte idl-byte" id="idl-int8" interface>int8</h4>
 
-The {{i8}} type is a signed integer
+The {{int8}} type is a signed integer
 type that has values in the range [−128, 127].
 
-{{i8}} constant values in IDL are
+{{int8}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{i8}} type is "<code>Byte</code>".
+{{int8}} type is "<code>Byte</code>".
 
 For legacy compatibility, <code>byte</code> is to be treated
-as an alias for {{i8}}, similar to:
+as an alias for {{int8}}, similar to:
 
 <pre no-highlight>
-    typedef (i8) byte;
+    typedef (int8) byte;
 </pre>
 
 
-<h4 oldids="dom-octet idl-octet" id="idl-u8" interface>u8</h4>
+<h4 oldids="dom-octet idl-octet" id="idl-uint8" interface>uint8</h4>
 
-The {{u8}} type is an unsigned integer
+The {{uint8}} type is an unsigned integer
 type that has values in the range [0, 255].
 
-{{u8}} constant values in IDL are
+{{uint8}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{u8}} type is "<code>Octet</code>".
+{{uint8}} type is "<code>Octet</code>".
 
 For legacy compatibility, <code>octet</code> is to be treated
-as an alias for {{u8}}, similar to:
+as an alias for {{uint8}}, similar to:
 
 <pre no-highlight>
-    typedef (u8) octet;
+    typedef (uint8) octet;
 </pre>
 
 
-<h4 oldids="dom-short idl-short" id="idl-i16" interface>i16</h4>
+<h4 oldids="dom-short idl-short" id="idl-int16" interface>int16</h4>
 
-The {{i16}} type is a signed integer
+The {{int16}} type is a signed integer
 type that has values in the range [−32768, 32767].
 
-{{i16}} constant values in IDL are
+{{int16}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{i16}} type is "<code>Short</code>".
+{{int16}} type is "<code>Short</code>".
 
 For legacy compatibility, <code>short</code> is to be treated
-as an alias for {{i16}}, similar to:
+as an alias for {{int16}}, similar to:
 
 <pre no-highlight>
-    typedef (i16) short;
+    typedef (int16) short;
 </pre>
 
 
-<h4 oldids="dom-unsignedshort idl-unsigned-short" id="idl-u16" interface>u16</h4>
+<h4 oldids="dom-unsignedshort idl-unsigned-short" id="idl-uint16" interface>uint16</h4>
 
-The {{u16}} type is an unsigned integer
+The {{uint16}} type is an unsigned integer
 type that has values in the range [0, 65535].
 
-{{u16}} constant values in IDL are
+{{uint16}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{u16}} type is "<code>UnsignedShort</code>".
+{{uint16}} type is "<code>UnsignedShort</code>".
 
 For legacy compatibility, <code>unsigned short</code> is to be treated
-as an alias for {{u16}}, similar to:
+as an alias for {{uint16}}, similar to:
 
 <pre no-highlight>
-    typedef (u16) unsigned short;
+    typedef (uint16) unsigned short;
 </pre>
 
 
-<h4 oldids="dom-long idl-long" id="idl-i32" interface>i32</h4>
+<h4 oldids="dom-long idl-long" id="idl-int32" interface>int32</h4>
 
-The {{i32}} type is a signed integer
+The {{int32}} type is a signed integer
 type that has values in the range [−2147483648, 2147483647].
 
-{{i32}} constant values in IDL are
+{{int32}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{i32}} type is "<code>Long</code>".
+{{int32}} type is "<code>Long</code>".
 
 For legacy compatibility, <code>long</code> is to be treated
-as an alias for {{i32}}, similar to:
+as an alias for {{int32}}, similar to:
 
 <pre no-highlight>
-    typedef (i32) long;
+    typedef (int32) long;
 </pre>
 
 
-<h4 oldids="dom-unsignedlong idl-unsigned-long" id="idl-u32" interface>u32</h4>
+<h4 oldids="dom-unsignedlong idl-unsigned-long" id="idl-uint32" interface>uint32</h4>
 
-The {{u32}} type is an unsigned integer
+The {{uint32}} type is an unsigned integer
 type that has values in the range [0, 4294967295].
 
-{{u32}} constant values in IDL are
+{{uint32}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{u32}} type is "<code>UnsignedLong</code>".
+{{uint32}} type is "<code>UnsignedLong</code>".
 
 For legacy compatibility, <code>unsigned long</code> is to be treated
-as an alias for {{u32}}, similar to:
+as an alias for {{uint32}}, similar to:
 
 <pre no-highlight>
-    typedef (u32) unsigned long;
+    typedef (uint32) unsigned long;
 </pre>
 
 
-<h4 oldids="dom-longlong idl-long-long" id="idl-i64" interface>i64</h4>
+<h4 oldids="dom-longlong idl-long-long" id="idl-int64" interface>int64</h4>
 
-The {{i64}} type is a signed integer
+The {{int64}} type is a signed integer
 type that has values in the range [−9223372036854775808, 9223372036854775807].
 
-{{i64}} constant values in IDL are
+{{int64}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{i64}} type is "<code>LongLong</code>".
+{{int64}} type is "<code>LongLong</code>".
 
 For legacy compatibility, <code>long long</code> is to be treated
-as an alias for {{i64}}, similar to:
+as an alias for {{int64}}, similar to:
 
 <pre no-highlight>
-    typedef (i64) long long;
+    typedef (int64) long long;
 </pre>
 
 
-<h4 oldids="dom-unsignedlonglong idl-unsigned-long-long" id="idl-u64" interface>u64</h4>
+<h4 oldids="dom-unsignedlonglong idl-unsigned-long-long" id="idl-uint64" interface>uint64</h4>
 
-The {{u64}} type is an unsigned integer
+The {{uint64}} type is an unsigned integer
 type that has values in the range [0, 18446744073709551615].
 
-{{u64}} constant values in IDL are
+{{uint64}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{u64}} type is "<code>UnsignedLongLong</code>".
+{{uint64}} type is "<code>UnsignedLongLong</code>".
 
 For legacy compatibility, <code>unsigned long long</code> is to be treated
-as an alias for {{u64}}, similar to:
+as an alias for {{uint64}}, similar to:
 
 <pre no-highlight>
-    typedef (u64) unsigned long long;
+    typedef (uint64) unsigned long long;
 </pre>
 
 
-<h4 oldids="dom-float idl-float" id="idl-f32" interface>f32</h4>
+<h4 oldids="dom-float idl-float" id="idl-float32" interface>float32</h4>
 
-The {{f32}} type is a floating point numeric
+The {{float32}} type is a floating point numeric
 type that corresponds to the set of finite single-precision 32 bit
 IEEE 754 floating point numbers. [[!IEEE-754]]
 
-When defined with the [{{UnrestrictedFloat}}] [=extended attribute=], the {{f32}} type
+When defined with the [{{UnrestrictedFloat}}] [=extended attribute=], the {{float32}} type
 additionally corresponds to IEEE 754 non-finite, and special "not a number" values (NaNs). [[!IEEE-754]]
 
-{{f32}} constant values in IDL are
+{{float32}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{f32}} type is "<code>Float</code>".
+{{float32}} type is "<code>Float</code>".
 
 <p class="advisement">
     Unless there are specific reasons to use a 32 bit floating point type,
     specifications should use
-    {{f64}} rather than {{f32}},
-    since the set of values that a {{f64}} can
+    {{float64}} rather than {{float32}},
+    since the set of values that a {{float64}} can
     represent more closely matches an ECMAScript Number.
 </p>
 
 For legacy compatibility, <code>float</code> is to be treated
-as an alias for {{f32}}, similar to:
+as an alias for {{float32}}, similar to:
 
 <pre no-highlight>
-    typedef (f32) float;
+    typedef (float32) float;
 </pre>
 
 
-<h4 oldids="dom-double idl-double" id="idl-f64" interface>f64</h4>
+<h4 oldids="dom-double idl-double" id="idl-float64" interface>float64</h4>
 
-The {{f64}} type is a floating point numeric
+The {{float64}} type is a floating point numeric
 type that corresponds to the set of finite double-precision 64 bit
 IEEE 754 floating point numbers. [[!IEEE-754]]
 
-When defined with the [{{UnrestrictedFloat}}] [=extended attribute=], the {{f64}} type
+When defined with the [{{UnrestrictedFloat}}] [=extended attribute=], the {{float64}} type
 additionally corresponds to IEEE 754 non-finite, and special "not a number" values (NaNs). [[!IEEE-754]]
 
-{{f64}} constant values in IDL are
+{{float64}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{f64}} type is "<code>Double</code>".
+{{float64}} type is "<code>Double</code>".
 
 For legacy compatibility, <code>double</code> is to be treated
-as an alias for {{f64}}, similar to:
+as an alias for {{float64}}, similar to:
 
 <pre no-highlight>
-    typedef (f64) double;
+    typedef (float64) double;
 </pre>
 
 
@@ -6094,7 +6094,7 @@ the set of all possible sequences of [=code units=].
 Such sequences are commonly interpreted as UTF-16 encoded strings [[!RFC2781]]
 although this is not required.
 While {{DOMString}} is defined to be
-an OMG IDL boxed [=sequence type|sequence=]&lt;{{u16}}&gt; valuetype
+an OMG IDL boxed [=sequence type|sequence=]&lt;{{uint16}}&gt; valuetype
 in [[DOM-LEVEL-3-CORE/core#ID-C74D1578|DOM Level 3 Core §The DOMString Type]],
 this document defines {{DOMString}} to be an intrinsic type
 so as to avoid special casing that sequence type
@@ -6147,7 +6147,7 @@ The [=type name=] of the
     {{DOMString}} values, even if it is expected
     that values of the string will always be in ASCII or some
     8 bit character encoding. [=sequence types|Sequences=] or
-    [=frozen array type|frozen arrays=] with {{u8}} or {{i8}}
+    [=frozen array type|frozen arrays=] with {{uint8}} or {{int8}}
     elements, {{Uint8Array}}, or {{Int8Array}} should be used for holding
     8 bit data rather than {{ByteString}}.
 </p>
@@ -6463,7 +6463,7 @@ union’s <dfn id="dfn-union-member-type" for="union" export>member types</dfn>.
 <div class="note">
 
     For example, you might write <code>(Node or DOMString)</code>
-    or <code>(f64 or sequence&lt;f64&gt;)</code>.  When applying a
+    or <code>(float64 or sequence&lt;float64&gt;)</code>.  When applying a
     <emu-t>?</emu-t> suffix to a
     [=union type=]
     as a whole, it is placed after the closing parenthesis,
@@ -6471,8 +6471,8 @@ union’s <dfn id="dfn-union-member-type" for="union" export>member types</dfn>.
 
     Note that the [=member types=]
     of a union type do not descend into nested union types.  So for
-    <code>(f64 or (sequence&lt;i32&gt; or Event) or (Node or DOMString)?)</code> the member types
-    are <code>f64</code>, <code>(sequence&lt;i32&gt; or Event)</code> and
+    <code>(float64 or (sequence&lt;int32&gt; or Event) or (Node or DOMString)?)</code> the member types
+    are <code>float64</code>, <code>(sequence&lt;int32&gt; or Event)</code> and
     <code>(Node or DOMString)?</code>.
 
 </div>
@@ -6506,10 +6506,10 @@ that matches the value.
 
 Note: For example, the [=flattened member types=]
 of the [=union type=]
-<code>(Node or (sequence&lt;i32&gt; or Event) or (XMLHttpRequest or DOMString)? or sequence&lt;(sequence&lt;f64&gt; or NodeList)&gt;)</code>
-are the six types <code>Node</code>, <code>sequence&lt;i32&gt;</code>, <code>Event</code>,
+<code>(Node or (sequence&lt;int32&gt; or Event) or (XMLHttpRequest or DOMString)? or sequence&lt;(sequence&lt;float64&gt; or NodeList)&gt;)</code>
+are the six types <code>Node</code>, <code>sequence&lt;int32&gt;</code>, <code>Event</code>,
 <code>XMLHttpRequest</code>, <code>DOMString</code> and
-<code>sequence&lt;(sequence&lt;f64&gt; or NodeList)&gt;</code>.
+<code>sequence&lt;(sequence&lt;float64&gt; or NodeList)&gt;</code>.
 
 <div algorithm>
 
@@ -6573,8 +6573,8 @@ the existing types. Such types are called <dfn export>annotated types</dfn>, and
 annotate are called <dfn export for="annotated types" lt="inner type">inner types</dfn>.
 
 <div class="example">
-    <code>[Clamp] i32</code> defines a new [=annotated type=], whose behavior is based on that of
-    the [=annotated types/inner type=] {{i32}}, but modified as specified by the [{{Clamp}}]
+    <code>[Clamp] int32</code> defines a new [=annotated type=], whose behavior is based on that of
+    the [=annotated types/inner type=] {{int32}}, but modified as specified by the [{{Clamp}}]
     extended attribute.
 </div>
 
@@ -6600,15 +6600,15 @@ The following extended attributes are <dfn for="extended attributes">applicable 
             <pre class="idl">
                 [Exposed=Window]
                 interface I {
-                    attribute [XAttr] i32 attrib;
-                    void f1(sequence<[XAttr] i32> arg);
-                    void f2(optional [XAttr] i32 arg);
+                    attribute [XAttr] int32 attrib;
+                    void f1(sequence<[XAttr] int32> arg);
+                    void f2(optional [XAttr] int32 arg);
 
-                    maplike&lt;[XAttr2] DOMString, [XAttr3] i32>;
+                    maplike&lt;[XAttr2] DOMString, [XAttr3] int32>;
                 };
 
                 dictionary D {
-                    required [XAttr] i32 member;
+                    required [XAttr] int32 member;
                 };
             </pre>
         </div>
@@ -6619,7 +6619,7 @@ The following extended attributes are <dfn for="extended attributes">applicable 
             <pre class="idl">
                 [Exposed=Window]
                 interface I {
-                    attribute [XAttr] (i32 or Node) attrib;
+                    attribute [XAttr] (int32 or Node) attrib;
                 };
             </pre>
         </div>
@@ -6634,7 +6634,7 @@ The following extended attributes are <dfn for="extended attributes">applicable 
             <pre class="idl">
                 [Exposed=Window]
                 interface I {
-                    void f([XAttr] i32 attrib);
+                    void f([XAttr] int32 attrib);
                 };
             </pre>
 
@@ -6652,7 +6652,7 @@ The following extended attributes are <dfn for="extended attributes">applicable 
         <div class="example">
             <pre class="idl">
                 dictionary D {
-                    [XAttr] i32 member;
+                    [XAttr] int32 member;
                 };
             </pre>
 
@@ -6665,7 +6665,7 @@ The following extended attributes are <dfn for="extended attributes">applicable 
 
         <div class="example">
             <pre class="idl">
-                typedef [XAttr] i32 xlong;
+                typedef [XAttr] int32 xlong;
             </pre>
         </div>
     1. Return |extended attributes|.
@@ -6679,7 +6679,7 @@ type name of the original type with the set of strings corresponding to the [=id
 [=extended attribute associated with=] the type, sorted in lexicographic order.
 
 <div class="example">
-    The [=type name=] for a type of the form <code>[B, A] i32?</code> is "LongOrNullAB".
+    The [=type name=] for a type of the form <code>[B, A] int32?</code> is "LongOrNullAB".
 </div>
 
 <h4 id="idl-buffer-source-types">Buffer source types</h4>
@@ -6848,7 +6848,7 @@ which form (or forms) it is in:
             <dfn id="dfn-xattr-argument-list" for="extended attribute" export>takes an argument list</dfn>
         </td>
         <td>
-            Not currently used; previously used by <code>[Constructor(f64 x, f64 y)]</code>
+            Not currently used; previously used by <code>[Constructor(float64 x, float64 y)]</code>
         </td>
     </tr>
     <tr>
@@ -6971,14 +6971,14 @@ five forms are allowed.
         "true"
         "unsigned"
         "void"
-        "i8"
-        "i16"
-        "i32"
-        "i64"
-        "u8"
-        "u16"
-        "u32"
-        "u64"
+        "int8"
+        "int16"
+        "int32"
+        "int64"
+        "uint8"
+        "uint16"
+        "uint32"
+        "uint64"
         ArgumentNameKeyword
         BufferRelatedType
 </pre>
@@ -7212,8 +7212,8 @@ ECMAScript value type.
     1.  If <a abstract-op>Type</a>(|V|) is Boolean, then
         return the {{boolean}} value that represents the same truth value.
     1.  If <a abstract-op>Type</a>(|V|) is Number, then
-        return the result of <a href="#es-to-f64">converting</a> |V|
-        to an {{f64}} [=extended attribute associated with|associated with=]
+        return the result of <a href="#es-to-float64">converting</a> |V|
+        to an {{float64}} [=extended attribute associated with|associated with=]
         the [{{UnrestrictedFloat}}] [=extended attribute=].
     1.  If <a abstract-op>Type</a>(|V|) is String, then
         return the result of <a href="#es-DOMString">converting</a> |V|
@@ -7283,179 +7283,179 @@ In effect, where <var ignore>x</var> is a Number value,
 “operating on <var ignore>x</var>” is shorthand for
 “operating on the mathematical real number that represents the same numeric value as <var ignore>x</var>”.
 
-<h5 oldids="es-byte" id="es-i8">i8</h5>
+<h5 oldids="es-byte" id="es-int8">int8</h5>
 
-<div oldids="es-to-byte" id="es-to-i8" algorithm="convert an ECMAScript value to i8">
+<div oldids="es-to-byte" id="es-to-int8" algorithm="convert an ECMAScript value to int8">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{i8}} value by running the following algorithm:
+    to an IDL {{int8}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 8, "<code>signed</code>").
-    1.  Return the IDL {{i8}} value that represents the same numeric value as |x|.
+    1.  Return the IDL {{int8}} value that represents the same numeric value as |x|.
 </div>
 
-<p oldids="byte-to-es" id="i8-to-es">
+<p oldids="byte-to-es" id="int8-to-es">
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{i8}} value to an ECMAScript
+    an IDL {{int8}} value to an ECMAScript
     value is a Number that represents
-    the same numeric value as the IDL {{i8}} value.
+    the same numeric value as the IDL {{int8}} value.
     The Number value will be an integer in the range [−128, 127].
 </p>
 
 
-<h5 oldids="es-octet" id="es-u8">u8</h5>
+<h5 oldids="es-octet" id="es-uint8">uint8</h5>
 
-<div oldids="es-to-octet" id="es-to-u8" algorithm="convert an ECMAScript value to u8">
+<div oldids="es-to-octet" id="es-to-uint8" algorithm="convert an ECMAScript value to uint8">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{u8}} value by running the following algorithm:
+    to an IDL {{uint8}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 8, "<code>unsigned</code>").
-    1.  Return the IDL {{u8}} value that represents the same numeric value as |x|.
+    1.  Return the IDL {{uint8}} value that represents the same numeric value as |x|.
 </div>
 
-<p oldids="octet-to-es" id="u8-to-es">
+<p oldids="octet-to-es" id="uint8-to-es">
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{u8}} value to an ECMAScript
+    an IDL {{uint8}} value to an ECMAScript
     value is a Number that represents
     the same numeric value as the IDL
-    {{u8}} value.
+    {{uint8}} value.
     The Number value will be an integer in the range [0, 255].
 </p>
 
 
-<h5 oldids="es-short" id="es-i16">i16</h5>
+<h5 oldids="es-short" id="es-int16">int16</h5>
 
-<div oldids="es-to-short" id="es-to-i16" algorithm="convert an ECMAScript value to i16">
+<div oldids="es-to-short" id="es-to-int16" algorithm="convert an ECMAScript value to int16">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{i16}} value by running the following algorithm:
+    to an IDL {{int16}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 16, "<code>signed</code>").
-    1.  Return the IDL {{i16}} value that represents the same numeric value as |x|.
+    1.  Return the IDL {{int16}} value that represents the same numeric value as |x|.
 
 </div>
 
-<p oldids="short-to-es" id="i16-to-es">
+<p oldids="short-to-es" id="int16-to-es">
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{i16}} value to an ECMAScript
+    an IDL {{int16}} value to an ECMAScript
     value is a Number that represents the
     same numeric value as the IDL
-    {{i16}} value.
+    {{int16}} value.
     The Number value will be an integer in the range [−32768, 32767].
 </p>
 
 
-<h5 oldids="es-unsigned-short" id="es-u16">u16</h5>
+<h5 oldids="es-unsigned-short" id="es-uint16">uint16</h5>
 
-<div oldids="es-to-unsigned-short" id="es-to-u16" algorithm="convert an ECMAScript value to u16">
+<div oldids="es-to-unsigned-short" id="es-to-uint16" algorithm="convert an ECMAScript value to uint16">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{u16}} value by running the following algorithm:
+    to an IDL {{uint16}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 16, "<code>unsigned</code>").
-    1.  Return the IDL {{u16}} value that represents the same numeric value as |x|.
+    1.  Return the IDL {{uint16}} value that represents the same numeric value as |x|.
 </div>
 
-<p oldids="unsigned-short-to-es" id="u16-to-es">
+<p oldids="unsigned-short-to-es" id="uint16-to-es">
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{u16}} value to an ECMAScript
+    an IDL {{uint16}} value to an ECMAScript
     value is a Number that
     represents the same numeric value as the IDL
-    {{u16}} value.
+    {{uint16}} value.
     The Number value will be an integer in the range [0, 65535].
 </p>
 
 
-<h5 oldids="es-long" id="es-i32">i32</h5>
+<h5 oldids="es-long" id="es-int32">int32</h5>
 
-<div oldids="es-to-long" id="es-to-i32" algorithm="convert an ECMAScript value to i32">
+<div oldids="es-to-long" id="es-to-int32" algorithm="convert an ECMAScript value to int32">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{i32}} value by running the following algorithm:
+    to an IDL {{int32}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 32, "<code>signed</code>").
-    1.  Return the IDL {{i32}} value that represents the same numeric value as |x|.
+    1.  Return the IDL {{int32}} value that represents the same numeric value as |x|.
 </div>
 
-<p oldids="long-to-es" id="i32-to-es">
+<p oldids="long-to-es" id="int32-to-es">
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{i32}} value to an ECMAScript
+    an IDL {{int32}} value to an ECMAScript
     value is a Number that
     represents the same numeric value as the IDL
-    {{i32}} value.
+    {{int32}} value.
     The Number value will be an integer in the range [−2147483648, 2147483647].
 </p>
 
 
-<h5 oldids="es-unsigned-long" id="es-u32">u32</h5>
+<h5 oldids="es-unsigned-long" id="es-uint32">uint32</h5>
 
-<div oldids="es-to-unsigned-long" id="es-to-u32" algorithm="convert an ECMAScript value to u32">
+<div oldids="es-to-unsigned-long" id="es-to-uint32" algorithm="convert an ECMAScript value to uint32">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{u32}} value  by running the following algorithm:
+    to an IDL {{uint32}} value  by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 32, "<code>unsigned</code>").
-    1.  Return the IDL {{u32}} value that represents the same numeric value as |x|.
+    1.  Return the IDL {{uint32}} value that represents the same numeric value as |x|.
 </div>
 
-<p oldids="unsigned-long-to-es" id="u32-to-es">
+<p oldids="unsigned-long-to-es" id="uint32-to-es">
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{u32}} value to an ECMAScript
+    an IDL {{uint32}} value to an ECMAScript
     value is a Number that
     represents the same numeric value as the IDL
-    {{u32}} value.
+    {{uint32}} value.
     The Number value will be an integer in the range [0, 4294967295].
 </p>
 
 
-<h5 oldids="es-long-long" id="es-i64">i64</h5>
+<h5 oldids="es-long-long" id="es-int64">int64</h5>
 
-<div oldids="es-to-long-long" id="es-to-i64" algorithm="convert an ECMAScript value to i64">
+<div oldids="es-to-long-long" id="es-to-int64" algorithm="convert an ECMAScript value to int64">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{i64}} value by running the following algorithm:
+    to an IDL {{int64}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 64, "<code>signed</code>").
-    1.  Return the IDL {{i64}} value that represents the same numeric value as |x|.
+    1.  Return the IDL {{int64}} value that represents the same numeric value as |x|.
 </div>
 
-<p oldids="long-long-to-es" id="i64-to-es">
+<p oldids="long-long-to-es" id="int64-to-es">
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{i64}} value to an ECMAScript
+    an IDL {{int64}} value to an ECMAScript
     value is a Number value that
-    represents the closest numeric value to the {{i64}},
+    represents the closest numeric value to the {{int64}},
     choosing the numeric value with an <em>even significand</em> if there are
     two [=equally close values=].
-    If the {{i64}} is in the range
+    If the {{int64}} is in the range
     [−2<sup>53</sup> + 1, 2<sup>53</sup> − 1], then the Number
     will be able to represent exactly the same value as the
-    {{i64}}.
+    {{int64}}.
 </p>
 
 
-<h5 oldids="es-unsigned-long-long" id="es-u64">u64</h5>
+<h5 oldids="es-unsigned-long-long" id="es-uint64">uint64</h5>
 
-<div oldids="es-to-unsigned-long-long" id="es-to-u64" algorithm="convert an ECMAScript value to u64">
+<div oldids="es-to-unsigned-long-long" id="es-to-uint64" algorithm="convert an ECMAScript value to uint64">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{u64}} value by running the following algorithm:
+    to an IDL {{uint64}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 64, "<code>unsigned</code>").
-    1.  Return the IDL {{u64}} value that represents the same numeric value as |x|.
+    1.  Return the IDL {{uint64}} value that represents the same numeric value as |x|.
 </div>
 
-<p oldids="unsigned-long-long-to-es" id="u64-to-es">
+<p oldids="unsigned-long-long-to-es" id="uint64-to-es">
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{u64}} value to an ECMAScript
+    an IDL {{uint64}} value to an ECMAScript
     value is a Number value that
-    represents the closest numeric value to the {{u64}},
+    represents the closest numeric value to the {{uint64}},
     choosing the numeric value with an <em>even significand</em> if there are
     two [=equally close values=].
-    If the {{u64}} is less than or equal to 2<sup>53</sup> − 1,
+    If the {{uint64}} is less than or equal to 2<sup>53</sup> − 1,
     then the Number will be able to
     represent exactly the same value as the
-    {{u64}}.
+    {{uint64}}.
 </p>
 
 <h5 id="es-integer-types-abstract-ops">Abstract operations</h5>
@@ -7478,7 +7478,7 @@ In effect, where <var ignore>x</var> is a Number value,
         1.  If |signedness| is "<code>unsigned</code>", then let |lowerBound| be 0.
         1.  Otherwise let |lowerBound| be −2<sup>53</sup> + 1.
 
-            Note: this ensures {{i64}} types
+            Note: this ensures {{int64}} types
             [=extended attribute associated with|associated with=] [{{EnforceRange}}] or
             [{{Clamp}}] [=extended attributes=] are representable in ECMAScript's [=Number type=]
             as unambiguous integers.
@@ -7518,18 +7518,18 @@ In effect, where <var ignore>x</var> is a Number value,
 
 <h4 id="es-decimal-types">Decimal types</h4>
 
-<h5 oldids="es-float es-unrestricted-float" id="es-f32">f32</h5>
+<h5 oldids="es-float es-unrestricted-float" id="es-float32">float32</h5>
 
-<div oldids="es-to-float es-to-unrestricted-float" id="es-to-f32" algorithm="convert an ECMAScript value to f32">
+<div oldids="es-to-float es-to-unrestricted-float" id="es-to-float32" algorithm="convert an ECMAScript value to float32">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{f32}} value by running the following algorithm:
+    to an IDL {{float32}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ToNumber</a>(|V|).
     1.  If the conversion is to an IDL type [=extended attribute associated with|associated with=]
         the [{{UnrestrictedFloat}}] [=extended attribute=], then:
         1.  If |x| is <emu-val>NaN</emu-val>, then
-            return the IDL {{f32}} value that represents
+            return the IDL {{float32}} value that represents
             the IEEE 754 NaN value with the bit pattern 0x7fc00000 [[!IEEE-754]].
     1.  Else, if |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
@@ -7555,35 +7555,35 @@ it must be canonicalized to a particular single precision IEEE 754 NaN value.  T
 mentioned above is chosen simply because it is the quiet NaN with the lowest
 value when its bit pattern is interpreted as an unsigned 32 bit integer.
 
-<div oldids="float-to-es unrestricted-float-to-es" id="f32-to-es">
+<div oldids="float-to-es unrestricted-float-to-es" id="float32-to-es">
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{f32}} value to an ECMAScript
+    an IDL {{float32}} value to an ECMAScript
     value is a Number:
 
-    1.  If the IDL {{f32}} value is a NaN,
+    1.  If the IDL {{float32}} value is a NaN,
         then the Number value is <emu-val>NaN</emu-val>.
     1.  Otherwise, the Number value is
         the one that represents the same numeric value as the IDL
-        {{f32}} value.
+        {{float32}} value.
 </div>
 
 
-<h5 oldids="es-double es-unrestricted-double" id="es-f32">f64</h5>
+<h5 oldids="es-double es-unrestricted-double" id="es-float32">float64</h5>
 
-<div oldids="es-to-double es-to-unrestricted-double" id="es-to-f64" algorithm="convert an ECMAScript value to f64">
+<div oldids="es-to-double es-to-unrestricted-double" id="es-to-float64" algorithm="convert an ECMAScript value to float64">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{f64}} value by running the following algorithm:
+    to an IDL {{float64}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ToNumber</a>(|V|).
     1.  If the conversion is to an IDL type [=extended attribute associated with|associated with=]
         the [{{UnrestrictedFloat}}] [=extended attribute=], then:
         1.  If |x| is <emu-val>NaN</emu-val>, then
-            return the IDL {{f64}} value that represents
+            return the IDL {{float64}} value that represents
             the IEEE 754 NaN value with the bit pattern 0x7ff8000000000000 [[!IEEE-754]].
     1.  Else, if |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
-    1.  Return the IDL {{f64}} value
+    1.  Return the IDL {{float64}} value
         that represents the same numeric value as |x|.
 </div>
 
@@ -7592,16 +7592,16 @@ it must be canonicalized to a particular double precision IEEE 754 NaN value.  T
 mentioned above is chosen simply because it is the quiet NaN with the lowest
 value when its bit pattern is interpreted as an unsigned 64 bit integer.
 
-<div oldids="double-to-es unrestricted-double-to-es" id="f64-to-es">
+<div oldids="double-to-es unrestricted-double-to-es" id="float64-to-es">
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{f64}} value to an ECMAScript
+    an IDL {{float64}} value to an ECMAScript
     value is a Number:
 
-    1.  If the IDL {{f64}} value is a NaN,
+    1.  If the IDL {{float64}} value is a NaN,
         then the Number value is <emu-val>NaN</emu-val>.
     1.  Otherwise, the Number value is
         the one that represents the same numeric value as the IDL
-        {{f64}} value.
+        {{float64}} value.
 </div>
 
 
@@ -8008,8 +8008,8 @@ ECMAScript Array values.
 
           sequence&lt;DOMString&gt; getSupportedImageCodecs();
 
-          void drawPolygon(sequence&lt;f64&gt; coordinates);
-          sequence&lt;f64&gt; getLastDrawnPolygon();
+          void drawPolygon(sequence&lt;float64&gt; coordinates);
+          sequence&lt;float64&gt; getLastDrawnPolygon();
 
           // ...
         };
@@ -8019,7 +8019,7 @@ ECMAScript Array values.
     object with elements of type String is used to
     represent a <code class="idl">sequence&lt;DOMString&gt;</code>, while an
     Array with elements of type Number
-    represents a <code class="idl">sequence&lt;f64&gt;</code>.  The
+    represents a <code class="idl">sequence&lt;float64&gt;</code>.  The
     Array objects are effectively passed by
     value; every time the <code>getSupportedImageCodecs()</code>
     function is called a new Array is
@@ -8052,10 +8052,10 @@ ECMAScript Array values.
         // An Array of Numbers...
         var a = [0, 0, 100, 0, 50, 62.5];
 
-        // ...can be passed to a platform object expecting a sequence&lt;f64&gt;.
+        // ...can be passed to a platform object expecting a sequence&lt;float64&gt;.
         canvas.drawPolygon(a);
 
-        // Each element will be converted to a f64 by first calling ToNumber().
+        // Each element will be converted to a float64 by first calling ToNumber().
         // So the following call is equivalent to the previous one, except that
         // "hi" will be alerted before drawPolygon() returns.
         a = [false, '',
@@ -8118,13 +8118,13 @@ ECMAScript Object values.
 <div class="example" id="example-es-record">
 
     Passing the ECMAScript value <code>{b: 3, a: 4}</code> as a
-    <code>[=record=]&lt;DOMString, f64></code> argument
+    <code>[=record=]&lt;DOMString, float64></code> argument
     would result in the IDL value «[ "<code>b</code>" → 3, "<code>a</code>" → 4 ]».
 
     Records only consider [=own property|own=] [=enumerable=]
     properties, so given an IDL operation
-    <code>record&lt;DOMString, f64>
-    identity(record&lt;DOMString, f64> arg)</code> which returns its
+    <code>record&lt;DOMString, float64>
+    identity(record&lt;DOMString, float64> arg)</code> which returns its
     argument, the following code passes its assertions:
 
     <pre highlight="js">
@@ -8149,17 +8149,17 @@ ECMAScript Object values.
         <thead><th>Value</th><th>Passed to type</th><th>Result</th></thead>
         <tr>
             <td><code>{"😞": 1}</code></td>
-            <td><code>[=record=]&lt;ByteString, f64></code></td>
+            <td><code>[=record=]&lt;ByteString, float64></code></td>
             <td>{{ECMAScript/TypeError}}</td>
         </tr>
         <tr>
             <td><code>{"\uD83D": 1}</code></td>
-            <td><code>[=record=]&lt;USVString, f64></code></td>
+            <td><code>[=record=]&lt;USVString, float64></code></td>
             <td>«[ "<code>\uFFFD</code>" → 1 ]»</td>
         </tr>
         <tr>
             <td><code>{"\uD83D": {hello: "world"}}</code></td>
-            <td><code>[=record=]&lt;DOMString, f64></code></td>
+            <td><code>[=record=]&lt;DOMString, float64></code></td>
             <td>«[ "<code>\uD83D</code>" → 0 ]»</td>
         </tr>
     </table>
@@ -8375,7 +8375,7 @@ JavaScript code.
 
     <pre highlight="webidl">
         interface I {
-          Promise&lt;void> delay([UnrestrictedFloat] f64 ms);
+          Promise&lt;void> delay([UnrestrictedFloat] float64 ms);
         };
     </pre>
 
@@ -8402,7 +8402,7 @@ JavaScript code.
 
     <pre highlight="webidl">
         interface I {
-          Promise&lt;void> validatedDelay([UnrestrictedFloat] f64 ms);
+          Promise&lt;void> validatedDelay([UnrestrictedFloat] float64 ms);
         };
     </pre>
 
@@ -8428,7 +8428,7 @@ JavaScript code.
 
     <pre highlight="webidl">
         interface I {
-          Promise&lt;any> addDelay(Promise&lt;any> promise, [UnrestrictedFloat] f64 ms);
+          Promise&lt;any> addDelay(Promise&lt;any> promise, [UnrestrictedFloat] float64 ms);
         };
     </pre>
 
@@ -8849,8 +8849,8 @@ See the rules for converting ECMAScript values to IDL [=buffer source types=] in
     <pre highlight="webidl">
         [Exposed=Window]
         interface RenderingContext {
-          void readPixels(i32 width, i32 height, BufferSource pixels);
-          void readPixelsShared(i32 width, i32 height, [AllowShared] BufferSource pixels);
+          void readPixels(int32 width, int32 height, BufferSource pixels);
+          void readPixelsShared(int32 width, int32 height, [AllowShared] BufferSource pixels);
         };
     </pre>
 
@@ -8886,21 +8886,21 @@ for the specific requirements that the use of
 
     In the following [=IDL fragment=],
     two [=operations=] are declared that
-    take three {{u8}} arguments; one uses
+    take three {{uint8}} arguments; one uses
     the [{{Clamp}}] [=extended attribute=]
     on all three arguments, while the other does not:
 
     <pre highlight="webidl">
         [Exposed=Window]
         interface GraphicsContext {
-          void setColor(u8 red, u8 green, u8 blue);
-          void setColorClamped([Clamp] u8 red, [Clamp] u8 green, [Clamp] u8 blue);
+          void setColor(uint8 red, uint8 green, uint8 blue);
+          void setColorClamped([Clamp] uint8 red, [Clamp] uint8 green, [Clamp] uint8 blue);
         };
     </pre>
 
     A call to <code>setColorClamped</code> with
     Number values that are out of range for an
-    {{u8}} are clamped to the range [0, 255].
+    {{uint8}} are clamped to the range [0, 255].
 
     <pre highlight="js">
         // Get an instance of GraphicsContext.
@@ -8939,7 +8939,7 @@ for which a [=corresponding default operation=] has been defined.
         [Exposed=Window]
         interface Animal {
           attribute DOMString name;
-          attribute u16 age;
+          attribute uint16 age;
           [Default] object toJSON();
         };
 
@@ -9017,21 +9017,21 @@ for the specific requirements that the use of
 
     In the following [=IDL fragment=],
     two [=operations=] are declared that
-    take three {{u8}} arguments; one uses
+    take three {{uint8}} arguments; one uses
     the [{{EnforceRange}}] [=extended attribute=]
     on all three arguments, while the other does not:
 
     <pre highlight="webidl">
         [Exposed=Window]
         interface GraphicsContext {
-          void setColor(u8 red, u8 green, u8 blue);
-          void setColorEnforcedRange([EnforceRange] u8 red, [EnforceRange] u8 green, [EnforceRange] u8 blue);
+          void setColor(uint8 red, uint8 green, uint8 blue);
+          void setColorEnforcedRange([EnforceRange] uint8 red, [EnforceRange] uint8 green, [EnforceRange] uint8 blue);
         };
     </pre>
 
     In an ECMAScript implementation of the IDL, a call to setColorEnforcedRange with
     Number values that are out of range for an
-    {{u8}} will result in an exception being
+    {{uint8}} will result in an exception being
     thrown.
 
     <pre highlight="js">
@@ -9216,9 +9216,9 @@ for the specific requirements that the use of
         // Dimensions is available for use in workers and on the main thread.
         [Exposed=(Window,Worker)]
         interface Dimensions {
-          constructor(f64 width, f64 height);
-          readonly attribute f64 width;
-          readonly attribute f64 height;
+          constructor(float64 width, float64 height);
+          readonly attribute float64 width;
+          readonly attribute float64 height;
         };
 
         // WorkerNavigator is only available in workers.  Evaluating WorkerNavigator
@@ -9239,7 +9239,7 @@ for the specific requirements that the use of
         // MathUtils is available for use in workers and on the main thread.
         [Exposed=(Window,Worker)]
         namespace MathUtils {
-          f64 someComplicatedFunction(f64 x, f64 y);
+          float64 someComplicatedFunction(float64 x, float64 y);
         };
 
         // WorkerUtils is only available in workers.  Evaluating WorkerUtils
@@ -9247,7 +9247,7 @@ for the specific requirements that the use of
         // doing so on the main thread will give you a ReferenceError.
         [Exposed=Worker]
         namespace WorkerUtils {
-          void setPriority(f64 x);
+          void setPriority(float64 x);
         };
 
         // NodeUtils is only available in the main thread.  Evaluating NodeUtils
@@ -9985,13 +9985,13 @@ for the specific requirements that the use of
     <pre highlight="webidl">
         [Exposed=Window]
         interface Storage {
-          void addEntry(u32 key, any value);
+          void addEntry(uint32 key, any value);
         };
 
         [Exposed=Window,
          NoInterfaceObject]
         interface Query {
-          any lookupEntry(u32 key);
+          any lookupEntry(uint32 key);
         };
     </pre>
 
@@ -10082,14 +10082,14 @@ for the specific requirements that the use of
     <pre highlight="webidl">
         [Exposed=Window]
         interface StringMap {
-          readonly attribute u32 length;
+          readonly attribute uint32 length;
           getter DOMString lookup(DOMString key);
         };
 
         [Exposed=Window,
          OverrideBuiltins]
         interface StringMap2 {
-          readonly attribute u32 length;
+          readonly attribute uint32 length;
           getter DOMString lookup(DOMString key);
         };
     </pre>
@@ -10219,7 +10219,7 @@ is to be implemented.
         [Exposed=Window]
         interface Person {
           [PutForwards=full] readonly attribute Name name;
-          attribute u16 age;
+          attribute uint16 age;
         };
     </pre>
 
@@ -10285,7 +10285,7 @@ for the specific requirements that the use of
     <pre highlight="webidl">
         [Exposed=Window]
         interface Counter {
-          [Replaceable] readonly attribute u32 value;
+          [Replaceable] readonly attribute uint32 value;
           void increment();
         };
     </pre>
@@ -10460,7 +10460,7 @@ that does specify [{{SecureContext}}].
         // In such a context, there will be no "HeartbeatSensor" property on Window.
         [SecureContext]
         interface HeartbeatSensor {
-          Promise&lt;f32&gt; getHeartbeatsPerMinute();
+          Promise&lt;float32&gt; getHeartbeatsPerMinute();
         };
 
         // The interface mixin members defined below will never be exposed in a non-secure context,
@@ -10714,7 +10714,7 @@ for the specific requirements that the use of
         [Exposed=Window]
         interface System {
           [Unforgeable] readonly attribute DOMString username;
-          readonly attribute i64 loginTime;
+          readonly attribute int64 loginTime;
         };
     </pre>
 
@@ -10768,21 +10768,21 @@ for the specific requirements that the use of
 
     In the following [=IDL fragment=],
     two [=operations=] are declared that
-    take three {{f64}} arguments; one uses
+    take three {{float64}} arguments; one uses
     the [{{UnrestrictedFloat}}] [=extended attribute=]
     on all three arguments, while the other does not:
 
     <pre highlight="webidl">
         [Exposed=Window]
         interface GraphicsContext {
-          void setColorFloat(f64 red, f64 green, f64 blue);
-          void setColorUnrestrictedFloat([UnrestrictedFloat] f64 red, [UnrestrictedFloat] f64 green, [UnrestrictedFloat] f64 blue);
+          void setColorFloat(float64 red, float64 green, float64 blue);
+          void setColorUnrestrictedFloat([UnrestrictedFloat] float64 red, [UnrestrictedFloat] float64 green, [UnrestrictedFloat] float64 blue);
         };
     </pre>
 
     In an ECMAScript implementation of the IDL, a call to setColor3f with
     Number values that are out of range for a
-    {{f64}} will result in an exception being
+    {{float64}} will result in an exception being
     thrown.
 
     <pre highlight="js">
@@ -14004,7 +14004,7 @@ A {{DOMException}} is represented by a
         [Exposed=Window]
         interface MathUtils {
           // If x is negative, throws a "<a href="#notsupportederror">NotSupportedError</a>" <a href="dfn-DOMException">DOMException</a>.
-          f64 computeSquareRoot(f64 x);
+          float64 computeSquareRoot(float64 x);
         };
     </pre>
 
@@ -14060,7 +14060,7 @@ the exact steps to take if <dfn>an exception was thrown</dfn>, or by explicitly 
         [Exposed=Window]
         interface ExceptionThrower {
           // This attribute always throws a NotSupportedError and never returns a value.
-          attribute i32 valueOf;
+          attribute int32 valueOf;
         };
     </pre>
 
@@ -14302,33 +14302,33 @@ interface DOMException { // but see below note about ECMAScript binding
   constructor(optional DOMString message = "", optional DOMString name = "Error");
   readonly attribute DOMString name;
   readonly attribute DOMString message;
-  readonly attribute u16 code;
+  readonly attribute uint16 code;
 
-  const u16 INDEX_SIZE_ERR = 1;
-  const u16 DOMSTRING_SIZE_ERR = 2;
-  const u16 HIERARCHY_REQUEST_ERR = 3;
-  const u16 WRONG_DOCUMENT_ERR = 4;
-  const u16 INVALID_CHARACTER_ERR = 5;
-  const u16 NO_DATA_ALLOWED_ERR = 6;
-  const u16 NO_MODIFICATION_ALLOWED_ERR = 7;
-  const u16 NOT_FOUND_ERR = 8;
-  const u16 NOT_SUPPORTED_ERR = 9;
-  const u16 INUSE_ATTRIBUTE_ERR = 10;
-  const u16 INVALID_STATE_ERR = 11;
-  const u16 SYNTAX_ERR = 12;
-  const u16 INVALID_MODIFICATION_ERR = 13;
-  const u16 NAMESPACE_ERR = 14;
-  const u16 INVALID_ACCESS_ERR = 15;
-  const u16 VALIDATION_ERR = 16;
-  const u16 TYPE_MISMATCH_ERR = 17;
-  const u16 SECURITY_ERR = 18;
-  const u16 NETWORK_ERR = 19;
-  const u16 ABORT_ERR = 20;
-  const u16 URL_MISMATCH_ERR = 21;
-  const u16 QUOTA_EXCEEDED_ERR = 22;
-  const u16 TIMEOUT_ERR = 23;
-  const u16 INVALID_NODE_TYPE_ERR = 24;
-  const u16 DATA_CLONE_ERR = 25;
+  const uint16 INDEX_SIZE_ERR = 1;
+  const uint16 DOMSTRING_SIZE_ERR = 2;
+  const uint16 HIERARCHY_REQUEST_ERR = 3;
+  const uint16 WRONG_DOCUMENT_ERR = 4;
+  const uint16 INVALID_CHARACTER_ERR = 5;
+  const uint16 NO_DATA_ALLOWED_ERR = 6;
+  const uint16 NO_MODIFICATION_ALLOWED_ERR = 7;
+  const uint16 NOT_FOUND_ERR = 8;
+  const uint16 NOT_SUPPORTED_ERR = 9;
+  const uint16 INUSE_ATTRIBUTE_ERR = 10;
+  const uint16 INVALID_STATE_ERR = 11;
+  const uint16 SYNTAX_ERR = 12;
+  const uint16 INVALID_MODIFICATION_ERR = 13;
+  const uint16 NAMESPACE_ERR = 14;
+  const uint16 INVALID_ACCESS_ERR = 15;
+  const uint16 VALIDATION_ERR = 16;
+  const uint16 TYPE_MISMATCH_ERR = 17;
+  const uint16 SECURITY_ERR = 18;
+  const uint16 NETWORK_ERR = 19;
+  const uint16 ABORT_ERR = 20;
+  const uint16 URL_MISMATCH_ERR = 21;
+  const uint16 QUOTA_EXCEEDED_ERR = 22;
+  const uint16 TIMEOUT_ERR = 23;
+  const uint16 INVALID_NODE_TYPE_ERR = 24;
+  const uint16 DATA_CLONE_ERR = 25;
 };
 </pre>
 
@@ -14377,7 +14377,7 @@ Their [=deserialization steps=], given <var>value</var> and <var>serialized</var
 
 <h3 id="DOMTimeStamp" typedef oldids="common-DOMTimeStamp">DOMTimeStamp</h3>
 
-<pre class="idl">typedef u64 DOMTimeStamp;</pre>
+<pre class="idl">typedef uint64 DOMTimeStamp;</pre>
 
 The {{DOMTimeStamp}} type is used for representing
 a number of milliseconds, either as an absolute time (relative to some epoch)
@@ -14643,8 +14643,8 @@ text is “<span class="input">a1</span>”, it is tokenized as a single <emu-t 
 and not as a separate <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> and <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>.
 If the longest possible match could match one of the above named terminal symbols or
 one of the other terminal symbols from the grammar, it must be tokenized as the latter.
-Thus, the input text “<span class="input">i32</span>” is tokenized as the quoted terminal symbol
-<emu-t>i32</emu-t> rather than an <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> called "<code>i32</code>",
+Thus, the input text “<span class="input">int32</span>” is tokenized as the quoted terminal symbol
+<emu-t>int32</emu-t> rather than an <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> called "<code>int32</code>",
 and “<span class="input">.</span>” is tokenized as the quoted terminal symbol
 <emu-t>.</emu-t> rather than an <emu-t class="regex"><a href="#prod-other">other</a></emu-t>.
 
@@ -14699,7 +14699,7 @@ The following typographic conventions are used in this document:
 *   Grammar terminals: <emu-t>sometoken</emu-t>
 *   Grammar non-terminals: <emu-nt>ExampleGrammarNonTerminal</emu-t>
 *   Grammar symbols: <emu-t class="regex">identifier</emu-t>
-*   IDL types: {{u32}}
+*   IDL types: {{uint32}}
 *   ECMAScript classes: {{ECMAScript/Map}}
 *   ECMAScript language types: Object
 *   Code snippets: <code>a = b + obj.f()</code>
@@ -14739,7 +14739,7 @@ The following typographic conventions are used in this document:
         // This is an IDL code block.
         [Exposed=Window]
         interface Example {
-          attribute i32 something;
+          attribute int32 something;
         };
     </pre>
     <pre highlight="js">

--- a/index.bs
+++ b/index.bs
@@ -451,7 +451,7 @@ commonly used on the web, ECMAScript, are consistently specified with
 low enough precision as to result in interoperability issues.  In
 addition, each specification must describe the same basic information,
 such as DOM interfaces described in IDL corresponding to properties
-on the ECMAScript global object, or the {{unsigned long}} IDL type mapping to the Number
+on the ECMAScript global object, or the {{u32}} IDL type mapping to the Number
 type in ECMAScript.
 
 This specification defines an IDL language similar to OMG IDL
@@ -534,9 +534,9 @@ in [[#es-extended-attributes]].
 
         [Exposed=Window]
         interface SolidColor : Paint {
-          attribute double red;
-          attribute double green;
-          attribute double blue;
+          attribute f64 red;
+          attribute f64 green;
+          attribute f64 blue;
         };
 
         [Exposed=Window]
@@ -547,14 +547,14 @@ in [[#es-extended-attributes]].
         [Exposed=Window]
         interface GraphicalWindow {
           constructor();
-          readonly attribute unsigned long width;
-          readonly attribute unsigned long height;
+          readonly attribute u32 width;
+          readonly attribute u32 height;
 
           attribute Paint currentPaint;
 
-          void drawRectangle(double x, double y, double width, double height);
+          void drawRectangle(f64 x, f64 y, f64 width, f64 height);
 
-          void drawText(double x, double y, DOMString text);
+          void drawText(f64 x, f64 y, DOMString text);
         };
     </pre>
 
@@ -770,7 +770,7 @@ across [=IDL fragments=].
         interface A {
         };
 
-        typedef sequence&lt;long&gt; SequenceOfLongs;
+        typedef sequence&lt;i32&gt; SequenceOfLongs;
     </pre>
 </div>
 
@@ -782,7 +782,7 @@ across [=IDL fragments=].
 
     <pre highlight="webidl">
         // Typedef identifier: "number"
-        typedef double number;
+        typedef f64 number;
 
         // Interface identifier: "System"
         [Exposed=Window]
@@ -1307,7 +1307,7 @@ No [=extended attributes=] defined in this specification are applicable to [=inc
 
     <pre highlight="webidl">
         interface Entry {
-          readonly attribute unsigned short entryType;
+          readonly attribute u16 entryType;
           // ...
         };
 
@@ -1696,11 +1696,11 @@ lie outside the valid range of values for its type, as given in
     1.  Let |result| be the Mathematical Value that would be obtained if
         |S| were parsed as an ECMAScript <emu-nt>[=NumericLiteral=]</emu-nt>.
     1.  If the <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token is being
-        used as the value for a {{float}} or {{unrestricted float}}, then
+        used as the value for a {{f32}} or {{unrestricted f32}}, then
         the value of the <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token
         is the IEEE 754 single-precision floating point number closest to |result|.
     1.  Otherwise, the <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token is being
-        used as the value for a {{double}} or {{unrestricted double}}, and
+        used as the value for a {{f64}} or {{unrestricted f64}}, and
         the value of the <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token
         is the IEEE 754 double-precision floating point number closest to |result|. [[!IEEE-754]]
 </div>
@@ -1713,17 +1713,17 @@ constant, dictionary member or optional argument is is being used as the
 value for:
 
 <dl class="switch">
-     :  Type {{unrestricted float}}, constant value <emu-t>Infinity</emu-t>
+     :  Type {{unrestricted f32}}, constant value <emu-t>Infinity</emu-t>
      :: The value is the IEEE 754 single-precision positive infinity value.
-     :  Type {{unrestricted double}}, constant value <emu-t>Infinity</emu-t>
+     :  Type {{unrestricted f64}}, constant value <emu-t>Infinity</emu-t>
      :: The value is the IEEE 754 double-precision positive infinity value.
-     :  Type {{unrestricted float}}, constant value <emu-t>-Infinity</emu-t>
+     :  Type {{unrestricted f32}}, constant value <emu-t>-Infinity</emu-t>
      :: The value is the IEEE 754 single-precision negative infinity value.
-     :  Type {{unrestricted double}}, constant value <emu-t>-Infinity</emu-t>
+     :  Type {{unrestricted f64}}, constant value <emu-t>-Infinity</emu-t>
      :: The value is the IEEE 754 double-precision negative infinity value.
-     :  Type {{unrestricted float}}, constant value <emu-t>NaN</emu-t>
+     :  Type {{unrestricted f32}}, constant value <emu-t>NaN</emu-t>
      :: The value is the IEEE 754 single-precision NaN value with the bit pattern 0x7fc00000.
-     :  Type {{unrestricted double}}, constant value <emu-t>NaN</emu-t>
+     :  Type {{unrestricted f64}}, constant value <emu-t>NaN</emu-t>
      :: The value is the IEEE 754 double-precision NaN value with the bit pattern 0x7ff8000000000000.
 </dl>
 
@@ -1732,7 +1732,7 @@ as the type of the constant, dictionary member or optional argument it is being 
 The value of the <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t> token must not
 lie outside the valid range of values for its type, as given in [[#idl-types]].
 Also, <emu-t>Infinity</emu-t>, <emu-t>-Infinity</emu-t> and <emu-t>NaN</emu-t> must not
-be used as the value of a {{float}} or {{double}}.
+be used as the value of a {{f32}} or {{f64}}.
 
 The value of the <emu-t>null</emu-t> token is the special
 <emu-val>null</emu-val> value that is a member of the
@@ -1762,7 +1762,7 @@ on which they appear.  It is language binding specific whether
     <pre highlight="webidl">
         [Exposed=Window]
         interface A {
-          const short rambaldi = 47;
+          const u16 rambaldi = 47;
         };
     </pre>
 
@@ -1817,9 +1817,9 @@ The following extended attributes are applicable to constants:
         [Exposed=Window]
         interface Util {
           const boolean DEBUG = false;
-          const octet LF = 10;
-          const unsigned long BIT_MASK = 0x0000fc00;
-          const double AVOGADRO = 6.022e23;
+          const u8 LF = 10;
+          const u32 BIT_MASK = 0x0000fc00;
+          const f64 AVOGADRO = 6.022e23;
         };
     </pre>
 </div>
@@ -2020,7 +2020,7 @@ are applicable only to regular attributes:
           readonly attribute DOMString name;
 
           // An attribute whose value can be assigned to.
-          attribute unsigned short age;
+          attribute u16 age;
         };
 
         [Exposed=Window]
@@ -2166,8 +2166,8 @@ language bindings.
     <pre highlight="webidl">
         [Exposed=Window]
         interface Dimensions {
-          attribute unsigned long width;
-          attribute unsigned long height;
+          attribute u32 width;
+          attribute u32 height;
         };
 
         [Exposed=Window]
@@ -2178,7 +2178,7 @@ language bindings.
 
           // Overloaded operations.
           void setDimensions(Dimensions size);
-          void setDimensions(unsigned long width, unsigned long height);
+          void setDimensions(u32 width, u32 height);
         };
     </pre>
 </div>
@@ -2216,10 +2216,10 @@ when the <emu-t>...</emu-t> token is used in their argument lists.
     <pre highlight="webidl">
         [Exposed=Window]
         interface IntegerSet {
-          readonly attribute unsigned long cardinality;
+          readonly attribute u32 cardinality;
 
-          void union(long... ints);
-          void intersection(long... ints);
+          void union(i32... ints);
+          void intersection(i32... ints);
         };
     </pre>
 
@@ -2360,7 +2360,7 @@ type=] that has a [=dictionary type=] in its [=flattened member types=].
     <pre highlight="webidl">
         [Exposed=Window]
         interface ColorCreator {
-          object createColor(double v1, double v2, double v3, optional double alpha);
+          object createColor(f64 v1, f64 v2, f64 v3, optional f64 alpha);
         };
     </pre>
 
@@ -2371,8 +2371,8 @@ type=] that has a [=dictionary type=] in its [=flattened member types=].
     <pre highlight="webidl">
         [Exposed=Window]
         interface ColorCreator {
-          object createColor(double v1, double v2, double v3);
-          object createColor(double v1, double v2, double v3, double alpha);
+          object createColor(f64 v1, f64 v2, f64 v3);
+          object createColor(f64 v1, f64 v2, f64 v3, f64 alpha);
         };
     </pre>
 </div>
@@ -2554,16 +2554,16 @@ in which case the [=default toJSON operation=] is exposed instead.
         interface Transaction {
           readonly attribute DOMString from;
           readonly attribute DOMString to;
-          readonly attribute double amount;
+          readonly attribute f64 amount;
           readonly attribute DOMString description;
-          readonly attribute unsigned long number;
+          readonly attribute u32 number;
           TransactionJSON toJSON();
         };
 
         dictionary TransactionJSON {
           Account from;
           Account to;
-          double amount;
+          f64 amount;
           DOMString description;
         };
     </pre>
@@ -2632,18 +2632,18 @@ See [[#interface-object]] for details on how a [=constructor operation=] is to b
     <pre highlight="webidl">
         [Exposed=Window]
         interface NodeList {
-          Node item(unsigned long index);
-          readonly attribute unsigned long length;
+          Node item(u32 index);
+          readonly attribute u32 length;
         };
 
         [Exposed=Window]
         interface Circle {
           constructor();
-          constructor(double radius);
-          attribute double r;
-          attribute double cx;
-          attribute double cy;
-          readonly attribute double circumference;
+          constructor(f64 radius);
+          attribute f64 r;
+          attribute f64 cx;
+          attribute f64 cy;
+          readonly attribute f64 circumference;
         };
     </pre>
 
@@ -2740,10 +2740,10 @@ will not be such functionality.
     <pre highlight="webidl">
         [Exposed=Window]
         interface Dictionary {
-          readonly attribute unsigned long propertyCount;
+          readonly attribute u32 propertyCount;
 
-          getter double (DOMString propertyName);
-          setter void (DOMString propertyName, double propertyValue);
+          getter f64 (DOMString propertyName);
+          setter void (DOMString propertyName, f64 propertyValue);
         };
     </pre>
 
@@ -2765,22 +2765,22 @@ simplify prose descriptions of an interface’s operations.
     <pre highlight="webidl">
         [Exposed=Window]
         interface Dictionary {
-          readonly attribute unsigned long propertyCount;
+          readonly attribute u32 propertyCount;
 
-          getter double getProperty(DOMString propertyName);
-          setter void setProperty(DOMString propertyName, double propertyValue);
+          getter f64 getProperty(DOMString propertyName);
+          setter void setProperty(DOMString propertyName, f64 propertyValue);
         };
     </pre>
     <pre highlight="webidl">
         [Exposed=Window]
         interface Dictionary {
-          readonly attribute unsigned long propertyCount;
+          readonly attribute u32 propertyCount;
 
-          double getProperty(DOMString propertyName);
-          void setProperty(DOMString propertyName, double propertyValue);
+          f64 getProperty(DOMString propertyName);
+          void setProperty(DOMString propertyName, f64 propertyValue);
 
-          getter double (DOMString propertyName);
-          setter void (DOMString propertyName, double propertyValue);
+          getter f64 (DOMString propertyName);
+          setter void (DOMString propertyName, f64 propertyValue);
         };
     </pre>
 </div>
@@ -2793,7 +2793,7 @@ take a {{DOMString}} as a property name,
 known as
 <dfn id="dfn-named-property-getter" export lt="named property getter">named property getters</dfn> and
 <dfn id="dfn-named-property-setter" export lt="named property setter">named property setters</dfn>,
-and ones that take an {{unsigned long}}
+and ones that take an {{u32}}
 as a property index, known as
 <dfn id="dfn-indexed-property-getter" export lt="indexed property getter">indexed property getters</dfn> and
 <dfn id="dfn-indexed-property-setter" export lt="indexed property setter">indexed property setters</dfn>.
@@ -2916,7 +2916,7 @@ a [=static attribute=].
         [Exposed=Window]
         interface Student {
           constructor();
-          attribute unsigned long id;
+          attribute u32 id;
           stringifier attribute DOMString name;
         };
     </pre>
@@ -2942,7 +2942,7 @@ a [=static attribute=].
         [Exposed=Window]
         interface Student {
           constructor();
-          attribute unsigned long id;
+          attribute u32 id;
           attribute DOMString? familyName;
           attribute DOMString givenName;
 
@@ -2999,17 +2999,17 @@ Interfaces that [=support indexed properties=] must define
 an [=integer types|integer-typed=] [=attribute=] named "<code>length</code>".
 
 Indexed property getters must
-be declared to take a single {{unsigned long}} argument.
+be declared to take a single {{u32}} argument.
 Indexed property setters must
-be declared to take two arguments, where the first is an {{unsigned long}}.
+be declared to take two arguments, where the first is an {{u32}}.
 
 <pre highlight="webidl" class="syntax">
     interface interface_identifier {
-      getter type identifier(unsigned long identifier);
-      setter type identifier(unsigned long identifier, type identifier);
+      getter type identifier(u32 identifier);
+      setter type identifier(u32 identifier, type identifier);
 
-      getter type (unsigned long identifier);
-      setter type (unsigned long identifier, type identifier);
+      getter type (u32 identifier);
+      setter type (u32 identifier, type identifier);
     };
 </pre>
 
@@ -3047,7 +3047,7 @@ The following requirements apply to the definitions of indexed property getters 
     <pre highlight="webidl">
         [Exposed=Window]
         interface A {
-          getter DOMString toWord(unsigned long index);
+          getter DOMString toWord(u32 index);
         };
     </pre>
 
@@ -3077,10 +3077,10 @@ The following requirements apply to the definitions of indexed property getters 
     <pre highlight="webidl">
         [Exposed=Window]
         interface OrderedMap {
-          readonly attribute unsigned long size;
+          readonly attribute u32 size;
 
-          getter any getByIndex(unsigned long index);
-          setter void setByIndex(unsigned long index, any value);
+          getter any getByIndex(u32 index);
+          setter void setByIndex(u32 index, any value);
 
           getter any get(DOMString name);
           setter void set(DOMString name, any value);
@@ -3261,11 +3261,11 @@ to an instance of the interface.
 
         [Exposed=Window]
         interface Circle {
-          attribute double cx;
-          attribute double cy;
-          attribute double radius;
+          attribute f64 cx;
+          attribute f64 cy;
+          attribute f64 radius;
 
-          static readonly attribute long triangulationCount;
+          static readonly attribute i32 triangulationCount;
           static Point triangulate(Circle c1, Circle c2, Circle c3);
         };
     </pre>
@@ -3333,7 +3333,7 @@ definitions.
         };
 
         partial interface A {
-          void f(double x);
+          void f(f64 x);
           void g();
         };
 
@@ -3437,7 +3437,7 @@ the same operation or constructor.
         For [=variadic=] operations and constructor extended attributes,
         the argument on which the ellipsis appears counts as a single argument.
 
-        Note: So <code>void f(long x, long... y);</code> is considered to be declared to take two arguments.
+        Note: So <code>void f(i32 x, i32... y);</code> is considered to be declared to take two arguments.
     1.  Let |max| be <a abstract-op>max</a>(|maxarg|, |N|).
     1.  [=set/For each=] operation or extended attribute |X| in |F|:
         1.  Let |arguments| be the [=list=] of arguments |X| is declared to take.
@@ -3487,9 +3487,9 @@ the same operation or constructor.
         [Exposed=Window]
         interface A {
           /* f1 */ void f(DOMString a);
-          /* f2 */ void f(Node a, DOMString b, double... c);
+          /* f2 */ void f(Node a, DOMString b, f64... c);
           /* f3 */ void f();
-          /* f4 */ void f(Event a, DOMString b, optional DOMString c, double... d);
+          /* f4 */ void f(Event a, DOMString b, optional DOMString c, f64... d);
         };
     </pre>
 
@@ -3503,12 +3503,12 @@ the same operation or constructor.
       «
         (f1, « DOMString »,                           « required »),
         (f2, « Node, DOMString »,                     « required, required »),
-        (f2, « Node, DOMString, double »,             « required, required, variadic »),
-        (f2, « Node, DOMString, double, double »,     « required, required, variadic, variadic »),
+        (f2, « Node, DOMString, f64 »,             « required, required, variadic »),
+        (f2, « Node, DOMString, f64, f64 »,     « required, required, variadic, variadic »),
         (f3, « »,                                     « »),
         (f4, « Event, DOMString »,                    « required, required »),
         (f4, « Event, DOMString, DOMString »,         « required, required, optional »),
-        (f4, « Event, DOMString, DOMString, double », « required, required, optional, variadic »)
+        (f4, « Event, DOMString, DOMString, f64 », « required, required, optional, variadic »)
       »
     </pre>
 </div>
@@ -3528,27 +3528,27 @@ the following algorithm returns <i>true</i>.
         None of the following pairs are distinguishable:
         <ul>
             <li>
-                <code>{{double}}?</code> and
+                <code>{{f64}}?</code> and
                 <code>Dictionary1</code>
             </li>
             <li>
-                <code>(Interface1 or {{long}})?</code> and
+                <code>(Interface1 or {{i32}})?</code> and
                 <code>(Interface2 or {{DOMString}})?</code>
             </li>
             <li>
-                <code>(Interface1 or {{long}}?)</code> and
+                <code>(Interface1 or {{i32}}?)</code> and
                 <code>(Interface2 or {{DOMString}})?</code>
             </li>
             <li>
-                <code>(Interface1 or {{long}}?)</code> and
+                <code>(Interface1 or {{i32}}?)</code> and
                 <code>(Interface2 or {{DOMString}}?)</code>
             </li>
             <li>
-                <code>(Dictionary1 or {{long}})</code> and
+                <code>(Dictionary1 or {{i32}})</code> and
                 <code>(Interface2 or {{DOMString}})?</code>
             </li>
             <li>
-                <code>(Dictionary1 or {{long}})</code> and
+                <code>(Dictionary1 or {{i32}})</code> and
                 <code>(Interface2 or {{DOMString}}?)</code>
             </li>
         </ul>
@@ -3735,12 +3735,12 @@ the following algorithm returns <i>true</i>.
     </ol>
 
     <div class="example" id="example-distinguishability-diff-types">
-        {{double}} and {{DOMString}} are distinguishable because
+        {{f64}} and {{DOMString}} are distinguishable because
         there is a ● at the intersection of [=numeric types=] with [=string types=].
     </div>
 
     <div class="example" id="example-distinguishability-same-category">
-        {{double}} and {{long}} are not distinguishable because they are both [=numeric types=],
+        {{f64}} and {{i32}} are not distinguishable because they are both [=numeric types=],
         and there is no ● or letter at the intersection of [=numeric types=] with [=numeric types=].
     </div>
 
@@ -3818,8 +3818,8 @@ be the same.
         [Exposed=Window]
         interface B {
           /* f1 */ void f(DOMString w);
-          /* f2 */ void f(long w, double x, Node y, Node z);
-          /* f3 */ void f(double w, double x, DOMString y, Node z);
+          /* f2 */ void f(i32 w, f64 x, Node y, Node z);
+          /* f3 */ void f(f64 w, f64 x, DOMString y, Node z);
         };
     </pre>
 
@@ -3828,8 +3828,8 @@ be the same.
     <pre class="set">
       «
         (f1, « DOMString »,                       « required »),
-        (f2, « long, double, Node, Node »,        « required, required, required, required »),
-        (f3, « double, double, DOMString, Node », « required, required, required, required »)
+        (f2, « i32, f64, Node, Node »,        « required, required, required, required »),
+        (f3, « f64, f64, DOMString, Node », « required, required, required, required »)
       »
     </pre>
 
@@ -3901,14 +3901,14 @@ determine what Web IDL language feature to use:
     class="note">This is almost never appropriate API design, and separate operations with distinct
     names usually are a better choice for such cases.</span>
 
-    Suppose there is an operation <code class="idl">calculate()</code> that accepts a {{long}},
+    Suppose there is an operation <code class="idl">calculate()</code> that accepts a {{i32}},
     {{DOMString}}, or <code class="idl">CalculatableInterface</code> (an [=interface type=]) as its
     only argument, and returns a value of the same type as its argument. It would be clearer to
     write the IDL fragment using [=overloaded=] operations as
 
     <pre highlight="webidl">
         interface A {
-          long calculate(long input);
+          i32 calculate(i32 input);
           DOMString calculate(DOMString input);
           CalculatableInterface calculate(CalculatableInterface input);
         };
@@ -3917,7 +3917,7 @@ determine what Web IDL language feature to use:
     than using a [=union type=] with a [=typedef=] as
 
     <pre highlight="webidl">
-        typedef (long or DOMString or CalculatableInterface) Calculatable;
+        typedef (i32 or DOMString or CalculatableInterface) Calculatable;
         interface A {
           Calculatable calculate(Calculatable input);
         };
@@ -3937,7 +3937,7 @@ determine what Web IDL language feature to use:
 
     <pre highlight="webidl">
         interface A {
-          long calculateNumber(long input);
+          i32 calculateNumber(i32 input);
           DOMString calculateString(DOMString input);
           CalculatableInterface calculateCalculatableInterface(CalculatableInterface input);
         };
@@ -4020,7 +4020,7 @@ determine what Web IDL language feature to use:
     different arguments, [=union types=] can sometimes be the only viable solution.
 
     <pre highlight="webidl">
-        typedef (long long or DOMString or CalculatableInterface) SupportedArgument;
+        typedef (i64 or DOMString or CalculatableInterface) SupportedArgument;
         interface A {
           void add(SupportedArgument operand1, SupportedArgument operand2);
         };
@@ -4031,13 +4031,13 @@ determine what Web IDL language feature to use:
 
     <pre highlight="webidl">
         interface A {
-          void add(long long operand1, long long operand2);
-          void add(long long operand1, DOMString operand2);
-          void add(long long operand1, CalculatableInterface operand2);
-          void add(DOMString operand1, long long operand2);
+          void add(i64 operand1, i64 operand2);
+          void add(i64 operand1, DOMString operand2);
+          void add(i64 operand1, CalculatableInterface operand2);
+          void add(DOMString operand1, i64 operand2);
           void add(DOMString operand1, DOMString operand2);
           void add(DOMString operand1, CalculatableInterface operand2);
-          void add(CalculatableInterface operand1, long long operand2);
+          void add(CalculatableInterface operand1, i64 operand2);
           void add(CalculatableInterface operand1, DOMString operand2);
           void add(CalculatableInterface operand1, CalculatableInterface operand2);
         };
@@ -4708,7 +4708,7 @@ Of the extended attributes defined in this specification, only the [{{Exposed}}]
     <pre highlight="webidl">
         namespace VectorUtils {
           readonly attribute Vector unit;
-          double dotProduct(Vector x, Vector y);
+          f64 dotProduct(Vector x, Vector y);
           Vector crossProduct(Vector x, Vector y);
         };
     </pre>
@@ -4801,7 +4801,7 @@ dictionary members.
     <pre highlight="webidl">
     dictionary Descriptor {
       DOMString name;
-      sequence&lt;unsigned long> serviceIdentifiers;
+      sequence&lt;u32> serviceIdentifiers;
     };
     </pre>
 
@@ -4939,23 +4939,23 @@ identifiers.
 
     <pre highlight="webidl">
         dictionary B : A {
-          long b;
-          long a;
+          i32 b;
+          i32 a;
         };
 
         dictionary A {
-          long c;
-          long g;
+          i32 c;
+          i32 g;
         };
 
         dictionary C : B {
-          long e;
-          long f;
+          i32 e;
+          i32 f;
         };
 
         partial dictionary A {
-          long h;
-          long d;
+          i32 h;
+          i32 d;
         };
     </pre>
 
@@ -5058,8 +5058,8 @@ No [=extended attributes=] are applicable to dictionaries.
         [Exposed=Window]
         interface Point {
           constructor();
-          attribute double x;
-          attribute double y;
+          attribute f64 x;
+          attribute f64 y;
         };
 
         dictionary PaintOptions {
@@ -5070,7 +5070,7 @@ No [=extended attributes=] are applicable to dictionaries.
 
         [Exposed=Window]
         interface GraphicsContext {
-          void drawRectangle(double width, double height, optional PaintOptions options);
+          void drawRectangle(f64 width, f64 height, optional PaintOptions options);
         };
     </pre>
 
@@ -5461,9 +5461,9 @@ defined in this specification are applicable to [=enumerations=].
         [Exposed=Window]
         interface Meal {
           attribute MealType type;
-          attribute double size;     // in grams
+          attribute f64 size;     // in grams
 
-          void initialize(MealType type, double size);
+          void initialize(MealType type, f64 size);
         };
     </pre>
 
@@ -5583,14 +5583,14 @@ defined in this specification are applicable to [=typedefs=].
     The following [=IDL fragment=]
     demonstrates the use of [=typedefs=]
     to allow the use of a short
-    [=identifier=] instead of a long
+    [=identifier=] instead of a i32
     [=sequence type=].
 
     <pre highlight="webidl">
         [Exposed=Window]
         interface Point {
-          attribute double x;
-          attribute double y;
+          attribute f64 x;
+          attribute f64 y;
         };
 
         typedef sequence&lt;Point&gt; Points;
@@ -5648,21 +5648,21 @@ corresponding to each type, and how [=constants=]
 of that type are represented.
 
 The following types are known as <dfn id="dfn-integer-type" export>integer types</dfn>:
-{{byte}},
-{{octet}},
-{{short}},
-{{unsigned short}},
-{{long}},
-{{unsigned long}},
-{{long long}} and
-{{unsigned long long}}.
+{{i8}},
+{{u8}},
+{{i16}},
+{{u16}},
+{{i32}},
+{{u32}},
+{{i64}} and
+{{u64}}.
 
 The following types are known as <dfn id="dfn-numeric-type" export>numeric types</dfn>:
 the [=integer types=],
-{{float}},
-{{unrestricted float}},
-{{double}} and
-{{unrestricted double}}.
+{{f32}},
+{{unrestricted f32}},
+{{f64}} and
+{{unrestricted f64}}.
 
 The <dfn id="dfn-primitive-type" export>primitive types</dfn> are
 {{boolean}} and the [=numeric types=].
@@ -5769,6 +5769,14 @@ type.
         "boolean"
         "byte"
         "octet"
+        "u8"
+        "u16"
+        "u32"
+        "u64"
+        "i8"
+        "i16"
+        "i32"
+        "i64"
 </pre>
 
 <pre class="grammar" id="prod-UnrestrictedFloatType">
@@ -5781,6 +5789,8 @@ type.
     FloatType :
         "float"
         "double"
+        "f32"
+        "f64"
 </pre>
 
 <pre class="grammar" id="prod-UnsignedIntegerType">
@@ -5835,8 +5845,8 @@ a discriminated union type, in that each of its values has a
 specific non-{{any}} type
 associated with it.  For example, one value of the
 {{any}} type is the
-{{unsigned long}}
-150, while another is the {{long}} 150.
+{{u32}}
+150, while another is the {{i32}} 150.
 These are distinct values.
 
 The particular type of an {{any}}
@@ -5867,172 +5877,256 @@ The [=type name=] of the
 {{boolean}} type is "<code>Boolean</code>".
 
 
-<h4 oldids="dom-byte" id="idl-byte" interface>byte</h4>
+<h4 oldids="dom-byte idl-byte" id="idl-i8" interface>i8</h4>
 
-The {{byte}} type is a signed integer
+The {{i8}} type is a signed integer
 type that has values in the range [−128, 127].
 
-{{byte}} constant values in IDL are
+{{i8}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{byte}} type is "<code>Byte</code>".
+{{i8}} type is "<code>Byte</code>".
+
+For legacy compatibility, <code>byte</code> is to be treated
+as an alias for {{i8}}, similar to:
+
+<pre highlight="webidl">
+    typedef (i8) byte;
+</pre>
 
 
-<h4 oldids="dom-octet" id="idl-octet" interface>octet</h4>
+<h4 oldids="dom-octet idl-octet" id="idl-u8" interface>u8</h4>
 
-The {{octet}} type is an unsigned integer
+The {{u8}} type is an unsigned integer
 type that has values in the range [0, 255].
 
-{{octet}} constant values in IDL are
+{{u8}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{octet}} type is "<code>Octet</code>".
+{{u8}} type is "<code>Octet</code>".
+
+For legacy compatibility, <code>octet</code> is to be treated
+as an alias for {{u8}}, similar to:
+
+<pre highlight="webidl">
+    typedef (u8) octet;
+</pre>
 
 
-<h4 oldids="dom-short" id="idl-short" interface>short</h4>
+<h4 oldids="dom-short idl-short" id="idl-i16" interface>i16</h4>
 
-The {{short}} type is a signed integer
+The {{i16}} type is a signed integer
 type that has values in the range [−32768, 32767].
 
-{{short}} constant values in IDL are
+{{i16}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{short}} type is "<code>Short</code>".
+{{i16}} type is "<code>Short</code>".
+
+For legacy compatibility, <code>short</code> is to be treated
+as an alias for {{i16}}, similar to:
+
+<pre highlight="webidl">
+    typedef (i16) short;
+</pre>
 
 
-<h4 oldids="dom-unsignedshort" id="idl-unsigned-short" interface>unsigned short</h4>
+<h4 oldids="dom-unsignedshort idl-unsigned-short" id="idl-u16" interface>u16</h4>
 
-The {{unsigned short}} type is an unsigned integer
+The {{u16}} type is an unsigned integer
 type that has values in the range [0, 65535].
 
-{{unsigned short}} constant values in IDL are
+{{u16}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{unsigned short}} type is "<code>UnsignedShort</code>".
+{{u16}} type is "<code>UnsignedShort</code>".
+
+For legacy compatibility, <code>unsigned short</code> is to be treated
+as an alias for {{u16}}, similar to:
+
+<pre highlight="webidl">
+    typedef (u16) unsigned short;
+</pre>
 
 
-<h4 oldids="dom-long" id="idl-long" interface>long</h4>
+<h4 oldids="dom-long idl-long" id="idl-i32" interface>i32</h4>
 
-The {{long}} type is a signed integer
+The {{i32}} type is a signed integer
 type that has values in the range [−2147483648, 2147483647].
 
-{{long}} constant values in IDL are
+{{i32}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{long}} type is "<code>Long</code>".
+{{i32}} type is "<code>Long</code>".
+
+For legacy compatibility, <code>long</code> is to be treated
+as an alias for {{i32}}, similar to:
+
+<pre highlight="webidl">
+    typedef (i32) long;
+</pre>
 
 
-<h4 oldids="dom-unsignedlong" id="idl-unsigned-long" interface>unsigned long</h4>
+<h4 oldids="dom-unsignedlong idl-unsigned-long" id="idl-u32" interface>u32</h4>
 
-The {{unsigned long}} type is an unsigned integer
+The {{u32}} type is an unsigned integer
 type that has values in the range [0, 4294967295].
 
-{{unsigned long}} constant values in IDL are
+{{u32}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{unsigned long}} type is "<code>UnsignedLong</code>".
+{{u32}} type is "<code>UnsignedLong</code>".
+
+For legacy compatibility, <code>unsigned long</code> is to be treated
+as an alias for {{u32}}, similar to:
+
+<pre highlight="webidl">
+    typedef (u32) unsigned long;
+</pre>
 
 
-<h4 oldids="dom-longlong" id="idl-long-long" interface>long long</h4>
+<h4 oldids="dom-longlong idl-long-long" id="idl-i64" interface>i64</h4>
 
-The {{long long}} type is a signed integer
+The {{i64}} type is a signed integer
 type that has values in the range [−9223372036854775808, 9223372036854775807].
 
-{{long long}} constant values in IDL are
+{{i64}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{long long}} type is "<code>LongLong</code>".
+{{i64}} type is "<code>LongLong</code>".
+
+For legacy compatibility, <code>long long</code> is to be treated
+as an alias for {{i64}}, similar to:
+
+<pre highlight="webidl">
+    typedef (i64) long long;
+</pre>
 
 
-<h4 oldids="dom-unsignedlonglong" id="idl-unsigned-long-long" interface>unsigned long long</h4>
+<h4 oldids="dom-unsignedlonglong idl-unsigned-long-long" id="idl-u64" interface>u64</h4>
 
-The {{unsigned long long}} type is an unsigned integer
+The {{u64}} type is an unsigned integer
 type that has values in the range [0, 18446744073709551615].
 
-{{unsigned long long}} constant values in IDL are
+{{u64}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{unsigned long long}} type is "<code>UnsignedLongLong</code>".
+{{u64}} type is "<code>UnsignedLongLong</code>".
+
+For legacy compatibility, <code>unsigned long long</code> is to be treated
+as an alias for {{u64}}, similar to:
+
+<pre highlight="webidl">
+    typedef (u64) unsigned long long;
+</pre>
 
 
-<h4 oldids="dom-float" id="idl-float" interface>float</h4>
+<h4 oldids="dom-float idl-float" id="idl-f32" interface>f32</h4>
 
-The {{float}} type is a floating point numeric
+The {{f32}} type is a floating point numeric
 type that corresponds to the set of finite single-precision 32 bit
 IEEE 754 floating point numbers. [[!IEEE-754]]
 
-{{float}} constant values in IDL are
+{{f32}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{float}} type is "<code>Float</code>".
+{{f32}} type is "<code>Float</code>".
 
 <p class="advisement">
     Unless there are specific reasons to use a 32 bit floating point type,
     specifications should use
-    {{double}} rather than {{float}},
-    since the set of values that a {{double}} can
+    {{f64}} rather than {{f32}},
+    since the set of values that a {{f64}} can
     represent more closely matches an ECMAScript Number.
 </p>
 
+For legacy compatibility, <code>float</code> is to be treated
+as an alias for {{f32}}, similar to:
 
-<h4 oldids="dom-unrestrictedfloat" id="idl-unrestricted-float" interface>unrestricted float</h4>
+<pre highlight="webidl">
+    typedef (f32) float;
+</pre>
 
-The {{unrestricted float}} type is a floating point numeric
+
+<h4 oldids="dom-unrestrictedfloat idl-unrestricted-float" id="idl-unrestricted-f32" interface>unrestricted f32</h4>
+
+The {{unrestricted f32}} type is a floating point numeric
 type that corresponds to the set of all possible single-precision 32 bit
 IEEE 754 floating point numbers, finite, non-finite, and special "not a number" values (NaNs). [[!IEEE-754]]
 
-{{unrestricted float}} constant values in IDL are
+{{unrestricted f32}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{unrestricted float}} type is "<code>UnrestrictedFloat</code>".
+{{unrestricted f32}} type is "<code>UnrestrictedFloat</code>".
+
+For legacy compatibility, <code>unrestricted float</code> is to be treated
+as an alias for {{unrestricted f32}}, similar to:
+
+<pre highlight="webidl">
+    typedef (unrestricted f32) unrestricted float;
+</pre>
 
 
-<h4 oldids="dom-double" id="idl-double" interface>double</h4>
+<h4 oldids="dom-double idl-double" id="idl-f64" interface>f64</h4>
 
-The {{double}} type is a floating point numeric
+The {{f64}} type is a floating point numeric
 type that corresponds to the set of finite double-precision 64 bit
 IEEE 754 floating point numbers. [[!IEEE-754]]
 
-{{double}} constant values in IDL are
+{{f64}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{double}} type is "<code>Double</code>".
+{{f64}} type is "<code>Double</code>".
+
+For legacy compatibility, <code>double</code> is to be treated
+as an alias for {{f64}}, similar to:
+
+<pre highlight="webidl">
+    typedef (f64) double;
+</pre>
 
 
-<h4 oldids="dom-unrestricteddouble" id="idl-unrestricted-double" interface>unrestricted double</h4>
+<h4 oldids="dom-unrestricteddouble idl-unrestricted-double" id="idl-unrestricted-f64" interface>unrestricted f64</h4>
 
-The {{unrestricted double}} type is a floating point numeric
+The {{unrestricted f64}} type is a floating point numeric
 type that corresponds to the set of all possible double-precision 64 bit
 IEEE 754 floating point numbers, finite, non-finite, and special "not a number" values (NaNs). [[!IEEE-754]]
 
-{{unrestricted double}} constant values in IDL are
+{{unrestricted f64}} constant values in IDL are
 represented with <emu-t class="regex"><a href="#prod-decimal">decimal</a></emu-t>
 tokens.
 
 The [=type name=] of the
-{{unrestricted double}} type is "<code>UnrestrictedDouble</code>".
+{{unrestricted f64}} type is "<code>UnrestrictedDouble</code>".
+
+For legacy compatibility, <code>unrestricted double</code> is to be treated
+as an alias for {{unrestricted f64}}, similar to:
+
+<pre highlight="webidl">
+    typedef (unrestricted f64) unrestricted double;
+</pre>
 
 
 <h4 oldids="dom-DOMString" id="idl-DOMString" interface>DOMString</h4>
@@ -6042,7 +6136,7 @@ the set of all possible sequences of [=code units=].
 Such sequences are commonly interpreted as UTF-16 encoded strings [[!RFC2781]]
 although this is not required.
 While {{DOMString}} is defined to be
-an OMG IDL boxed [=sequence type|sequence=]&lt;{{unsigned short}}&gt; valuetype
+an OMG IDL boxed [=sequence type|sequence=]&lt;{{u16}}&gt; valuetype
 in [[DOM-LEVEL-3-CORE/core#ID-C74D1578|DOM Level 3 Core §The DOMString Type]],
 this document defines {{DOMString}} to be an intrinsic type
 so as to avoid special casing that sequence type
@@ -6095,7 +6189,7 @@ The [=type name=] of the
     {{DOMString}} values, even if it is expected
     that values of the string will always be in ASCII or some
     8 bit character encoding. [=sequence types|Sequences=] or
-    [=frozen array type|frozen arrays=] with {{octet}} or {{byte}}
+    [=frozen array type|frozen arrays=] with {{u8}} or {{i8}}
     elements, {{Uint8Array}}, or {{Int8Array}} should be used for holding
     8 bit data rather than {{ByteString}}.
 </p>
@@ -6411,7 +6505,7 @@ union’s <dfn id="dfn-union-member-type" for="union" export>member types</dfn>.
 <div class="note">
 
     For example, you might write <code>(Node or DOMString)</code>
-    or <code>(double or sequence&lt;double&gt;)</code>.  When applying a
+    or <code>(f64 or sequence&lt;f64&gt;)</code>.  When applying a
     <emu-t>?</emu-t> suffix to a
     [=union type=]
     as a whole, it is placed after the closing parenthesis,
@@ -6419,8 +6513,8 @@ union’s <dfn id="dfn-union-member-type" for="union" export>member types</dfn>.
 
     Note that the [=member types=]
     of a union type do not descend into nested union types.  So for
-    <code>(double or (sequence&lt;long&gt; or Event) or (Node or DOMString)?)</code> the member types
-    are <code>double</code>, <code>(sequence&lt;long&gt; or Event)</code> and
+    <code>(f64 or (sequence&lt;i32&gt; or Event) or (Node or DOMString)?)</code> the member types
+    are <code>f64</code>, <code>(sequence&lt;i32&gt; or Event)</code> and
     <code>(Node or DOMString)?</code>.
 
 </div>
@@ -6454,10 +6548,10 @@ that matches the value.
 
 Note: For example, the [=flattened member types=]
 of the [=union type=]
-<code>(Node or (sequence&lt;long&gt; or Event) or (XMLHttpRequest or DOMString)? or sequence&lt;(sequence&lt;double&gt; or NodeList)&gt;)</code>
-are the six types <code>Node</code>, <code>sequence&lt;long&gt;</code>, <code>Event</code>,
+<code>(Node or (sequence&lt;i32&gt; or Event) or (XMLHttpRequest or DOMString)? or sequence&lt;(sequence&lt;f64&gt; or NodeList)&gt;)</code>
+are the six types <code>Node</code>, <code>sequence&lt;i32&gt;</code>, <code>Event</code>,
 <code>XMLHttpRequest</code>, <code>DOMString</code> and
-<code>sequence&lt;(sequence&lt;double&gt; or NodeList)&gt;</code>.
+<code>sequence&lt;(sequence&lt;f64&gt; or NodeList)&gt;</code>.
 
 <div algorithm>
 
@@ -6521,8 +6615,8 @@ the existing types. Such types are called <dfn export>annotated types</dfn>, and
 annotate are called <dfn export for="annotated types" lt="inner type">inner types</dfn>.
 
 <div class="example">
-    <code>[Clamp] long</code> defines a new [=annotated type=], whose behavior is based on that of
-    the [=annotated types/inner type=] {{long}}, but modified as specified by the [{{Clamp}}]
+    <code>[Clamp] i32</code> defines a new [=annotated type=], whose behavior is based on that of
+    the [=annotated types/inner type=] {{i32}}, but modified as specified by the [{{Clamp}}]
     extended attribute.
 </div>
 
@@ -6547,15 +6641,15 @@ The following extended attributes are <dfn for="extended attributes">applicable 
             <pre class="idl">
                 [Exposed=Window]
                 interface I {
-                    attribute [XAttr] long attrib;
-                    void f1(sequence<[XAttr] long> arg);
-                    void f2(optional [XAttr] long arg);
+                    attribute [XAttr] i32 attrib;
+                    void f1(sequence<[XAttr] i32> arg);
+                    void f2(optional [XAttr] i32 arg);
 
-                    maplike&lt;[XAttr2] DOMString, [XAttr3] long>;
+                    maplike&lt;[XAttr2] DOMString, [XAttr3] i32>;
                 };
 
                 dictionary D {
-                    required [XAttr] long member;
+                    required [XAttr] i32 member;
                 };
             </pre>
         </div>
@@ -6566,7 +6660,7 @@ The following extended attributes are <dfn for="extended attributes">applicable 
             <pre class="idl">
                 [Exposed=Window]
                 interface I {
-                    attribute [XAttr] (long or Node) attrib;
+                    attribute [XAttr] (i32 or Node) attrib;
                 };
             </pre>
         </div>
@@ -6581,7 +6675,7 @@ The following extended attributes are <dfn for="extended attributes">applicable 
             <pre class="idl">
                 [Exposed=Window]
                 interface I {
-                    void f([XAttr] long attrib);
+                    void f([XAttr] i32 attrib);
                 };
             </pre>
 
@@ -6599,7 +6693,7 @@ The following extended attributes are <dfn for="extended attributes">applicable 
         <div class="example">
             <pre class="idl">
                 dictionary D {
-                    [XAttr] long member;
+                    [XAttr] i32 member;
                 };
             </pre>
 
@@ -6612,7 +6706,7 @@ The following extended attributes are <dfn for="extended attributes">applicable 
 
         <div class="example">
             <pre class="idl">
-                typedef [XAttr] long xlong;
+                typedef [XAttr] i32 xlong;
             </pre>
         </div>
     1. Return |extended attributes|.
@@ -6626,7 +6720,7 @@ type name of the original type with the set of strings corresponding to the [=id
 [=extended attribute associated with=] the type, sorted in lexicographic order.
 
 <div class="example">
-    The [=type name=] for a type of the form <code>[B, A] long?</code> is "LongOrNullAB".
+    The [=type name=] for a type of the form <code>[B, A] i32?</code> is "LongOrNullAB".
 </div>
 
 <h4 id="idl-buffer-source-types">Buffer source types</h4>
@@ -6795,7 +6889,7 @@ which form (or forms) it is in:
             <dfn id="dfn-xattr-argument-list" for="extended attribute" export>takes an argument list</dfn>
         </td>
         <td>
-            Not currently used; previously used by <code>[Constructor(double x, double y)]</code>
+            Not currently used; previously used by <code>[Constructor(f64 x, f64 y)]</code>
         </td>
     </tr>
     <tr>
@@ -6918,6 +7012,14 @@ five forms are allowed.
         "true"
         "unsigned"
         "void"
+        "i8"
+        "i16"
+        "i32"
+        "i64"
+        "u8"
+        "u16"
+        "u32"
+        "u64"
         ArgumentNameKeyword
         BufferRelatedType
 </pre>
@@ -7152,7 +7254,7 @@ ECMAScript value type.
         return the {{boolean}} value that represents the same truth value.
     1.  If <a abstract-op>Type</a>(|V|) is Number, then
         return the result of <a href="#es-to-unrestricted-double">converting</a> |V|
-        to an {{unrestricted double}}.
+        to an {{unrestricted f64}}.
     1.  If <a abstract-op>Type</a>(|V|) is String, then
         return the result of <a href="#es-DOMString">converting</a> |V|
         to a {{DOMString}}.
@@ -7221,179 +7323,179 @@ In effect, where <var ignore>x</var> is a Number value,
 “operating on <var ignore>x</var>” is shorthand for
 “operating on the mathematical real number that represents the same numeric value as <var ignore>x</var>”.
 
-<h5 id="es-byte">byte</h5>
+<h5 oldids="es-byte" id="es-i8">i8</h5>
 
-<div id="es-to-byte" algorithm="convert an ECMAScript value to byte">
+<div oldids="es-to-byte" id="es-to-i8" algorithm="convert an ECMAScript value to i8">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{byte}} value by running the following algorithm:
+    to an IDL {{i8}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 8, "<code>signed</code>").
-    1.  Return the IDL {{byte}} value that represents the same numeric value as |x|.
+    1.  Return the IDL {{i8}} value that represents the same numeric value as |x|.
 </div>
 
-<p id="byte-to-es">
+<p oldids="byte-to-es" id="i8-to-es">
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{byte}} value to an ECMAScript
+    an IDL {{i8}} value to an ECMAScript
     value is a Number that represents
-    the same numeric value as the IDL {{byte}} value.
+    the same numeric value as the IDL {{i8}} value.
     The Number value will be an integer in the range [−128, 127].
 </p>
 
 
-<h5 id="es-octet">octet</h5>
+<h5 oldids="es-octet" id="es-u8">u8</h5>
 
-<div id="es-to-octet" algorithm="convert an ECMAScript value to octet">
+<div oldids="es-to-octet" id="es-to-u8" algorithm="convert an ECMAScript value to u8">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{octet}} value by running the following algorithm:
+    to an IDL {{u8}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 8, "<code>unsigned</code>").
-    1.  Return the IDL {{octet}} value that represents the same numeric value as |x|.
+    1.  Return the IDL {{u8}} value that represents the same numeric value as |x|.
 </div>
 
-<p id="octet-to-es">
+<p oldids="octet-to-es" id="u8-to-es">
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{octet}} value to an ECMAScript
+    an IDL {{u8}} value to an ECMAScript
     value is a Number that represents
     the same numeric value as the IDL
-    {{octet}} value.
+    {{u8}} value.
     The Number value will be an integer in the range [0, 255].
 </p>
 
 
-<h5 id="es-short">short</h5>
+<h5 oldids="es-short" id="es-i16">i16</h5>
 
-<div id="es-to-short" algorithm="convert an ECMAScript value to short">
+<div oldids="es-to-short" id="es-to-i16" algorithm="convert an ECMAScript value to i16">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{short}} value by running the following algorithm:
+    to an IDL {{i16}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 16, "<code>signed</code>").
-    1.  Return the IDL {{short}} value that represents the same numeric value as |x|.
+    1.  Return the IDL {{i16}} value that represents the same numeric value as |x|.
 
 </div>
 
-<p id="short-to-es">
+<p oldids="short-to-es" id="i16-to-es">
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{short}} value to an ECMAScript
+    an IDL {{i16}} value to an ECMAScript
     value is a Number that represents the
     same numeric value as the IDL
-    {{short}} value.
+    {{i16}} value.
     The Number value will be an integer in the range [−32768, 32767].
 </p>
 
 
-<h5 id="es-unsigned-short">unsigned short</h5>
+<h5 oldids="es-unsigned-short" id="es-u16">u16</h5>
 
-<div id="es-to-unsigned-short" algorithm="convert an ECMAScript value to unsigned short">
+<div oldids="es-to-unsigned-short" id="es-to-u16" algorithm="convert an ECMAScript value to u16">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{unsigned short}} value by running the following algorithm:
+    to an IDL {{u16}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 16, "<code>unsigned</code>").
-    1.  Return the IDL {{unsigned short}} value that represents the same numeric value as |x|.
+    1.  Return the IDL {{u16}} value that represents the same numeric value as |x|.
 </div>
 
-<p id="unsigned-short-to-es">
+<p oldids="unsigned-short-to-es" id="u16-to-es">
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{unsigned short}} value to an ECMAScript
+    an IDL {{u16}} value to an ECMAScript
     value is a Number that
     represents the same numeric value as the IDL
-    {{unsigned short}} value.
+    {{u16}} value.
     The Number value will be an integer in the range [0, 65535].
 </p>
 
 
-<h5 id="es-long">long</h5>
+<h5 oldids="es-long" id="es-i32">i32</h5>
 
-<div id="es-to-long" algorithm="convert an ECMAScript value to long">
+<div oldids="es-to-long" id="es-to-i32" algorithm="convert an ECMAScript value to i32">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{long}} value by running the following algorithm:
+    to an IDL {{i32}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 32, "<code>signed</code>").
-    1.  Return the IDL {{long}} value that represents the same numeric value as |x|.
+    1.  Return the IDL {{i32}} value that represents the same numeric value as |x|.
 </div>
 
-<p id="long-to-es">
+<p oldids="long-to-es" id="i32-to-es">
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{long}} value to an ECMAScript
+    an IDL {{i32}} value to an ECMAScript
     value is a Number that
     represents the same numeric value as the IDL
-    {{long}} value.
+    {{i32}} value.
     The Number value will be an integer in the range [−2147483648, 2147483647].
 </p>
 
 
-<h5 id="es-unsigned-long">unsigned long</h5>
+<h5 oldids="es-unsigned-long" id="es-u32">u32</h5>
 
-<div id="es-to-unsigned-long" algorithm="convert an ECMAScript value to unsigned long">
+<div oldids="es-to-unsigned-long" id="es-to-u32" algorithm="convert an ECMAScript value to u32">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{unsigned long}} value  by running the following algorithm:
+    to an IDL {{u32}} value  by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 32, "<code>unsigned</code>").
-    1.  Return the IDL {{unsigned long}} value that represents the same numeric value as |x|.
+    1.  Return the IDL {{u32}} value that represents the same numeric value as |x|.
 </div>
 
-<p id="unsigned-long-to-es">
+<p oldids="unsigned-long-to-es" id="u32-to-es">
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{unsigned long}} value to an ECMAScript
+    an IDL {{u32}} value to an ECMAScript
     value is a Number that
     represents the same numeric value as the IDL
-    {{unsigned long}} value.
+    {{u32}} value.
     The Number value will be an integer in the range [0, 4294967295].
 </p>
 
 
-<h5 id="es-long-long">long long</h5>
+<h5 oldids="es-long-long" id="es-i64">i64</h5>
 
-<div id="es-to-long-long" algorithm="convert an ECMAScript value to long long">
+<div oldids="es-to-long-long" id="es-to-i64" algorithm="convert an ECMAScript value to i64">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{long long}} value by running the following algorithm:
+    to an IDL {{i64}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 64, "<code>signed</code>").
-    1.  Return the IDL {{long long}} value that represents the same numeric value as |x|.
+    1.  Return the IDL {{i64}} value that represents the same numeric value as |x|.
 </div>
 
-<p id="long-long-to-es">
+<p oldids="long-long-to-es" id="i64-to-es">
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{long long}} value to an ECMAScript
+    an IDL {{i64}} value to an ECMAScript
     value is a Number value that
-    represents the closest numeric value to the {{long long}},
+    represents the closest numeric value to the {{i64}},
     choosing the numeric value with an <em>even significand</em> if there are
     two [=equally close values=].
-    If the {{long long}} is in the range
+    If the {{i64}} is in the range
     [−2<sup>53</sup> + 1, 2<sup>53</sup> − 1], then the Number
     will be able to represent exactly the same value as the
-    {{long long}}.
+    {{i64}}.
 </p>
 
 
-<h5 id="es-unsigned-long-long">unsigned long long</h5>
+<h5 oldids="es-unsigned-long-long" id="es-u64">u64</h5>
 
-<div id="es-to-unsigned-long-long" algorithm="convert an ECMAScript value to unsigned long long">
+<div oldids="es-to-unsigned-long-long" id="es-to-u64" algorithm="convert an ECMAScript value to u64">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{unsigned long long}} value by running the following algorithm:
+    to an IDL {{u64}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ConvertToInt</a>(|V|, 64, "<code>unsigned</code>").
-    1.  Return the IDL {{unsigned long long}} value that represents the same numeric value as |x|.
+    1.  Return the IDL {{u64}} value that represents the same numeric value as |x|.
 </div>
 
-<p id="unsigned-long-long-to-es">
+<p oldids="unsigned-long-long-to-es" id="u64-to-es">
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{unsigned long long}} value to an ECMAScript
+    an IDL {{u64}} value to an ECMAScript
     value is a Number value that
-    represents the closest numeric value to the {{unsigned long long}},
+    represents the closest numeric value to the {{u64}},
     choosing the numeric value with an <em>even significand</em> if there are
     two [=equally close values=].
-    If the {{unsigned long long}} is less than or equal to 2<sup>53</sup> − 1,
+    If the {{u64}} is less than or equal to 2<sup>53</sup> − 1,
     then the Number will be able to
     represent exactly the same value as the
-    {{unsigned long long}}.
+    {{u64}}.
 </p>
 
 <h5 id="es-integer-types-abstract-ops">Abstract operations</h5>
@@ -7416,7 +7518,7 @@ In effect, where <var ignore>x</var> is a Number value,
         1.  If |signedness| is "<code>unsigned</code>", then let |lowerBound| be 0.
         1.  Otherwise let |lowerBound| be −2<sup>53</sup> + 1.
 
-            Note: this ensures {{long long}} types
+            Note: this ensures {{i64}} types
             [=extended attribute associated with|associated with=] [{{EnforceRange}}] or
             [{{Clamp}}] [=extended attributes=] are representable in ECMAScript's [=Number type=]
             as unambiguous integers.
@@ -7454,12 +7556,12 @@ In effect, where <var ignore>x</var> is a Number value,
 </div>
 
 
-<h4 id="es-float">float</h4>
+<h4 oldids="es-float" id="es-f32">f32</h4>
 
-<div id="es-to-float" algorithm="convert an ECMAScript value to float">
+<div oldids="es-to-float" id="es-to-f32" algorithm="convert an ECMAScript value to f32">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{float}} value by running the following algorithm:
+    to an IDL {{f32}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ToNumber</a>(|V|).
     1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
@@ -7477,23 +7579,23 @@ In effect, where <var ignore>x</var> is a Number value,
     1.  Return |y|.
 </div>
 
-<p id="float-to-es">
+<p oldids="float-to-es" id="f32-to-es">
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{float}} value to an ECMAScript
+    an IDL {{f32}} value to an ECMAScript
     value is the Number value that represents the same numeric value as the IDL
-    {{float}} value.
+    {{f32}} value.
 </p>
 
 
-<h4 id="es-unrestricted-float">unrestricted float</h4>
+<h4 oldids="es-unrestricted-float" id="es-unrestricted-f32">unrestricted f32</h4>
 
-<div id="es-to-unrestricted-float" algorithm="convert an ECMAScript value to unrestricted float">
+<div oldids="es-to-unrestricted-float" id="es-to-unrestricted-f32" algorithm="convert an ECMAScript value to unrestricted f32">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{unrestricted float}} value by running the following algorithm:
+    to an IDL {{unrestricted f32}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ToNumber</a>(|V|).
-    1.  If |x| is <emu-val>NaN</emu-val>, then return the IDL {{unrestricted float}} value that represents the IEEE 754 NaN value with the bit pattern 0x7fc00000 [[!IEEE-754]].
+    1.  If |x| is <emu-val>NaN</emu-val>, then return the IDL {{unrestricted f32}} value that represents the IEEE 754 NaN value with the bit pattern 0x7fc00000 [[!IEEE-754]].
     1.  Let |S| be the set of finite IEEE 754 single-precision floating
         point values except −0, but with two special values added: 2<sup>128</sup> and
         −2<sup>128</sup>.
@@ -7513,54 +7615,54 @@ it must be canonicalized to a particular single precision IEEE 754 NaN value.  T
 mentioned above is chosen simply because it is the quiet NaN with the lowest
 value when its bit pattern is interpreted as an unsigned 32 bit integer.
 
-<div id="unrestricted-float-to-es" algorithm="convert an unrestricted float to an ECMAScript value">
+<div oldids="unrestricted-float-to-es" id="unrestricted-f32-to-es" algorithm="convert an unrestricted f32 to an ECMAScript value">
 
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{unrestricted float}} value to an ECMAScript
+    an IDL {{unrestricted f32}} value to an ECMAScript
     value is a Number:
 
-    1.  If the IDL {{unrestricted float}} value is a NaN,
+    1.  If the IDL {{unrestricted f32}} value is a NaN,
         then the Number value is <emu-val>NaN</emu-val>.
     1.  Otherwise, the Number value is
         the one that represents the same numeric value as the IDL
-        {{unrestricted float}} value.
+        {{unrestricted f32}} value.
 </div>
 
 
-<h4 id="es-double">double</h4>
+<h4 oldids="es-double" id="es-f64">f64</h4>
 
-<div id="es-to-double" algorithm="convert an ECMAScript value to double">
+<div oldids="es-to-double" id="es-to-f64" algorithm="convert an ECMAScript value to f64">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{double}} value by running the following algorithm:
+    to an IDL {{f64}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ToNumber</a>(|V|).
     1.  If |x| is <emu-val>NaN</emu-val>, +∞, or −∞,
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
-    1.  Return the IDL {{double}} value
+    1.  Return the IDL {{f64}} value
         that represents the same numeric value as |x|.
 </div>
 
-<p id="double-to-es">
+<p oldids="double-to-es" id="f64-to-es">
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{double}} value to an ECMAScript
+    an IDL {{f64}} value to an ECMAScript
     value is the Number value that represents the
-    same numeric value as the IDL {{double}} value.
+    same numeric value as the IDL {{f64}} value.
 </p>
 
 
-<h4 id="es-unrestricted-double">unrestricted double</h4>
+<h4 oldids="es-unrestricted-double" id="es-unrestricted-f64">unrestricted f64</h4>
 
-<div id="es-to-unrestricted-double" algorithm="convert an ECMAScript value to unrestricted double">
+<div oldids="es-to-unrestricted-double" id="es-to-unrestricted-f64" algorithm="convert an ECMAScript value to unrestricted f64">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
-    to an IDL {{unrestricted double}} value by running the following algorithm:
+    to an IDL {{unrestricted f64}} value by running the following algorithm:
 
     1.  Let |x| be [=?=] <a abstract-op>ToNumber</a>(|V|).
     1.  If |x| is <emu-val>NaN</emu-val>, then
-        return the IDL {{unrestricted double}} value that represents
+        return the IDL {{unrestricted f64}} value that represents
         the IEEE 754 NaN value with the bit pattern 0x7ff8000000000000 [[!IEEE-754]].
-    1.  Return the IDL {{unrestricted double}} value
+    1.  Return the IDL {{unrestricted f64}} value
         that represents the same numeric value as |x|.
 </div>
 
@@ -7569,17 +7671,17 @@ it must be canonicalized to a particular double precision IEEE 754 NaN value.  T
 mentioned above is chosen simply because it is the quiet NaN with the lowest
 value when its bit pattern is interpreted as an unsigned 64 bit integer.
 
-<div id="unrestricted-double-to-es" algorithm="convert an unrestricted double to an ECMAScript value">
+<div oldids="unrestricted-double-to-es" id="unrestricted-f64-to-es" algorithm="convert an unrestricted f64 to an ECMAScript value">
 
     The result of [=converted to an ECMAScript value|converting=]
-    an IDL {{unrestricted double}} value to an ECMAScript
+    an IDL {{unrestricted f64}} value to an ECMAScript
     value is a Number:
 
-    1.  If the IDL {{unrestricted double}} value is a NaN,
+    1.  If the IDL {{unrestricted f64}} value is a NaN,
         then the Number value is <emu-val>NaN</emu-val>.
     1.  Otherwise, the Number value is
         the one that represents the same numeric value as the IDL
-        {{unrestricted double}} value.
+        {{unrestricted f64}} value.
 </div>
 
 
@@ -7986,8 +8088,8 @@ ECMAScript Array values.
 
           sequence&lt;DOMString&gt; getSupportedImageCodecs();
 
-          void drawPolygon(sequence&lt;double&gt; coordinates);
-          sequence&lt;double&gt; getLastDrawnPolygon();
+          void drawPolygon(sequence&lt;f64&gt; coordinates);
+          sequence&lt;f64&gt; getLastDrawnPolygon();
 
           // ...
         };
@@ -7997,7 +8099,7 @@ ECMAScript Array values.
     object with elements of type String is used to
     represent a <code class="idl">sequence&lt;DOMString&gt;</code>, while an
     Array with elements of type Number
-    represents a <code class="idl">sequence&lt;double&gt;</code>.  The
+    represents a <code class="idl">sequence&lt;f64&gt;</code>.  The
     Array objects are effectively passed by
     value; every time the <code>getSupportedImageCodecs()</code>
     function is called a new Array is
@@ -8030,10 +8132,10 @@ ECMAScript Array values.
         // An Array of Numbers...
         var a = [0, 0, 100, 0, 50, 62.5];
 
-        // ...can be passed to a platform object expecting a sequence&lt;double&gt;.
+        // ...can be passed to a platform object expecting a sequence&lt;f64&gt;.
         canvas.drawPolygon(a);
 
-        // Each element will be converted to a double by first calling ToNumber().
+        // Each element will be converted to a f64 by first calling ToNumber().
         // So the following call is equivalent to the previous one, except that
         // "hi" will be alerted before drawPolygon() returns.
         a = [false, '',
@@ -8096,13 +8198,13 @@ ECMAScript Object values.
 <div class="example" id="example-es-record">
 
     Passing the ECMAScript value <code>{b: 3, a: 4}</code> as a
-    <code>[=record=]&lt;DOMString, double></code> argument
+    <code>[=record=]&lt;DOMString, f64></code> argument
     would result in the IDL value «[ "<code>b</code>" → 3, "<code>a</code>" → 4 ]».
 
     Records only consider [=own property|own=] [=enumerable=]
     properties, so given an IDL operation
-    <code>record&lt;DOMString, double>
-    identity(record&lt;DOMString, double> arg)</code> which returns its
+    <code>record&lt;DOMString, f64>
+    identity(record&lt;DOMString, f64> arg)</code> which returns its
     argument, the following code passes its assertions:
 
     <pre highlight="js">
@@ -8127,17 +8229,17 @@ ECMAScript Object values.
         <thead><th>Value</th><th>Passed to type</th><th>Result</th></thead>
         <tr>
             <td><code>{"😞": 1}</code></td>
-            <td><code>[=record=]&lt;ByteString, double></code></td>
+            <td><code>[=record=]&lt;ByteString, f64></code></td>
             <td>{{ECMAScript/TypeError}}</td>
         </tr>
         <tr>
             <td><code>{"\uD83D": 1}</code></td>
-            <td><code>[=record=]&lt;USVString, double></code></td>
+            <td><code>[=record=]&lt;USVString, f64></code></td>
             <td>«[ "<code>\uFFFD</code>" → 1 ]»</td>
         </tr>
         <tr>
             <td><code>{"\uD83D": {hello: "world"}}</code></td>
-            <td><code>[=record=]&lt;DOMString, double></code></td>
+            <td><code>[=record=]&lt;DOMString, f64></code></td>
             <td>«[ "<code>\uD83D</code>" → 0 ]»</td>
         </tr>
     </table>
@@ -8353,7 +8455,7 @@ JavaScript code.
 
     <pre highlight="webidl">
         interface I {
-          Promise&lt;void> delay(unrestricted double ms);
+          Promise&lt;void> delay(unrestricted f64 ms);
         };
     </pre>
 
@@ -8380,7 +8482,7 @@ JavaScript code.
 
     <pre highlight="webidl">
         interface I {
-          Promise&lt;void> validatedDelay(unrestricted double ms);
+          Promise&lt;void> validatedDelay(unrestricted f64 ms);
         };
     </pre>
 
@@ -8406,7 +8508,7 @@ JavaScript code.
 
     <pre highlight="webidl">
         interface I {
-          Promise&lt;any> addDelay(Promise&lt;any> promise, unrestricted double ms);
+          Promise&lt;any> addDelay(Promise&lt;any> promise, unrestricted f64 ms);
         };
     </pre>
 
@@ -8827,8 +8929,8 @@ See the rules for converting ECMAScript values to IDL [=buffer source types=] in
     <pre highlight="webidl">
         [Exposed=Window]
         interface RenderingContext {
-          void readPixels(long width, long height, BufferSource pixels);
-          void readPixelsShared(long width, long height, [AllowShared] BufferSource pixels);
+          void readPixels(i32 width, i32 height, BufferSource pixels);
+          void readPixelsShared(i32 width, i32 height, [AllowShared] BufferSource pixels);
         };
     </pre>
 
@@ -8864,21 +8966,21 @@ for the specific requirements that the use of
 
     In the following [=IDL fragment=],
     two [=operations=] are declared that
-    take three {{octet}} arguments; one uses
+    take three {{u8}} arguments; one uses
     the [{{Clamp}}] [=extended attribute=]
     on all three arguments, while the other does not:
 
     <pre highlight="webidl">
         [Exposed=Window]
         interface GraphicsContext {
-          void setColor(octet red, octet green, octet blue);
-          void setColorClamped([Clamp] octet red, [Clamp] octet green, [Clamp] octet blue);
+          void setColor(u8 red, u8 green, u8 blue);
+          void setColorClamped([Clamp] u8 red, [Clamp] u8 green, [Clamp] u8 blue);
         };
     </pre>
 
     A call to <code>setColorClamped</code> with
     Number values that are out of range for an
-    {{octet}} are clamped to the range [0, 255].
+    {{u8}} are clamped to the range [0, 255].
 
     <pre highlight="js">
         // Get an instance of GraphicsContext.
@@ -8917,7 +9019,7 @@ for which a [=corresponding default operation=] has been defined.
         [Exposed=Window]
         interface Animal {
           attribute DOMString name;
-          attribute unsigned short age;
+          attribute u16 age;
           [Default] object toJSON();
         };
 
@@ -8995,21 +9097,21 @@ for the specific requirements that the use of
 
     In the following [=IDL fragment=],
     two [=operations=] are declared that
-    take three {{octet}} arguments; one uses
+    take three {{u8}} arguments; one uses
     the [{{EnforceRange}}] [=extended attribute=]
     on all three arguments, while the other does not:
 
     <pre highlight="webidl">
         [Exposed=Window]
         interface GraphicsContext {
-          void setColor(octet red, octet green, octet blue);
-          void setColorEnforcedRange([EnforceRange] octet red, [EnforceRange] octet green, [EnforceRange] octet blue);
+          void setColor(u8 red, u8 green, u8 blue);
+          void setColorEnforcedRange([EnforceRange] u8 red, [EnforceRange] u8 green, [EnforceRange] u8 blue);
         };
     </pre>
 
     In an ECMAScript implementation of the IDL, a call to setColorEnforcedRange with
     Number values that are out of range for an
-    {{octet}} will result in an exception being
+    {{u8}} will result in an exception being
     thrown.
 
     <pre highlight="js">
@@ -9194,9 +9296,9 @@ for the specific requirements that the use of
         // Dimensions is available for use in workers and on the main thread.
         [Exposed=(Window,Worker)]
         interface Dimensions {
-          constructor(double width, double height);
-          readonly attribute double width;
-          readonly attribute double height;
+          constructor(f64 width, f64 height);
+          readonly attribute f64 width;
+          readonly attribute f64 height;
         };
 
         // WorkerNavigator is only available in workers.  Evaluating WorkerNavigator
@@ -9217,7 +9319,7 @@ for the specific requirements that the use of
         // MathUtils is available for use in workers and on the main thread.
         [Exposed=(Window,Worker)]
         namespace MathUtils {
-          double someComplicatedFunction(double x, double y);
+          f64 someComplicatedFunction(f64 x, f64 y);
         };
 
         // WorkerUtils is only available in workers.  Evaluating WorkerUtils
@@ -9225,7 +9327,7 @@ for the specific requirements that the use of
         // doing so on the main thread will give you a ReferenceError.
         [Exposed=Worker]
         namespace WorkerUtils {
-          void setPriority(double x);
+          void setPriority(f64 x);
         };
 
         // NodeUtils is only available in the main thread.  Evaluating NodeUtils
@@ -9963,13 +10065,13 @@ for the specific requirements that the use of
     <pre highlight="webidl">
         [Exposed=Window]
         interface Storage {
-          void addEntry(unsigned long key, any value);
+          void addEntry(u32 key, any value);
         };
 
         [Exposed=Window,
          NoInterfaceObject]
         interface Query {
-          any lookupEntry(unsigned long key);
+          any lookupEntry(u32 key);
         };
     </pre>
 
@@ -10060,14 +10162,14 @@ for the specific requirements that the use of
     <pre highlight="webidl">
         [Exposed=Window]
         interface StringMap {
-          readonly attribute unsigned long length;
+          readonly attribute u32 length;
           getter DOMString lookup(DOMString key);
         };
 
         [Exposed=Window,
          OverrideBuiltins]
         interface StringMap2 {
-          readonly attribute unsigned long length;
+          readonly attribute u32 length;
           getter DOMString lookup(DOMString key);
         };
     </pre>
@@ -10197,7 +10299,7 @@ is to be implemented.
         [Exposed=Window]
         interface Person {
           [PutForwards=full] readonly attribute Name name;
-          attribute unsigned short age;
+          attribute u16 age;
         };
     </pre>
 
@@ -10263,7 +10365,7 @@ for the specific requirements that the use of
     <pre highlight="webidl">
         [Exposed=Window]
         interface Counter {
-          [Replaceable] readonly attribute unsigned long value;
+          [Replaceable] readonly attribute u32 value;
           void increment();
         };
     </pre>
@@ -10438,7 +10540,7 @@ that does specify [{{SecureContext}}].
         // In such a context, there will be no "HeartbeatSensor" property on Window.
         [SecureContext]
         interface HeartbeatSensor {
-          Promise&lt;float&gt; getHeartbeatsPerMinute();
+          Promise&lt;f32&gt; getHeartbeatsPerMinute();
         };
 
         // The interface mixin members defined below will never be exposed in a non-secure context,
@@ -10692,7 +10794,7 @@ for the specific requirements that the use of
         [Exposed=Window]
         interface System {
           [Unforgeable] readonly attribute DOMString username;
-          readonly attribute long long loginTime;
+          readonly attribute i64 loginTime;
         };
     </pre>
 
@@ -13924,7 +14026,7 @@ A {{DOMException}} is represented by a
         [Exposed=Window]
         interface MathUtils {
           // If x is negative, throws a "<a href="#notsupportederror">NotSupportedError</a>" <a href="dfn-DOMException">DOMException</a>.
-          double computeSquareRoot(double x);
+          f64 computeSquareRoot(f64 x);
         };
     </pre>
 
@@ -13980,7 +14082,7 @@ the exact steps to take if <dfn>an exception was thrown</dfn>, or by explicitly 
         [Exposed=Window]
         interface ExceptionThrower {
           // This attribute always throws a NotSupportedError and never returns a value.
-          attribute long valueOf;
+          attribute i32 valueOf;
         };
     </pre>
 
@@ -14222,33 +14324,33 @@ interface DOMException { // but see below note about ECMAScript binding
   constructor(optional DOMString message = "", optional DOMString name = "Error");
   readonly attribute DOMString name;
   readonly attribute DOMString message;
-  readonly attribute unsigned short code;
+  readonly attribute u16 code;
 
-  const unsigned short INDEX_SIZE_ERR = 1;
-  const unsigned short DOMSTRING_SIZE_ERR = 2;
-  const unsigned short HIERARCHY_REQUEST_ERR = 3;
-  const unsigned short WRONG_DOCUMENT_ERR = 4;
-  const unsigned short INVALID_CHARACTER_ERR = 5;
-  const unsigned short NO_DATA_ALLOWED_ERR = 6;
-  const unsigned short NO_MODIFICATION_ALLOWED_ERR = 7;
-  const unsigned short NOT_FOUND_ERR = 8;
-  const unsigned short NOT_SUPPORTED_ERR = 9;
-  const unsigned short INUSE_ATTRIBUTE_ERR = 10;
-  const unsigned short INVALID_STATE_ERR = 11;
-  const unsigned short SYNTAX_ERR = 12;
-  const unsigned short INVALID_MODIFICATION_ERR = 13;
-  const unsigned short NAMESPACE_ERR = 14;
-  const unsigned short INVALID_ACCESS_ERR = 15;
-  const unsigned short VALIDATION_ERR = 16;
-  const unsigned short TYPE_MISMATCH_ERR = 17;
-  const unsigned short SECURITY_ERR = 18;
-  const unsigned short NETWORK_ERR = 19;
-  const unsigned short ABORT_ERR = 20;
-  const unsigned short URL_MISMATCH_ERR = 21;
-  const unsigned short QUOTA_EXCEEDED_ERR = 22;
-  const unsigned short TIMEOUT_ERR = 23;
-  const unsigned short INVALID_NODE_TYPE_ERR = 24;
-  const unsigned short DATA_CLONE_ERR = 25;
+  const u16 INDEX_SIZE_ERR = 1;
+  const u16 DOMSTRING_SIZE_ERR = 2;
+  const u16 HIERARCHY_REQUEST_ERR = 3;
+  const u16 WRONG_DOCUMENT_ERR = 4;
+  const u16 INVALID_CHARACTER_ERR = 5;
+  const u16 NO_DATA_ALLOWED_ERR = 6;
+  const u16 NO_MODIFICATION_ALLOWED_ERR = 7;
+  const u16 NOT_FOUND_ERR = 8;
+  const u16 NOT_SUPPORTED_ERR = 9;
+  const u16 INUSE_ATTRIBUTE_ERR = 10;
+  const u16 INVALID_STATE_ERR = 11;
+  const u16 SYNTAX_ERR = 12;
+  const u16 INVALID_MODIFICATION_ERR = 13;
+  const u16 NAMESPACE_ERR = 14;
+  const u16 INVALID_ACCESS_ERR = 15;
+  const u16 VALIDATION_ERR = 16;
+  const u16 TYPE_MISMATCH_ERR = 17;
+  const u16 SECURITY_ERR = 18;
+  const u16 NETWORK_ERR = 19;
+  const u16 ABORT_ERR = 20;
+  const u16 URL_MISMATCH_ERR = 21;
+  const u16 QUOTA_EXCEEDED_ERR = 22;
+  const u16 TIMEOUT_ERR = 23;
+  const u16 INVALID_NODE_TYPE_ERR = 24;
+  const u16 DATA_CLONE_ERR = 25;
 };
 </pre>
 
@@ -14297,7 +14399,7 @@ Their [=deserialization steps=], given <var>value</var> and <var>serialized</var
 
 <h3 id="DOMTimeStamp" typedef oldids="common-DOMTimeStamp">DOMTimeStamp</h3>
 
-<pre class="idl">typedef unsigned long long DOMTimeStamp;</pre>
+<pre class="idl">typedef u64 DOMTimeStamp;</pre>
 
 The {{DOMTimeStamp}} type is used for representing
 a number of milliseconds, either as an absolute time (relative to some epoch)
@@ -14563,8 +14665,8 @@ text is “<span class="input">a1</span>”, it is tokenized as a single <emu-t 
 and not as a separate <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> and <emu-t class="regex"><a href="#prod-integer">integer</a></emu-t>.
 If the longest possible match could match one of the above named terminal symbols or
 one of the other terminal symbols from the grammar, it must be tokenized as the latter.
-Thus, the input text “<span class="input">long</span>” is tokenized as the quoted terminal symbol
-<emu-t>long</emu-t> rather than an <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> called "<code>long</code>",
+Thus, the input text “<span class="input">i32</span>” is tokenized as the quoted terminal symbol
+<emu-t>i32</emu-t> rather than an <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> called "<code>i32</code>",
 and “<span class="input">.</span>” is tokenized as the quoted terminal symbol
 <emu-t>.</emu-t> rather than an <emu-t class="regex"><a href="#prod-other">other</a></emu-t>.
 
@@ -14619,7 +14721,7 @@ The following typographic conventions are used in this document:
 *   Grammar terminals: <emu-t>sometoken</emu-t>
 *   Grammar non-terminals: <emu-nt>ExampleGrammarNonTerminal</emu-t>
 *   Grammar symbols: <emu-t class="regex">identifier</emu-t>
-*   IDL types: {{unsigned long}}
+*   IDL types: {{u32}}
 *   ECMAScript classes: {{ECMAScript/Map}}
 *   ECMAScript language types: Object
 *   Code snippets: <code>a = b + obj.f()</code>
@@ -14659,7 +14761,7 @@ The following typographic conventions are used in this document:
         // This is an IDL code block.
         [Exposed=Window]
         interface Example {
-          attribute long something;
+          attribute i32 something;
         };
     </pre>
     <pre highlight="js">


### PR DESCRIPTION
Since there was support for <https://github.com/heycam/webidl/issues/843>, I decided to go ahead with opening a PR for this.

I decided to go with `i*` for signed integers because it’s what browser engines and the **Rust** programming language use and due to **ECMAScript** providing implicit support for 32‑bit signed integers using the binary **OR** operator, but none for unsigned integers:

```js
let numI32 = (num | 0); // Converts `num` to a 32-bit signed integer
```

**ECMAScript** `Array`s also restrict the length to a positive 32‑bit signed integer.

## Depends on:

- [ ] <https://github.com/heycam/webidl/pull/857>

---

Resolves #843

🔗 [**PR Preview**](https://pr-preview.s3.amazonaws.com/EB-Forks/webidl/pull/856.html)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/EB-Forks/webidl/pull/856.html" title="Last updated on Sep 6, 2020, 7:42 AM UTC (46cef88)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/856/691b8d2...EB-Forks:46cef88.html" title="Last updated on Sep 6, 2020, 7:42 AM UTC (46cef88)">Diff</a>