### PR TITLE
add links for dotted intrinsic form

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -86,28 +86,26 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: Set; url: sec-set-objects
         text: SharedArrayBuffer; url: sec-sharedarraybuffer-objects
         text: %AsyncIteratorPrototype%; url: sec-asynciteratorprototype
-        text: %ArrayPrototype%; url: sec-properties-of-the-array-prototype-object
-        text: %ErrorPrototype%; url: sec-properties-of-the-error-prototype-object
-        text: %FunctionPrototype%; url: sec-properties-of-the-function-prototype-object
+        text: %Array.prototype%; url: sec-properties-of-the-array-prototype-object
+        text: %Error.prototype%; url: sec-properties-of-the-error-prototype-object
+        text: %Function.prototype%; url: sec-properties-of-the-function-prototype-object
         text: %IteratorPrototype%; url: sec-%iteratorprototype%-object
-        text: %MapPrototype%; url: sec-properties-of-the-map-prototype-object
-        text: %ObjectPrototype%; url: sec-properties-of-the-object-prototype-object
+        text: %Map.prototype%; url: sec-properties-of-the-map-prototype-object
+        text: %Object.prototype%; url: sec-properties-of-the-object-prototype-object
         text: %Promise%; url: sec-promise-constructor
-        text: %SetPrototype%; url: sec-properties-of-the-set-prototype-object
+        text: %Set.prototype%; url: sec-properties-of-the-set-prototype-object
     type: exception; for: ECMAScript
         text: Error; url: sec-error-objects
         text: SyntaxError; url: sec-native-error-types-used-in-this-standard-syntaxerror
         text: TypeError; url: sec-native-error-types-used-in-this-standard-typeerror
     type: method; for: ECMAScript
         text: JSON.stringify(); url: sec-json.stringify
-        text: %ArrayProto_entries%; url: sec-array.prototype.entries
-        text: %ArrayProto_forEach%; url: sec-array.prototype.foreach
-        text: %ArrayProto_keys%; url: sec-array.prototype.keys
-        text: %ArrayProto_values%; url: sec-array.prototype.values
-        text: %ObjProto_toString%; url: sec-object.prototype.tostring
-        text: %Promise_reject%; url: sec-promise.reject
-        text: %Promise_resolve%; url: sec-promise.resolve
-        text: %PromiseProto_then%; url: sec-promise.prototype.then
+        text: %Array.prototype.entries%; url: sec-array.prototype.entries
+        text: %Array.prototype.forEach%; url: sec-array.prototype.foreach
+        text: %Array.prototype.keys%; url: sec-array.prototype.keys
+        text: %Array.prototype.values%; url: sec-array.prototype.values
+        text: %Promise.reject%; url: sec-promise.reject
+        text: %Promise.prototype.then%; url: sec-promise.prototype.then
         text: all(); for: Promise; url: #sec-promise.all
     type: const; for: ECMAScript
         url: sec-well-known-symbols
@@ -4772,7 +4770,7 @@ Of the extended attributes defined in this specification, only the [{{Exposed}}]
 
     An ECMAScript implementation would then expose a global <code class="idl">VectorUtils</code>
     data property which was a simple object (with prototype
-    {{%ObjectPrototype%}}) with enumerable data properties for each declared operation, and
+    {{%Object.prototype%}}) with enumerable data properties for each declared operation, and
     enumerable get-only accessors for each declared attribute:
 
     <pre highlight="js">
@@ -6909,7 +6907,7 @@ string "<code>ObservableArray</code>".
     there and in the [=observable array attribute/delete an indexed value=] algorithm.
 
     Another thing to note about the above code example is how all of the ECMAScript array methods
-    from {{%ArrayPrototype%}} work on the observable array. Indeed, it fully behaves like an
+    from {{%Array.prototype%}} work on the observable array. Indeed, it fully behaves like an
     <code>Array</code> instance:
 
     <pre highlight="js">
