### PR TITLE
Update DOMException language to reflect standardized stack accessor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14925,10 +14925,10 @@ The [=class string=] of a [=namespace object=] is the [=namespace=]'s [=identifi
 In the JavaScript binding, the [=interface prototype object=] for {{DOMException}}
 has its \[[Prototype]] [=/internal slot=] set to the intrinsic object {{%Error.prototype%}},
 as defined in the [=create an interface prototype object=] abstract operation.
-It also has an \[[ErrorData]] slot, like all built-in exceptions.
+It also has \[[ErrorData]] and \[[Stack]] slots, like all built-in exceptions.
 
-Additionally, if an implementation gives native {{Error}} objects special powers or
-nonstandard properties (such as a <code>stack</code> property),
+Additionally, if an implementation gives native {{Error}} objects other special powers or
+nonstandard properties (such as <code>line</code> and <code>column</code> properties),
 it should also expose those on {{DOMException}} objects.
 
 <h4 id="js-exception-objects" oldids="es-exception-objects" dfn>Exception objects</h4>
@@ -15236,8 +15236,9 @@ Their [=serialization steps=], given <var>value</var> and <var>serialized</var>,
 <ol>
     <li>Set <var>serialized</var>.\[[Name]] to <var>value</var>'s [=DOMException/name=].</li>
     <li>Set <var>serialized</var>.\[[Message]] to <var>value</var>'s [=DOMException/message=].</li>
+    <li>Set <var>serialized</var>.\[[Stack]] to an implementation-defined string derived from <var>value</var>.\[[Stack]].</li>
     <li>User agents should attach a serialized representation of any interesting accompanying data
-    which are not yet specified, notably the <code>stack</code> property, to
+    which are not yet specified, notably the <code>line</code> and <code>column</code> properties, to
     <var>serialized</var>.</li>
 </ol>
 
@@ -15246,6 +15247,7 @@ Their [=deserialization steps=], given <var>value</var> and <var>serialized</var
 <ol>
     <li>Set <var>value</var>'s [=DOMException/name=] to <var>serialized</var>.\[[Name]].</li>
     <li>Set <var>value</var>'s [=DOMException/message=] to <var>serialized</var>.\[[Message]].</li>
+    <li>Set <var>value</var>.\[[Stack]] to <var>serialized</var>.\[[Stack]].</li>
     <li>If any other data is attached to <var>serialized</var>, then deserialize and attach it to
     <var>value</var>.</li>
 </ol>


### PR DESCRIPTION
Since DOMException objects have [[ErrorData]], the Error.prototype.stack accessor from the Error Stack Accessor proposal naturally applies to them. Update the language to reflect that stack is now a specified accessor property rather than a nonstandard property that implementations "should" expose.

See https://github.com/tc39/proposal-error-stack-accessor/issues/9 and https://github.com/tc39/proposal-error-stack-accessor/issues/8

<!--
Thank you for contributing to the Web IDL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Reached TC39 stage 3 and implementers appear on board.
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/58397
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: Captcha :-( 
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2042301
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=315550
   * Deno: https://github.com/denoland/deno/issues/34388
   * Node.js: https://github.com/nodejs/node/issues/63579
   * webidl2.js: https://github.com/w3c/webidl2.js/issues/843
   * widlparser: https://github.com/plinss/widlparser/issues/96
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

<!-- (See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.) -->


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1578.html" title="Last updated on May 26, 2026, 7:16 AM UTC (627f1c6)">Preview</a> | <a href="https://whatpr.org/webidl/1578/e1300e9...627f1c6.html" title="Last updated on May 26, 2026, 7:16 AM UTC (627f1c6)">Diff</a>