### PR TITLE
Remove DOMTimeStamp

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14699,16 +14699,6 @@ Their [=deserialization steps=], given <var>value</var> and <var>serialized</var
     <var>value</var>.</li>
 </ol>
 
-<h3 id="DOMTimeStamp" typedef oldids="common-DOMTimeStamp">DOMTimeStamp</h3>
-
-<pre class="idl">typedef unsigned long long DOMTimeStamp;</pre>
-
-The {{DOMTimeStamp}} type is used for representing
-a number of milliseconds, either as an absolute time (relative to some epoch)
-or as a relative amount of time.  Specifications that use this type will need
-to define how the number of milliseconds is to be interpreted.
-
-
 <h3 id="Function" callback oldids="common-Function">Function</h3>
 
 <pre class="idl">callback Function = any (any... arguments);</pre>


### PR DESCRIPTION
Closes #2 

DOMTimeStamp becomes LegacyTimeStamp in HR-TIME.
https://github.com/w3c/hr-time/pull/124