@@ -7191,7 +7189,7 @@ Unless otherwise specified, the \[[Extensible]] internal slot
 of objects defined in this section has the value <emu-val>true</emu-val>.
 
 Unless otherwise specified, the \[[Prototype]] internal slot
-of objects defined in this section is {{%ObjectPrototype%}}.
+of objects defined in this section is {{%Object.prototype%}}.
 
 Some objects described in this section are defined to have a <dfn id="dfn-class-string" export>class string</dfn>,
 which is the string to include in the string returned from <code>Object.prototype.toString</code>.
@@ -7983,7 +7981,7 @@ up on the ECMAScript object are not necessarily the same as the object’s prope
     to an ECMAScript Object value by
     running the following algorithm (where |D| is the [=dictionary=]):
 
-    1.  Let |O| be [=!=] [$OrdinaryObjectCreate$]({{%ObjectPrototype%}}).
+    1.  Let |O| be [=!=] [$OrdinaryObjectCreate$]({{%Object.prototype%}}).
     1.  Let |dictionaries| be a list consisting of |D| and all of |D|’s [=inherited dictionaries=],
         in order from least to most derived.
     1.  For each dictionary |dictionary| in |dictionaries|, in order:
@@ -8277,7 +8275,7 @@ ECMAScript Object values.
     [=converted to an ECMAScript value|converted=]
     to an ECMAScript value as follows:
 
-    1.  Let |result| be [=!=] [$OrdinaryObjectCreate$]({{%ObjectPrototype%}}).
+    1.  Let |result| be [=!=] [$OrdinaryObjectCreate$]({{%Object.prototype%}}).
     1.  [=map/For each=] |key| → |value| of |D|:
         1.  Let |esKey| be |key| [=converted to an ECMAScript value=].
         1.  Let |esValue| be |value| [=converted to an ECMAScript value=].
@@ -8454,7 +8452,7 @@ IDL [=promise type=] values are represented by ECMAScript [=PromiseCapability=] 
         |newCapability|).
 
     Note: This algorithm will behave in a very similar way to the
-    {{%PromiseProto_then%|Promise.then()}} method.
+    {{%Promise.prototype.then%|Promise.then()}} method.
     In particular, if the steps return a value of type |U| or
     <code><a interface>Promise</a>&lt;|U|&gt;</code>, this algorithm returns a
     <code><a interface>Promise</a>&lt;|U|&gt;</code> as well.
@@ -11186,7 +11184,7 @@ default interfaces do not have such steps.
         1.  Assert: |O| is an object that [=implements=] |I|.
         1.  Assert: |O|.\[[Realm]] is |realm|.
         1.  Return |O|.
-    1.  Let |constructorProto| be |realm|.\[[Intrinsics]].[[{{%FunctionPrototype%}}]].
+    1.  Let |constructorProto| be |realm|.\[[Intrinsics]].[[{{%Function.prototype%}}]].
     1.  If |I| inherits from some other interface |P|,
         then set |constructorProto| to the [=interface object=] of |P| in |realm|.
     1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|steps|, « \[[Unforgeables]] »,
@@ -11287,8 +11285,8 @@ with the [{{LegacyNoInterfaceObject}}] [=extended attribute=].
         then set |proto| to the [=interface prototype object=] in |realm|
         of that [=inherited interface=].
     1.  Otherwise, if |interface| is the {{DOMException}} [=interface=],
-        then set |proto| to |realm|.\[[Intrinsics]].[[{{%ErrorPrototype%}}]].
-    1.  Otherwise, set |proto| to |realm|.\[[Intrinsics]].[[{{%ObjectPrototype%}}]].
+        then set |proto| to |realm|.\[[Intrinsics]].[[{{%Error.prototype%}}]].
+    1.  Otherwise, set |proto| to |realm|.\[[Intrinsics]].[[{{%Object.prototype%}}]].
     1.  Assert: <a abstract-op>Type</a>(|proto|) is Object.
     1.  Let |interfaceProtoObj| be [=!=] [$OrdinaryObjectCreate$](|proto|).
     1.  If |interface| has any [=member=] declared with the [{{Unscopable}}] [=extended attribute=],
