### PR TITLE
Editorial: Avoid changing internal methods of ordinary objects

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11288,16 +11288,17 @@ with the [{{LegacyNoInterfaceObject}}] [=extended attribute=].
         then set |proto| to |realm|.\[[Intrinsics]].[[{{%Error.prototype%}}]].
     1.  Otherwise, set |proto| to |realm|.\[[Intrinsics]].[[{{%Object.prototype%}}]].
     1.  Assert: <a abstract-op>Type</a>(|proto|) is Object.
+    1.  Let |interfaceProtoObj| be null.
     1.  If |interface| is declared with the [{{Global}}] [=extended attribute=], or
         |interface| is in the set of [=inherited interfaces=] of an interface
         that is declared with the [{{Global}}] [=extended attribute=], then:
-        1.  Let |interfaceProtoObj| be [=!=] [$MakeBasicObject$](« \[[Prototype]], \[[Extensible]] »).
+        1.  Set |interfaceProtoObj| to [=!=] [$MakeBasicObject$](« \[[Prototype]], \[[Extensible]] »).
         1.  Set |interfaceProtoObj|.\[[Prototype]] to |proto|.
         1.  Set the internal methods of |interfaceProtoObj|
             which are specific to [=immutable prototype exotic objects=]
             to the definitions specified in
             [=ECMA-262 Immutable prototype exotic objects=].
-    1.  Else, let |interfaceProtoObj| be [=!=] [$OrdinaryObjectCreate$](|proto|).
+    1.  Otherwise, set |interfaceProtoObj| to [=!=] [$OrdinaryObjectCreate$](|proto|).
     1.  If |interface| has any [=member=] declared with the [{{Unscopable}}] [=extended attribute=],
         then:
 

--- a/index.bs
+++ b/index.bs
@@ -11288,7 +11288,16 @@ with the [{{LegacyNoInterfaceObject}}] [=extended attribute=].
         then set |proto| to |realm|.\[[Intrinsics]].[[{{%Error.prototype%}}]].
     1.  Otherwise, set |proto| to |realm|.\[[Intrinsics]].[[{{%Object.prototype%}}]].
     1.  Assert: <a abstract-op>Type</a>(|proto|) is Object.
-    1.  Let |interfaceProtoObj| be [=!=] [$OrdinaryObjectCreate$](|proto|).
+    1.  If |interface| is declared with the [{{Global}}] [=extended attribute=], or
+        |interface| is in the set of [=inherited interfaces=] of an interface
+        that is declared with the [{{Global}}] [=extended attribute=], then:
+        1.  Let |interfaceProtoObj| be [=!=] [$MakeBasicObject$](« \[[Prototype]], \[[Extensible]] »).
+        1.  Set |interfaceProtoObj|.\[[Prototype]] to |proto|.
+        1.  Set the internal methods of |interfaceProtoObj|
+            which are specific to [=immutable prototype exotic objects=]
+            to the definitions specified in
+            [=ECMA-262 Immutable prototype exotic objects=].
+    1.  Else, let |interfaceProtoObj| be [=!=] [$OrdinaryObjectCreate$](|proto|).
     1.  If |interface| has any [=member=] declared with the [{{Unscopable}}] [=extended attribute=],
         then:
 
@@ -11305,13 +11314,6 @@ with the [{{LegacyNoInterfaceObject}}] [=extended attribute=].
             \[[Writable]]: <emu-val>false</emu-val>, \[[Enumerable]]: <emu-val>false</emu-val>,
             \[[Configurable]]: <emu-val>true</emu-val>}.
         1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|interfaceProtoObj|, {{@@unscopables}}, |desc|).
-    1.  If |interface| is declared with the [{{Global}}] [=extended attribute=], or
-        |interface| is in the set of [=inherited interfaces=] of an interface
-        that is declared with the [{{Global}}] [=extended attribute=], then:
-        1.  Set the internal methods of |interfaceProtoObj|
-            which are specific to [=immutable prototype exotic objects=]
-            to the definitions specified in
-            [=ECMA-262 Immutable prototype exotic objects=].
     1.  If |interface| is not declared with the [{{Global}}] [=extended attribute=], then:
         1.  [=Define the regular attributes=] of |interface| on |interfaceProtoObj| given |realm|.
         1.  [=Define the regular operations=] of |interface| on |interfaceProtoObj| given |realm|.


### PR DESCRIPTION
This fixes up <https://github.com/heycam/webidl/pull/871>, where I missed the fact that interface prototype objects of global objects and objects in the prototype chain of global objects have their `[[SetPrototypeOf]]` internal method changed in a way that makes them [immutable prototype exotic objects][immutable-prototype-exotic-objects].

---

Changing the `[[SetPrototypeOf]]` method of the result of [`OrdinaryObjectCreate`] goes against the intention of separating [`OrdinaryObjectCreate`] and [`MakeBasicObject`], so this fixes that.

[immutable-prototype-exotic-objects]: https://tc39.es/ecma262/#sec-immutable-prototype-exotic-objects
[`OrdinaryObjectCreate`]: https://tc39.es/ecma262/#sec-ordinaryobjectcreate
[`MakeBasicObject`]: https://tc39.es/ecma262/#sec-makebasicobject


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/EB-Forks/webidl/pull/901.html" title="Last updated on Jul 6, 2020, 10:24 PM UTC (2131856)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/901/79bd7e0...EB-Forks:2131856.html" title="Last updated on Jul 6, 2020, 10:24 PM UTC (2131856)">Diff</a>