### PR TITLE
Fix IsDetachedBuffer check in ArrayBuffer transfer

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9435,7 +9435,7 @@ a reference to the same object that the IDL value represents.
 
     1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
         |arrayBuffer| to a JavaScript value.
-    1.  If [$IsDetachedBuffer$](|jsArrayBuffer|) is false, then [=JavaScript/throw=] a
+    1.  If [$IsDetachedBuffer$](|jsArrayBuffer|) is true, then [=JavaScript/throw=] a
         <l spec=ecmascript>{{TypeError}}</l>.
     1.  Let |arrayBufferData| be |jsArrayBuffer|.\[[ArrayBufferData]].
     1.  Let |arrayBufferByteLength| be |jsArrayBuffer|.\[[ArrayBufferByteLength]].


### PR DESCRIPTION
Pretty sure this is the only thing that makes sense, and this is just flipped?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1557.html" title="Last updated on Jan 2, 2026, 1:38 PM UTC (fb3b044)">Preview</a> | <a href="https://whatpr.org/webidl/1557/a6602fd...fb3b044.html" title="Last updated on Jan 2, 2026, 1:38 PM UTC (fb3b044)">Diff</a>