### PR TITLE
Normative: Add `null` type, and allow it as a return type (excl. unions)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5839,6 +5839,7 @@ type.
         UnsignedIntegerType
         UnrestrictedFloatType
         "undefined"
+        "null"
         "boolean"
         "byte"
         "octet"
@@ -5936,6 +5937,21 @@ or a non-[=dictionary member/required=] [=dictionary member=].
 
 Note: This value was previously spelled <code>void</code>,
 and more limited in how it was allowed to be used.
+
+
+<h4 id="idl-null" interface>null</h4>
+
+The {{null}} type has a unique value.
+
+{{null}} constant values in IDL
+are represented with the <emu-t>null</emu-t> token.
+
+The [=type name=] of the {{null}} type is "<code>Null</code>".
+
+{{null}} must not be used in a union or as the type of an argument in any circumstance
+(in an [=operation=], [=callback function=], [=constructor operation=], etc),
+or the type of a [=dictionary member=], whether directly or in a union.
+Instead, use a [=nullable type=].
 
 
 <h4 oldids="dom-boolean" id="idl-boolean" interface>boolean</h4>
@@ -7422,6 +7438,19 @@ ECMAScript value type.
 <p id="undefined-to-es" oldids="void-to-es">
     The unique IDL {{undefined}} value is [=converted to an ECMAScript value|converted=] to the
     ECMAScript <emu-val>undefined</emu-val> value.
+</p>
+
+
+<h4 id="es-null">null</h4>
+
+<p id="es-to-null">
+    An ECMAScript value |V| is [=converted to an IDL value|converted=] to an IDL {{null}} value by
+    returning the unique {{null}} value, ignoring |V|.
+</p>
+
+<p id="null-to-es">
+    The unique IDL {{null}} value is [=converted to an ECMAScript value|converted=] to the
+    ECMAScript <emu-val>null</emu-val> value.
 </p>
 
 


### PR DESCRIPTION
This complements <https://github.com/heycam/webidl/pull/906> and makes it possible to specify the legacy `PluginArray` and `MediaTypeArray` APIs without using a nullable `object?` type: <https://github.com/whatwg/html/pull/6296#discussion_r559340322>

```diff webidl
 [Exposed=Window]
 interface PluginArray {
 	undefined refresh();
 	readonly attribute unsigned long length;
-	object? item(unsigned long index);
-	object? namedItem(DOMString name);
+	null item(unsigned long index);
+	null namedItem(DOMString name);
 };
 
 [Exposed=Window]
 interface MimeTypeArray {
 	readonly attribute unsigned long length;
-	object? item(unsigned long index);
-	object? namedItem(DOMString name);
+	null item(unsigned long index);
+	null namedItem(DOMString name);
 };
```

---

Unlike <https://github.com/heycam/webidl/issues/866>, this keeps nullable types for now.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/EB-Forks/webidl/pull/950.html" title="Last updated on Jan 22, 2021, 8:02 AM UTC (fc1cb79)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/950/29afaf0...EB-Forks:fc1cb79.html" title="Last updated on Jan 22, 2021, 8:02 AM UTC (fc1cb79)">Diff</a>