### PR TITLE
Editorial: rename advisement class to warning

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -371,18 +371,6 @@ urlPrefix: https://tc39.es/proposal-resizablearraybuffer/; spec: RESIZABLE-BUFFE
         .csstransforms #distinguishable-table thead th:last-child div span {
           border-bottom: none;
         }
-
-        #toc .current,
-        #toc .current-parent {
-          border-right-width: 3px;
-          border-right-style: solid;
-          border-right-color: #3980B5;
-        }
-
-        #toc .current {
-          background: rgba(75%, 75%, 75%, .25);
-          border-right-color: #054572;
-        }
 </style>
 
 
@@ -1397,7 +1385,7 @@ Note: See also the similarly named [=callback function=] definition.
 
 [=Callback interfaces=] must define exactly one [=regular operation=].
 
-<div class="advisement">
+<div class="warning">
 
     Specification authors should not define
     [=callback interfaces=]
@@ -1574,7 +1562,7 @@ A <dfn id="dfn-constant" export>constant</dfn> is a declaration (matching
 <emu-nt><a href="#prod-Const">Const</a></emu-nt>) used to bind a constant value to a name.
 Constants can appear on [=interfaces=] and [=callback interfaces=].
 
-<p class="advisement">
+<p class="warning">
     Constants have in the past primarily been used to define
     named integer codes in the style of an enumeration.  The Web platform
     is moving away from this design pattern in favor of the use of strings.
@@ -2240,7 +2228,7 @@ corresponding argument omitted.
     };
 </pre>
 
-<p class="advisement">
+<p class="warning">
     It is strongly suggested not to use a [=optional argument/default value=]
     of <emu-val>true</emu-val> for {{boolean}}-typed arguments,
     as this can be confusing for authors who might otherwise expect the default
@@ -4801,7 +4789,7 @@ members' entries might or might not [=map/exist=] in the dictionary value.
     existing in the dictionary value otherwise.
 </p>
 
-<p class="advisement">
+<p class="warning">
     As with [=optional argument/default value|operation argument default values=], it is strongly
     encouraged not to use <emu-val>true</emu-val> as the [=dictionary member/default value=] for
     {{boolean}}-typed [=dictionary members=], as this can be confusing for authors who might
@@ -5184,7 +5172,7 @@ entails in the ECMAScript language binding.
 The <dfn id="dfn-error-names-table" export>error names table</dfn> below lists all the allowed error names
 for {{DOMException}}, a description, and legacy code values.
 
-<p class="advisement">
+<p class="warning">
     The {{DOMException}} names marked as deprecated are kept for legacy purposes but their usage is discouraged.
 </p>
 
@@ -5390,7 +5378,7 @@ as a comma-separated list of <emu-t class="regex"><a href="#prod-string">string<
 The list of [=enumeration values=]
 must not include duplicates.
 
-<p class="advisement">
+<p class="warning">
     It is strongly suggested that enumeration values be all lowercase,
     and that multiple words be separated using dashes or not be
     separated at all, unless there is a specific reason to use another
@@ -5988,7 +5976,7 @@ tokens.
 The [=type name=] of the
 {{float}} type is "<code>Float</code>".
 
-<p class="advisement">
+<p class="warning">
     Unless there are specific reasons to use a 32 bit floating point type,
     specifications should use
     {{double}} rather than {{float}},
@@ -6101,7 +6089,7 @@ can be set to [=value of string literal tokens|the value=] of a
 The [=type name=] of the
 {{ByteString}} type is "<code>ByteString</code>".
 
-<p class="advisement">
+<p class="warning">
     Specifications should only use
     {{ByteString}} for interfacing with protocols
     that use bytes and strings interchangeably, such as HTTP.  In general,
@@ -6132,7 +6120,7 @@ can be set to [=value of string literal tokens|the value=] of a
 The [=type name=] of the
 {{USVString}} type is "<code>USVString</code>".
 
-<p class="advisement">
+<p class="warning">
     Specifications should only use
     {{USVString}} for APIs that perform
     text processing and need a string of Unicode
@@ -6511,7 +6499,7 @@ Each pair of [=flattened member types=]
 in a [=union type=], <var ignore>T</var> and <var ignore>U</var>,
 must be [=distinguishable=].
 
