### PR TITLE
Adjust sample code so it makes more sense

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6931,7 +6931,7 @@ string "<code>ObservableArray</code>".
         building.employees.push(new Employee("B"));
         building.employees.push(new Employee("C"));
 
-        building.employees.splice(1, 1);
+        building.employees.splice(2, 1);
         const employeeB = building.employees.pop();
 
         building.employees = [new Employee("D"), employeeB, new Employee("C")];


### PR DESCRIPTION
In order for the following line, pop(), to return "employeeB", employeeB needs to be on the "top" of the stack, meaning the splice should remove employeeC at index 2. :)