### PR TITLE
Use an "end of iteration" signal instead of undefined

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4354,8 +4354,8 @@ Prose accompanying an [=interface=] with an [=asynchronously iterable declaratio
 <dfn id="dfn-get-the-next-iteration-result" export>get the next iteration result</dfn> algorithm.
 This algorithm receives the instance of the [=interface=] that is being iterated, as well as the
 async iterator itself (which can be useful for storing state).
-It must return a {{Promise}} that either rejects, resolves with <dfn export>end of iteration</dfn>
-to signal the end of the iteration, or resolves with one of the following:
+It must return a {{Promise}} that either rejects, resolves with a special <dfn export>end of
+iteration</dfn> value to signal the end of the iteration, or resolves with one of the following:
 
 : for [=value asynchronously iterable declarations=]:
 ::  a value of the type given in the declaration;

--- a/index.bs
+++ b/index.bs
@@ -4354,13 +4354,13 @@ Prose accompanying an [=interface=] with an [=asynchronously iterable declaratio
 <dfn id="dfn-get-the-next-iteration-result" export>get the next iteration result</dfn> algorithm.
 This algorithm receives the instance of the [=interface=] that is being iterated, as well as the
 async iterator itself (which can be useful for storing state).
-It must return a {{Promise}} that either rejects, resolves with undefined to signal the end of the
-iteration, or resolves with one of the following:
+It must return a {{Promise}} that either rejects, resolves with <dfn export>end of iteration</dfn>
+to signal the end of the iteration, or resolves with one of the following:
 
 : for [=value asynchronously iterable declarations=]:
 ::  a value of the type given in the declaration;
 : for [=pair asynchronously iterable declarations=]:
-::  a tuple containing a value of the first type given in the declaration, and a value of the second type given in the declaration.
+::  a [=pair=] containing a value of the first type given in the declaration, and a value of the second type given in the declaration.
 
 The prose may also define an <dfn export>asynchronous iterator return</dfn> algorithm. This
 algorithm receives the instance of the [=interface=] that is being iterated, the async iterator
@@ -4434,7 +4434,7 @@ or have any [=inherited interfaces=] that have [=interface members=] with these 
             Note: |iterator|'s [=SessionManager async iterator/current state=] might no longer be
             present in the open sessions.
         1.  If |key| is null, then:
-            1.  Resolve |promise| with undefined.
+            1.  Resolve |promise| with [=end of iteration=].
         1.  Otherwise:
             1.  Let |session| be the <code class="idl">Session</code> object corresponding to |key|.
             1.  Resolve |promise| with (|username|, |session|).
@@ -12531,7 +12531,7 @@ The \[[Prototype]] [=internal slot=] of an [=asynchronous iterator prototype obj
         1.  Let |fulfillSteps| be the following steps, given |next|:
             1.  Set |object|'s [=default asynchronous iterator object/ongoing promise=] to
                 null.
-            1.  If |next| is <emu-val>undefined</emu-val>, then:
+            1.  If |next| is [=end of iteration=], then:
                 1.  Set |object|'s [=default asynchronous iterator object/is finished=] to true.
                 1.  Return [=!=] [$CreateIterResultObject$](<emu-val>undefined</emu-val>,
                     <emu-val>true</emu-val>).


### PR DESCRIPTION
The use of undefined as a sentinel for the end of iteration was problematic for value iterators, where the possible value space could contain undefined.

@TimothyGu, could you take a look?

There's another issue lurking here which is that promises should only be resolved with either Web IDL values (if these are Web IDL `Promise<T>`s) or JS values (if these are JS promises). I considered adding a note explaining that end-of-iteration could be represented as a unique Web IDL/JS object with identity, and a pair could be represented as an appropriate Web IDL dictionary/JS null-prototype object, but I couldn't decide what type of promise these were. I guess we can figure that out as a followup, if we really want to.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/885.html" title="Last updated on May 21, 2020, 4:24 PM UTC (f9bab58)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/885/4a3c045...f9bab58.html" title="Last updated on May 21, 2020, 4:24 PM UTC (f9bab58)">Diff</a>