### PR TITLE
Make async iterator return() and next() more like async generators

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12543,8 +12543,13 @@ The \[[Prototype]] [=internal slot=] of an [=asynchronous iterator prototype obj
                 1.  Let |value| be |next|, [=converted to an ECMAScript value=].
                 1.  Return [=!=] [$CreateIterResultObject$](|value|, <emu-val>false</emu-val>).
         1.  Let |onFulfilled| be [=!=] [$CreateBuiltinFunction$](|fulfillSteps|, « »).
-        1.  Perform [=!=] [$PerformPromiseThen$](|nextPromise|, |onFulfilled|,
-            <emu-val>undefined</emu-val>, |nextPromiseCapability|).
+        1.  Let |rejectSteps| be the following steps, given |reason|:
+            1.  Set |object|'s [=default asynchronous iterator object/ongoing promise=] to
+                null.
+            1.  [=ECMAScript/Throw=] |reason|.
+        1.  Let |onRejected| be [=!=] [$CreateBuiltinFunction$](|rejectSteps|, « »).
+        1.  Perform [=!=] [$PerformPromiseThen$](|nextPromise|, |onFulfilled|, |onRejected|,
+            |nextPromiseCapability|).
         1.  Return |nextPromiseCapability|.\[[Promise]].
 
     1.  Let |promise| be |object|'s [=default asynchronous iterator object/ongoing promise=].

--- a/index.bs
+++ b/index.bs
@@ -12608,8 +12608,7 @@ The \[[Prototype]] [=internal slot=] of an [=asynchronous iterator prototype obj
     1.  Let |returnSteps| be the following steps:
         1.  Let |returnPromiseCapability| be [=!=] [$NewPromiseCapability$]({{%Promise%}}).
         1.  If |object|'s [=default asynchronous iterator object/is finished=] is true, then:
-            1.  Let |result| be [$CreateIterResultObject$](<emu-val>undefined</emu-val>,
-                <emu-val>true</emu-val>).
+            1.  Let |result| be [$CreateIterResultObject$](|value|, <emu-val>true</emu-val>).
             1.  Perform [=!=] [$Call$](|returnPromiseCapability|.\[[Resolve]],
                 <emu-val>undefined</emu-val>, « |result| »).
             1.  Return |returnPromiseCapability|.\[[Promise]].

--- a/index.bs
+++ b/index.bs
@@ -12546,25 +12546,26 @@ The \[[Prototype]] [=internal slot=] of an [=asynchronous iterator prototype obj
         1.  Let |rejectSteps| be the following steps, given |reason|:
             1.  Set |object|'s [=default asynchronous iterator object/ongoing promise=] to
                 null.
+            1.  Set |object|'s [=default asynchronous iterator object/is finished=] to true.
             1.  [=ECMAScript/Throw=] |reason|.
         1.  Let |onRejected| be [=!=] [$CreateBuiltinFunction$](|rejectSteps|, « »).
         1.  Perform [=!=] [$PerformPromiseThen$](|nextPromise|, |onFulfilled|, |onRejected|,
             |nextPromiseCapability|).
         1.  Return |nextPromiseCapability|.\[[Promise]].
 
-    1.  Let |promise| be |object|'s [=default asynchronous iterator object/ongoing promise=].
+    1.  Let |ongoingPromise| be |object|'s [=default asynchronous iterator object/ongoing promise=].
 
-    1.  If |promise| is not null, then:
+    1.  If |ongoingPromise| is not null, then:
         1.  Let |afterOngoingPromiseCapability| be [=!=] [$NewPromiseCapability$]({{%Promise%}}).
-        1.  Let |onFulfilled| be [=!=] [$CreateBuiltinFunction$](|nextSteps|, « »).
-        1.  Perform [=!=] [$PerformPromiseThen$](|promise|, |onFulfilled|,
-            <emu-val>undefined</emu-val>, |afterOngoingPromiseCapability|).
+        1.  Let |onSettled| be [=!=] [$CreateBuiltinFunction$](|nextSteps|, « »).
+        1.  Perform [=!=] [$PerformPromiseThen$](|ongoingPromise|, |onSettled|, |onSettled|,
+            |afterOngoingPromiseCapability|).
         1.  Set |object|'s [=default asynchronous iterator object/ongoing promise=] to
             |afterOngoingPromiseCapability|.\[[Promise]].
 
     1.  Otherwise:
-        1.  Run |nextSteps| and set |object|'s
-            [=default asynchronous iterator object/ongoing promise=] to the result.
+        1.  Set |object|'s [=default asynchronous iterator object/ongoing promise=] to the result of
+            running |nextSteps|.
 
     1.  Return |object|'s [=default asynchronous iterator object/ongoing promise=].
 </div>
@@ -12604,31 +12605,39 @@ The \[[Prototype]] [=internal slot=] of an [=asynchronous iterator prototype obj
             <emu-val>undefined</emu-val>, « |error| »).
         1.  Return |returnPromiseCapability|.\[[Promise]].
 
-    1.  If |object|'s [=default asynchronous iterator object/ongoing promise=] is not null, then:
-        1.  Let |error| be a new {{ECMAScript/TypeError}}.
-        1.  Perform [=!=] [$Call$](|returnPromiseCapability|.\[[Reject]],
-            <emu-val>undefined</emu-val>, « |error| »).
-        1.  Return |returnPromiseCapability|.\[[Promise]].
+    1.  Let |returnSteps| be the following steps:
+        1.  Let |returnPromiseCapability| be [=!=] [$NewPromiseCapability$]({{%Promise%}}).
+        1.  If |object|'s [=default asynchronous iterator object/is finished=] is true, then:
+            1.  Let |result| be [$CreateIterResultObject$](<emu-val>undefined</emu-val>,
+                <emu-val>true</emu-val>).
+            1.  Perform [=!=] [$Call$](|returnPromiseCapability|.\[[Resolve]],
+                <emu-val>undefined</emu-val>, « |result| »).
+            1.  Return |returnPromiseCapability|.\[[Promise]].
+        1.  Set |object|'s [=default asynchronous iterator object/is finished=] to true.
+        1.  Return the result of running the [=asynchronous iterator return=] algorithm for
+            |interface|, given |object|'s [=default asynchronous iterator object/target=], |object|,
+            and |value|.
 
-    1.  If |object|'s [=default asynchronous iterator object/is finished=] is true, then:
-        1.  Let |result| be [=!=] [$CreateIterResultObject$](|value|,
-            <emu-val>true</emu-val>).
-        1.  Perform [=!=] [$Call$](|returnPromiseCapability|.\[[Resolve]],
-            <emu-val>undefined</emu-val>, « |result| »).
-        1.  Return |returnPromiseCapability|.\[[Promise]].
+    1.  Let |returnStepsPromise| be null.
 
-    1.  Set |object|'s [=default asynchronous iterator object/is finished=] to true.
+    1.  Let |ongoingPromise| be |object|'s [=default asynchronous iterator object/ongoing promise=].
 
-    1.  Let |returnPromise| be the result of running the [=asynchronous iterator return=] algorithm
-        for |interface|, given |object|'s [=default asynchronous iterator object/target=],
-        |object|, and |value|.
+    1.  If |ongoingPromise| is not null, then:
+        1.  Let |afterOngoingPromiseCapability| be [=!=] [$NewPromiseCapability$]({{%Promise%}}).
+        1.  Let |onSettled| be [=!=] [$CreateBuiltinFunction$](|returnSteps|, « »).
+        1.  Perform [=!=] [$PerformPromiseThen$](|ongoingPromise|, |onSettled|, |onSettled|,
+            |afterOngoingPromiseCapability|).
+        1.  Set |returnStepsPromise| to |afterOngoingPromiseCapability|.\[[Promise]].
+
+    1.  Otherwise:
+        1.  Set |returnStepsPromise| to the result of running |returnSteps|.
 
     1.  Let |fulfillSteps| be the following steps:
         1.  Return [=!=] [$CreateIterResultObject$](|value|, <emu-val>true</emu-val>).
 
     1.  Let |onFulfilled| be [=!=] [$CreateBuiltinFunction$](|fulfillSteps|, « »).
 
-    1.  Perform [=!=] [$PerformPromiseThen$](|returnPromise|, |onFulfilled|,
+    1.  Perform [=!=] [$PerformPromiseThen$](|returnStepsPromise|, |onFulfilled|,
         <emu-val>undefined</emu-val>, |returnPromiseCapability|).
 
     1.  Return |returnPromiseCapability|.\[[Promise]].


### PR DESCRIPTION
Previously, we would only set the async iterator's "ongoing promise" to null when the async iterator next steps succeeded. This meant that calling return() after a failed next() would not call the async iterator return steps, thus potentially preventing the cleanup of any associated resources. This changes the spec to reset the ongoing promise after the async iterator next steps complete, regardless of whether they succeed or fail.

Credit to @TimothyGu for finding this in https://github.com/jsdom/webidl2js/pull/224#discussion_r433333677. (Timothy, please review!)

Tests for this are added in the Streams context in various commits of https://github.com/web-platform-tests/wpt/pull/22982.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/891.html" title="Last updated on Jun 10, 2020, 6:33 PM UTC (48daab8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/891/fe3b0cc...48daab8.html" title="Last updated on Jun 10, 2020, 6:33 PM UTC (48daab8)">Diff</a>