### PR TITLE
Normative: Match ECMA‑262 order of the `constructor` property

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11374,6 +11374,9 @@ with the [{{LegacyNoInterfaceObject}}] [=extended attribute=].
             to the definitions specified in
             [=ECMA-262 Immutable prototype exotic objects=].
     1.  Otherwise, set |interfaceProtoObj| to [=!=] [$OrdinaryObjectCreate$](|proto|).
+    1.  If the [{{LegacyNoInterfaceObject}}] [=extended attribute=] was not specified on |interface|, then:
+        1.  Let |constructor| be the [=interface object=] of |interface| in |realm|.
+        1.  Perform [=!=] [$CreateMethodProperty$](|interfaceProtoObj|, "<code>constructor</code>", |constructor|).
     1.  If |interface| has any [=member=] declared with the [{{Unscopable}}] [=extended attribute=],
         then:
 
@@ -11397,12 +11400,6 @@ with the [{{LegacyNoInterfaceObject}}] [=extended attribute=].
         1.  [=Define the asynchronous iteration methods=] of |interface| on |interfaceProtoObj|
             given |realm|.
     1.  [=Define the constants=] of |interface| on |interfaceProtoObj| given |realm|.
-    1.  If the [{{LegacyNoInterfaceObject}}] [=extended attribute=] was not specified on |interface|, then:
-        1.  Let |constructor| be the [=interface object=] of |interface| in |realm|.
-        1.  Let |desc| be the PropertyDescriptor{\[[Writable]]: <emu-val>true</emu-val>,
-            \[[Enumerable]]: <emu-val>false</emu-val>, \[[Configurable]]: <emu-val>true</emu-val>,
-            \[[Value]]: |constructor|}.
-        1.  Perform [=!=] <a abstract-op>DefinePropertyOrThrow</a>(|interfaceProtoObj|, "<code>constructor</code>", |desc|).
     1.  Return |interfaceProtoObj|.
 </div>
 


### PR DESCRIPTION
In **ECMA‑262**, the `"constructor"` property is the first property that’s added to the prototype object after its creation.

---

This matches **V8**’s implementation of built‑in objects, including ones implemented using **WebIDL**.