### PR TITLE
More fixes for `undefined`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3608,6 +3608,7 @@ the following algorithm returns <i>true</i>.
         <thead>
             <tr>
                 <th class="corner"></th>
+                <th><div><span>undefined</span></div>
                 <th><div><span>boolean</span></div>
                 <th><div><span>numeric types</span></div>
                 <th><div><span>bigint</span></div>
@@ -3620,7 +3621,21 @@ the following algorithm returns <i>true</i>.
                 <th><div><span>sequence-like</span></div>
         </thead>
         <tr>
+            <th>undefined
+            <td>
+            <td>●
+            <td>●
+            <td>●
+            <td>●
+            <td>●
+            <td>●
+            <td>●
+            <td>●
+            <td>●
+            <td>●
+        <tr>
             <th>boolean
+            <td class="belowdiagonal">
             <td>
             <td>●
             <td>●
@@ -3633,6 +3648,7 @@ the following algorithm returns <i>true</i>.
             <td>●
         <tr>
             <th>numeric types
+            <td class="belowdiagonal">
             <td class="belowdiagonal">
             <td>
             <td>
@@ -3647,6 +3663,7 @@ the following algorithm returns <i>true</i>.
             <th>bigint
             <td class="belowdiagonal">
             <td class="belowdiagonal">
+            <td class="belowdiagonal">
             <td>(b)
             <td>●
             <td>●
@@ -3657,6 +3674,7 @@ the following algorithm returns <i>true</i>.
             <td>●
         <tr>
             <th>string types
+            <td class="belowdiagonal">
             <td class="belowdiagonal">
             <td class="belowdiagonal">
             <td class="belowdiagonal">
@@ -3673,6 +3691,7 @@ the following algorithm returns <i>true</i>.
             <td class="belowdiagonal">
             <td class="belowdiagonal">
             <td class="belowdiagonal">
+            <td class="belowdiagonal">
             <td>
             <td>●
             <td>
@@ -3681,6 +3700,7 @@ the following algorithm returns <i>true</i>.
             <td>
         <tr>
             <th>symbol
+            <td class="belowdiagonal">
             <td class="belowdiagonal">
             <td class="belowdiagonal">
             <td class="belowdiagonal">
@@ -3699,12 +3719,14 @@ the following algorithm returns <i>true</i>.
             <td class="belowdiagonal">
             <td class="belowdiagonal">
             <td class="belowdiagonal">
+            <td class="belowdiagonal">
             <td>(a)
             <td>●
             <td>●
             <td>●
         <tr>
             <th>callback function
+            <td class="belowdiagonal">
             <td class="belowdiagonal">
             <td class="belowdiagonal">
             <td class="belowdiagonal">
@@ -3725,10 +3747,12 @@ the following algorithm returns <i>true</i>.
             <td class="belowdiagonal">
             <td class="belowdiagonal">
             <td class="belowdiagonal">
+            <td class="belowdiagonal">
             <td>
             <td>●
         <tr>
             <th>sequence-like
+            <td class="belowdiagonal">
             <td class="belowdiagonal">
             <td class="belowdiagonal">
             <td class="belowdiagonal">
@@ -7348,8 +7372,7 @@ ECMAScript value type.
     to an IDL {{any}} value by running the following algorithm:
 
     1.  If |V| is <emu-val>undefined</emu-val>, then
-        return an {{object}} reference to a special object that represents
-        the ECMAScript <emu-val>undefined</emu-val> value.
+        return the unique {{undefined}} IDL value.
     1.  If |V| is <emu-val>null</emu-val>, then
         return the <emu-val>null</emu-val> {{object|object?}} reference.
     1.  If <a abstract-op>Type</a>(|V|) is Boolean, then
@@ -7371,15 +7394,10 @@ ECMAScript value type.
 </div>
 
 <p id="any-to-es">
