### PR TITLE
Rename all legacy extended attributes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -238,9 +238,6 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
 
 <pre class=biblio>
 {
-    "GEOMETRY": {
-        "aliasOf": "GEOMETRY-1"
-    },
     "JSSTDLIB": {
         "href": "https://github.com/tc39/proposal-javascript-standard-library/",
         "title": "Standard Library Proposal"
@@ -8965,11 +8962,11 @@ algorithm.
 </div>
 
 
-<h3 id="es-extended-attributes">ECMAScript-specific extended attributes</h3>
+<h3 id="es-extended-attributes">Extended attributes</h3>
 
 This section defines a number of
 [=extended attributes=]
-whose presence affects only the ECMAScript binding.
+whose presence affects the ECMAScript binding.
 
 
 <h4 id="AllowShared" extended-attribute lt="AllowShared">[AllowShared]</h4>
@@ -9565,446 +9562,6 @@ corresponding to [=interface members=].
 </div>
 
 
-<h4 id="LegacyNamespace" extended-attribute lt="LegacyNamespace">[LegacyNamespace]</h4>
-
-<p class="advisement">
-    The [{{LegacyNamespace}}] [=extended attribute=] is an undesirable feature.
-    It exists only so that legacy Web platform features can be specified.
-    It should not be used in specifications
-    unless required to specify the behavior of legacy APIs,
-    or for consistency with these APIs.
-    Instead, interface names
-    can be formed with a naming convention of starting with a particular prefix for
-    a set of interfaces, as part of the identifier, rather than using a namespace.
-    Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyNamespace]">filing an issue</a>
-    before proceeding.
-</p>
-
-If the [{{LegacyNamespace}}] [=extended attribute=] appears on an [=interface=], it indicates that
-the [=interface object=] for this interface will not be created as a property of the global
-object, but rather as a property of the [=namespace=] identified by the argument to the extended
-attribute.
-
-The [{{LegacyNamespace}}] extended attribute [=takes an identifier|take an identifier=].
-This identifier must be the identifier of a namespace.
-
-The [{{LegacyNamespace}}] and [{{LegacyNoInterfaceObject}}]
-extended attributes must not be specified on the same interface.
-
-See [[#namespace-object]] for details on how an interface is exposed on a namespace.
-
-<div class="example">
-    The following [=IDL fragment=] defines a [=namespace=] and an [=interface=] which
-    uses [{{LegacyNamespace}}] to be defined inside of it.
-
-    <pre highlight="webidl">
-        namespace Foo { };
-
-        [LegacyNamespace=Foo]
-        interface Bar {
-          constructor();
-        };
-    </pre>
-
-    In an ECMAScript implementation of the above namespace and interface, the
-    constructor Bar can be accessed as follows:
-
-    <pre highlight="js">
-        var instance = new Foo.Bar();
-    </pre>
-</div>
-
-
-<h4 id="LegacyUnenumerableNamedProperties" extended-attribute lt="LegacyUnenumerableNamedProperties">[LegacyUnenumerableNamedProperties]</h4>
-
-<div class="advisement">
-
-    The [{{LegacyUnenumerableNamedProperties}}] [=extended attribute=] is an undesirable feature.
-    It exists only so that legacy Web platform features can be specified.
-    It should not be used in specifications
-    unless required to specify the behavior of legacy APIs,
-    or for consistency with these APIs.
-    Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyUnenumerableNamedProperties]">filing an issue</a>
-    before proceeding.
-
-    <small class="non-normative">
-        The [{{LegacyUnenumerableNamedProperties}}] [=extended attribute=] appears on
-        the following [=interfaces=]:
-        {{HTMLCollection}},
-        {{NamedNodeMap}},
-        {{HTMLAllCollection}},
-        {{HTMLFormElement}},
-        {{PluginArray}},
-        {{MimeTypeArray}},
-        {{Plugin}}, and
-        {{Window}}. [[DOM]] [[HTML]]
-    </small>
-
-</div>
-
-If the [{{LegacyUnenumerableNamedProperties}}]
-[=extended attribute=]
-appears on a [=interface=]
-that [=support named properties|supports named properties=],
-it indicates that all the interface's named properties are unenumerable.
-
-The [{{LegacyUnenumerableNamedProperties}}]
-extended attribute must
-[=takes no arguments|take no arguments=]
-and must not appear on an interface
-that does not define a [=named property getter=].
-
-If the [{{LegacyUnenumerableNamedProperties}}]
-extended attribute is specified on an interface, then it applies to all its derived interfaces and
-must not be specified on any of them.
-
-See [[#legacy-platform-object-getownproperty]]
-for the specific requirements that the use of
-[{{LegacyUnenumerableNamedProperties}}]
-entails.
-
-
-<h4 id="LegacyWindowAlias" extended-attribute lt="LegacyWindowAlias">[LegacyWindowAlias]</h4>
-
-<div class="advisement">
-
-    The [{{LegacyWindowAlias}}] [=extended attribute=] is an undesirable feature.
-    It exists only so that legacy Web platform features can be specified.
-    It should not be used in specifications
-    unless required to specify the behavior of legacy APIs,
-    or for consistency with these APIs.
-    Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyWindowAlias]">filing an issue</a>
-    before proceeding.
-
-    <small class="non-normative">
-        The [{{LegacyWindowAlias}}] [=extended attribute=] appears on the following [=interfaces=]:
-        {{DOMPoint}},
-        {{DOMRect}},
-        {{DOMMatrix}}, and
-        {{URL}}. [[GEOMETRY]] [[URL]]
-    </small>
-
-</div>
-
-If the [{{LegacyWindowAlias}}] [=extended attribute=] appears on an [=interface=],
-it indicates that the {{Window}} [=interface=] will have a property
-for each [=identifier=] mentioned in the extended attribute,
-whose value is the [=interface object=] for the interface.
-
-The [{{LegacyWindowAlias}}] extended attribute must either
-[=takes an identifier|take an identifier=] or
-[=takes an identifier list|take an identifier list=].
-The <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t>s that occur after the
-“<emu-t>=</emu-t>” are the [{{LegacyWindowAlias}}]'s <dfn lt="LegacyWindowAlias identifier">identifiers</dfn>.
-
-Each of the [=LegacyWindowAlias identifier|identifiers=] of [{{LegacyWindowAlias}}]
-must not be the same as one used by a [{{LegacyWindowAlias}}]
-extended attribute on this interface or another interface,
-must not be the same as the [=LegacyFactoryFunction identifier|identifier=] used by a [{{LegacyFactoryFunction}}]
-extended attribute on this interface or another interface,
-must not be the same as an [=identifier=] of an interface that has an [=interface object=],
-and must not be one of the [=reserved identifiers=].
-
-The [{{LegacyWindowAlias}}] and [{{LegacyNoInterfaceObject}}]
-extended attributes must not be specified on the same interface.
-
-The [{{LegacyWindowAlias}}] and [{{LegacyNamespace}}]
-extended attributes must not be specified on the same interface.
-
-The [{{LegacyWindowAlias}}] extended attribute must not be specified
-on an interface that does not include the {{Window}} [=interface=]
-in its [=exposure set=].
-
-An interface must not have more than one [{{LegacyWindowAlias}}] extended attributes specified.
-
-See [[#es-interfaces]] for details on how legacy window aliases
-are to be implemented.
-
-<div class="example">
-
-    The following IDL defines an interface that uses the
-    [{{LegacyWindowAlias}}] extended attribute.
-
-    <pre highlight="webidl">
-        [Exposed=Window,
-         LegacyWindowAlias=WebKitCSSMatrix]
-        interface DOMMatrix : DOMMatrixReadOnly {
-          // ...
-        };
-    </pre>
-
-    An ECMAScript implementation that supports this interface will
-    expose two properties on the {{Window}} object with the same value
-    and the same characteristics;
-    one for exposing the [=interface object=] normally,
-    and one for exposing it with a legacy name.
-
-    <pre highlight="js">
-        WebKitCSSMatrix === DOMMatrix;     // Evaluates to true.
-
-        var m = new WebKitCSSMatrix();     // Creates a new object that
-                                           // implements DOMMatrix.
-
-        m.constructor === DOMMatrix;       // Evaluates to true.
-        m.constructor === WebKitCSSMatrix; // Evaluates to true.
-        {}.toString.call(m);               // Evaluates to '[object DOMMatrix]'.
-    </pre>
-</div>
-
-
-<h4 id="LegacyLenientSetter" extended-attribute lt="LegacyLenientSetter" oldids="LenientSetter">[LegacyLenientSetter]</h4>
-
-<div class="advisement">
-
-    Specifications should not use [{{LegacyLenientSetter}}]
-    unless required for compatibility reasons.  Pages have been observed
-    where authors have attempted to polyfill an IDL attribute by assigning
-    to the property, but have accidentally done so even if the property
-    exists.  In strict mode, this would cause an exception to be thrown,
-    potentially breaking page.  Without [{{LegacyLenientSetter}}],
-    this could prevent a browser from shipping the feature.
-    Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyLenientSetter]">filing an issue</a>
-    before proceeding.
-
-    <small class="non-normative">
-        The [{{LegacyLenientSetter}}] [=extended attribute=] appears on
-        the {{Document/fullscreenEnabled}} and {{Document/fullscreenEnabled}} [=attributes=]
-        of the {{Document}} interface, and on
-        the {{DocumentOrShadowRoot/fullscreenElement}} [=attribute=]
-        of the {{DocumentOrShadowRoot}} [=interface mixin=]. [[FULLSCREEN]]
-    </small>
-
-</div>
-
-If the [{{LegacyLenientSetter}}]
-[=extended attribute=]
-appears on a [=read only=]
-[=regular attribute=],
-it indicates that a no-op setter will be generated for the attribute’s
-accessor property.  This results in erroneous assignments to the property
-in strict mode to be ignored rather than causing an exception to be thrown.
-
-The [{{LegacyLenientSetter}}] extended attribute
-must [=takes no arguments|take no arguments=].
-It must not be used on anything other than
-a [=read only=] [=regular attribute=].
-
-An attribute with the [{{LegacyLenientSetter}}]
-extended attribute must not also be declared
-with the [{{PutForwards}}]
-or [{{Replaceable}}] extended attributes.
-
-The [{{LegacyLenientSetter}}] extended attribute must not be used on an attribute declared on a
-[=namespace=].
-
-See the <a href="#es-attributes">Attributes</a> section for how
-[{{LegacyLenientSetter}}] is to be implemented.
-
-<div class="example">
-
-    The following IDL fragment defines an interface that uses the
-    [{{LegacyLenientSetter}}] extended
-    attribute.
-
-    <pre highlight="webidl">
-        [Exposed=Window]
-        interface Example {
-          [LegacyLenientSetter] readonly attribute DOMString x;
-          readonly attribute DOMString y;
-        };
-    </pre>
-
-    An ECMAScript implementation that supports this interface will
-    have a setter on the accessor property that correspond to x,
-    which allows any assignment to be ignored in strict mode.
-
-    <pre highlight="js">
-        "use strict";
-
-        var example = getExample();  // Get an instance of Example.
-
-        // Fine; while we are in strict mode, there is a setter that is a no-op.
-        example.x = 1;
-
-        // Throws a TypeError, since we are in strict mode and there is no setter.
-        example.y = 1;
-    </pre>
-</div>
-
-
-<h4 id="LegacyLenientThis" extended-attribute lt="LegacyLenientThis" oldids="LenientThis">[LegacyLenientThis]</h4>
-
-<div class="advisement">
-
-    Specifications should not use [{{LegacyLenientThis}}]
-    unless required for compatibility reasons.
-    Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyLenientThis]">filing an issue</a>
-    before proceeding.
-
-    <small class="non-normative">
-        The [{{LegacyLenientThis}}] [=extended attribute=] appears on
-        the {{Document/onreadystatechange}},
-        {{Document/onmouseenter}}, and
-        {{Document/onmouseleave}} [=attributes=]
-        of the {{Document}} interface. [[HTML]]
-    </small>
-
-</div>
-
-If the [{{LegacyLenientThis}}]
-[=extended attribute=]
-appears on a [=regular attribute=],
-it indicates that invocations of the attribute’s getter or setter
-with a <emu-val>this</emu-val> value that is not an
-object that [=implements=] the [=interface=]
-on which the attribute appears will be ignored.
-
-The [{{LegacyLenientThis}}] extended attribute
-must
-[=takes no arguments|take no arguments=].
-It must not be used on a
-[=static attribute=].
-
-The [{{LegacyLenientThis}}] extended attribute must not be used on an attribute declared on a
-[=namespace=].
-
-See the <a href="#es-attributes">Attributes</a> section for how
-[{{LegacyLenientThis}}]
-is to be implemented.
-
-<div class="example">
-
-    The following IDL fragment defines an interface that uses the
-    [{{LegacyLenientThis}}] extended
-    attribute.
-
-    <pre highlight="webidl">
-        [Exposed=Window]
-        interface Example {
-          [LegacyLenientThis] attribute DOMString x;
-          attribute DOMString y;
-        };
-    </pre>
-
-    An ECMAScript implementation that supports this interface will
-    allow the getter and setter of the accessor property that corresponds
-    to x to be invoked with something other than an <code class="idl">Example</code>
-    object.
-
-    <pre highlight="js">
-        var example = getExample();  // Get an instance of Example.
-        var obj = { };
-
-        // Fine.
-        example.x;
-
-        // Ignored, since the this value is not an Example object and [LegacyLenientThis] is used.
-        Object.getOwnPropertyDescriptor(Example.prototype, "x").get.call(obj);
-
-        // Also ignored, since Example.prototype is not an Example object and [LegacyLenientThis] is used.
-        Example.prototype.x;
-
-        // Throws a TypeError, since Example.prototype is not an Example object.
-        Example.prototype.y;
-    </pre>
-</div>
-
-
-<h4 id="LegacyFactoryFunction" extended-attribute lt="LegacyFactoryFunction">[LegacyFactoryFunction]</h4>
-
-<div class="advisement">
-
-    [{{LegacyFactoryFunction}}] [=extended attribute=] is an undesirable feature.
-    It exists only so that legacy Web platform features can be specified.
-    It should not be used in specifications
-    unless required to specify the behavior of legacy APIs,
-    or for consistency with these APIs.
-    Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyFactoryFunction]">filing an issue</a>
-    before proceeding.
-
-    <small class="non-normative">
-        The [{{LegacyFactoryFunction}}] [=extended attribute=] appears on the following [=interfaces=]:
-        {{HTMLAudioElement}},
-        {{HTMLOptionElement}}, and
-        {{HTMLImageElement}}. [[HTML]]
-    </small>
-
-</div>
-
-If the [{{LegacyFactoryFunction}}]
-[=extended attribute=]
-appears on an [=interface=],
-it indicates that the ECMAScript global object will have a property with the
-specified name whose value is a function that can
-create objects that implement the interface.
-Multiple [{{LegacyFactoryFunction}}] extended
-attributes may appear on a given interface.
-
-The [{{LegacyFactoryFunction}}] extended attribute must
-[=takes a named argument list|take a named argument list=].
-The <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> that occurs directly after the
-“<emu-t>=</emu-t>” is the [{{LegacyFactoryFunction}}]'s <dfn lt="LegacyFactoryFunction identifier">identifier</dfn>.
-For each [{{LegacyFactoryFunction}}] extended attribute on the interface,
-there will be a way to construct an object that
-[=implements=] the interface by passing the specified arguments to the [=constructor=]
-that is the value of the aforementioned property.
-
-The [=LegacyFactoryFunction identifier|identifier=] used for the legacy factory function must not
-be the same as that used by a [{{LegacyFactoryFunction}}]
-extended attribute on another interface, must not
-be the same as an [=LegacyWindowAlias identifier|identifier=] used by a [{{LegacyWindowAlias}}]
-extended attribute on this interface or another interface,
-must not be the same as an [=identifier=] of an interface
-that has an [=interface object=],
-and must not be one of the
-[=reserved identifiers=].
-
-The [{{LegacyFactoryFunction}}] and [{{Global}}] [=extended attributes=] must not be specified on the
-same [=interface=].
-
-See [[#legacy-factory-functions]] for details on how legacy factory functions
-are to be implemented.
-
-<div class="example">
-
-    The following IDL defines an interface that uses the
-    [{{LegacyFactoryFunction}}] extended
-    attribute.
-
-    <pre highlight="webidl">
-        [Exposed=Window,
-         LegacyFactoryFunction=Audio(DOMString src)]
-        interface HTMLAudioElement : HTMLMediaElement {
-          // ...
-        };
-    </pre>
-
-    An ECMAScript implementation that supports this interface will
-    allow the construction of <code class="idl">HTMLAudioElement</code>
-    objects using the <code class="idl">Audio</code> function.
-
-    <pre highlight="js">
-        typeof Audio;                   // Evaluates to 'function'.
-
-        var a2 = new Audio('a.flac');   // Creates an HTMLAudioElement using the
-                                        // one-argument constructor.
-    </pre>
-
-    As an additional legacy quirk, these factory functions will have a <code>prototype</code>
-    property equal to the <code>prototype</code> of the original interface:
-
-    <pre highlight="js">
-        console.assert(Audio.prototype === HTMLAudioElement.prototype);
-    </pre>
-</div>
-
-
 <h4 id="NewObject" extended-attribute lt="NewObject">[NewObject]</h4>
 
 If the [{{NewObject}}]
@@ -10042,214 +9599,6 @@ a [=promise type=].
           [NewObject] Element createElement(DOMString localName);
           // ...
         };
-    </pre>
-</div>
-
-
-<h4 id="LegacyNoInterfaceObject" extended-attribute lt="LegacyNoInterfaceObject" oldids="NoInterfaceObject">[LegacyNoInterfaceObject]</h4>
-
-<div class="advisement">
-
-    The [{{LegacyNoInterfaceObject}}] [=extended attribute=] is an undesirable feature.
-    It exists only so that legacy Web platform features can be specified.
-    It should not be used in specifications
-    unless required to specify the behavior of legacy APIs,
-    or for consistency with these APIs.
-    Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyNoInterfaceObject]">filing an issue</a>
-    before proceeding.
-
-    <small class="non-normative">
-        The [{{LegacyNoInterfaceObject}}] [=extended attribute=] appears on the following [=interfaces=]:
-
-        {{WEBGL_compressed_texture_astc}},
-        {{WEBGL_compressed_texture_s3tc_srgb}},
-        {{WEBGL_draw_buffers}},
-        {{WEBGL_lose_context}},
-        {{ANGLE_instanced_arrays}},
-        {{EXT_blend_minmax}},
-        {{EXT_color_buffer_float}},
-        {{EXT_disjoint_timer_query}},
-        {{OES_standard_derivatives}}, and
-        {{OES_vertex_array_object}}.
-        (various [[WEBGL]] extension specifications)
-    </small>
-
-</div>
-
-If the [{{LegacyNoInterfaceObject}}] [=extended attribute=] appears on an [=interface=],
-it indicates that an [=interface object=]
-will not exist for the interface in the ECMAScript binding.
-
-The [{{LegacyNoInterfaceObject}}] extended attribute
-must [=takes no arguments|take no arguments=].
-
-The [{{LegacyNoInterfaceObject}}] extended attribute
-must not be specified on an interface that has any
-[=constructors=] or [=static operations=] defined on it.
-
-Note: Combining the [{{LegacyNoInterfaceObject}}] and [{{LegacyFactoryFunction}}] extended attribute is not
-forbidden, however.
-
-An interface that does not have the [{{LegacyNoInterfaceObject}}] extended
-attribute specified must not inherit
-from an interface that has the [{{LegacyNoInterfaceObject}}] extended
-attribute specified.
-
-See [[#es-interfaces]]
-for the specific requirements that the use of
-[{{LegacyNoInterfaceObject}}] entails.
-
-<div class="example">
-
-    The following [=IDL fragment=] defines two interfaces, one whose interface object
-    is exposed on the ECMAScript global object, and one whose isn’t:
-
-    <pre highlight="webidl">
-        [Exposed=Window]
-        interface Storage {
-          void addEntry(unsigned long key, any value);
-        };
-
-        [Exposed=Window,
-         LegacyNoInterfaceObject]
-        interface Query {
-          any lookupEntry(unsigned long key);
-        };
-    </pre>
-
-    An ECMAScript implementation of the above IDL would allow
-    manipulation of <code class="idl">Storage</code>’s
-    prototype, but not <code class="idl">Query</code>’s.
-
-    <pre highlight="js">
-        typeof Storage;                        // evaluates to "object"
-
-        // Add some tracing alert() call to Storage.addEntry.
-        var fn = Storage.prototype.addEntry;
-        Storage.prototype.addEntry = function(key, value) {
-          alert('Calling addEntry()');
-          return fn.call(this, key, value);
-        };
-
-        typeof Query;                          // evaluates to "undefined"
-        var fn = Query.prototype.lookupEntry;  // exception, Query isn’t defined
-    </pre>
-</div>
-
-
-<h4 id="LegacyOverrideBuiltIns" extended-attribute lt="LegacyOverrideBuiltIns" oldids="OverrideBuiltins">[LegacyOverrideBuiltIns]</h4>
-
-<div class="advisement">
-
-    The [{{LegacyOverrideBuiltIns}}] [=extended attribute=] is an undesirable feature.
-    It exists only so that legacy Web platform features can be specified.
-    It should not be used in specifications
-    unless required to specify the behavior of legacy APIs,
-    or for consistency with these APIs.
-    Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyOverrideBuiltIns]">filing an issue</a>
-    before proceeding.
-
-    <small class="non-normative">
-        The [{{LegacyOverrideBuiltIns}}] [=extended attribute=] appears on the
-        {{DOMStringMap}},
-        {{Document}}, and
-        {{HTMLFormElement}} [=interfaces=]. [[HTML]]
-    </small>
-
-</div>
-
-If the [{{LegacyOverrideBuiltIns}}]
-[=extended attribute=]
-appears on an [=interface=],
-it indicates that for a [=legacy platform object=] implementing the interface,
-properties corresponding to all of
-the object’s [=supported property names=]
-will appear to be on the object,
-regardless of what other properties exist on the object or its
-prototype chain.  This means that named properties will always shadow
-any properties that would otherwise appear on the object.
-This is in contrast to the usual behavior, which is for named properties
-to be exposed only if there is no property with the
-same name on the object itself or somewhere on its prototype chain.
-
-The [{{LegacyOverrideBuiltIns}}]
-extended attribute must
-[=takes no arguments|take no arguments=]
-and must not appear on an interface
-that does not define a [=named property getter=]
-or that also is declared with the [{{Global}}] [=extended attribute=].
-If the extended attribute is specified on
-a [=partial interface=]
-definition, then that partial interface definition must
-be the part of the interface definition that defines
-the [=named property getter=].
-
-If the [{{LegacyOverrideBuiltIns}}] extended attribute is specified on a
-[=partial interface=] definition, it is considered to appear on the
-[=interface=] itself.
-
-See [[#es-legacy-platform-objects]]
-and [[#legacy-platform-object-defineownproperty]]
-for the specific requirements that the use of
-[{{LegacyOverrideBuiltIns}}] entails.
-
-<div class="example">
-
-    The following [=IDL fragment=]
-    defines two [=interfaces=],
-    one that has a [=named property getter=]
-    and one that does not.
-
-    <pre highlight="webidl">
-        [Exposed=Window]
-        interface StringMap {
-          readonly attribute unsigned long length;
-          getter DOMString lookup(DOMString key);
-        };
-
-        [Exposed=Window,
-         LegacyOverrideBuiltIns]
-        interface StringMap2 {
-          readonly attribute unsigned long length;
-          getter DOMString lookup(DOMString key);
-        };
-    </pre>
-
-    In an ECMAScript implementation of these two interfaces,
-    getting certain properties on objects implementing
-    the interfaces will result in different values:
-
-    <pre highlight="js">
-        // Obtain an instance of StringMap.  Assume that it has "abc", "length" and
-        // "toString" as supported property names.
-        var map1 = getStringMap();
-
-        // This invokes the named property getter.
-        map1.abc;
-
-        // This fetches the "length" property on the object that corresponds to the
-        // length attribute.
-        map1.length;
-
-        // This fetches the "toString" property from the object's prototype chain.
-        map1.toString;
-
-        // Obtain an instance of StringMap2.  Assume that it also has "abc", "length"
-        // and "toString" as supported property names.
-        var map2 = getStringMap2();
-
-        // This invokes the named property getter.
-        map2.abc;
-
-        // This also invokes the named property getter, despite the fact that the "length"
-        // property on the object corresponds to the length attribute.
-        map2.length;
-
-        // This too invokes the named property getter, despite the fact that "toString" is
-        // a property in map2's prototype chain.
-        map2.toString;
     </pre>
 </div>
 
@@ -10609,29 +9958,519 @@ that does specify [{{SecureContext}}].
 </div>
 
 
-<h4 id="LegacyTreatNonObjectAsNull" extended-attribute lt="LegacyTreatNonObjectAsNull" oldids="TreatNonObjectAsNull">[LegacyTreatNonObjectAsNull]</h4>
+<h4 id="Unscopable" extended-attribute lt="Unscopable">[Unscopable]</h4>
 
-<div class="advisement">
+If the [{{Unscopable}}]
+[=extended attribute=]
+appears on a [=regular attribute=]
+or [=regular operation=], it
+indicates that an object that [=implements=] an interface with the given
+interface member will not include its property name in any object
+environment record with it as its base object.  The result of this is
+that bare identifiers matching the property name will not resolve to
+the property in a <code>with</code> statement.  This is achieved by
+including the property name on the
+[=interface prototype object=]’s
+{{@@unscopables}} property’s value.
 
-    The [{{LegacyTreatNonObjectAsNull}}] [=extended attribute=] is an undesirable feature.
-    It exists only so that legacy Web platform features can be specified.
-    It should not be used in specifications
-    unless required to specify the behavior of legacy APIs,
-    or for consistency with these APIs.
-    Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyTreatNonObjectAsNull]">filing an issue</a>
-    before proceeding.
+The [{{Unscopable}}]
+extended attribute must
+[=takes no arguments|take no arguments=].
 
-    <small class="non-normative">
-        The [{{LegacyTreatNonObjectAsNull}}] [=extended attribute=] appears on
-        the [=callback functions=] {{EventHandlerNonNull}},
-        {{OnBeforeUnloadEventHandlerNonNull}}, and
-        {{OnErrorEventHandlerNonNull}}
-        used as the type of [=event handler IDL attributes=]
-        such as <code>onclick</code> and <code>onerror</code>. [[HTML]]
-    </small>
+The [{{Unscopable}}]
+extended attribute must not appear on
+anything other than a [=regular attribute=]
+or [=regular operation=].
 
+The [{{Unscopable}}] extended attribute must not be used on an attribute declared on a
+[=namespace=].
+
+See [[#interface-prototype-object]]
+for the specific requirements that the use of
+[{{Unscopable}}] entails.
+
+<div class="note">
+
+    For example, with the following IDL:
+
+    <pre highlight="webidl">
+        [Exposed=Window]
+        interface Thing {
+          void f();
+          [Unscopable] g();
+        };
+    </pre>
+
+    the <code class="idl">f</code> property can be referenced with a bare identifier
+    in a <code>with</code> statement but the <code class="idl">g</code> property cannot:
+
+    <pre highlight="js">
+        var thing = getThing();  // An instance of Thing
+        with (thing) {
+          f;                     // Evaluates to a Function object.
+          g;                     // Throws a ReferenceError.
+        }
+    </pre>
 </div>
+
+
+<h3 id="es-legacy-extended-attributes">Legacy extended attributes</h3>
+
+This section defines a number of [=extended attributes=] whose presence affects the ECMAScript
+binding. Unlike those in [[#es-extended-attributes]], these exist only so that legacy Web platform
+features can be specified. They should not be used in specifications, unless required to specify the
+behavior of legacy APIs.
+
+Editors who believe they have a good reason for using these extended attributes are strongly advised
+to discuss this by
+<a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20a%20legacy%20extended%20attribute">filing an issue</a>
+before proceeding.
+
+
+<h4 id="LegacyFactoryFunction" extended-attribute lt="LegacyFactoryFunction">[LegacyFactoryFunction]</h4>
+
+<p class="advisement">Instead of using this feature, give your interface a [=constructor operation=].</p>
+
+If the [{{LegacyFactoryFunction}}]
+[=extended attribute=]
+appears on an [=interface=],
+it indicates that the ECMAScript global object will have a property with the
+specified name whose value is a function that can
+create objects that implement the interface.
+Multiple [{{LegacyFactoryFunction}}] extended
+attributes may appear on a given interface.
+
+The [{{LegacyFactoryFunction}}] extended attribute must
+[=takes a named argument list|take a named argument list=].
+The <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> that occurs directly after the
+“<emu-t>=</emu-t>” is the [{{LegacyFactoryFunction}}]'s <dfn lt="LegacyFactoryFunction identifier">identifier</dfn>.
+For each [{{LegacyFactoryFunction}}] extended attribute on the interface,
+there will be a way to construct an object that
+[=implements=] the interface by passing the specified arguments to the [=constructor=]
+that is the value of the aforementioned property.
+
+The [=LegacyFactoryFunction identifier|identifier=] used for the legacy factory function must not
+be the same as that used by a [{{LegacyFactoryFunction}}]
+extended attribute on another interface, must not
+be the same as an [=LegacyWindowAlias identifier|identifier=] used by a [{{LegacyWindowAlias}}]
+extended attribute on this interface or another interface,
+must not be the same as an [=identifier=] of an interface
+that has an [=interface object=],
+and must not be one of the
+[=reserved identifiers=].
+
+The [{{LegacyFactoryFunction}}] and [{{Global}}] [=extended attributes=] must not be specified on the
+same [=interface=].
+
+See [[#legacy-factory-functions]] for details on how legacy factory functions
+are to be implemented.
+
+<div class="example">
+
+    The following IDL defines an interface that uses the
+    [{{LegacyFactoryFunction}}] extended
+    attribute.
+
+    <pre highlight="webidl">
+        [Exposed=Window,
+         LegacyFactoryFunction=Audio(DOMString src)]
+        interface HTMLAudioElement : HTMLMediaElement {
+          // ...
+        };
+    </pre>
+
+    An ECMAScript implementation that supports this interface will
+    allow the construction of <code class="idl">HTMLAudioElement</code>
+    objects using the <code class="idl">Audio</code> function.
+
+    <pre highlight="js">
+        typeof Audio;                   // Evaluates to 'function'.
+
+        var a2 = new Audio('a.flac');   // Creates an HTMLAudioElement using the
+                                        // one-argument constructor.
+    </pre>
+
+    As an additional legacy quirk, these factory functions will have a <code>prototype</code>
+    property equal to the <code>prototype</code> of the original interface:
+
+    <pre highlight="js">
+        console.assert(Audio.prototype === HTMLAudioElement.prototype);
+    </pre>
+</div>
+
+
+<h4 id="LegacyLenientSetter" extended-attribute lt="LegacyLenientSetter" oldids="LenientSetter">[LegacyLenientSetter]</h4>
+
+If the [{{LegacyLenientSetter}}]
+[=extended attribute=]
+appears on a [=read only=]
+[=regular attribute=],
+it indicates that a no-op setter will be generated for the attribute’s
+accessor property.  This results in erroneous assignments to the property
+in strict mode to be ignored rather than causing an exception to be thrown.
+
+<p class="note">Pages have been observed where authors have attempted to polyfill an IDL attribute
+by assigning to the property, but have accidentally done so even if the property exists. In strict
+mode, this would cause an exception to be thrown, potentially breaking page. Without
+[{{LegacyLenientSetter}}], this could prevent a browser from shipping the feature.</p>
+
+The [{{LegacyLenientSetter}}] extended attribute
+must [=takes no arguments|take no arguments=].
+It must not be used on anything other than
+a [=read only=] [=regular attribute=].
+
+An attribute with the [{{LegacyLenientSetter}}]
+extended attribute must not also be declared
+with the [{{PutForwards}}]
+or [{{Replaceable}}] extended attributes.
+
+The [{{LegacyLenientSetter}}] extended attribute must not be used on an attribute declared on a
+[=namespace=].
+
+See the <a href="#es-attributes">Attributes</a> section for how
+[{{LegacyLenientSetter}}] is to be implemented.
+
+<div class="example">
+
+    The following IDL fragment defines an interface that uses the
+    [{{LegacyLenientSetter}}] extended
+    attribute.
+
+    <pre highlight="webidl">
+        [Exposed=Window]
+        interface Example {
+          [LegacyLenientSetter] readonly attribute DOMString x;
+          readonly attribute DOMString y;
+        };
+    </pre>
+
+    An ECMAScript implementation that supports this interface will
+    have a setter on the accessor property that correspond to x,
+    which allows any assignment to be ignored in strict mode.
+
+    <pre highlight="js">
+        "use strict";
+
+        var example = getExample();  // Get an instance of Example.
+
+        // Fine; while we are in strict mode, there is a setter that is a no-op.
+        example.x = 1;
+
+        // Throws a TypeError, since we are in strict mode and there is no setter.
+        example.y = 1;
+    </pre>
+</div>
+
+
+<h4 id="LegacyLenientThis" extended-attribute lt="LegacyLenientThis" oldids="LenientThis">[LegacyLenientThis]</h4>
+
+If the [{{LegacyLenientThis}}]
+[=extended attribute=]
+appears on a [=regular attribute=],
+it indicates that invocations of the attribute’s getter or setter
+with a <emu-val>this</emu-val> value that is not an
+object that [=implements=] the [=interface=]
+on which the attribute appears will be ignored.
+
+The [{{LegacyLenientThis}}] extended attribute
+must
+[=takes no arguments|take no arguments=].
+It must not be used on a
+[=static attribute=].
+
+The [{{LegacyLenientThis}}] extended attribute must not be used on an attribute declared on a
+[=namespace=].
+
+See the <a href="#es-attributes">Attributes</a> section for how
+[{{LegacyLenientThis}}]
+is to be implemented.
+
+<div class="example">
+
+    The following IDL fragment defines an interface that uses the
+    [{{LegacyLenientThis}}] extended
+    attribute.
+
+    <pre highlight="webidl">
+        [Exposed=Window]
+        interface Example {
+          [LegacyLenientThis] attribute DOMString x;
+          attribute DOMString y;
+        };
+    </pre>
+
+    An ECMAScript implementation that supports this interface will
+    allow the getter and setter of the accessor property that corresponds
+    to x to be invoked with something other than an <code class="idl">Example</code>
+    object.
+
+    <pre highlight="js">
+        var example = getExample();  // Get an instance of Example.
+        var obj = { };
+
+        // Fine.
+        example.x;
+
+        // Ignored, since the this value is not an Example object and [LegacyLenientThis] is used.
+        Object.getOwnPropertyDescriptor(Example.prototype, "x").get.call(obj);
+
+        // Also ignored, since Example.prototype is not an Example object and [LegacyLenientThis] is used.
+        Example.prototype.x;
+
+        // Throws a TypeError, since Example.prototype is not an Example object.
+        Example.prototype.y;
+    </pre>
+</div>
+
+
+<h4 id="LegacyNamespace" extended-attribute lt="LegacyNamespace">[LegacyNamespace]</h4>
+
+<p class="advisement">Instead of using this feature, interface names can be formed with a naming
+convention of starting with a particular prefix for a set of interfaces, as part of the identifier,
+without the intervening dot.</p>
+
+If the [{{LegacyNamespace}}] [=extended attribute=] appears on an [=interface=], it indicates that
+the [=interface object=] for this interface will not be created as a property of the global
+object, but rather as a property of the [=namespace=] identified by the argument to the extended
+attribute.
+
+The [{{LegacyNamespace}}] extended attribute [=takes an identifier|take an identifier=].
+This identifier must be the identifier of a namespace.
+
+The [{{LegacyNamespace}}] and [{{LegacyNoInterfaceObject}}]
+extended attributes must not be specified on the same interface.
+
+See [[#namespace-object]] for details on how an interface is exposed on a namespace.
+
+<div class="example">
+    The following [=IDL fragment=] defines a [=namespace=] and an [=interface=] which
+    uses [{{LegacyNamespace}}] to be defined inside of it.
+
+    <pre highlight="webidl">
+        namespace Foo { };
+
+        [LegacyNamespace=Foo]
+        interface Bar {
+          constructor();
+        };
+    </pre>
+
+    In an ECMAScript implementation of the above namespace and interface, the
+    constructor Bar can be accessed as follows:
+
+    <pre highlight="js">
+        var instance = new Foo.Bar();
+    </pre>
+</div>
+
+
+<h4 id="LegacyNoInterfaceObject" extended-attribute lt="LegacyNoInterfaceObject" oldids="NoInterfaceObject">[LegacyNoInterfaceObject]</h4>
+
+If the [{{LegacyNoInterfaceObject}}] [=extended attribute=] appears on an [=interface=],
+it indicates that an [=interface object=]
+will not exist for the interface in the ECMAScript binding.
+
+The [{{LegacyNoInterfaceObject}}] extended attribute
+must [=takes no arguments|take no arguments=].
+
+The [{{LegacyNoInterfaceObject}}] extended attribute
+must not be specified on an interface that has any
+[=constructors=] or [=static operations=] defined on it.
+
+An interface that does not have the [{{LegacyNoInterfaceObject}}] extended
+attribute specified must not inherit
+from an interface that has the [{{LegacyNoInterfaceObject}}] extended
+attribute specified.
+
+See [[#es-interfaces]]
+for the specific requirements that the use of
+[{{LegacyNoInterfaceObject}}] entails.
+
+<div class="example">
+
+    The following [=IDL fragment=] defines two interfaces, one whose interface object
+    is exposed on the ECMAScript global object, and one whose isn’t:
+
+    <pre highlight="webidl">
+        [Exposed=Window]
+        interface Storage {
+          void addEntry(unsigned long key, any value);
+        };
+
+        [Exposed=Window,
+         LegacyNoInterfaceObject]
+        interface Query {
+          any lookupEntry(unsigned long key);
+        };
+    </pre>
+
+    An ECMAScript implementation of the above IDL would allow
+    manipulation of <code class="idl">Storage</code>’s
+    prototype, but not <code class="idl">Query</code>’s.
+
+    <pre highlight="js">
+        typeof Storage;                        // evaluates to "object"
+
+        // Add some tracing alert() call to Storage.addEntry.
+        var fn = Storage.prototype.addEntry;
+        Storage.prototype.addEntry = function(key, value) {
+          alert('Calling addEntry()');
+          return fn.call(this, key, value);
+        };
+
+        typeof Query;                          // evaluates to "undefined"
+        var fn = Query.prototype.lookupEntry;  // exception, Query isn’t defined
+    </pre>
+</div>
+
+
+<h4 id="LegacyNullToEmptyString" extended-attribute lt="LegacyNullToEmptyString" oldids="TreatNullAs">[LegacyNullToEmptyString]</h4>
+
+If the [{{LegacyNullToEmptyString}}] [=extended attribute=] appears on the {{DOMString}} type, it creates a new
+IDL type such that that when an ECMAScript <emu-val>null</emu-val> is converted to the IDL type, it
+will be handled differently from its default handling. Instead of being stringified to
+"<code>null</code>", which is the default, it will be converted to the empty string.
+
+The [{{LegacyNullToEmptyString}}] extended attribute must not be
+[=extended attribute associated with|associated with=] a type that is not {{DOMString}}.
+
+Note: This means that even <code class="idl">DOMString?</code> must not use [{{LegacyNullToEmptyString}}], since
+<emu-val>null</emu-val> is a valid value of that type.
+
+See [[#es-DOMString]] for the specific requirements that the use of [{{LegacyNullToEmptyString}}] entails.
+
+<div class="example">
+    The following [=IDL fragment=] defines an interface that has one attribute whose type has the
+    extended attribute, and one operation whose argument's type has the extended attribute:
+
+    <pre highlight="webidl">
+        [Exposed=Window]
+        interface Dog {
+          attribute DOMString name;
+          attribute [LegacyNullToEmptyString] DOMString owner;
+
+          boolean isMemberOfBreed([LegacyNullToEmptyString] DOMString breedName);
+        };
+    </pre>
+
+    An ECMAScript implementation implementing the <code class="idl">Dog</code>
+    interface would convert a <emu-val>null</emu-val> value
+    assigned to the <code>owner</code> property or passed as the
+    argument to the <code>isMemberOfBreed</code> function
+    to the empty string rather than "<code>null</code>":
+
+    <pre highlight="js">
+        var d = getDog();         // Assume d is a platform object implementing the Dog
+                                  // interface.
+
+        d.name = null;            // This assigns the string "null" to the .name
+                                  // property.
+
+        d.owner = null;           // This assigns the string "" to the .owner property.
+
+        d.isMemberOfBreed(null);  // This passes the string "" to the isMemberOfBreed
+                                  // function.
+    </pre>
+</div>
+
+
+<h4 id="LegacyOverrideBuiltIns" extended-attribute lt="LegacyOverrideBuiltIns" oldids="OverrideBuiltins">[LegacyOverrideBuiltIns]</h4>
+
+If the [{{LegacyOverrideBuiltIns}}]
+[=extended attribute=]
+appears on an [=interface=],
+it indicates that for a [=legacy platform object=] implementing the interface,
+properties corresponding to all of
+the object’s [=supported property names=]
+will appear to be on the object,
+regardless of what other properties exist on the object or its
+prototype chain.  This means that named properties will always shadow
+any properties that would otherwise appear on the object.
+This is in contrast to the usual behavior, which is for named properties
+to be exposed only if there is no property with the
+same name on the object itself or somewhere on its prototype chain.
+
+The [{{LegacyOverrideBuiltIns}}]
+extended attribute must
+[=takes no arguments|take no arguments=]
+and must not appear on an interface
+that does not define a [=named property getter=]
+or that also is declared with the [{{Global}}] [=extended attribute=].
+If the extended attribute is specified on
+a [=partial interface=]
+definition, then that partial interface definition must
+be the part of the interface definition that defines
+the [=named property getter=].
+
+If the [{{LegacyOverrideBuiltIns}}] extended attribute is specified on a
+[=partial interface=] definition, it is considered to appear on the
+[=interface=] itself.
+
+See [[#es-legacy-platform-objects]]
+and [[#legacy-platform-object-defineownproperty]]
+for the specific requirements that the use of
+[{{LegacyOverrideBuiltIns}}] entails.
+
+<div class="example">
+
+    The following [=IDL fragment=]
+    defines two [=interfaces=],
+    one that has a [=named property getter=]
+    and one that does not.
+
+    <pre highlight="webidl">
+        [Exposed=Window]
+        interface StringMap {
+          readonly attribute unsigned long length;
+          getter DOMString lookup(DOMString key);
+        };
+
+        [Exposed=Window,
+         LegacyOverrideBuiltIns]
+        interface StringMap2 {
+          readonly attribute unsigned long length;
+          getter DOMString lookup(DOMString key);
+        };
+    </pre>
+
+    In an ECMAScript implementation of these two interfaces,
+    getting certain properties on objects implementing
+    the interfaces will result in different values:
+
+    <pre highlight="js">
+        // Obtain an instance of StringMap.  Assume that it has "abc", "length" and
+        // "toString" as supported property names.
+        var map1 = getStringMap();
+
+        // This invokes the named property getter.
+        map1.abc;
+
+        // This fetches the "length" property on the object that corresponds to the
+        // length attribute.
+        map1.length;
+
+        // This fetches the "toString" property from the object's prototype chain.
+        map1.toString;
+
+        // Obtain an instance of StringMap2.  Assume that it also has "abc", "length"
+        // and "toString" as supported property names.
+        var map2 = getStringMap2();
+
+        // This invokes the named property getter.
+        map2.abc;
+
+        // This also invokes the named property getter, despite the fact that the "length"
+        // property on the object corresponds to the length attribute.
+        map2.length;
+
+        // This too invokes the named property getter, despite the fact that "toString" is
+        // a property in map2's prototype chain.
+        map2.toString;
+    </pre>
+</div>
+
+
+<h4 id="LegacyTreatNonObjectAsNull" extended-attribute lt="LegacyTreatNonObjectAsNull" oldids="TreatNonObjectAsNull">[LegacyTreatNonObjectAsNull]</h4>
 
 If the [{{LegacyTreatNonObjectAsNull}}] [=extended attribute=] appears on a [=callback function=], then
 it indicates that any value assigned to an [=attribute=] whose type is a [=nullable type|nullable=]
@@ -10696,65 +10535,28 @@ for the specific requirements that the use of
 </div>
 
 
-<h4 id="LegacyNullToEmptyString" extended-attribute lt="LegacyNullToEmptyString" oldids="TreatNullAs">[LegacyNullToEmptyString]</h4>
+<h4 id="LegacyUnenumerableNamedProperties" extended-attribute lt="LegacyUnenumerableNamedProperties">[LegacyUnenumerableNamedProperties]</h4>
 
-<p class="advisement">
-    The [{{LegacyNullToEmptyString}}] [=extended attribute=] is an undesirable feature.
-    It exists only so that legacy Web platform features can be specified.
-    It should not be used in specifications
-    unless required to specify the behavior of legacy APIs,
-    or for consistency with these APIs.
-    Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyNullToEmptyString]">filing an issue</a>
-    before proceeding.
-</div>
+If the [{{LegacyUnenumerableNamedProperties}}]
+[=extended attribute=]
+appears on a [=interface=]
+that [=support named properties|supports named properties=],
+it indicates that all the interface's named properties are unenumerable.
 
-If the [{{LegacyNullToEmptyString}}] [=extended attribute=] appears on the {{DOMString}} type, it creates a new
-IDL type such that that when an ECMAScript <emu-val>null</emu-val> is converted to the IDL type, it
-will be handled differently from its default handling. Instead of being stringified to
-"<code>null</code>", which is the default, it will be converted to the empty string.
+The [{{LegacyUnenumerableNamedProperties}}]
+extended attribute must
+[=takes no arguments|take no arguments=]
+and must not appear on an interface
+that does not define a [=named property getter=].
 
-The [{{LegacyNullToEmptyString}}] extended attribute must not be
-[=extended attribute associated with|associated with=] a type that is not {{DOMString}}.
+If the [{{LegacyUnenumerableNamedProperties}}]
+extended attribute is specified on an interface, then it applies to all its derived interfaces and
+must not be specified on any of them.
 
-Note: This means that even <code class="idl">DOMString?</code> must not use [{{LegacyNullToEmptyString}}], since
-<emu-val>null</emu-val> is a valid value of that type.
-
-See [[#es-DOMString]] for the specific requirements that the use of [{{LegacyNullToEmptyString}}] entails.
-
-<div class="example">
-    The following [=IDL fragment=] defines an interface that has one attribute whose type has the
-    extended attribute, and one operation whose argument's type has the extended attribute:
-
-    <pre highlight="webidl">
-        [Exposed=Window]
-        interface Dog {
-          attribute DOMString name;
-          attribute [LegacyNullToEmptyString] DOMString owner;
-
-          boolean isMemberOfBreed([LegacyNullToEmptyString] DOMString breedName);
-        };
-    </pre>
-
-    An ECMAScript implementation implementing the <code class="idl">Dog</code>
-    interface would convert a <emu-val>null</emu-val> value
-    assigned to the <code>owner</code> property or passed as the
-    argument to the <code>isMemberOfBreed</code> function
-    to the empty string rather than "<code>null</code>":
-
-    <pre highlight="js">
-        var d = getDog();         // Assume d is a platform object implementing the Dog
-                                  // interface.
-
-        d.name = null;            // This assigns the string "null" to the .name
-                                  // property.
-
-        d.owner = null;           // This assigns the string "" to the .owner property.
-
-        d.isMemberOfBreed(null);  // This passes the string "" to the isMemberOfBreed
-                                  // function.
-    </pre>
-</div>
+See [[#legacy-platform-object-getownproperty]]
+for the specific requirements that the use of
+[{{LegacyUnenumerableNamedProperties}}]
+entails.
 
 
 <h4 id="LegacyUnforgeable" extended-attribute lt="LegacyUnforgeable" oldids="Unforgeable">[LegacyUnforgeable]</h4>
@@ -10864,58 +10666,70 @@ for the specific requirements that the use of
 </div>
 
 
-<h4 id="Unscopable" extended-attribute lt="Unscopable">[Unscopable]</h4>
+<h4 id="LegacyWindowAlias" extended-attribute lt="LegacyWindowAlias">[LegacyWindowAlias]</h4>
 
-If the [{{Unscopable}}]
-[=extended attribute=]
-appears on a [=regular attribute=]
-or [=regular operation=], it
-indicates that an object that [=implements=] an interface with the given
-interface member will not include its property name in any object
-environment record with it as its base object.  The result of this is
-that bare identifiers matching the property name will not resolve to
-the property in a <code>with</code> statement.  This is achieved by
-including the property name on the
-[=interface prototype object=]’s
-{{@@unscopables}} property’s value.
+If the [{{LegacyWindowAlias}}] [=extended attribute=] appears on an [=interface=],
+it indicates that the {{Window}} [=interface=] will have a property
+for each [=identifier=] mentioned in the extended attribute,
+whose value is the [=interface object=] for the interface.
 
-The [{{Unscopable}}]
-extended attribute must
-[=takes no arguments|take no arguments=].
+The [{{LegacyWindowAlias}}] extended attribute must either
+[=takes an identifier|take an identifier=] or
+[=takes an identifier list|take an identifier list=].
+The <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t>s that occur after the
+“<emu-t>=</emu-t>” are the [{{LegacyWindowAlias}}]'s <dfn lt="LegacyWindowAlias identifier">identifiers</dfn>.
 
-The [{{Unscopable}}]
-extended attribute must not appear on
-anything other than a [=regular attribute=]
-or [=regular operation=].
+Each of the [=LegacyWindowAlias identifier|identifiers=] of [{{LegacyWindowAlias}}]
+must not be the same as one used by a [{{LegacyWindowAlias}}]
+extended attribute on this interface or another interface,
+must not be the same as the [=LegacyFactoryFunction identifier|identifier=] used by a [{{LegacyFactoryFunction}}]
+extended attribute on this interface or another interface,
+must not be the same as an [=identifier=] of an interface that has an [=interface object=],
+and must not be one of the [=reserved identifiers=].
 
-The [{{Unscopable}}] extended attribute must not be used on an attribute declared on a
-[=namespace=].
+The [{{LegacyWindowAlias}}] and [{{LegacyNoInterfaceObject}}]
+extended attributes must not be specified on the same interface.
 
-See [[#interface-prototype-object]]
-for the specific requirements that the use of
-[{{Unscopable}}] entails.
+The [{{LegacyWindowAlias}}] and [{{LegacyNamespace}}]
+extended attributes must not be specified on the same interface.
 
-<div class="note">
+The [{{LegacyWindowAlias}}] extended attribute must not be specified
+on an interface that does not include the {{Window}} [=interface=]
+in its [=exposure set=].
 
-    For example, with the following IDL:
+An interface must not have more than one [{{LegacyWindowAlias}}] extended attributes specified.
+
+See [[#es-interfaces]] for details on how legacy window aliases
+are to be implemented.
+
+<div class="example">
+
+    The following IDL defines an interface that uses the
+    [{{LegacyWindowAlias}}] extended attribute.
 
     <pre highlight="webidl">
-        [Exposed=Window]
-        interface Thing {
-          void f();
-          [Unscopable] g();
+        [Exposed=Window,
+         LegacyWindowAlias=WebKitCSSMatrix]
+        interface DOMMatrix : DOMMatrixReadOnly {
+          // ...
         };
     </pre>
 
-    the <code class="idl">f</code> property can be referenced with a bare identifier
-    in a <code>with</code> statement but the <code class="idl">g</code> property cannot:
+    An ECMAScript implementation that supports this interface will
+    expose two properties on the {{Window}} object with the same value
+    and the same characteristics;
+    one for exposing the [=interface object=] normally,
+    and one for exposing it with a legacy name.
 
     <pre highlight="js">
-        var thing = getThing();  // An instance of Thing
-        with (thing) {
-          f;                     // Evaluates to a Function object.
-          g;                     // Throws a ReferenceError.
-        }
+        WebKitCSSMatrix === DOMMatrix;     // Evaluates to true.
+
+        var m = new WebKitCSSMatrix();     // Creates a new object that
+                                           // implements DOMMatrix.
+
+        m.constructor === DOMMatrix;       // Evaluates to true.
+        m.constructor === WebKitCSSMatrix; // Evaluates to true.
+        {}.toString.call(m);               // Evaluates to '[object DOMMatrix]'.
     </pre>
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1916,7 +1916,7 @@ ignored or an exception is thrown.
 </pre>
 
 Attributes whose type is a [=promise type=] must be [=read only=]. Additionally, they cannot have
-any of the [=extended attributes=] [{{LenientSetter}}], [{{PutForwards}}], [{{Replaceable}}], or
+any of the [=extended attributes=] [{{LegacyLenientSetter}}], [{{PutForwards}}], [{{Replaceable}}], or
 [{{SameObject}}].
 
 A [=regular attribute=]
@@ -1967,7 +1967,7 @@ are applicable to regular and static attributes:
 
 The following [=extended attributes=]
 are applicable only to regular attributes:
-[{{LenientSetter}}],
+[{{LegacyLenientSetter}}],
 [{{LenientThis}}],
 [{{PutForwards}}],
 [{{Replaceable}}],
@@ -9755,23 +9755,23 @@ are to be implemented.
 </div>
 
 
-<h4 id="LenientSetter" extended-attribute lt="LenientSetter">[LenientSetter]</h4>
+<h4 id="LegacyLenientSetter" extended-attribute lt="LegacyLenientSetter" oldids="LenientSetter">[LegacyLenientSetter]</h4>
 
 <div class="advisement">
 
-    Specifications should not use [{{LenientSetter}}]
+    Specifications should not use [{{LegacyLenientSetter}}]
     unless required for compatibility reasons.  Pages have been observed
     where authors have attempted to polyfill an IDL attribute by assigning
     to the property, but have accidentally done so even if the property
     exists.  In strict mode, this would cause an exception to be thrown,
-    potentially breaking page.  Without [{{LenientSetter}}],
+    potentially breaking page.  Without [{{LegacyLenientSetter}}],
     this could prevent a browser from shipping the feature.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LenientSetter]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyLenientSetter]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
-        The [{{LenientSetter}}] [=extended attribute=] appears on
+        The [{{LegacyLenientSetter}}] [=extended attribute=] appears on
         the {{Document/fullscreenEnabled}} and {{Document/fullscreenEnabled}} [=attributes=]
         of the {{Document}} interface, and on
         the {{DocumentOrShadowRoot/fullscreenElement}} [=attribute=]
@@ -9780,7 +9780,7 @@ are to be implemented.
 
 </div>
 
-If the [{{LenientSetter}}]
+If the [{{LegacyLenientSetter}}]
 [=extended attribute=]
 appears on a [=read only=]
 [=regular attribute=],
@@ -9788,32 +9788,32 @@ it indicates that a no-op setter will be generated for the attribute’s
 accessor property.  This results in erroneous assignments to the property
 in strict mode to be ignored rather than causing an exception to be thrown.
 
-The [{{LenientSetter}}] extended attribute
+The [{{LegacyLenientSetter}}] extended attribute
 must [=takes no arguments|take no arguments=].
 It must not be used on anything other than
 a [=read only=] [=regular attribute=].
 
-An attribute with the [{{LenientSetter}}]
+An attribute with the [{{LegacyLenientSetter}}]
 extended attribute must not also be declared
 with the [{{PutForwards}}]
 or [{{Replaceable}}] extended attributes.
 
-The [{{LenientSetter}}] extended attribute must not be used on an attribute declared on a
+The [{{LegacyLenientSetter}}] extended attribute must not be used on an attribute declared on a
 [=namespace=].
 
 See the <a href="#es-attributes">Attributes</a> section for how
-[{{LenientSetter}}] is to be implemented.
+[{{LegacyLenientSetter}}] is to be implemented.
 
 <div class="example">
 
     The following IDL fragment defines an interface that uses the
-    [{{LenientSetter}}] extended
+    [{{LegacyLenientSetter}}] extended
     attribute.
 
     <pre highlight="webidl">
         [Exposed=Window]
         interface Example {
-          [LenientSetter] readonly attribute DOMString x;
+          [LegacyLenientSetter] readonly attribute DOMString x;
           readonly attribute DOMString y;
         };
     </pre>
@@ -10322,7 +10322,7 @@ encountered more than once.
 
 An attribute with the [{{PutForwards}}]
 extended attribute must not also be declared
-with the [{{LenientSetter}}] or
+with the [{{LegacyLenientSetter}}] or
 [{{Replaceable}}] extended attributes.
 
 The [{{PutForwards}}]
@@ -10398,7 +10398,7 @@ extended attribute must
 
 An attribute with the [{{Replaceable}}]
 extended attribute must not also be declared
-with the [{{LenientSetter}}] or
+with the [{{LegacyLenientSetter}}] or
 [{{PutForwards}}] extended attributes.
 
 The [{{Replaceable}}]
@@ -11781,7 +11781,7 @@ in which case they are exposed on every object that [=implements=] the interface
         1. Assert: |attribute| is [=read only=].
         1. Return <emu-val>undefined</emu-val>.
     1.  If |attribute| is [=read only=] and does not have a
-        [{{LenientSetter}}], [{{PutForwards}}] or [{{Replaceable}}] [=extended attribute=], return
+        [{{LegacyLenientSetter}}], [{{PutForwards}}] or [{{Replaceable}}] [=extended attribute=], return
         <emu-val>undefined</emu-val>; there is no [=attribute setter=] function.
     1.  Assert: |attribute|'s type is not a [=promise type=].
     1.  Let |steps| be the following series of steps:
@@ -11806,7 +11806,7 @@ in which case they are exposed on every object that [=implements=] the interface
                 1.  Perform [=?=] <a abstract-op>CreateDataProperty</a>(|esValue|, |id|, |V|).
                 1.  Return <emu-val>undefined</emu-val>.
             1.  If |validThis| is false, then return <emu-val>undefined</emu-val>.
-            1.  If |attribute| is declared with a [{{LenientSetter}}] extended attribute, then
+            1.  If |attribute| is declared with a [{{LegacyLenientSetter}}] extended attribute, then
                 return <emu-val>undefined</emu-val>.
             1.  If |attribute| is declared with a [{{PutForwards}}] extended attribute, then:
                 1.  Let |Q| be [=?=] <a abstract-op>Get</a>(|esValue|, |id|).

--- a/index.bs
+++ b/index.bs
@@ -1010,7 +1010,7 @@ The following extended attributes are applicable to interfaces:
 [{{Global}}],
 [{{LegacyWindowAlias}}],
 [{{LegacyFactoryFunction}}],
-[{{NoInterfaceObject}}],
+[{{LegacyNoInterfaceObject}}],
 [{{LegacyOverrideBuiltIns}}], and
 [{{SecureContext}}].
 
@@ -1020,7 +1020,7 @@ The following extended attributes are applicable to [=partial interfaces=]:
 [{{SecureContext}}].
 
 [=Interfaces=] which are not annotated
-with a [{{NoInterfaceObject}}] [=extended attribute=]
+with a [{{LegacyNoInterfaceObject}}] [=extended attribute=]
 must be annotated with an [{{Exposed}}] [=extended attribute=].
 
 <div algorithm>
@@ -9589,7 +9589,7 @@ attribute.
 The [{{LegacyNamespace}}] extended attribute [=takes an identifier|take an identifier=].
 This identifier must be the identifier of a namespace.
 
-The [{{LegacyNamespace}}] and [{{NoInterfaceObject}}]
+The [{{LegacyNamespace}}] and [{{LegacyNoInterfaceObject}}]
 extended attributes must not be specified on the same interface.
 
 See [[#namespace-object]] for details on how an interface is exposed on a namespace.
@@ -9708,7 +9708,7 @@ extended attribute on this interface or another interface,
 must not be the same as an [=identifier=] of an interface that has an [=interface object=],
 and must not be one of the [=reserved identifiers=].
 
-The [{{LegacyWindowAlias}}] and [{{NoInterfaceObject}}]
+The [{{LegacyWindowAlias}}] and [{{LegacyNoInterfaceObject}}]
 extended attributes must not be specified on the same interface.
 
 The [{{LegacyWindowAlias}}] and [{{LegacyNamespace}}]
@@ -10046,29 +10046,22 @@ a [=promise type=].
 </div>
 
 
-<h4 id="NoInterfaceObject" extended-attribute lt="NoInterfaceObject">[NoInterfaceObject]</h4>
+<h4 id="LegacyNoInterfaceObject" extended-attribute lt="LegacyNoInterfaceObject" oldids="NoInterfaceObject">[LegacyNoInterfaceObject]</h4>
 
 <div class="advisement">
 
-    The [{{NoInterfaceObject}}] [=extended attribute=] is an undesirable feature.
+    The [{{LegacyNoInterfaceObject}}] [=extended attribute=] is an undesirable feature.
     It exists only so that legacy Web platform features can be specified.
     It should not be used in specifications
     unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[NoInterfaceObject]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyNoInterfaceObject]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
-        The [{{NoInterfaceObject}}] [=extended attribute=] appears on the following [=interfaces=]:
+        The [{{LegacyNoInterfaceObject}}] [=extended attribute=] appears on the following [=interfaces=]:
 
-        {{Geolocation}},
-        {{Coordinates}},
-        {{Position}},
-        {{PositionError}},
-        {{DeviceAcceleration}},
-        {{DeviceRotationRate}},
-        {{ConstrainablePattern}},
         {{WEBGL_compressed_texture_astc}},
         {{WEBGL_compressed_texture_s3tc_srgb}},
         {{WEBGL_draw_buffers}},
@@ -10079,45 +10072,33 @@ a [=promise type=].
         {{EXT_disjoint_timer_query}},
         {{OES_standard_derivatives}}, and
         {{OES_vertex_array_object}}.
-        [[GEOLOCATION-API]]
-        [[ORIENTATION-EVENT]]
-        [[MEDIACAPTURE-STREAMS]]
         (various [[WEBGL]] extension specifications)
     </small>
 
-    Note: Previously, the [{{NoInterfaceObject}}] [=extended attribute=] could also be used
-    to annotate [=interfaces=], which other [=interfaces=] could then implement
-    (using the defunct "implements statement") as if they were mixins.
-    There is now dedicated syntax to cater for this use case
-    in the form of [=interface mixins=] and [=includes statements=].
-    Using the [{{NoInterfaceObject}}] [=extended attribute=]
-    for this purpose is no longer supported.
-    Specifications which still do are strongly encouraged
-    to migrate to [=interface mixins=] as soon as possible.
 </div>
 
-If the [{{NoInterfaceObject}}] [=extended attribute=] appears on an [=interface=],
+If the [{{LegacyNoInterfaceObject}}] [=extended attribute=] appears on an [=interface=],
 it indicates that an [=interface object=]
 will not exist for the interface in the ECMAScript binding.
 
-The [{{NoInterfaceObject}}] extended attribute
+The [{{LegacyNoInterfaceObject}}] extended attribute
 must [=takes no arguments|take no arguments=].
 
-The [{{NoInterfaceObject}}] extended attribute
+The [{{LegacyNoInterfaceObject}}] extended attribute
 must not be specified on an interface that has any
 [=constructors=] or [=static operations=] defined on it.
 
-Note: Combining the [{{NoInterfaceObject}}] and [{{LegacyFactoryFunction}}] extended attribute is not
+Note: Combining the [{{LegacyNoInterfaceObject}}] and [{{LegacyFactoryFunction}}] extended attribute is not
 forbidden, however.
 
-An interface that does not have the [{{NoInterfaceObject}}] extended
+An interface that does not have the [{{LegacyNoInterfaceObject}}] extended
 attribute specified must not inherit
-from an interface that has the [{{NoInterfaceObject}}] extended
+from an interface that has the [{{LegacyNoInterfaceObject}}] extended
 attribute specified.
 
 See [[#es-interfaces]]
 for the specific requirements that the use of
-[{{NoInterfaceObject}}] entails.
+[{{LegacyNoInterfaceObject}}] entails.
 
 <div class="example">
 
@@ -10131,7 +10112,7 @@ for the specific requirements that the use of
         };
 
         [Exposed=Window,
-         NoInterfaceObject]
+         LegacyNoInterfaceObject]
         interface Query {
           any lookupEntry(unsigned long key);
         };
@@ -11252,7 +11233,7 @@ Note: The HTML Standard defines how a security check is performed. [[!HTML]]
 
 For every [=interface=] that is [=exposed=] in
 a given [=Realm=] and that is not declared with
-the [{{NoInterfaceObject}}] or [{{LegacyNamespace}}] [=extended attributes=],
+the [{{LegacyNoInterfaceObject}}] or [{{LegacyNamespace}}] [=extended attributes=],
 a corresponding property exists on the [=Realm=]'s [=Realm/global object=].
 The name of the property is the [=identifier=] of the interface,
 and its value is an object called the <dfn id="dfn-interface-object" export>interface object</dfn>.
@@ -11424,7 +11405,7 @@ implement the interface on which the
 There will exist an <dfn id="dfn-interface-prototype-object" export>interface prototype object</dfn>
 for every [=interface=] defined,
 regardless of whether the interface was declared
-with the [{{NoInterfaceObject}}] [=extended attribute=].
+with the [{{LegacyNoInterfaceObject}}] [=extended attribute=].
 
 <div algorithm>
 
@@ -11475,7 +11456,7 @@ with the [{{NoInterfaceObject}}] [=extended attribute=].
         1.  [=Define the asynchronous iteration methods=] of |interface| on |interfaceProtoObj|
             given |realm|.
     1.  [=Define the constants=] of |interface| on |interfaceProtoObj| given |realm|.
-    1.  If the [{{NoInterfaceObject}}] [=extended attribute=] was not specified on |interface|, then:
+    1.  If the [{{LegacyNoInterfaceObject}}] [=extended attribute=] was not specified on |interface|, then:
         1.  Let |constructor| be the [=interface object=] of |interface| in |realm|.
         1.  Let |desc| be the PropertyDescriptor{\[[Writable]]: <emu-val>true</emu-val>,
             \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>,
@@ -11498,14 +11479,14 @@ Issue: Define those properties imperatively instead.
 
     The [=interface prototype object=]
     of an [=interface=] that is defined with
-    the [{{NoInterfaceObject}}]
+    the [{{LegacyNoInterfaceObject}}]
     [=extended attribute=]
     will be accessible.
     For example, with the following IDL:
 
     <pre highlight="webidl">
         [Exposed=Window,
-         NoInterfaceObject]
+         LegacyNoInterfaceObject]
         interface Foo {
         };
 
@@ -13239,7 +13220,7 @@ the Realm given as an argument.
     1.  Sort |interfaces| in such a way that if |A| and |B| are [=list/items=] of |interfaces|,
         and |A| [=interface/inherits=] from |B|, |A| has a higher index in |interfaces| than |B|.
     1.  [=list/iterate|For every=] |interface| of |interfaces|:
-        1.  If |interface| is not declared with the [{{NoInterfaceObject}}] or
+        1.  If |interface| is not declared with the [{{LegacyNoInterfaceObject}}] or
             [{{LegacyNamespace}}] [=extended attributes=], then:
             1.  Let |id| be |interface|'s [=identifier=].
             1.  Let |interfaceObject| be the result of [=create an interface object|creating

--- a/index.bs
+++ b/index.bs
@@ -1968,7 +1968,7 @@ are applicable to regular and static attributes:
 The following [=extended attributes=]
 are applicable only to regular attributes:
 [{{LegacyLenientSetter}}],
-[{{LenientThis}}],
+[{{LegacyLenientThis}}],
 [{{PutForwards}}],
 [{{Replaceable}}],
 [{{Unforgeable}}].
@@ -9836,18 +9836,18 @@ See the <a href="#es-attributes">Attributes</a> section for how
 </div>
 
 
-<h4 id="LenientThis" extended-attribute lt="LenientThis">[LenientThis]</h4>
+<h4 id="LegacyLenientThis" extended-attribute lt="LegacyLenientThis" oldids="LenientThis">[LegacyLenientThis]</h4>
 
 <div class="advisement">
 
-    Specifications should not use [{{LenientThis}}]
+    Specifications should not use [{{LegacyLenientThis}}]
     unless required for compatibility reasons.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LenientThis]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyLenientThis]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
-        The [{{LenientThis}}] [=extended attribute=] appears on
+        The [{{LegacyLenientThis}}] [=extended attribute=] appears on
         the {{Document/onreadystatechange}},
         {{Document/onmouseenter}}, and
         {{Document/onmouseleave}} [=attributes=]
@@ -9856,7 +9856,7 @@ See the <a href="#es-attributes">Attributes</a> section for how
 
 </div>
 
-If the [{{LenientThis}}]
+If the [{{LegacyLenientThis}}]
 [=extended attribute=]
 appears on a [=regular attribute=],
 it indicates that invocations of the attribute’s getter or setter
@@ -9864,29 +9864,29 @@ with a <emu-val>this</emu-val> value that is not an
 object that [=implements=] the [=interface=]
 on which the attribute appears will be ignored.
 
-The [{{LenientThis}}] extended attribute
+The [{{LegacyLenientThis}}] extended attribute
 must
 [=takes no arguments|take no arguments=].
 It must not be used on a
 [=static attribute=].
 
-The [{{LenientThis}}] extended attribute must not be used on an attribute declared on a
+The [{{LegacyLenientThis}}] extended attribute must not be used on an attribute declared on a
 [=namespace=].
 
 See the <a href="#es-attributes">Attributes</a> section for how
-[{{LenientThis}}]
+[{{LegacyLenientThis}}]
 is to be implemented.
 
 <div class="example">
 
     The following IDL fragment defines an interface that uses the
-    [{{LenientThis}}] extended
+    [{{LegacyLenientThis}}] extended
     attribute.
 
     <pre highlight="webidl">
         [Exposed=Window]
         interface Example {
-          [LenientThis] attribute DOMString x;
+          [LegacyLenientThis] attribute DOMString x;
           attribute DOMString y;
         };
     </pre>
@@ -9903,10 +9903,10 @@ is to be implemented.
         // Fine.
         example.x;
 
-        // Ignored, since the this value is not an Example object and [LenientThis] is used.
+        // Ignored, since the this value is not an Example object and [LegacyLenientThis] is used.
         Object.getOwnPropertyDescriptor(Example.prototype, "x").get.call(obj);
 
-        // Also ignored, since Example.prototype is not an Example object and [LenientThis] is used.
+        // Also ignored, since Example.prototype is not an Example object and [LegacyLenientThis] is used.
         Example.prototype.x;
 
         // Throws a TypeError, since Example.prototype is not an Example object.
@@ -11741,13 +11741,13 @@ in which case they are exposed on every object that [=implements=] the interface
                     <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, or |realm|'s
                     [=Realm/global object=] otherwise.
                     (This will subsequently cause a {{ECMAScript/TypeError}} in a few steps, if
-                    the global object does not implement |target| and [{{LenientThis}}] is not
+                    the global object does not implement |target| and [{{LegacyLenientThis}}] is not
                     specified.)
                     <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
                 1.  If |esValue| [=is a platform object=], then [=perform a security check=],
                     passing |esValue|, |attribute|'s [=identifier=], and "getter".
                 1.  If |esValue| does not [=implement=] |target|, then:
-                    1.  If |attribute| was specified with the [{{LenientThis}}]
+                    1.  If |attribute| was specified with the [{{LegacyLenientThis}}]
                         [=extended attribute=], then return <emu-val>undefined</emu-val>.
                     1.  Otherwise, [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
                 1.  If |attribute|'s type is an [=observable array type=], then return |esValue|'s
@@ -11794,13 +11794,13 @@ in which case they are exposed on every object that [=implements=] the interface
                 <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, or |realm|'s
                 [=Realm/global object=] otherwise.
                 (This will subsequently cause a {{ECMAScript/TypeError}} in a few steps, if
-                the global object does not implement |target| and [{{LenientThis}}] is not
+                the global object does not implement |target| and [{{LegacyLenientThis}}] is not
                 specified.)
                 <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
             1.  If |esValue| [=is a platform object=], then [=perform a security check=], passing
                 |esValue|, |id|, and "setter".
             1.  Let |validThis| be true if |esValue| [=implements=] |target|, or false otherwise.
-            1.  If |validThis| is false and |attribute| was not specified with the [{{LenientThis}}]
+            1.  If |validThis| is false and |attribute| was not specified with the [{{LegacyLenientThis}}]
                 [=extended attribute=], then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
             1.  If |attribute| is declared with the [{{Replaceable}}] extended attribute, then:
                 1.  Perform [=?=] <a abstract-op>CreateDataProperty</a>(|esValue|, |id|, |V|).
@@ -11936,7 +11936,7 @@ in which case they are exposed on every object that [=implements=] the interface
                     <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, or |realm|'s
                     [=Realm/global object=] otherwise.
                     (This will subsequently cause a {{ECMAScript/TypeError}} in a few steps, if
-                    the global object does not implement |target| and [{{LenientThis}}] is not
+                    the global object does not implement |target| and [{{LegacyLenientThis}}] is not
                     specified.)
                     <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=18547#c9 -->
                 1.  If |esValue| [=is a platform object=], then [=perform a security check=],

--- a/index.bs
+++ b/index.bs
@@ -1971,7 +1971,7 @@ are applicable only to regular attributes:
 [{{LegacyLenientThis}}],
 [{{PutForwards}}],
 [{{Replaceable}}],
-[{{Unforgeable}}].
+[{{LegacyUnforgeable}}].
 
 <pre class="grammar" id="prod-ReadOnlyMember">
     ReadOnlyMember :
@@ -2414,7 +2414,7 @@ The following extended attributes are applicable to operations:
 [{{Exposed}}],
 [{{NewObject}}],
 [{{SecureContext}}],
-[{{Unforgeable}}].
+[{{LegacyUnforgeable}}].
 
 <pre class="grammar" id="prod-DefaultValue">
     DefaultValue :
@@ -10781,9 +10781,9 @@ See [[#es-DOMString]] for the specific requirements that the use of [{{TreatNull
 </div>
 
 
-<h4 id="Unforgeable" extended-attribute lt="Unforgeable">[Unforgeable]</h4>
+<h4 id="LegacyUnforgeable" extended-attribute lt="LegacyUnforgeable" oldids="Unforgeable">[LegacyUnforgeable]</h4>
 
-If the [{{Unforgeable}}] [=extended attribute=] appears on
+If the [{{LegacyUnforgeable}}] [=extended attribute=] appears on
 [=regular attributes=] or non-[=static operations|static=] [=operations=],
 it indicates that the attribute or operation
 will be reflected as an ECMAScript property
@@ -10797,18 +10797,18 @@ rather than on its prototype.
 An attribute or operation is said to be
 <dfn id="dfn-unforgeable-on-an-interface" export>unforgeable</dfn> on a given interface |A|
 if the attribute or operation is declared on |A|,
-and is annotated with the [{{Unforgeable}}] [=extended attribute=].
+and is annotated with the [{{LegacyUnforgeable}}] [=extended attribute=].
 
-The [{{Unforgeable}}] extended attribute must [=takes no arguments|take no arguments=].
+The [{{LegacyUnforgeable}}] extended attribute must [=takes no arguments|take no arguments=].
 
-The [{{Unforgeable}}] [=extended attribute=] must not appear
+The [{{LegacyUnforgeable}}] [=extended attribute=] must not appear
 on anything other than a [=regular attribute=]
 or a non-[=static operations|static=] [=operation=].
 If it does appear on an [=operation=],
 then it must appear on all operations
 with the same [=identifier=] on that interface.
 
-The [{{Unforgeable}}] extended attribute must not be used
+The [{{LegacyUnforgeable}}] extended attribute must not be used
 on an attribute declared on a [=namespace=].
 
 If an attribute or operation |X| is [=unforgeable=] on an interface |A|,
@@ -10824,7 +10824,7 @@ with the same [=identifier=] as |X|.
     <pre highlight="webidl">
         [Exposed=Window]
         interface A1 {
-          [Unforgeable] readonly attribute DOMString x;
+          [LegacyUnforgeable] readonly attribute DOMString x;
         };
         [Exposed=Window]
         interface B1 : A1 {
@@ -10846,18 +10846,18 @@ See [[#es-attributes]],
 [[#es-legacy-platform-objects]] and
 [[#legacy-platform-object-defineownproperty]]
 for the specific requirements that the use of
-[{{Unforgeable}}] entails.
+[{{LegacyUnforgeable}}] entails.
 
 <div class="example">
 
     The following [=IDL fragment=] defines
     an interface that has two [=attributes=],
-    one of which is designated as [{{Unforgeable}}]:
+    one of which is designated as [{{LegacyUnforgeable}}]:
 
     <pre highlight="webidl">
         [Exposed=Window]
         interface System {
-          [Unforgeable] readonly attribute DOMString username;
+          [LegacyUnforgeable] readonly attribute DOMString username;
           readonly attribute long long loginTime;
         };
     </pre>

--- a/index.bs
+++ b/index.bs
@@ -6548,7 +6548,7 @@ The following extended attributes are <dfn for="extended attributes">applicable 
 [{{AllowShared}}],
 [{{Clamp}}],
 [{{EnforceRange}}], and
-[{{TreatNullAs}}].
+[{{LegacyNullToEmptyString}}].
 
 <div algorithm>
     The <dfn for="IDL type" lt="extended attribute associated with|extended attributes associated with">extended attributes associated with</dfn>
@@ -7735,7 +7735,7 @@ value when its bit pattern is interpreted as an unsigned 64 bit integer.
     to an IDL {{DOMString}} value by running the following algorithm:
 
     1.  If |V| is <emu-val>null</emu-val> and the conversion is to an IDL type
-        [=extended attribute associated with|associated with=] the [{{TreatNullAs}}] extended
+        [=extended attribute associated with|associated with=] the [{{LegacyNullToEmptyString}}] extended
         attribute, then return the {{DOMString}} value that represents the empty string.
     1.  Let |x| be <a abstract-op>ToString</a>(|V|).
     1.  Return the IDL {{DOMString}} value that represents the same sequence of code units as the one the ECMAScript String value |x| represents.
@@ -10715,34 +10715,31 @@ for the specific requirements that the use of
 </div>
 
 
-<h4 id="TreatNullAs" extended-attribute lt="TreatNullAs">[TreatNullAs]</h4>
+<h4 id="LegacyNullToEmptyString" extended-attribute lt="LegacyNullToEmptyString" oldids="TreatNullAs">[LegacyNullToEmptyString]</h4>
 
 <p class="advisement">
-    The [{{TreatNullAs}}] [=extended attribute=] is an undesirable feature.
+    The [{{LegacyNullToEmptyString}}] [=extended attribute=] is an undesirable feature.
     It exists only so that legacy Web platform features can be specified.
     It should not be used in specifications
     unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[TreatNullAs]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyNullToEmptyString]">filing an issue</a>
     before proceeding.
 </div>
 
-If the [{{TreatNullAs}}] [=extended attribute=] appears on the {{DOMString}} type, it creates a new
+If the [{{LegacyNullToEmptyString}}] [=extended attribute=] appears on the {{DOMString}} type, it creates a new
 IDL type such that that when an ECMAScript <emu-val>null</emu-val> is converted to the IDL type, it
 will be handled differently from its default handling. Instead of being stringified to
 "<code>null</code>", which is the default, it will be converted to the empty string.
 
-The [{{TreatNullAs}}] extended attribute must [=takes an identifier|take the identifier=]
-<code>EmptyString</code>.
-
-The [{{TreatNullAs}}] extended attribute must not be
+The [{{LegacyNullToEmptyString}}] extended attribute must not be
 [=extended attribute associated with|associated with=] a type that is not {{DOMString}}.
 
-Note: This means that even <code class="idl">DOMString?</code> must not use [{{TreatNullAs}}], since
+Note: This means that even <code class="idl">DOMString?</code> must not use [{{LegacyNullToEmptyString}}], since
 <emu-val>null</emu-val> is a valid value of that type.
 
-See [[#es-DOMString]] for the specific requirements that the use of [{{TreatNullAs}}] entails.
+See [[#es-DOMString]] for the specific requirements that the use of [{{LegacyNullToEmptyString}}] entails.
 
 <div class="example">
     The following [=IDL fragment=] defines an interface that has one attribute whose type has the
@@ -10752,9 +10749,9 @@ See [[#es-DOMString]] for the specific requirements that the use of [{{TreatNull
         [Exposed=Window]
         interface Dog {
           attribute DOMString name;
-          attribute [TreatNullAs=EmptyString] DOMString owner;
+          attribute [LegacyNullToEmptyString] DOMString owner;
 
-          boolean isMemberOfBreed([TreatNullAs=EmptyString] DOMString breedName);
+          boolean isMemberOfBreed([LegacyNullToEmptyString] DOMString breedName);
         };
     </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -1011,12 +1011,12 @@ The following extended attributes are applicable to interfaces:
 [{{LegacyWindowAlias}}],
 [{{NamedConstructor}}],
 [{{NoInterfaceObject}}],
-[{{OverrideBuiltins}}], and
+[{{LegacyOverrideBuiltIns}}], and
 [{{SecureContext}}].
 
 The following extended attributes are applicable to [=partial interfaces=]:
 [{{Exposed}}],
-[{{OverrideBuiltins}}], and
+[{{LegacyOverrideBuiltIns}}], and
 [{{SecureContext}}].
 
 [=Interfaces=] which are not annotated
@@ -9457,10 +9457,10 @@ used on an [=interface=], then:
 *   The interface must not define a [=named property setter=].
 *   The interface must not define [=indexed property getters=] or [=indexed property setter|setters=].
 *   The interface must not define a [=constructor operation=].
-*   The interface must not also be declared with the [{{OverrideBuiltins}}]
+*   The interface must not also be declared with the [{{LegacyOverrideBuiltIns}}]
     extended attribute.
 *   The interface must not [=interface/inherit=] from another interface with the
-    [{{OverrideBuiltins}}] extended attribute.
+    [{{LegacyOverrideBuiltIns}}] extended attribute.
 *   Any other interface must not [=interface/inherit=] from it.
 
 If [{{Global}}] is specified on
@@ -10159,21 +10159,21 @@ for the specific requirements that the use of
 </div>
 
 
-<h4 id="OverrideBuiltins" extended-attribute lt="OverrideBuiltins">[OverrideBuiltins]</h4>
+<h4 id="LegacyOverrideBuiltIns" extended-attribute lt="LegacyOverrideBuiltIns" oldids="OverrideBuiltins">[LegacyOverrideBuiltIns]</h4>
 
 <div class="advisement">
 
-    The [{{OverrideBuiltins}}] [=extended attribute=] is an undesirable feature.
+    The [{{LegacyOverrideBuiltIns}}] [=extended attribute=] is an undesirable feature.
     It exists only so that legacy Web platform features can be specified.
     It should not be used in specifications
     unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[OverrideBuiltins]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyOverrideBuiltIns]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
-        The [{{OverrideBuiltins}}] [=extended attribute=] appears on the
+        The [{{LegacyOverrideBuiltIns}}] [=extended attribute=] appears on the
         {{DOMStringMap}},
         {{Document}}, and
         {{HTMLFormElement}} [=interfaces=]. [[HTML]]
@@ -10181,7 +10181,7 @@ for the specific requirements that the use of
 
 </div>
 
-If the [{{OverrideBuiltins}}]
+If the [{{LegacyOverrideBuiltIns}}]
 [=extended attribute=]
 appears on an [=interface=],
 it indicates that for a [=legacy platform object=] implementing the interface,
@@ -10195,7 +10195,7 @@ This is in contrast to the usual behavior, which is for named properties
 to be exposed only if there is no property with the
 same name on the object itself or somewhere on its prototype chain.
 
-The [{{OverrideBuiltins}}]
+The [{{LegacyOverrideBuiltIns}}]
 extended attribute must
 [=takes no arguments|take no arguments=]
 and must not appear on an interface
@@ -10207,14 +10207,14 @@ definition, then that partial interface definition must
 be the part of the interface definition that defines
 the [=named property getter=].
 
-If the [{{OverrideBuiltins}}] extended attribute is specified on a
+If the [{{LegacyOverrideBuiltIns}}] extended attribute is specified on a
 [=partial interface=] definition, it is considered to appear on the
 [=interface=] itself.
 
 See [[#es-legacy-platform-objects]]
 and [[#legacy-platform-object-defineownproperty]]
 for the specific requirements that the use of
-[{{OverrideBuiltins}}] entails.
+[{{LegacyOverrideBuiltIns}}] entails.
 
 <div class="example">
 
@@ -10231,7 +10231,7 @@ for the specific requirements that the use of
         };
 
         [Exposed=Window,
-         OverrideBuiltins]
+         LegacyOverrideBuiltIns]
         interface StringMap2 {
           readonly attribute unsigned long length;
           getter DOMString lookup(DOMString key);
@@ -13436,7 +13436,7 @@ Additionally, [=legacy platform objects=] have internal methods as defined in:
         and |P| is not an [=unforgeable property name=]
         of |O|, then:
         1.  Let |creating| be true if |P| is not a [=supported property name=], and false otherwise.
-        1.  If |O| [=implements=] an interface with the [{{OverrideBuiltins}}]
+        1.  If |O| [=implements=] an interface with the [{{LegacyOverrideBuiltIns}}]
             [=extended attribute=] or |O| does not have an own property
             named |P|, then:
             1.  If |creating| is false and |O| does not implement an
@@ -13559,7 +13559,7 @@ internal method as follows.
     The <dfn id="dfn-named-property-visibility" export>named property visibility algorithm</dfn>
     is used to determine if a given named property is exposed on an object.
     Some named properties are not exposed on an object depending on whether
-    the [{{OverrideBuiltins}}] [=extended attribute=] was used.
+    the [{{LegacyOverrideBuiltIns}}] [=extended attribute=] was used.
     The algorithm operates as follows, with property name |P| and object |O|:
 
     1.  If |P| is not a [=supported property name=] of |O|, then return false.
@@ -13569,7 +13569,7 @@ internal method as follows.
           because in practice those are always set up before objects have any supported property names,
           and once set up will make the corresponding named properties invisible.
 
-    1.  If |O| [=implements=] an interface that has the [{{OverrideBuiltins}}]
+    1.  If |O| [=implements=] an interface that has the [{{LegacyOverrideBuiltIns}}]
         [=extended attribute=], then return true.
     1.  Let |prototype| be |O|.\[[GetPrototypeOf]]().
     1.  While |prototype| is not null:
@@ -13585,10 +13585,10 @@ internal method as follows.
 
     1.  Indexed properties.
     1.  Own properties, including unforgeable attributes and operations.
-    1.  Then, if [{{OverrideBuiltins}}]:
+    1.  Then, if [{{LegacyOverrideBuiltIns}}]:
         1.  Named properties.
         1.  Properties from the prototype chain.
-    1.  Otherwise, if not [{{OverrideBuiltins}}]:
+    1.  Otherwise, if not [{{LegacyOverrideBuiltIns}}]:
         1.  Properties from the prototype chain.
         1.  Named properties.
 </div>

--- a/index.bs
+++ b/index.bs
@@ -1009,7 +1009,7 @@ The following extended attributes are applicable to interfaces:
 [{{Exposed}}],
 [{{Global}}],
 [{{LegacyWindowAlias}}],
-[{{NamedConstructor}}],
+[{{LegacyFactoryFunction}}],
 [{{NoInterfaceObject}}],
 [{{LegacyOverrideBuiltIns}}], and
 [{{SecureContext}}].
@@ -2211,7 +2211,7 @@ is the final argument in the operation’s argument list.
 
 [=Extended attributes=]
 that [=takes an argument list|take an argument list=]
-([{{NamedConstructor}}], of those
+([{{LegacyFactoryFunction}}], of those
 defined in this specification) and [=callback functions=]
 are also considered to be [=variadic=]
 when the <emu-t>...</emu-t> token is used in their argument lists.
@@ -3352,7 +3352,7 @@ definitions.
     </pre>
 
     Note that [=constructor operations=] and
-    [{{NamedConstructor}}]
+    [{{LegacyFactoryFunction}}]
     [=extended attributes=] are disallowed from appearing
     on [=partial interface=] definitions,
     so there is no need to also disallow overloading for constructors.
@@ -3363,7 +3363,7 @@ An <dfn id="dfn-effective-overload-set" export>effective overload set</dfn>
 represents the allowable invocations for a particular
 [=operation=],
 constructor (specified with a [=constructor operation=]
-or [{{NamedConstructor}}]), or
+or [{{LegacyFactoryFunction}}]), or
 [=callback function=].
 The algorithm to [=compute the effective overload set=]
 operates on one of the following four types of IDL constructs, and listed with them below are
@@ -3377,9 +3377,9 @@ the inputs to the algorithm needed to compute the set.
  :  For constructors
  :: *   the [=interface=] on which the [=constructor operations=] are to be found
     *   the number of arguments to be passed
- :  For named constructors
- :: *   the [=interface=] on which the [{{NamedConstructor}}] [=extended attributes=] are to be found
-    *   the [=identifier=] of the named constructors
+ :  For legacy factory functions
+ :: *   the [=interface=] on which the [{{LegacyFactoryFunction}}] [=extended attributes=] are to be found
+    *   the [=identifier=] of the legacy factory function
     *   the number of arguments to be passed
 
 An [=effective overload set=] is used, among other things, to determine whether there are
@@ -3392,7 +3392,7 @@ whose [=tuple/items=] are described below:
 *   A <dfn for="effective overload set tuple">callable</dfn> is an [=operation=]
     if the [=effective overload set=] is for [=regular operations=],
     [=static operations=], or [=constructor operations=]; and it is an [=extended attribute=]
-    if the [=effective overload set=] is for [=named constructors=].
+    if the [=effective overload set=] is for [=legacy factory functions=].
 *   A <dfn>type list</dfn> is a [=list=] of IDL types.
 *   An <dfn>optionality list</dfn> is a [=list=] of
     three possible <dfn id="dfn-optionality-value" export>optionality values</dfn>
@@ -3412,7 +3412,7 @@ the same operation or constructor.
     The algorithm below describes how to <dfn>compute the effective overload set</dfn>.
     The following input variables are used, if they are required:
 
-    *   the identifier of the operation or named constructor is |A|
+    *   the identifier of the operation or legacy factory function is |A|
     *   the argument count is |N|
     *   the interface is |I|
 
@@ -3433,17 +3433,17 @@ the same operation or constructor.
              :  For constructors
              :: The elements of |F| are the
                 [=constructor operations=] on interface |I|.
-             :  For named constructors
+             :  For legacy factory functions
              :: The elements of |F| are the
-                [{{NamedConstructor}}]
+                [{{LegacyFactoryFunction}}]
                 [=extended attributes=] on interface |I| whose
                 [=takes a named argument list|named argument lists’=]
                 identifiers are |A|.
         </dl>
 
     1.  Let |maxarg| be the maximum number of arguments the operations,
-        constructor extended attributes or callback functions in |F| are declared to take.
-        For [=variadic=] operations and constructor extended attributes,
+        legacy factory functions, or callback functions in |F| are declared to take.
+        For [=variadic=] operations and legacy factory functions,
         the argument on which the ellipsis appears counts as a single argument.
 
         Note: So <code>void f(long x, long... y);</code> is considered to be declared to take two arguments.
@@ -6949,7 +6949,7 @@ which form (or forms) it is in:
             <dfn id="dfn-xattr-named-argument-list" for="extended attribute" export>takes a named argument list</dfn>
         </td>
         <td>
-            <code>[NamedConstructor=Image(DOMString src)]</code>
+            <code>[LegacyFactoryFunction=Image(DOMString src)]</code>
         </td>
     </tr>
     <tr>
@@ -7202,7 +7202,7 @@ and comprise the following:
 
 *   [=interface objects=]
 *   [=legacy callback interface objects=]
-*   [=named constructors=]
+*   [=legacy factory functions=]
 *   [=interface prototype objects=]
 *   [=named properties objects=]
 *   [=iterator prototype objects=]
@@ -9703,7 +9703,7 @@ The <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t>s that
 Each of the [=LegacyWindowAlias identifier|identifiers=] of [{{LegacyWindowAlias}}]
 must not be the same as one used by a [{{LegacyWindowAlias}}]
 extended attribute on this interface or another interface,
-must not be the same as the [=NamedConstructor identifier|identifier=] used by a [{{NamedConstructor}}]
+must not be the same as the [=LegacyFactoryFunction identifier|identifier=] used by a [{{LegacyFactoryFunction}}]
 extended attribute on this interface or another interface,
 must not be the same as an [=identifier=] of an interface that has an [=interface object=],
 and must not be one of the [=reserved identifiers=].
@@ -9915,21 +9915,21 @@ is to be implemented.
 </div>
 
 
-<h4 id="NamedConstructor" extended-attribute lt="NamedConstructor">[NamedConstructor]</h4>
+<h4 id="LegacyFactoryFunction" extended-attribute lt="LegacyFactoryFunction">[LegacyFactoryFunction]</h4>
 
 <div class="advisement">
 
-    [{{NamedConstructor}}] [=extended attribute=] is an undesirable feature.
+    [{{LegacyFactoryFunction}}] [=extended attribute=] is an undesirable feature.
     It exists only so that legacy Web platform features can be specified.
     It should not be used in specifications
     unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[NamedConstructor]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyFactoryFunction]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
-        The [{{NamedConstructor}}] [=extended attribute=] appears on the following [=interfaces=]:
+        The [{{LegacyFactoryFunction}}] [=extended attribute=] appears on the following [=interfaces=]:
         {{HTMLAudioElement}},
         {{HTMLOptionElement}}, and
         {{HTMLImageElement}}. [[HTML]]
@@ -9937,30 +9937,26 @@ is to be implemented.
 
 </div>
 
-If the [{{NamedConstructor}}]
+If the [{{LegacyFactoryFunction}}]
 [=extended attribute=]
 appears on an [=interface=],
 it indicates that the ECMAScript global object will have a property with the
-specified name whose value is a [=constructor=] that can
+specified name whose value is a function that can
 create objects that implement the interface.
-Multiple [{{NamedConstructor}}] extended
+Multiple [{{LegacyFactoryFunction}}] extended
 attributes may appear on a given interface.
 
-The [{{NamedConstructor}}] extended attribute must either
-[=takes an identifier|take an identifier=] or
+The [{{LegacyFactoryFunction}}] extended attribute must
 [=takes a named argument list|take a named argument list=].
 The <emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t> that occurs directly after the
-“<emu-t>=</emu-t>” is the [{{NamedConstructor}}]'s <dfn lt="NamedConstructor identifier">identifier</dfn>.
-The first form, <code>[NamedConstructor=<emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t>]</code>,
-has the same meaning as using an empty argument list,
-<code>[NamedConstructor=<emu-t class="regex"><a href="#prod-identifier">identifier</a></emu-t>()]</code>.
-For each [{{NamedConstructor}}] extended attribute on the interface,
+“<emu-t>=</emu-t>” is the [{{LegacyFactoryFunction}}]'s <dfn lt="LegacyFactoryFunction identifier">identifier</dfn>.
+For each [{{LegacyFactoryFunction}}] extended attribute on the interface,
 there will be a way to construct an object that
 [=implements=] the interface by passing the specified arguments to the [=constructor=]
 that is the value of the aforementioned property.
 
-The [=NamedConstructor identifier|identifier=] used for the named constructor must not
-be the same as that used by a [{{NamedConstructor}}]
+The [=LegacyFactoryFunction identifier|identifier=] used for the legacy factory function must not
+be the same as that used by a [{{LegacyFactoryFunction}}]
 extended attribute on another interface, must not
 be the same as an [=LegacyWindowAlias identifier|identifier=] used by a [{{LegacyWindowAlias}}]
 extended attribute on this interface or another interface,
@@ -9969,22 +9965,21 @@ that has an [=interface object=],
 and must not be one of the
 [=reserved identifiers=].
 
-The [{{NamedConstructor}}] and [{{Global}}] [=extended attributes=] must not be specified on the
+The [{{LegacyFactoryFunction}}] and [{{Global}}] [=extended attributes=] must not be specified on the
 same [=interface=].
 
-See [[#named-constructors]] for details on how named constructors
+See [[#legacy-factory-functions]] for details on how legacy factory functions
 are to be implemented.
 
 <div class="example">
 
     The following IDL defines an interface that uses the
-    [{{NamedConstructor}}] extended
+    [{{LegacyFactoryFunction}}] extended
     attribute.
 
     <pre highlight="webidl">
         [Exposed=Window,
-         NamedConstructor=Audio,
-         NamedConstructor=Audio(DOMString src)]
+         LegacyFactoryFunction=Audio(DOMString src)]
         interface HTMLAudioElement : HTMLMediaElement {
           // ...
         };
@@ -9992,17 +9987,20 @@ are to be implemented.
 
     An ECMAScript implementation that supports this interface will
     allow the construction of <code class="idl">HTMLAudioElement</code>
-    objects using the <code class="idl">Audio</code> [=constructor=].
+    objects using the <code class="idl">Audio</code> function.
 
     <pre highlight="js">
         typeof Audio;                   // Evaluates to 'function'.
 
-        var a1 = new Audio();           // Creates a new object that implements
-                                        // HTMLAudioElement, using the zero-argument
-                                        // constructor.
-
         var a2 = new Audio('a.flac');   // Creates an HTMLAudioElement using the
                                         // one-argument constructor.
+    </pre>
+
+    As an additional legacy quirk, these factory functions will have a <code>prototype</code>
+    property equal to the <code>prototype</code> of the original interface:
+
+    <pre highlight="js">
+        console.assert(Audio.prototype === HTMLAudioElement.prototype);
     </pre>
 </div>
 
@@ -10109,7 +10107,7 @@ The [{{NoInterfaceObject}}] extended attribute
 must not be specified on an interface that has any
 [=constructors=] or [=static operations=] defined on it.
 
-Note: Combining the [{{NoInterfaceObject}}] and [{{NamedConstructor}}] extended attribute is not
+Note: Combining the [{{NoInterfaceObject}}] and [{{LegacyFactoryFunction}}] extended attribute is not
 forbidden, however.
 
 An interface that does not have the [{{NoInterfaceObject}}] extended
@@ -11269,12 +11267,12 @@ there exists a corresponding property on the {{Window}} global object.
 The name of the property is the given [=LegacyWindowAlias identifier|identifier=],
 and its value is a reference to the [=interface object=] for the [=interface=].
 
-In addition, for every [{{NamedConstructor}}] extended attribute on an [=exposed=] interface,
+In addition, for every [{{LegacyFactoryFunction}}] extended attribute on an [=exposed=] interface,
 a corresponding property exists on the ECMAScript global object.
-The name of the property is the [{{NamedConstructor}}]'s [=NamedConstructor identifier|identifier=],
-and its value is an object called a <dfn id="dfn-named-constructor" export>named constructor</dfn>,
-which allows construction of objects that implement the interface.
-The characteristics of a named constructor are described in [[#named-constructors]].
+The name of the property is the [{{LegacyFactoryFunction}}]'s [=LegacyFactoryFunction identifier|identifier=],
+and its value is an object called a <dfn id="dfn-legacy-factory-function" export oldids="dfn-named-constructor">legacy factory function</dfn>,
+which allows creation of objects that implement the interface.
+The characteristics of a legacy factory function are described in [[#legacy-factory-functions]].
 
 
 <h4 id="interface-object" oldids="es-interface-call,es-constructible-interfaces">Interface object</h4>
@@ -11377,27 +11375,27 @@ default interfaces do not have such steps.
 </div>
 
 
-<h4 id="named-constructors">Named constructors</h4>
+<h4 id="legacy-factory-functions" oldids="named-constructors">Legacy factory functions</h4>
 
-A [=named constructor=] that exists due to one or more
-[{{NamedConstructor}}] [=extended attributes=]
-with a given [=NamedConstructor identifier|identifier=] is a [=built-in function object=].
+A [=legacy factory function=] that exists due to one or more
+[{{LegacyFactoryFunction}}] [=extended attributes=]
+with a given [=LegacyFactoryFunction identifier|identifier=] is a [=built-in function object=].
 It allows constructing objects that
 implement the interface on which the
-[{{NamedConstructor}}] extended attributes appear.
+[{{LegacyFactoryFunction}}] extended attributes appear.
 
 <div algorithm>
 
-    The [=named constructor=] with [=NamedConstructor identifier|identifier=] |id|
+    The [=legacy factory function=] with [=LegacyFactoryFunction identifier|identifier=] |id|
     for a given [=interface=] |I| in Realm |realm|
-    is <dfn lt="create a named constructor">created</dfn> as follows:
+    is <dfn lt="create a legacy factory function">created</dfn> as follows:
 
     1.  Let |steps| be the following steps:
         1.  If {{NewTarget}} is <emu-val>undefined</emu-val>, then
             [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
         1.  Let |args| be the passed arguments.
         1.  Let |n| be the [=list/size=] of |args|.
-        1.  [=Compute the effective overload set=] for named constructors with [=identifier=] |id|
+        1.  [=Compute the effective overload set=] for legacy factory functions with [=identifier=] |id|
             on [=interface=] |I| and with argument count |n|, and let |S| be the result.
         1.  Let &lt;|constructor|, |values|&gt; be the result of passing |S| and
             |args| to the [=overload resolution algorithm=].
@@ -11413,7 +11411,7 @@ implement the interface on which the
         1.  Return |O|.
     1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
     1.  Perform [=!=] <a abstract-op>SetFunctionName</a>(|F|, |id|).
-    1.  [=Compute the effective overload set=] for named constructors with [=identifier=] |id|
+    1.  [=Compute the effective overload set=] for legacy factory functions with [=identifier=] |id|
         on [=interface=] |I| and with argument count 0, and let |S| be the result.
     1.  Let |length| be the length of the shortest argument list of the entries in |S|.
     1.  Perform [=!=] <a abstract-op>SetFunctionLength</a>(|F|, |length|).
@@ -13255,13 +13253,14 @@ the Realm given as an argument.
                 1.  [=list/iterate|For every=] [=LegacyWindowAlias identifier|identifier=] |id| in
                     [{{LegacyWindowAlias}}]'s [=LegacyWindowAlias identifier|identifiers=]:
                     1.  Perform [=!=] [$CreateMethodProperty$](|target|, |id|, |interfaceObject|).
-        1.  If the |interface| is declared with a [{{NamedConstructor}}] [=extended attribute=],
+        1.  If the |interface| is declared with a [{{LegacyFactoryFunction}}] [=extended attribute=],
             then:
-            1.  [=list/iterate|For every=] [=NamedConstructor identifier|identifier=] |id| in
-                [{{NamedConstructor}}]'s [=NamedConstructor identifier|identifiers=]:
-                1.  Let |namedConstructor| be the result of [=create a named constructor|creating
-                    a named constructor=] with |id| for |interface| in |realm|.
-                1.  Perform [=!=] [$CreateMethodProperty$](|target|, |id|, |namedConstructor|).
+            1.  [=list/iterate|For every=] [=LegacyFactoryFunction identifier|identifier=] |id| in
+                [{{LegacyFactoryFunction}}]'s [=LegacyFactoryFunction identifier|identifiers=]:
+                1.  Let |legacyFactoryFunction| be the result of
+                    [=create a legacy factory function|creating a legacy factory function=] with
+                    |id| for |interface| in |realm|.
+                1.  Perform [=!=] [$CreateMethodProperty$](|target|, |id|, |legacyFactoryFunction|).
     1.  [=list/iterate|For every=] [=callback interface=] |interface| that is [=exposed=] in
         |realm| and on which [=constants=] are defined:
         1.  Let |id| be |interface|'s [=identifier=].
@@ -14912,7 +14911,7 @@ terminal symbol <emu-t>const</emu-t>, an
 "<code>A</code>" is distinct from one named "<code>a</code>", and an
 [=extended attribute=]
 [<code class="idl">namedconstructor</code>] will not be recognized as
-the [{{NamedConstructor}}]
+the [{{LegacyFactoryFunction}}]
 extended attribute.
 
 Implicitly, any number of <emu-t class="regex"><a href="#prod-whitespace">whitespace</a></emu-t> and

--- a/index.bs
+++ b/index.bs
@@ -5530,7 +5530,7 @@ sign gives the signature of the callback function type.
 be used as the type of a [=constant=].
 
 The following extended attribute is applicable to callback functions:
-[{{TreatNonObjectAsNull}}].
+[{{LegacyTreatNonObjectAsNull}}].
 
 <div data-fill-with="grammar-CallbackOrInterfaceOrMixin"></div>
 
@@ -6259,7 +6259,7 @@ An [=identifier=] that identifies
 a [=callback function=] is used to refer to
 a type whose values are references to objects that are functions with the given signature.
 
-Note: If the [{{TreatNonObjectAsNull}}] [=extended attribute=] is specified on the [=definition=] of
+Note: If the [{{LegacyTreatNonObjectAsNull}}] [=extended attribute=] is specified on the [=definition=] of
 the [=callback function=], the values can be references to objects that are not functions.
 
 An IDL value of the callback function type is represented by a tuple of an object
@@ -7980,7 +7980,7 @@ values.
 <h4 id="es-callback-function">Callback function types</h4>
 
 IDL [=callback function types=] are represented by ECMAScript [=function objects=], except in the
-[{{TreatNonObjectAsNull}}] case, when they can be any object.
+[{{LegacyTreatNonObjectAsNull}}] case, when they can be any object.
 
 <div id="es-to-callback-function" algorithm="convert an ECMAScript value to callback function">
 
@@ -7993,7 +7993,7 @@ IDL [=callback function types=] are represented by ECMAScript [=function objects
         to |V| being assigned to an [=attribute=]
         whose type is a [=nullable type|nullable=]
         [=callback function=]
-        that is annotated with [{{TreatNonObjectAsNull}}],
+        that is annotated with [{{LegacyTreatNonObjectAsNull}}],
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return the IDL [=callback function type=] value
         that represents a reference to the same object that |V| represents, with the
@@ -8025,7 +8025,7 @@ the ECMAScript <emu-val>null</emu-val> value.
         to |V| being assigned to an [=attribute=]
         whose type is a [=nullable type|nullable=]
         [=callback function=]
-        that is annotated with [{{TreatNonObjectAsNull}}],
+        that is annotated with [{{LegacyTreatNonObjectAsNull}}],
         then return the IDL
         [=nullable type=] <code class="idl">|T|?</code>
         value <emu-val>null</emu-val>.
@@ -10630,21 +10630,21 @@ that does specify [{{SecureContext}}].
 </div>
 
 
-<h4 id="TreatNonObjectAsNull" extended-attribute lt="TreatNonObjectAsNull">[TreatNonObjectAsNull]</h4>
+<h4 id="LegacyTreatNonObjectAsNull" extended-attribute lt="LegacyTreatNonObjectAsNull" oldids="TreatNonObjectAsNull">[LegacyTreatNonObjectAsNull]</h4>
 
 <div class="advisement">
 
-    The [{{TreatNonObjectAsNull}}] [=extended attribute=] is an undesirable feature.
+    The [{{LegacyTreatNonObjectAsNull}}] [=extended attribute=] is an undesirable feature.
     It exists only so that legacy Web platform features can be specified.
     It should not be used in specifications
     unless required to specify the behavior of legacy APIs,
     or for consistency with these APIs.
     Editors who wish to use this feature are strongly advised to discuss this
-    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[TreatNonObjectAsNull]">filing an issue</a>
+    by <a href="https://github.com/heycam/webidl/issues/new?title=Intent%20to%20use%20[LegacyTreatNonObjectAsNull]">filing an issue</a>
     before proceeding.
 
     <small class="non-normative">
-        The [{{TreatNonObjectAsNull}}] [=extended attribute=] appears on
+        The [{{LegacyTreatNonObjectAsNull}}] [=extended attribute=] appears on
         the [=callback functions=] {{EventHandlerNonNull}},
         {{OnBeforeUnloadEventHandlerNonNull}}, and
         {{OnErrorEventHandlerNonNull}}
@@ -10654,7 +10654,7 @@ that does specify [{{SecureContext}}].
 
 </div>
 
-If the [{{TreatNonObjectAsNull}}] [=extended attribute=] appears on a [=callback function=], then
+If the [{{LegacyTreatNonObjectAsNull}}] [=extended attribute=] appears on a [=callback function=], then
 it indicates that any value assigned to an [=attribute=] whose type is a [=nullable type|nullable=]
 [=callback function=] will be converted more loosely: if the value is not an object, it will be
 converted to null, and if the value is not [=ECMAScript/callable=], it will be converted to a
@@ -10662,19 +10662,19 @@ converted to null, and if the value is not [=ECMAScript/callable=], it will be c
 
 See [[#es-nullable-type]], [[#es-callback-function]] and [[#es-invoking-callback-functions]]
 for the specific requirements that the use of
-[{{TreatNonObjectAsNull}}] entails.
+[{{LegacyTreatNonObjectAsNull}}] entails.
 
 <div class="example">
 
     The following [=IDL fragment=] defines an interface that has one
-    attribute whose type is a [{{TreatNonObjectAsNull}}]-annotated
+    attribute whose type is a [{{LegacyTreatNonObjectAsNull}}]-annotated
     [=callback function=] and another whose type is a
     [=callback function=] without the [=extended attribute=]:
 
     <pre highlight="webidl">
         callback OccurrenceHandler = void (DOMString details);
 
-        [TreatNonObjectAsNull]
+        [LegacyTreatNonObjectAsNull]
         callback ErrorHandler = void (DOMString details);
 
         [Exposed=Window]
@@ -14086,7 +14086,7 @@ described in the previous section).
     1.  Let |F| be the ECMAScript object corresponding to |callable|.
     1.  If [=!=] <a abstract-op>IsCallable</a>(|F|) is <emu-val>false</emu-val>:
         1.  Note: This is only possible when the [=callback function=] came from an attribute
-            marked with [{{TreatNonObjectAsNull}}].
+            marked with [{{LegacyTreatNonObjectAsNull}}].
         1.  If the callback function's return type is {{void}}, return.
         1.  Return the result of [=converted to an IDL value|converting=]
             <emu-val>undefined</emu-val> to the callback function's return type.


### PR DESCRIPTION
This pull request contains a series of commits that together close #350. I suggest we rebase-merge, instead of squash-merge, to better make the individual changes clear from the history.

I've updated #350 with a list of specifications that use these extended attributes, and will work on corresponding pull requests to them.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/870.html" title="Last updated on Apr 8, 2020, 9:37 PM UTC (102a68b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/870/42a9d4b...102a68b.html" title="Last updated on Apr 8, 2020, 9:37 PM UTC (102a68b)">Diff</a>