### PR TITLE
Require [Exposed] even when marked as [LegacyNoInterfaceObject]

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1016,9 +1016,7 @@ The following extended attributes are applicable to [=partial interfaces=]:
 [{{LegacyOverrideBuiltIns}}], and
 [{{SecureContext}}].
 
-[=Interfaces=] which are not annotated
-with a [{{LegacyNoInterfaceObject}}] [=extended attribute=]
-must be annotated with an [{{Exposed}}] [=extended attribute=].
+[=Interfaces=] must be annotated with an [{{Exposed}}] [=extended attribute=].
 
 <div algorithm>
 


### PR DESCRIPTION
Fixes #919 