### PR TITLE
fix: Only install `@@toStringTag` on the prototype

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11516,8 +11516,7 @@ Issue: Define those properties imperatively instead.
 
 </div>
 
-The [=class string=] of an [=interface prototype object=] is the concatenation of
-the [=interface=]’s [=qualified name=] and the string "<code>Prototype</code>".
+The [=class string=] of an [=interface prototype object=] is the [=interface=]’s [=qualified name=].
 
 
 <h4 id="named-properties-object">Named properties object</h4>
@@ -13389,12 +13388,6 @@ the [=Realm=] associated with a platform object is changed, its
 updated to be the [=interface prototype object=]
 of the [=primary interface=]
 from the [=platform object=]’s newly associated [=Realm=].
-
-The [=class string=] of
-a platform object that implements one or more interfaces
-must be the [=qualified name=] of
-the [=primary interface=]
-of the platform object.
 
 Additionally, [=platform objects=] which implement an [=interface=]
 which has a [{{Global}}] [=extended attribute=]


### PR DESCRIPTION
Supersedes and closes #357

---

This matches the behaviour of **Chromium**, **WebIDL2JS** and the pre‑**ES2015** `[[Class]]` internal slot, which is still used in **Firefox** and **WebKit**.