### PR TITLE
Meta: fix linking to "incumbent settings object"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6277,8 +6277,8 @@ about the execution context at the time the language binding specific object ref
 converted to an IDL value.
 
 Note: For ECMAScript objects, the [=callback context=] is used to hold a reference to the
-[=incumbent settings object=] at the time the Object value is converted to an IDL callback
-interface type value. See [[#es-callback-interface]].
+<a spec="HTML">incumbent settings object</a> at the time the Object value is converted to an IDL
+callback interface type value. See [[#es-callback-interface]].
 
 There is no way to represent a constant object reference value for a particular
 [=callback interface type=] in IDL.
@@ -6338,7 +6338,7 @@ An IDL value of the callback function type is represented by a tuple of an objec
 reference and a [=callback context=].
 
 Note: As with [=callback interface types=], the [=callback context=] is used to hold a
-reference to the [=incumbent settings object=] at
+reference to the <a spec="HTML">incumbent settings object</a> at
 the time an ECMAScript Object value is converted to an IDL
 callback function type value.  See [[#es-callback-function]].
 
@@ -7996,7 +7996,7 @@ values are represented by ECMAScript Object values (including [=function objects
 
     1.  If <a abstract-op>Type</a>(|V|) is not Object, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return the IDL [=callback interface type=] value that represents a reference to |V|, with
-        the [=incumbent settings object=] as the [=callback context=].
+        the <a spec="HTML">incumbent settings object</a> as the [=callback context=].
 </div>
 
 <p id="callback-interface-to-es">
@@ -8118,7 +8118,7 @@ IDL [=callback function types=] are represented by ECMAScript [=function objects
         then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return the IDL [=callback function type=] value
         that represents a reference to the same object that |V| represents, with the
-        [=incumbent settings object=] as the [=callback context=].
+        <a spec="HTML">incumbent settings object</a> as the [=callback context=].
 </div>
 
 <p id="callback-function-to-es">


### PR DESCRIPTION
Although it was un-exported from HTML recently, Web IDL is one of the very few specs which has legitimate reason to link to it.