### PR TITLE
Normative: Add `BigInt64Array` and `BigUint64Array`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5746,7 +5746,9 @@ The <dfn id="dfn-typed-array-type" export>typed array types</dfn> are
 {{Uint16Array}},
 {{Uint32Array}},
 {{Uint8ClampedArray}},
-{{Float32Array}} and
+{{BigInt64Array}},
+{{BigUint64Array}},
+{{Float32Array}}, and
 {{Float64Array}}.
 
 The <dfn id="dfn-buffer-source-type" export>buffer source types</dfn>
@@ -6749,22 +6751,21 @@ data.  The table below lists these types and the kind of buffer or view they rep
     <tr><th>Type</th><th>Kind of buffer</th></tr>
     <tr><td><dfn id="idl-ArrayBuffer" interface>ArrayBuffer</dfn></td><td>An object that holds a pointer (which may be null) to a buffer of a fixed number of bytes</td></tr>
     <tr><td><dfn id="idl-DataView" interface>DataView</dfn></td><td>A view on to an {{ArrayBuffer}} that allows typed access to integers and floating point values stored at arbitrary offsets into the buffer</td></tr>
-        <tr><td>
-            <dfn id="idl-Int8Array" interface>Int8Array</dfn>,<br/>
+    <tr><td><dfn id="idl-Int8Array" interface>Int8Array</dfn>,<br/>
             <dfn id="idl-Int16Array" interface>Int16Array</dfn>,<br/>
-        <dfn id="idl-Int32Array" interface>Int32Array</dfn></td>
-    <td>A view on to an {{ArrayBuffer}} that exposes it as an array of two’s complement signed integers of the given size in bits</td></tr>
-        <tr><td>
-            <dfn id="idl-Uint8Array" interface>Uint8Array</dfn>,<br/>
+            <dfn id="idl-Int32Array" interface>Int32Array</dfn>,<br/>
+            <dfn id="idl-BigInt64Array" interface>BigInt64Array</dfn></td>
+        <td>A view on to an {{ArrayBuffer}} that exposes it as an array of two’s complement signed integers of the given size in bits</td></tr>
+    <tr><td><dfn id="idl-Uint8Array" interface>Uint8Array</dfn>,<br/>
             <dfn id="idl-Uint16Array" interface>Uint16Array</dfn>,<br/>
-        <dfn id="idl-Uint32Array" interface>Uint32Array</dfn></td>
-    <td>A view on to an {{ArrayBuffer}} that exposes it as an array of unsigned integers of the given size in bits</td></tr>
-        <tr><td><dfn id="idl-Uint8ClampedArray" interface>Uint8ClampedArray</dfn></td>
-    <td>A view on to an {{ArrayBuffer}} that exposes it as an array of unsigned 8 bit integers with clamped conversions</td></tr>
-        <tr><td>
-            <dfn id="idl-Float32Array" interface>Float32Array</dfn>,<br/>
-        <dfn id="idl-Float64Array" interface>Float64Array</dfn></td>
-    <td>A view on to an {{ArrayBuffer}} that exposes it as an array of IEEE 754 floating point numbers of the given size in bits</td></tr>
+            <dfn id="idl-Uint32Array" interface>Uint32Array</dfn>,<br/>
+            <dfn id="idl-BigUint64Array" interface>BigUint64Array</dfn></td>
+        <td>A view on to an {{ArrayBuffer}} that exposes it as an array of unsigned integers of the given size in bits</td></tr>
+    <tr><td><dfn id="idl-Uint8ClampedArray" interface>Uint8ClampedArray</dfn></td>
+        <td>A view on to an {{ArrayBuffer}} that exposes it as an array of unsigned 8 bit integers with clamped conversions</td></tr>
+    <tr><td><dfn id="idl-Float32Array" interface>Float32Array</dfn>,<br/>
+            <dfn id="idl-Float64Array" interface>Float64Array</dfn></td>
+        <td>A view on to an {{ArrayBuffer}} that exposes it as an array of IEEE 754 floating point numbers of the given size in bits</td></tr>
 </table>
 
 Note: These types all correspond to classes defined in ECMAScript.
@@ -6831,6 +6832,8 @@ how interacting with buffer source types works in the ECMAScript language bindin
         "Uint16Array"
         "Uint32Array"
         "Uint8ClampedArray"
+        "BigInt64Array"
+        "BigUint64Array"
         "Float32Array"
         "Float64Array"
 </pre>
@@ -8971,6 +8974,8 @@ that unless the type is [=extended attributes associated with|associated with=] 
     {{Uint16Array}},
     {{Uint32Array}},
     {{Uint8ClampedArray}},
+    {{BigInt64Array}},
+    {{BigUint64Array}},
     {{Float32Array}} or
     {{Float64Array}} value
     by running the following algorithm:
@@ -14442,6 +14447,7 @@ must support.
 <pre class="idl">
     typedef (Int8Array or Int16Array or Int32Array or
              Uint8Array or Uint16Array or Uint32Array or Uint8ClampedArray or
+             BigInt64Array or BigUint64Array or
              Float32Array or Float64Array or DataView) ArrayBufferView;
 </pre>
 


### PR DESCRIPTION
Now that we have [the `bigint` type][idl-bigint] (<https://github.com/heycam/webidl/pull/525>), it makes sense to add these as well.

[idl-bigint]: https://heycam.github.io/webidl/#idl-bigint

---

review?(@domenic, @littledan, @heycam, @TimothyGu)