@@ -11387,7 +11385,7 @@ for that interface on which named properties are exposed.
     1.  Let |proto| be null.
     1.  If |interface| is declared to inherit from another interface,
         then set |proto| to the [=interface prototype object=] in |realm| for the [=inherited interface=].
-    1.  Otherwise, set |proto| to |realm|.\[[Intrinsics]].[[{{%ObjectPrototype%}}]].
+    1.  Otherwise, set |proto| to |realm|.\[[Intrinsics]].[[{{%Object.prototype%}}]].
     1.  Let |obj| be [=!=] [$MakeBasicObject$](« \[[Prototype]], \[[Extensible]] »).
     1.  Set |obj|.\[[GetOwnProperty]] as specified in [[#named-properties-object-getownproperty]].
     1.  Set |obj|.\[[DefineOwnProperty]] as specified in [[#named-properties-object-defineownproperty]].
@@ -11602,7 +11600,7 @@ in which case they are exposed on every object that [=implements=] the interface
         And then, if <a lt="an exception was thrown">an exception |E| was thrown</a>:
 
         1.  If |attribute|'s type is a [=promise type=], then return
-            [=!=] <a abstract-op>Call</a>({{%Promise_reject%}}, {{%Promise%}}, «|E|»).
+            [=!=] <a abstract-op>Call</a>({{%Promise.reject%}}, {{%Promise%}}, «|E|»).
         1.  Otherwise, end these steps and allow the exception to propagate.
     1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
     1.  Let |name| be the string "<code>get </code>" prepended to |attribute|'s [=identifier=].
@@ -11806,7 +11804,7 @@ in which case they are exposed on every object that [=implements=] the interface
 
         1.  If |op| has a [=return type=]
             that is a [=promise type=], then return
-            [=!=] <a abstract-op>Call</a>({{%Promise_reject%}}, {{%Promise%}}, «|E|»).
+            [=!=] <a abstract-op>Call</a>({{%Promise.reject%}}, {{%Promise%}}, «|E|»).
         1.  Otherwise, end these steps and allow the exception to propagate.
     1.  Let |F| be [=!=] <a abstract-op>CreateBuiltinFunction</a>(|steps|, « », |realm|).
     1.  Perform [=!=] <a abstract-op>SetFunctionName</a>(|F|, |id|).
@@ -11854,7 +11852,7 @@ A [=regular operation=] that does not [=have default method steps=] must not be 
         for [=interface=] |I|.
     1.  Invoke [=collect attribute values of an inheritance stack=] given [=this=], |stack|, and
         |map|.
-    1.  Let |result| be [=!=] [$OrdinaryObjectCreate$]({{%ObjectPrototype%}}).
+    1.  Let |result| be [=!=] [$OrdinaryObjectCreate$]({{%Object.prototype%}}).
     1.  [=map/For each=] |key| → |value| of |map|,
         1.  Let |k| be |key| [=converted to an ECMAScript value=].
         1.  Let |v| be |value| [=converted to an ECMAScript value=].
@@ -12154,16 +12152,16 @@ property is the String value "<code>forEach</code>".
 
     1.  If |definition| has an [=indexed property getter=], then:
         1.  Perform [=!=] [$CreateMethodProperty$](|target|, {{@@iterator}},
-            {{%ArrayProto_values%}}).
+            {{%Array.prototype.values%}}).
         1.  If |definition| has a [=value iterator=], then:
             1.  Perform [=!=] [$CreateDataProperty$](|target|, "<code>entries</code>",
-                {{%ArrayProto_entries%}}).
+                {{%Array.prototype.entries%}}).
             1.  Perform [=!=] [$CreateDataProperty$](|target|, "<code>keys</code>",
-                {{%ArrayProto_keys%}}).
+                {{%Array.prototype.keys%}}).
             1.  Perform [=!=] [$CreateDataProperty$](|target|, "<code>values</code>",
-                {{%ArrayProto_values%}}).
+                {{%Array.prototype.values%}}).
             1.  Perform [=!=] [$CreateDataProperty$](|target|, "<code>forEach</code>",
-                {{%ArrayProto_forEach%}}).
+                {{%Array.prototype.forEach%}}).
     1.  Otherwise, if |definition| has a [=pair iterator=], then:
         1.  Define the {{@@iterator}} and <code class="idl">entries</code> methods:
             1.  Let |steps| be the following series of steps:
