### PR TITLE
Update obsolete note on duplicate Proxy [[OwnPropertyKeys]] entries

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8259,8 +8259,8 @@ ECMAScript Object values.
             1.  Let |typedValue| be |value| [=converted to an IDL value=] of type |V|.
             1.  [=map/Set=] |result|[|typedKey|] to |typedValue|.
 
-                Note: it's possible that |typedKey| is already in |result|, if |O| is a proxy
-                object.
+                Note: It's possible that |typedKey| is already in |result|,
+                if |K| is {{USVString}} and |key| contains unpaired surrogates.
     1.  Return |result|.
 </div>
 


### PR DESCRIPTION
The note was added in #180, a few months before https://github.com/tc39/ecma262/pull/833 was merged.

_cc_ @domenic @bzbarsky


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shvaikalesh/webidl/pull/925.html" title="Last updated on Oct 15, 2020, 9:21 AM UTC (ec9e010)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/925/accdef1...shvaikalesh:ec9e010.html" title="Last updated on Oct 15, 2020, 9:21 AM UTC (ec9e010)">Diff</a>