### PR TITLE
Editorial: add back syntax highlighting for observable array example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6805,8 +6805,7 @@ string "<code>ObservableArray</code>".
 <div class="example">
     The following [=IDL fragment=] defines an [=interface=] with an observable array attribute:
 
-    <!-- TODO: use highlight="idl" after parser update. -->
-    <pre>
+    <pre highlight="webidl">
         [Exposed=Window]
         interface Building {
           attribute ObservableArray&lt;Employee> employees;


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/869.html" title="Last updated on Apr 8, 2020, 8:29 PM UTC (78861cb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/869/42a9d4b...78861cb.html" title="Last updated on Apr 8, 2020, 8:29 PM UTC (78861cb)">Diff</a>