@@ -13918,7 +13916,7 @@ the special value “missing”, which represents a missing optional argument.
         1.  If |completion| is a normal completion, return |completion|.
         1.  If |completion| is an [=abrupt completion=] and the operation has a [=return type=]
             that is <em>not</em> a [=promise type=], return |completion|.
-        1.  Let |rejectedPromise| be [=!=] <a abstract-op>Call</a>({{%Promise_reject%}},
+        1.  Let |rejectedPromise| be [=!=] <a abstract-op>Call</a>({{%Promise.reject%}},
             {{%Promise%}}, «|completion|.\[[Value]]»).
         1.  Return the result of [=converted to an IDL value|converting=]
             |rejectedPromise| to the operation's return type.
@@ -14007,7 +14005,7 @@ described in the previous section).
         1.  If |completion| is a normal completion, return |completion|.
         1.  If |completion| is an [=abrupt completion=] and the callback function has a
             [=return type=] that is <em>not</em> a [=promise type=], return |completion|.
-        1.  Let |rejectedPromise| be [=!=] <a abstract-op>Call</a>({{%Promise_reject%}},
+        1.  Let |rejectedPromise| be [=!=] <a abstract-op>Call</a>({{%Promise.reject%}},
             {{%Promise%}}, «|completion|.\[[Value]]»).
         1.  Return the result of [=converted to an IDL value|converting=]
             |rejectedPromise| to the callback function's return type.
@@ -14067,7 +14065,7 @@ The characteristics of a namespace object are described in [[#namespace-object]]
     The namespace object for a given [=namespace=] |namespace| and [=Realm=] |realm|
     is <dfn lt="create a namespace object">created</dfn> as follows:
 
-    1.  Let |namespaceObject| be [=!=] [$OrdinaryObjectCreate$](|realm|.\[[Intrinsics]].[[{{%ObjectPrototype%}}]]).
+    1.  Let |namespaceObject| be [=!=] [$OrdinaryObjectCreate$](|realm|.\[[Intrinsics]].[[{{%Object.prototype%}}]]).
     1.  [=Define the regular attributes=] of |namespace| on |namespaceObject| given |realm|.
     1.  [=Define the regular operations=] of |namespace| on |namespaceObject| given |realm|.
     1.  For each [=exposed=] [=interface=] |interface| which has the [{{LegacyNamespace}}] extended
@@ -14085,7 +14083,7 @@ The characteristics of a namespace object are described in [[#namespace-object]]
 <h4 id="es-DOMException-specialness" oldids="es-DOMException-constructor-object, es-DOMException-prototype-object">{{DOMException}} custom bindings</h4>
 
 In the ECMAScript binding, the [=interface prototype object=] for {{DOMException}}
-has its \[[Prototype]] [=internal slot=] set to the intrinsic object {{%ErrorPrototype%}},
+has its \[[Prototype]] [=internal slot=] set to the intrinsic object {{%Error.prototype%}},
 as defined in the [=create an interface prototype object=] abstract operation.
 
 Additionally, if an implementation gives native {{ECMAScript/Error}} objects special powers or


### PR DESCRIPTION
In the ecma262 spec, we've added a [new intrinsic notation form](https://github.com/tc39/ecma262/pull/1376) that will avoid unbounded growth of our list of intrinsics.

Specifically, things like `%ArrayPrototype%` and `%ObjProto_valueOf%` should now be represented as `%Array.prototype%` and `%Object.prototype.valueOf%`, respectively.

Our intention is to delete the "legacy" forms entirely in favor of the dotted forms.

Closes #897.