### PR TITLE
Fix ObservableArray's lt

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6803,7 +6803,7 @@ The [=type name=] of a frozen array
 type is the concatenation of the type name for |T| and the string
 "<code>Array</code>".
 
-<h4 id="idl-observable-array" interface lt="ObservableArrayT|ObservableArray&lt;T&gt;">Observable array types — ObservableArray&lt;|T|&gt;</h4>
+<h4 id="idl-observable-array" interface lt="ObservableArray|ObservableArray&lt;T&gt;">Observable array types — ObservableArray&lt;|T|&gt;</h4>
 
 An <dfn id="dfn-observable-array-type" export>observable array type</dfn> is a parameterized type
 whose values are references to a combination of a mutable list of objects of type |T|, as well as


### PR DESCRIPTION
I'm gonna be pushing some Bikeshed fixes that link more WebIDL types that are currently left unlinked in IDL blocks, and ObservableArray having a gratuitously different `lt` value than similar types like FrozenArray is troublesome.