### PR TITLE
Named properties object: allow symbols in [[DefineOwnProperty]] and [[Delete]]

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -157,6 +157,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: NormalCompletion; url: sec-normalcompletion
         text: OrdinaryObjectCreate; url: sec-ordinaryobjectcreate
         text: OrdinaryDefineOwnProperty; url: sec-ordinarydefineownproperty
+        text: OrdinaryDelete; url: sec-ordinarydelete
         text: OrdinaryGetOwnProperty; url: sec-ordinarygetownproperty
         text: OrdinaryPreventExtensions; url: sec-ordinarypreventextensions
         text: OrdinarySetWithOwnDescriptor; url: sec-ordinarysetwithowndescriptor
@@ -11632,20 +11633,23 @@ is the concatenation of the [=interface=]’s
 
 <div algorithm="to invoke the [[DefineOwnProperty]] internal method of named properties object">
 
-    When the \[[DefineOwnProperty]] internal method of a [=named properties object=] is called,
+    When the \[[DefineOwnProperty]] internal method of a [=named properties object=] |O|
+    is called with property key |P| and [=Property Descriptor=] |Desc|,
     the following steps are taken:
 
-    1.  Return <emu-val>false</emu-val>.
+    1.  If [$Type$](|P|) is String, then return <emu-val>false</emu-val>.
+    1.  Otherwise, return [=?=] [$OrdinaryDefineOwnProperty$](|O|, |P|, |Desc|).
 </div>
 
 <h5 id="named-properties-object-delete">\[[Delete]]</h5>
 
 <div algorithm="to invoke the [[Delete]] internal method of named properties object">
 
-    When the \[[Delete]] internal method of a [=named properties object=] is called,
-    the following steps are taken:
+    When the \[[Delete]] internal method of a [=named properties object=] |O|
+    is called with property key |P|, the following steps are taken:
 
-    1.  Return <emu-val>false</emu-val>.
+    1.  If [$Type$](|P|) is String, then return <emu-val>false</emu-val>.
+    1.  Otherwise, return [=?=] [$OrdinaryDelete$](|O|, |P|).
 </div>
 
 


### PR DESCRIPTION
Given that `X` is [named properties object](https://heycam.github.io/webidl/#named-properties-object) for `Window`, the following code:

```js
Object.defineProperty(X, Symbol.toStringTag,
  Object.getOwnPropertyDescriptor(X, Symbol.toStringTag));
```

should throw `TypeError` per current spec. While being compliant with [invariants of EIM](https://tc39.es/ecma262/#sec-invariants-of-the-essential-internal-methods), this behavior is very weird.

The same snippet for `X` that is [module namespace object](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects) doesn't throw, even though the namespace is non-extensible and its `Symbol.toStringTag` is non-configurable.

While we could just special-case `Symbol.toStringTag` or own properties that are symbols, I suggest we treat symbols in [`[[DefineOwnProperty]]`](https://heycam.github.io/webidl/#named-properties-object-defineownproperty) and [`[[Delete]]`](https://heycam.github.io/webidl/#named-properties-object-delete) the same way as ordinary methods do. To prevent clashes with [supported property names](https://html.spec.whatwg.org/multipage/window-object.html#named-access-on-the-window-object), it's critical for `WindowProperties` to prohibit expando properties that are strings, but not symbols.

Proposed change feels like an expected behavior, reducing divergence with ordinary methods, and aligns [named properties object](https://heycam.github.io/webidl/#named-properties-object) with [legacy platforms objects](https://heycam.github.io/webidl/#legacy-platform-object-defineownproperty) & [module namespace object](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-defineownproperty-p-desc). It is already implemented in **Blink** and also, with [bug #222918](https://bugs.webkit.org/show_bug.cgi?id=222918), in **WebKit**.

Currently, no browser features spec-perfect `WindowProperties` object, so this change can be implemented along with [fixing current spec incompatibilities](https://github.com/web-platform-tests/wpt/pull/27970#issue-588774871).

Tests: https://github.com/web-platform-tests/wpt/pull/27970.

_cc_ @domenic @evilpie