### PR TITLE
Install @@toStringTag on namespace objects

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14042,7 +14042,7 @@ The characteristics of a namespace object are described in [[#namespace-object]]
     1.  Return |namespaceObject|.
 </div>
 
-The [=class string=] of a [=namespace object=] is the [=interface=]’s [=identifier=].
+The [=class string=] of a [=namespace object=] is the [=namespace=]’s [=identifier=].
 
 
 <h3 id="es-exceptions">Exceptions</h3>

--- a/index.bs
+++ b/index.bs
@@ -14042,6 +14042,8 @@ The characteristics of a namespace object are described in [[#namespace-object]]
     1.  Return |namespaceObject|.
 </div>
 
+The [=class string=] of a [=namespace object=] is the [=interface=]’s [=identifier=].
+
 
 <h3 id="es-exceptions">Exceptions</h3>
 


### PR DESCRIPTION
Follow-up of #357.

This change aligns WebIDL [namespace objects](https://heycam.github.io/webidl/#namespace-object) with ECMA-262 ones like [`Math`](https://tc39.es/ecma262/#sec-math-@@tostringtag) and [`Atomics`](https://tc39.es/ecma262/#sec-atomics-@@tostringtag).

Chrome (84.0.4126.0) already implements this PR:
```js
WebAssembly[Symbol.toStringTag] // => "WebAssembly"
```

_cc_ @domenic


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shvaikalesh/webidl/pull/873.html" title="Last updated on Jul 21, 2020, 1:48 PM UTC (083d283)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/873/350fb2a...shvaikalesh:083d283.html" title="Last updated on Jul 21, 2020, 1:48 PM UTC (083d283)">Diff</a>