### PR TITLE
Editorial: Add missing `oldids` attribute to `[LegacyFactoryFunction]`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10060,7 +10060,7 @@ to discuss this by
 before proceeding.
 
 
-<h4 id="LegacyFactoryFunction" extended-attribute lt="LegacyFactoryFunction">[LegacyFactoryFunction]</h4>
+<h4 id="LegacyFactoryFunction" extended-attribute lt="LegacyFactoryFunction" oldids="NamedConstructor">[LegacyFactoryFunction]</h4>
 
 <p class="advisement">Instead of using this feature, give your interface a [=constructor operation=].</p>
 
@@ -14775,7 +14775,7 @@ terminal symbol <emu-t>const</emu-t>, an
 [=identifier=]
 "<code>A</code>" is distinct from one named "<code>a</code>", and an
 [=extended attribute=]
-[<code class="idl">namedconstructor</code>] will not be recognized as
+[<code class="idl">legacyfactoryfunction</code>] will not be recognized as
 the [{{LegacyFactoryFunction}}]
 extended attribute.
 


### PR DESCRIPTION
This was missed by @domenic in <https://github.com/heycam/webidl/pull/870>, thus breaking cross‑links from specifications that haven’t been updated.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/EB-Forks/webidl/pull/872.html" title="Last updated on Apr 22, 2020, 4:54 PM UTC (ec7a391)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/872/a03c53a...EB-Forks:ec7a391.html" title="Last updated on Apr 22, 2020, 4:54 PM UTC (ec7a391)">Diff</a>