### PR TITLE
More fixes for observable array type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6368,9 +6368,10 @@ character after an existing type.
 The [=nullable types/inner type=] must not be:
 
 *   {{any}},
-*   a [=Promise type=],
+*   a [=promise type=],
+*   an [=observable array type=],
 *   another nullable type, or
-*   a [=union type=] that itself [=includes a nullable type=]
+*   an [=union type=] that itself [=includes a nullable type=]
     or has a dictionary type as one of its [=flattened member types=].
 
 Note: Although dictionary types can in general be nullable,
@@ -6825,10 +6826,12 @@ An <dfn id="dfn-observable-array-type" export>observable array type</dfn> is a p
 whose values are references to a combination of a mutable list of objects of type |T|, as well as
 behavior to perform when author code modifies the contents of the list.
 
-The parameterized type must not be a [=dictionary type=], [=sequence type=], or [=record type=].
+The parameterized type must not be a [=dictionary type=], [=sequence type=], [=record type=], or [=observable array type=].
 
 Similar to [=sequence types=] and [=frozen array types=], observable array types wrap around
 ECMAScript array types, imposing additional semantics on their usage.
+
+Observable array types are non-nullable, but T may be nullable.
 
 Observable array types must only be used as the type of [=regular attributes=] defined on an [=interface=].
 

--- a/index.bs
+++ b/index.bs
@@ -6371,7 +6371,7 @@ The [=nullable types/inner type=] must not be:
 *   a [=promise type=],
 *   an [=observable array type=],
 *   another nullable type, or
-*   an [=union type=] that itself [=includes a nullable type=]
+*   a [=union type=] that itself [=includes a nullable type=]
     or has a dictionary type as one of its [=flattened member types=].
 
 Note: Although dictionary types can in general be nullable,
@@ -6831,8 +6831,6 @@ or [=observable array type=]. However, |T| may be nullable.
 
 Similar to [=sequence types=] and [=frozen array types=], observable array types wrap around
 ECMAScript array types, imposing additional semantics on their usage.
-
-Observable array types are non-nullable, but |T| may be nullable.
 
 Observable array types must only be used as the type of [=regular attributes=] defined on an [=interface=].
 

--- a/index.bs
+++ b/index.bs
@@ -6826,7 +6826,8 @@ An <dfn id="dfn-observable-array-type" export>observable array type</dfn> is a p
 whose values are references to a combination of a mutable list of objects of type |T|, as well as
 behavior to perform when author code modifies the contents of the list.
 
-The parameterized type must not be a [=dictionary type=], [=sequence type=], [=record type=], or [=observable array type=].
+The parameterized type |T| must not be a [=dictionary type=], [=sequence type=], [=record type=],
+or [=observable array type=]. However, |T| may be nullable.
 
 Similar to [=sequence types=] and [=frozen array types=], observable array types wrap around
 ECMAScript array types, imposing additional semantics on their usage.

--- a/index.bs
+++ b/index.bs
@@ -6831,7 +6831,7 @@ The parameterized type must not be a [=dictionary type=], [=sequence type=], [=r
 Similar to [=sequence types=] and [=frozen array types=], observable array types wrap around
 ECMAScript array types, imposing additional semantics on their usage.
 
-Observable array types are non-nullable, but T may be nullable.
+Observable array types are non-nullable, but |T| may be nullable.
 
 Observable array types must only be used as the type of [=regular attributes=] defined on an [=interface=].
 


### PR DESCRIPTION
Per https://heycam.github.io/webidl/#es-observable-array, 
> Instead of the usual conversion algorithms, observable array types have special handling as part of the [attribute getter]((https://heycam.github.io/webidl/#dfn-attribute-getter) and [attribute setter](https://heycam.github.io/webidl/#dfn-attribute-setter) algorithms.

So I think using observable array type as the inner type of an observable array type, e.g. `ObservableArray<ObservableArray<boolean>>`, or a nullable type, e.g. `ObservableArray<boolean>?`, should be disallowed. Otherwise, spec isn't clear how to handle/get the observable array exotic objects for the inner types.