### PR TITLE
Editorial: add missing args for CreateBuiltinFunction

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -13030,7 +13030,7 @@ and the string "<code> Iterator</code>".
             1.  Run the [=asynchronous iterator initialization steps=] for |definition| with
                 |idlObject|, |iterator|, and |idlArgs|, if any such steps exist.
             1.  Return |iterator|.
-        1.  Let |F| be [$CreateBuiltinFunction$](|steps|, 0, <code>values</code>, « », |realm|).
+        1.  Let |F| be [$CreateBuiltinFunction$](|steps|, 0, "<code>values</code>", « », |realm|).
         1.  Perform [=!=] [$CreateDataPropertyOrThrow$](|target|, "<code>values</code>", |F|).
         1.  If |definition| has a [=value asynchronously iterable declaration=], then perform [=!=]
             [$DefineMethodProperty$](|target|, {{%Symbol.asyncIterator%}}, |F|, false).


### PR DESCRIPTION
Previously, `length` and `name` arguments for [CreateBuiltinFunction](https://tc39.es/ecma262/#sec-createbuiltinfunction) were missing.
This PR adds them to align with the ECMAScript specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1539.html" title="Last updated on Nov 12, 2025, 4:56 AM UTC (ebefded)">Preview</a> | <a href="https://whatpr.org/webidl/1539/a79e69e...ebefded.html" title="Last updated on Nov 12, 2025, 4:56 AM UTC (ebefded)">Diff</a>