-    An IDL {{any}} value is
-    [=converted to an ECMAScript value=]
-    as follows.  If the value is an {{object}}
-    reference to a special object that represents an ECMAScript <emu-val>undefined</emu-val>
-    value, then it is converted to the ECMAScript
-    <emu-val>undefined</emu-val> value.  Otherwise,
-    the rules for converting the [=specific type=]
-    of the IDL {{any}} value
-    as described in the remainder of this section are performed.
+    An IDL {{any}} value is [=converted to an ECMAScript value=]
+    according to the rules for converting
+    the [=specific type=] of the IDL {{any}} value
+    as described in the remainder of this section.
 </p>
 
 
@@ -8884,11 +8902,7 @@ that correspond to the union’s [=member types=].
 <p id="union-to-es">
     An IDL union type value is
     [=converted to an ECMAScript value=]
-    as follows.  If the value is an {{object}}
-    reference to a special object that represents an ECMAScript <emu-val>undefined</emu-val>
-    value, then it is converted to the ECMAScript
-    <emu-val>undefined</emu-val> value.  Otherwise,
-    the rules for converting the [=specific type=]
+    according to the rules for converting the [=specific type=]
     of the IDL union type value as described in this section ([[#es-type-mapping]]).
 </p>
 

--- a/index.bs
+++ b/index.bs
@@ -6598,6 +6598,13 @@ Please
 before using this feature.
 </p>
 
+A type <dfn id="dfn-includes-undefined" export>includes undefined</dfn> if:
+
+*   the type is {{undefined}}, or
+*   the type is a [=nullable type=] and its [=nullable types/inner type=] [=contains undefined=], or
+*   the type is an [=annotated type=] and its [=annotated types/inner type=] [=contains undefined=], or
+*   the type is a [=union type=] and one of its [=member types=] [=contains undefined=].
+
 [=Union type=] constant values
 in IDL are represented in the same way that constant values of their
 [=member types=] would be
@@ -8142,6 +8149,9 @@ the ECMAScript <emu-val>null</emu-val> value.
         then return the IDL
         [=nullable type=] <code class="idl">|T|?</code>
         value <emu-val>null</emu-val>.
+    1.  Otherwise, if |V| is <emu-val>undefined</emu-val>,
+        and |T| [=includes undefined=],
+        return the unique {{undefined}} value.
     1.  Otherwise, if |V| is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, then return the IDL
         [=nullable type=] <code class="idl">|T|?</code>
         value <emu-val>null</emu-val>.
@@ -8803,18 +8813,15 @@ that correspond to the union’s [=member types=].
     To [=converted to an IDL value|convert an ECMAScript value=] |V| to an IDL [=union type=]
     value is done as follows:
 
-    1.  If the [=union type=]
-        [=includes a nullable type=] and
+    1.  If the [=union type=] [=includes undefined=]
+        and |V| is <emu-val>undefined</emu-val>,
+        then return the unique {{undefined}} value.
+    1.  If the [=union type=] [=includes a nullable type=] and
         |V| is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>,
         then return the IDL value <emu-val>null</emu-val>.
     1.  Let |types| be the [=flattened member types=]
         of the [=union type=].
-    1.  If |V| is <emu-val>undefined</emu-val>, then:
-        1.  If |types| includes {{undefined}}, then return the
-            unique {{undefined}} value.
-        1.  If |types| includes a [=dictionary type=], then return the
-            result of [=converted to an IDL value|converting=] |V| to that dictionary type.
-    1.  If |V| is <emu-val>null</emu-val>, then:
+    1.  If |V| is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, then:
         1.  If |types| includes a [=dictionary type=], then return the
             result of [=converted to an IDL value|converting=] |V| to that dictionary type.
     1.  If |V| [=is a platform object=], then:

--- a/index.bs
+++ b/index.bs
@@ -8275,9 +8275,9 @@ ECMAScript Array values.
         // Each element will be converted to a double by first calling ToNumber().
         // So the following call is equivalent to the previous one, except that
         // "hi" will be alerted before drawPolygon() returns.
-        a = [false, '',
-             { valueOf: function() { alert('hi'); return 100; } }, 0,
-             '50', new Number(62.5)];
+        a = [false, "",
+             { valueOf: function() { alert("hi); return 100; } }, 0,
+             "50", new Number(62.5)];
         canvas.drawPolygon(a);
 
         // Modifying an Array that was passed to drawPolygon() is guaranteed not to

--- a/index.bs
+++ b/index.bs
@@ -3631,7 +3631,7 @@ the following algorithm returns <i>true</i>.
             <td>●
             <td>●
             <td>●
-            <td>●
+            <td>
             <td>●
         <tr>
             <th>boolean
@@ -8809,7 +8809,12 @@ that correspond to the union’s [=member types=].
         then return the IDL value <emu-val>null</emu-val>.
     1.  Let |types| be the [=flattened member types=]
         of the [=union type=].
-    1.  If |V| is <emu-val>null</emu-val> or <emu-val>undefined</emu-val>, then:
+    1.  If |V| is <emu-val>undefined</emu-val>, then:
+        1.  If |types| includes {{undefined}}, then return the
+            unique {{undefined}} value.
+        1.  If |types| includes a [=dictionary type=], then return the
+            result of [=converted to an IDL value|converting=] |V| to that dictionary type.
+    1.  If |V| is <emu-val>null</emu-val>, then:
         1.  If |types| includes a [=dictionary type=], then return the
             result of [=converted to an IDL value|converting=] |V| to that dictionary type.
     1.  If |V| [=is a platform object=], then:

--- a/index.bs
+++ b/index.bs
@@ -6601,9 +6601,9 @@ before using this feature.
 A type <dfn id="dfn-includes-undefined" export>includes undefined</dfn> if:
 
 *   the type is {{undefined}}, or
-*   the type is a [=nullable type=] and its [=nullable types/inner type=] [=contains undefined=], or
-*   the type is an [=annotated type=] and its [=annotated types/inner type=] [=contains undefined=], or
-*   the type is a [=union type=] and one of its [=member types=] [=contains undefined=].
+*   the type is a [=nullable type=] and its [=nullable types/inner type=] [=includes undefined=], or
+*   the type is an [=annotated type=] and its [=annotated types/inner type=] [=includes undefined=], or
+*   the type is a [=union type=] and one of its [=member types=] [=includes undefined=].
 
 [=Union type=] constant values
 in IDL are represented in the same way that constant values of their

--- a/index.bs
+++ b/index.bs
@@ -8304,7 +8304,7 @@ ECMAScript Array values.
         // So the following call is equivalent to the previous one, except that
         // "hi" will be alerted before drawPolygon() returns.
         a = [false, "",
-             { valueOf: function() { alert("hi); return 100; } }, 0,
+             { valueOf: function() { alert("hi"); return 100; } }, 0,
              "50", new Number(62.5)];
         canvas.drawPolygon(a);
 

--- a/index.bs
+++ b/index.bs
@@ -326,7 +326,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
           text-align: right;
         }
 
-        #distinguishable-table tr:first-child th {
+        #distinguishable-table thead th {
           white-space: nowrap;
           text-align: center;
         }
@@ -340,7 +340,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
           padding: 5px 10px;
         }
 
-        .csstransforms #distinguishable-table tr:first-child th {
+        .csstransforms #distinguishable-table thead th {
           text-align: left;
           border: none;
           height: 100px;
@@ -362,7 +362,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
           width: 30px;
         }
 
-        .csstransforms #distinguishable-table tr:first-child th div span {
+        .csstransforms #distinguishable-table thead th div span {
           border-bottom: 1px solid #ccc;
           padding: 5px 10px;
           display: block;
@@ -370,7 +370,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
           text-align: left
         }
 
-        .csstransforms #distinguishable-table tr:first-child th:last-child div span {
+        .csstransforms #distinguishable-table thead th:last-child div span {
           border-bottom: none;
         }
 
@@ -3605,169 +3605,140 @@ the following algorithm returns <i>true</i>.
     </dl>
 
     <table id="distinguishable-table" class="matrix data complex">
+        <thead>
+            <tr>
+                <th class="corner"></th>
+                <th><div><span>boolean</span></div>
+                <th><div><span>numeric types</span></div>
+                <th><div><span>bigint</span></div>
+                <th><div><span>string types</span></div>
+                <th><div><span>object</span></div>
+                <th><div><span>symbol</span></div>
+                <th><div><span>interface-like</span></div>
+                <th><div><span>callback function</span></div>
+                <th><div><span>dictionary-like</span></div>
+                <th><div><span>sequence-like</span></div>
+        </thead>
         <tr>
-            <th class="corner"></th>
-                <th><div>
-                    <span>boolean</span>
-            </div></th>
-                <th><div>
-                    <span>numeric types</span>
-            </div></th>
-                <th><div>
-                    <span>bigint</span>
-            </div></th>
-                <th><div>
-                    <span>string types</span>
-            </div></th>
-                <th><div>
-                    <span>object</span>
-            </div></th>
-                <th><div>
-                    <span>symbol</span>
-            </div></th>
-                <th><div>
-                    <span>interface-like</span>
-                </div></th>
-                <th><div>
-                    <span>callback function</span>
-            </div></th>
-                <th><div>
-                    <span>dictionary-like</span>
-            </div></th>
-                <th><div>
-                    <span>sequence-like</span>
-            </div></th>
-        </tr>
+            <th>boolean
+            <td>
+            <td>●
+            <td>●
+            <td>●
+            <td>●
+            <td>●
+            <td>●
+            <td>●
+            <td>●
+            <td>●
         <tr>
-            <th>boolean</th>
-            <td></td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-        </tr>
+            <th>numeric types
+            <td class="belowdiagonal">
+            <td>
+            <td>
+            <td>●
+            <td>●
+            <td>●
+            <td>●
+            <td>●
+            <td>●
+            <td>●
         <tr>
-            <th>numeric types</th>
-            <td class="belowdiagonal"></td>
-            <td></td>
-            <td></td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-        </tr>
+            <th>bigint
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td>(b)
+            <td>●
+            <td>●
+            <td>●
+            <td>●
+            <td>●
+            <td>●
+            <td>●
         <tr>
-            <th>bigint</th>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td>(b)</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-        </tr>
+            <th>string types
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td>
+            <td>●
+            <td>●
+            <td>●
+            <td>●
+            <td>●
+            <td>●
         <tr>
-            <th>string types</th>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td></td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-        </tr>
+            <th>object
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td>
+            <td>●
+            <td>
+            <td>
+            <td>
+            <td>
         <tr>
-            <th>object</th>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td></td>
-            <td>●</td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-        </tr>
+            <th>symbol
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td>
+            <td>●
+            <td>●
+            <td>●
+            <td>●
         <tr>
-            <th>symbol</th>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td></td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-        </tr>
+            <th>interface-like
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td>(a)
+            <td>●
+            <td>●
+            <td>●
         <tr>
-            <th>interface-like</th>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td>(a)</td>
-            <td>●</td>
-            <td>●</td>
-            <td>●</td>
-        </tr>
+            <th>callback function
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td>
+            <td>
+            <td>●
         <tr>
-            <th>callback function</th>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td></td>
-            <td></td>
-            <td>●</td>
-        </tr>
+            <th>dictionary-like
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td>
+            <td>●
         <tr>
-            <th>dictionary-like</th>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td></td>
-            <td>●</td>
-        </tr>
-        <tr>
-            <th>sequence-like</th>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td class="belowdiagonal"></td>
-            <td></td>
-        </tr>
+            <th>sequence-like
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td class="belowdiagonal">
+            <td>
     </table>
 
     <ol type="a">


### PR DESCRIPTION
* Added `undefined` to the distinguishability table
* Removed text from any/union conversion that handled `undefined` specially, now that it's just an ordinary IDL value.
* Editorially, cleaned up the markup for the distinguishability table, and changed one unrelated code example to use double-quotes on a few strings, as it was inconsistent with quote usage elsewhere in the same example, and the empty string messed up Bikeshed's syntax-highlighting for the rest of the spec from that point on.

Currently a draft because there's an open question in <https://github.com/heycam/webidl/issues/962#issuecomment-796938662>, don't merge until that's answered and likely has another commit addressing it.