### PR TITLE
Fix "react to a promise"'s default handlers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8427,19 +8427,17 @@ IDL [=promise type=] values are represented by ECMAScript [=PromiseCapability=] 
     1.  Let |onFulfilledSteps| be the following steps given argument |V|:
         1.  Let |value| be the result of [=converted to an IDL value|converting=] |V| to an IDL
             value of type |T|.
-        1.  If there are no steps that are required to be run if the promise was fulfilled, then
-            return <emu-val>undefined</emu-val>.
-        1.  Let |result| be the result of performing any steps that were required to be run if
-            the promise was fulfilled, given |value| if |T| is not {{undefined}}.
+        1.  If there is a set of steps to be run if the promise was fulfilled, then let |result| be
+            the result of performing them, given |value| if |T| is not {{undefined}}. Otherwise, let
+            |result| be |value|.
         1.  Return |result|, [=converted to an ECMAScript value=].
     1.  Let |onFulfilled| be [=!=] [$CreateBuiltinFunction$](|onFulfilledSteps|, « »):
     1.  Let |onRejectedSteps| be the following steps given argument |R|:
         1.  Let |reason| be the result of [=converted to an IDL value|converting=]
             |R| to an IDL value of type {{any}}.
-        1.  If there are no steps that are required to be run if the promise was rejected, then
-            return <emu-val>undefined</emu-val>.
-        1.  Let |result| be the result of performing any steps that were required to be run if the
-            promise was rejected, given |reason|.
+        1.  If there is a set of steps to be run if the promise was rejected, then let |result| be
+            the result of performing them, given |reason|. Otherwise, let |result| be
+            [=a promise rejected with=] |reason|.
         1.  Return |result|, [=converted to an ECMAScript value=].
     1.  Let |onRejected| be [=!=] [$CreateBuiltinFunction$](|onRejectedSteps|, « »):
     1.  Let |constructor| be |promise|.\[[Promise]].\[[Realm]].\[[Intrinsics]].[[{{%Promise%}}]].
@@ -8463,7 +8461,7 @@ IDL [=promise type=] values are represented by ECMAScript [=PromiseCapability=] 
     <code><a interface>Promise</a>&lt;|T|&gt;</code> |promise| given some steps |steps| taking a
     value of type |T|, perform the following steps:
 
-    1.  [=promise/React=] to |promise|:
+    1.  Return the result of [=promise/reacting=] to |promise|:
         *   If |promise| was fulfilled with value |v|, then:
             1.  Perform |steps| with |v|.
 </div>
@@ -8474,7 +8472,7 @@ IDL [=promise type=] values are represented by ECMAScript [=PromiseCapability=] 
     <code><a interface>Promise</a>&lt;<var ignore>T</var>&gt;</code> |promise| given some steps
     |steps| taking an ECMAScript value, perform the following steps:
 
-    1.  [=promise/React=] to |promise|:
+    1.  Return the result of [=promise/reacting=] to |promise|:
         *   If |promise| was rejected with reason |r|, then:
             1.  Perform |steps| with |r|.
 </div>


### PR DESCRIPTION
"React to a promise"'s default handlers used to return undefined rather than propagating the resolved value or the rejection reason to the returned promise. This change fixes that, and changes "upon fulfillment" and "upon rejection" to return the resulting promise.

Closes #921.
