### PR TITLE
Allow HTML to integrate with MakeRealm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10052,13 +10052,14 @@ Otherwise, it is the [=host interface=]'s [=exposure set=].
     <dfn id="dfn-exposed" export>exposed</dfn> in a given [=realm=] |realm| if the following steps
     return true:
 
-    1.  If |construct|'s [=exposure set=] is not <code>*</code>, and |realm|.\[[GlobalObject]] does
-        not implement an [=interface=] that is in |construct|'s [=exposure set=], then return false.
-    1.  If |realm|'s [=realm/settings object=] is not a [=secure context=], and |construct| is
+    1.  Let |settings| be |realm|'s [=realm/settings object=].
+    1.  If |construct|'s [=exposure set=] is not <code>*</code>, and the [=set/intersection=] of
+        |settings|'s [=environment settings object/global names=] and |construct|'s
+        [=exposure set=] is [=set/empty=], then return false.
+    1.  If |settings| is not a [=secure context=], and |construct| is
         [=conditionally exposed=] on [{{SecureContext}}], then return false.
-    1.  If |realm|'s [=realm/settings object=]'s
-        [=environment settings object/cross-origin isolated capability=] is false, and |construct|
-        is [=conditionally exposed=] on [{{CrossOriginIsolated}}], then return false.
+    1.  If |settings|'s [=environment settings object/cross-origin isolated capability=] is false,
+        and |construct| is [=conditionally exposed=] on [{{CrossOriginIsolated}}], then return false.
     1.  Return true.
 </div>
 
@@ -10096,9 +10097,9 @@ Otherwise, it is the [=host interface=]'s [=exposure set=].
     1.  Otherwise, return false.
 </div>
 
-Note: Since it is not possible for the [=relevant settings object=]
-for a JavaScript global object to change whether it is a
-[=secure context=] or [=environment settings object/cross-origin isolated capability=] over time, an
+Note: Since an [=environment settings object=]'s
+[=environment settings object/global names=], its [=secure context=] status, and its
+[=environment settings object/cross-origin isolated capability=] do not change over its lifetime, an
 implementation's decision to create properties for an interface or interface member can be made
 once, at the time the [=initial objects=] are created.
 


### PR DESCRIPTION
This complements https://github.com/whatwg/html/pull/12580 to make https://github.com/tc39/ecma262/pull/3728 work.

In particular when we allocate a global object we cannot simultaneously expect it to be able to tell us about what is exposed on it. That needs to be known ahead of time. (With this refactoring it is stored on the environment settings object instead.)

----

This should be editorial.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 15, 2026, 6:07 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fwhatwg%2Fwebidl%2F739aebf63d3ad1001f78b4bcd4d63ab29681e779%2Findex.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%201608)

**Error output:**

```json
[
    {
        "lineNum": "10057:22",
        "messageType": "link",
        "text": "No 'dfn' refs found for 'global names' with for='['environment settings object']'."
    },
    {
        "lineNum": "10101:1",
        "messageType": "link",
        "text": "No 'dfn' refs found for 'global names' with for='['environment settings object']'."
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20whatwg/webidl%231608.)._

</details>
