### PR TITLE
Remove disused entries from error names table (2.8.1.)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5291,11 +5291,6 @@ over just using {{SyntaxError!!exception}} to refer to the {{DOMException}}. [[D
             <td><strong>Deprecated.</strong> Use {{RangeError}} instead.</td></td>
             <td><dfn id="dom-domexception-index_size_err" for="DOMException" const export><code>INDEX_SIZE_ERR</code></dfn>&nbsp;(1)</td>
         </tr>
-        <tr class="deprecated">
-            <td>"<dfn id="domstringsizeerror" exception export><code>DOMStringSizeError</code></dfn>"</td>
-            <td><strong>Deprecated.</strong> Use {{RangeError}} instead.</td>
-            <td><dfn id="dom-domexception-domstring_size_err" for="DOMException" const><code>DOMSTRING_SIZE_ERR</code></dfn>&nbsp;(2)</td>
-        </tr>
         <tr>
             <td>"<dfn id="hierarchyrequesterror" exception export><code>HierarchyRequestError</code></dfn>"</td>
             <td>The operation would yield an incorrect [=node tree=]. [[!DOM]]</td>
@@ -5310,11 +5305,6 @@ over just using {{SyntaxError!!exception}} to refer to the {{DOMException}}. [[D
             <td>"<dfn id="invalidcharactererror" exception export><code>InvalidCharacterError</code></dfn>"</td>
             <td>The string contains invalid characters.</td>
             <td><dfn id="dom-domexception-invalid_character_err" for="DOMException" const export><code>INVALID_CHARACTER_ERR</code></dfn>&nbsp;(5)</td>
-        </tr>
-        <tr class="deprecated">
-            <td>"<dfn id="nodataallowederror" exception export><code>NoDataAllowedError</code></dfn>"</td>
-            <td><strong>Deprecated.</strong></td>
-            <td><dfn id="dom-domexception-no_data_allowed_err" for="DOMException" const><code>NO_DATA_ALLOWED_ERR</code></dfn>&nbsp;(6)</td>
         </tr>
         <tr>
             <td>"<dfn id="nomodificationallowederror" exception export><code>NoModificationAllowedError</code></dfn>"</td>
@@ -5365,11 +5355,6 @@ over just using {{SyntaxError!!exception}} to refer to the {{DOMException}}. [[D
                 "{{NotAllowedError!!exception}}" {{DOMException}} for denied requests instead.
             </td>
             <td><dfn id="dom-domexception-invalid_access_err" for="DOMException" const><code>INVALID_ACCESS_ERR</code></dfn>&nbsp;(15)</td>
-        </tr>
-        <tr class="deprecated">
-            <td>"<dfn id="validationerror" exception export><code>ValidationError</code></dfn>"</td>
-            <td><strong>Deprecated.</strong></td>
-            <td><dfn id="dom-domexception-validation_err" for="DOMException" const><code>VALIDATION_ERR</code></dfn>&nbsp;(16)</td>
         </tr>
         <tr class="deprecated">
             <td>"<dfn id="typemismatcherror" exception export><code>TypeMismatchError</code></dfn>"</td>


### PR DESCRIPTION
No major browser implements these 3 error-name-to-error-code mappings in DOMException constructor. So this PR suggests removing these 3 entries from the table.

We found this while updating web platform test at https://github.com/web-platform-tests/wpt/pull/27181.

cc @domenic 