-<p class="advisement" id="limit-bigint-numeric-unions">
+<p class="warning" id="limit-bigint-numeric-unions">
 It is possible to create a union of {{bigint}} and a [=numeric type=].
 However, this is generally only supposed to be used for interfaces such as
 [[ECMA-402#numberformat-objects|NumberFormat]], which formats the values rather than using them in
@@ -7103,7 +7091,7 @@ specifications may also override the definitions of any internal method or inter
 [=platform object=] that is an instance of an [=interface=]. These objects with changed semantics
 shall be treated in accordance with the rules for exotic objects.
 
-<p class="advisement">
+<p class="warning">
     As overriding internal ECMAScript object methods is a low level operation and
     can result in objects that behave differently from ordinary objects,
     this facility should not be used unless necessary
@@ -9029,7 +9017,7 @@ a reference to the same object that the IDL value represents.
         |startingOffset|.
 </div>
 
-<div class="advisement">
+<div class="warning">
     Extreme care must be taken when writing specification text that
     [=ArrayBuffer/writes=] into an {{ArrayBuffer}} or {{ArrayBufferView}}, as the underlying data
     can easily be changed by the script author or other APIs at unpredictable times. This is
@@ -10356,7 +10344,7 @@ before proceeding.
 
 <h4 id="LegacyFactoryFunction" extended-attribute lt="LegacyFactoryFunction" oldids="NamedConstructor">[LegacyFactoryFunction]</h4>
 
-<p class="advisement">Instead of using this feature, give your interface a [=constructor operation=].</p>
+<p class="warning">Instead of using this feature, give your interface a [=constructor operation=].</p>
 
 If the [{{LegacyFactoryFunction}}]
 [=extended attribute=]
@@ -10552,7 +10540,7 @@ is to be implemented.
 
 <h4 id="LegacyNamespace" extended-attribute lt="LegacyNamespace">[LegacyNamespace]</h4>
 
-<p class="advisement">Instead of using this feature, interface names can be formed with a naming
+<p class="warning">Instead of using this feature, interface names can be formed with a naming
 convention of starting with a particular prefix for a set of interfaces, as part of the identifier,
 without the intervening dot.</p>
 
@@ -11445,7 +11433,7 @@ An interface may have <dfn export>overridden constructor steps</dfn>, which can
 change the behavior of the [=interface object=] when called or constructed. By
 default interfaces do not have such steps.
 
-<p class="advisement">
+<p class="warning">
     In general, constructors are described by defining a [=constructor operation=] and its behavior.
     The [=overridden constructor steps=] are used only for more complicated situations.
     Editors who wish to use this feature are strongly advised to discuss this by
@@ -15015,7 +15003,7 @@ The following typographic conventions are used in this document:
         This is an example.
     </div>
 *   Normative warnings:
-    <p class="advisement">
+    <p class="warning">
         This is a warning.
     </p>
 *   Code blocks:
@@ -15118,134 +15106,4 @@ available under the
     /*! modernizr 3.3.1 (Custom Build) | MIT *
      * https://modernizr.com/download/?-csstransforms-setclasses !*/
     !function(e,n,t){function r(e,n){return typeof e===n}function o(){var e,n,t,o,s,i,a;for(var l in C)if(C.hasOwnProperty(l)){if(e=[],n=C[l],n.name&&(e.push(n.name.toLowerCase()),n.options&&n.options.aliases&&n.options.aliases.length))for(t=0;t<n.options.aliases.length;t++)e.push(n.options.aliases[t].toLowerCase());for(o=r(n.fn,"function")?n.fn():n.fn,s=0;s<e.length;s++)i=e[s],a=i.split("."),1===a.length?Modernizr[a[0]]=o:(!Modernizr[a[0]]||Modernizr[a[0]]instanceof Boolean||(Modernizr[a[0]]=new Boolean(Modernizr[a[0]])),Modernizr[a[0]][a[1]]=o),g.push((o?"":"no-")+a.join("-"))}}function s(e){var n=_.className,t=Modernizr._config.classPrefix||"";if(S&&(n=n.baseVal),Modernizr._config.enableJSClass){var r=new RegExp("(^|\\s)"+t+"no-js(\\s|$)");n=n.replace(r,"$1"+t+"js$2")}Modernizr._config.enableClasses&&(n+=" "+t+e.join(" "+t),S?_.className.baseVal=n:_.className=n)}function i(e,n){return!!~(""+e).indexOf(n)}function a(){return"function"!=typeof n.createElement?n.createElement(arguments[0]):S?n.createElementNS.call(n,"http://www.w3.org/2000/svg",arguments[0]):n.createElement.apply(n,arguments)}function l(e){return e.replace(/([a-z])-([a-z])/g,function(e,n,t){return n+t.toUpperCase()}).replace(/^-/,"")}function f(e,n){return function(){return e.apply(n,arguments)}}function u(e,n,t){var o;for(var s in e)if(e[s]in n)return t===!1?e[s]:(o=n[e[s]],r(o,"function")?f(o,t||n):o);return!1}function d(e){return e.replace(/(\[A-Z])/g,function(e,n){return"-"+n.toLowerCase()}).replace(/^ms-/,"-ms-")}function c(){var e=n.body;return e||(e=a(S?"svg":"body"),e.fake=!0),e}function p(e,t,r,o){var s,i,l,f,u="modernizr",d=a("div"),p=c();if(parseInt(r,10))for(;r--;)l=a("div"),l.id=o?o[r]:u+(r+1),d.appendChild(l);return s=a("style"),s.type="text/css",s.id="s"+u,(p.fake?p:d).appendChild(s),p.appendChild(d),s.styleSheet?s.styleSheet.cssText=e:s.appendChild(n.createTextNode(e)),d.id=u,p.fake&&(p.style.background="",p.style.overflow="hidden",f=_.style.overflow,_.style.overflow="hidden",_.appendChild(p)),i=t(d,e),p.fake?(p.parentNode.removeChild(p),_.style.overflow=f,_.offsetHeight):d.parentNode.removeChild(d),!!i}function m(n,r){var o=n.length;if("CSS"in e&&"supports"in e.CSS){for(;o--;)if(e.CSS.supports(d(n[o]),r))return!0;return!1}if("CSSSupportsRule"in e){for(var s=[];o--;)s.push("("+d(n[o])+":"+r+")");return s=s.join(" or "),p("@supports ("+s+") { #modernizr { position: absolute; } }",function(e){return"absolute"==getComputedStyle(e,null).position})}return t}function h(e,n,o,s){function f(){d&&(delete z.style,delete z.modElem)}if(s=r(s,"undefined")?!1:s,!r(o,"undefined")){var u=m(e,o);if(!r(u,"undefined"))return u}for(var d,c,p,h,v,y=["modernizr","tspan","samp"];!z.style&&y.length;)d=!0,z.modElem=a(y.shift()),z.style=z.modElem.style;for(p=e.length,c=0;p>c;c++)if(h=e[c],v=z.style[h],i(h,"-")&&(h=l(h)),z.style[h]!==t){if(s||r(o,"undefined"))return f(),"pfx"==n?h:!0;try{z.style[h]=o}catch(g){}if(z.style[h]!=v)return f(),"pfx"==n?h:!0}return f(),!1}function v(e,n,t,o,s){var i=e.charAt(0).toUpperCase()+e.slice(1),a=(e+" "+b.join(i+" ")+i).split(" ");return r(n,"string")||r(n,"undefined")?h(a,n,o,s):(a=(e+" "+E.join(i+" ")+i).split(" "),u(a,n,t))}function y(e,n,r){return v(e,t,t,n,r)}var g=[],C=[],w={_version:"3.3.1",_config:{classPrefix:"",enableClasses:!0,enableJSClass:!0,usePrefixes:!0},_q:[],on:function(e,n){var t=this;setTimeout(function(){n(t[e])},0)},addTest:function(e,n,t){C.push({name:e,fn:n,options:t})},addAsyncTest:function(e){C.push({name:null,fn:e})}},Modernizr=function(){};Modernizr.prototype=w,Modernizr=new Modernizr;var _=n.documentElement,S="svg"===_.nodeName.toLowerCase(),x="Moz O ms Webkit",b=w._config.usePrefixes?x.split(" "):[];w._cssomPrefixes=b;var E=w._config.usePrefixes?x.toLowerCase().split(" "):[];w._domPrefixes=E;var P={elem:a("modernizr")};Modernizr._q.push(function(){delete P.elem});var z={style:P.elem.style};Modernizr._q.unshift(function(){delete z.style}),w.testAllProps=v,w.testAllProps=y,Modernizr.addTest("csstransforms",function(){return-1===navigator.userAgent.indexOf("Android 2.")&&y("transform","scale(1)",!0)}),o(),s(g),delete w.addTest,delete w.addAsyncTest;for(var N=0;N<Modernizr._q.length;N++)Modernizr._q\[N]();e.Modernizr=Modernizr}(window,document);
-
-    // Scrollspy
-    var createScrollSpy = (function() {
-
-        function targetId(element) {
-            return (element.href || "").split("#")[1] || null;
-        }
-
-        function getScrollTop() {
-            return (window.pageYOffset !== undefined)
-                ? window.pageYOffset
-                : (document.documentElement || document.body.parentNode || document.body).scrollTop;
-        }
-
-        function addClassToParents(element, className, parentClassName) {
-            do {
-                element = element.parentNode;
-            } while (element && element.tagName != "LI")
-            if (element) {
-                var a = element.querySelector("a");
-                if (a) a.className = className;
-                addClassToParents(element, parentClassName ? parentClassName : className);
-            }
-        }
-
-        function getPosition(element, container) {
-            var eR = element.getBoundingClientRect();
-            var cR = container.getBoundingClientRect();
-            if (eR.bottom < cR.top) return "above";
-            if (eR.top > cR.bottom) return "below";
-            return "visible";
-        }
-
-        function createScrollSpy(options) {
-            options = options || {};
-
-            var OFFSET = 80,
-                needsUpdate = false,
-                previous = null,
-                current = null,
-                currentNav = null,
-                tocContainer,
-                toc,
-                sections;
-
-            tocContainer = document.querySelector(options.id);
-            toc = [].slice.call(tocContainer.querySelectorAll("a"), 0);
-            sections = toc.reduce(function(sections, a) {
-                var id = targetId(a);
-                var section = id ? document.getElementById(id) : null;
-                if (section) { sections.push(section); }
-                return sections;
-            }, []);
-
-            function onscroll() {
-                if (!needsUpdate) {
-                    needsUpdate = true;
-                    requestAnimationFrame(updatePosition);
-                }
-            }
-
-            function updatePosition() {
-                needsUpdate = false;
-                var scrollTop = (options.offset || 0) + getScrollTop();
-                current = sections.filter(function(section){
-                    return section.offsetTop < scrollTop;
-                }).pop();
-                current = current ? current.id : null;
-
-                if (previous !== current) {
-                    previous = current;
-                    toc.forEach(function(a) {
-                        if (targetId(a) == current) {
-                            currentNav = a;
-                        } else {
-                            a.className = "";
-                        }
-                    });
-                    if (options.markParents) {
-                        addClassToParents(currentNav, options.className, options.parentClassName)
-                    } else {
-                        currentNav.className = options.className;
-                    }
-                    if (options.scrollIntoView && typeof currentNav.scrollIntoView == "function") {
-                        var p = getPosition(currentNav, tocContainer);
-                        if (p == "above") {
-                            currentNav.scrollIntoView(true);
-                        } else if (p == "below") {
-                            currentNav.scrollIntoView(false);
-                        }
-                    }
-                }
-            }
-
-            return {
-                start: function() {
-                    window.addEventListener("scroll", onscroll, false);
-                },
-
-                stop: function() {
-                    window.removeEventListener("scroll", onscroll, false);
-                    toc.forEach(function(a) {
-                        a.className = "";
-                    });
-                }
-            }
-        }
-
-        return createScrollSpy;
-    })();
-
-    (function() {
-        var spy = createScrollSpy({
-            offset: 80,
-            id: "#toc",
-            className: "current",
-            parentClassName: "current-parent",
-            markParents: true,
-            scrollIntoView: true
-        });
-
-        var mm = window.matchMedia('screen and (min-width: 78em)');
-        if (mm.matches) {
-            spy.start();
-        }
-        mm.addListener(function(m) {
-            if (m.matches) spy.start();
-            else spy.stop();
-        });
-    })();
 </script>


### PR DESCRIPTION
And clean up some legacy ToC code.

Fixes #1034.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1037.html" title="Last updated on Oct 7, 2021, 10:02 AM UTC (2f9386c)">Preview</a> | <a href="https://whatpr.org/webidl/1037/968459a...2f9386c.html" title="Last updated on Oct 7, 2021, 10:02 AM UTC (2f9386c)">Diff</a>