### PR TITLE
Editorial: Add syntax highlighting to async iterable syntax example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4312,8 +4312,7 @@ An [=interface=] can be declared to be asynchronously iterable by using an
 (matching <emu-nt><a href="#prod-AsyncIterable">AsyncIterable</a></emu-nt>) in the body of the
 [=interface=].
 
-<!-- TODO: add highlight="webidl" after idlparser gets updated -->
-<pre class="syntax">
+<pre highlight="webidl" class="syntax">
     interface interface_identifier {
       async iterable&lt;value_type&gt;;
       async iterable&lt;value_type&gt;(/* arguments... */);


### PR DESCRIPTION
This is now supported by **widlparser** and **bikeshed**.