### PR TITLE
Named properties object: enumerate supported properties in [[OwnPropertyKeys]]

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -159,6 +159,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: OrdinaryDefineOwnProperty; url: sec-ordinarydefineownproperty
         text: OrdinaryGetOwnProperty; url: sec-ordinarygetownproperty
         text: OrdinaryPreventExtensions; url: sec-ordinarypreventextensions
+        text: OrdinaryOwnPropertyKeys; url: sec-ordinaryownpropertykeys
         text: OrdinarySetWithOwnDescriptor; url: sec-ordinarysetwithowndescriptor
         text: PerformPromiseThen; url: sec-performpromisethen
         text: ProxyCreate; url: sec-proxycreate
@@ -11584,6 +11585,7 @@ for that interface on which named properties are exposed.
     1.  Set |obj|.\[[Delete]] as specified in [[#named-properties-object-delete]].
     1.  Set |obj|.\[[SetPrototypeOf]] as specified in [[#named-properties-object-setprototypeof]].
     1.  Set |obj|.\[[PreventExtensions]] as specified in [[#named-properties-object-preventextensions]].
+    1.  Set |obj|.\[[OwnPropertyKeys]] as specified in [[#named-properties-object-ownpropertykeys]].
     1.  Set |obj|.\[[Prototype]] to |proto|.
     1.  Return |obj|.
 </div>
@@ -11672,6 +11674,23 @@ is the concatenation of the [=interface=]’s
 
     Note: this keeps [=named properties object=] extensible by
     making \[[PreventExtensions]] fail.
+</div>
+
+
+<h5 id="named-properties-object-ownpropertykeys">\[[OwnPropertyKeys]]</h5>
+
+<div algorithm="to invoke the [[OwnPropertyKeys]] internal method of named properties object">
+
+    When the \[[OwnPropertyKeys]] internal method of a [=named properties object=] |O| is called,
+    the following steps are taken:
+
+    1.  Let |keys| be a new empty [=list=] of ECMAScript String and Symbol values.
+    1.  [=list|For each=] |P| of |O|’s [=supported property names=] that is visible according
+        to the [=named property visibility algorithm=], [=list|append=] |P| to |keys|.
+    1.  Let |symbolKeys| be [=!=] [$OrdinaryOwnPropertyKeys$](|O|).
+    1.  [=list/Extend=] |keys| with |symbolKeys|.
+    1.  Assert: |keys| has no duplicate items.
+    1.  Return |keys|.
 </div>
 
 


### PR DESCRIPTION
Currently, Gecko implements proposed `[[OwnPropertyKeys]]` semantics, but Blink and WebKit do not.

This PR feels like an expected behavior and aligns [named properties object](https://heycam.github.io/webidl/#named-properties-object) with [legacy platform objects](https://heycam.github.io/webidl/#legacy-platform-object-ownpropertykeys) on enumerating supported property names.

Since only `Window` has  [named properties object](https://heycam.github.io/webidl/#named-properties-object), and it also has a [`LegacyUnenumerableNamedProperties`](https://heycam.github.io/webidl/#LegacyUnenumerableNamedProperties) extended attribute, this change has no performance impact on `for (var k in window) {}`.

If this is feasible to implement in Blink, I will contribute extensive WPT coverage and author a patch for WebKit. Once #963 and `[[OwnPropertyKeys]]` discrepancies are resolved, `WindowProperties` will be 100% compatible across all implementations!