### PR TITLE
Fix missing return value for ObservableArray "set the length"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14052,6 +14052,7 @@ those of normal <code>Array</code> instances:
             |handler|.\[[BackingList]][|indexToDelete|] and |indexToDelete|.
         1.  [=list/Remove=] the last item from |handler|.\[[BackingList]].
         1.  Set |indexToDelete| to |indexToDelete| &minus; 1.
+    1.  Return <emu-val>true</emu-val>.
 </div>
 
 <div algorithm>


### PR DESCRIPTION
Closes #1050.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1051.html" title="Last updated on Oct 19, 2021, 8:48 PM UTC (d27e078)">Preview</a> | <a href="https://whatpr.org/webidl/1051/f13d944...d27e078.html" title="Last updated on Oct 19, 2021, 8:48 PM UTC (d27e078)">Diff</a>