### PR TITLE
Specify that dictionaries can't be the type of attr/constant

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6321,8 +6321,9 @@ implicitly understood from context that the map is being treated as an instance 
 dictionary type. However, there is no way to represent a constant dictionary value inside IDL
 fragments.
 
-The [=type name=] of a dictionary type
-is the [=identifier=] of the dictionary.
+Dictionaries must not be used as the type of an [=attribute=] or [=constant=].
+
+The [=type name=] of a dictionary type is the [=identifier=] of the dictionary.
 
 
 <h4 id="idl-enumeration" dfn export>Enumeration types</h4>
@@ -6442,9 +6443,7 @@ The literal syntax for [=lists=] may also be used to represent sequences, when i
 understood from context that the list is being treated as a sequences. However, there is no way to
 represent a constant sequence value inside IDL fragments.
 
-Sequences must not be used as the
-type of an [=attribute=] or
-[=constant=].
+Sequences must not be used as the type of an [=attribute=] or [=constant=].
 
 Note: This restriction exists so that it is clear to specification writers
 and API users that [=sequence types|sequences=]
@@ -6478,8 +6477,7 @@ being kept by that object. Similarly, any record returned from a
 platform object will be a copy and modifications made to it will not be visible
 to the platform object.
 
-Records must not be used as the type of an [=attribute=] or
-[=constant=].
+Records must not be used as the type of an [=attribute=] or [=constant=].
 
 The [=type name=] of a record type is the concatenation of the type
 name for |K|, the type name for |V| and the string "<code>Record</code>".


### PR DESCRIPTION
The same sentence is already in [Dictionary section](https://heycam.github.io/webidl/#idl-dictionaries), and this change copy-pastes it to the [Types - Dictionary types](https://heycam.github.io/webidl/#idl-dictionary) for consistency with other Types sections.