### PR TITLE
Editorial: Fix broken heading tags

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11843,7 +11843,7 @@ A [=regular operation=] that does not [=have default method steps=] must not be 
 [{{Default}}] [=extended attribute=].
 
 
-<h6 id="es-default-tojson">Default toJSON operation</h5>
+<h6 id="es-default-tojson">Default toJSON operation</h6>
 
 <div algorithm>
 
@@ -14424,7 +14424,7 @@ The {{BufferSource}} typedef is used to represent objects
 that are either themselves an {{ArrayBuffer}} or which
 provide a view on to an {{ArrayBuffer}}.
 
-<h3 id="idl-DOMException" interface oldids="dfn-DOMException">DOMException</h4>
+<h3 id="idl-DOMException" interface oldids="dfn-DOMException">DOMException</h3>
 
 The {{DOMException}} type is an [=interface type=] defined by the following IDL
 fragment:

--- a/index.bs
+++ b/index.bs
@@ -2562,7 +2562,7 @@ that can be turned into a JSON string
 by the {{JSON.stringify()}} function.
 Additionally, in the ECMAScript language binding,
 the <code>toJSON</code> operation can take a [{{Default}}] [=extended attribute=],
-in which case the [=default toJSON operation=] is exposed instead.
+in which case the [=default toJSON steps=] are exposed instead.
 
 <div class="example" id="tojson-example">
 
@@ -9166,7 +9166,7 @@ that [=has default method steps=] defined.
         alice.toJSON();
 
         // Evaluates to an object like this (notice how "breed" is absent,
-        // as the Dog interface doesn't declare a default toJSON operation):
+        // as the Dog interface doesn't use the default toJSON steps):
         //
         // {
         //   name: "Tramp",


### PR DESCRIPTION
Blocks <https://github.com/heycam/webidl/pull/857>

This also fixes‑up <https://github.com/heycam/webidl/pull/882>, which missed a `[=default toJSON operation=]` link.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/EB-Forks/webidl/pull/884.html" title="Last updated on May 17, 2020, 4:19 PM UTC (413934c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/884/ea3af2c...EB-Forks:413934c.html" title="Last updated on May 17, 2020, 4:19 PM UTC (413934c)">Diff</a>