### PR TITLE
Fix markup error

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8538,7 +8538,7 @@ JavaScript Object values.
     constrained among the three string types.
     The following conversions have the described results:
     <table class="data">
-        <thead><th>Value</th><th>Passed to type</th><th>Result</th></thead>
+        <thead><tr><th>Value</th><th>Passed to type</th><th>Result</th></thead>
         <tr>
             <td><code>{"😞": 1}</code></td>
             <td><code>[=record=]&lt;ByteString, double></code></td>
@@ -12579,9 +12579,10 @@ the table, and the operation must have the return type given in the third column
 
 <table id="table-default-method-steps" class="data">
 <thead>
-    <th>[=Identifier=]
-    <th>[=Default method steps=]
-    <th>[=Return type=]</th>
+    <tr>
+        <th>[=Identifier=]
+        <th>[=Default method steps=]
+        <th>[=Return type=]</th>
 <tbody>
     <tr>
         <td>"<code>toJSON</code>"


### PR DESCRIPTION
Two tables were missing `<tr>` in their head.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1550.html" title="Last updated on Dec 2, 2025, 10:09 PM UTC (aace1ea)">Preview</a> | <a href="https://whatpr.org/webidl/1550/4c55acb...aace1ea.html" title="Last updated on Dec 2, 2025, 10:09 PM UTC (aace1ea)">Diff</a>