### PR TITLE
Allow to use LegacyNullToEmptyString on USVString.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10377,13 +10377,13 @@ for the specific requirements that the use of
 
 <h4 id="LegacyNullToEmptyString" extended-attribute lt="LegacyNullToEmptyString" oldids="TreatNullAs">[LegacyNullToEmptyString]</h4>
 
-If the [{{LegacyNullToEmptyString}}] [=extended attribute=] appears on the {{DOMString}} type, it creates a new
-IDL type such that that when an ECMAScript <emu-val>null</emu-val> is converted to the IDL type, it
-will be handled differently from its default handling. Instead of being stringified to
+If the [{{LegacyNullToEmptyString}}] [=extended attribute=] appears on the {{DOMString}} or {{USVString}} type,
+it creates a new IDL type such that that when an ECMAScript <emu-val>null</emu-val> is converted to the IDL type,
+it will be handled differently from its default handling. Instead of being stringified to
 "<code>null</code>", which is the default, it will be converted to the empty string.
 
 The [{{LegacyNullToEmptyString}}] extended attribute must not be
-[=extended attribute associated with|associated with=] a type that is not {{DOMString}}.
+[=extended attribute associated with|associated with=] a type that is not {{DOMString}} or {{USVString}}.
 
 Note: This means that even <code class="idl">DOMString?</code> must not use [{{LegacyNullToEmptyString}}], since
 <emu-val>null</emu-val> is a valid value of that type.


### PR DESCRIPTION
This is needed for the CSSOM spec, as that allows to use USVString as
the underlying string type.

Given the USVString conversion to JS values is already calling into the
DOMString conversion, there's no need to modify that section even, which
is great.

cc https://github.com/w3c/csswg-drafts/issues/5010