### PR TITLE
Editorial: Use CreateBuiltinFunction for (async) iterator return and next methods

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12946,7 +12946,8 @@ must be {{%Iterator.prototype%}}.
 
     An [=iterator prototype object=] must have a <code class="idl">next</code> data property with attributes
     { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
-    and whose value is a [=built-in function object=] that behaves as follows:
+    and whose value is the [=built-in function object=] [$CreateBuiltinFunction$](|nextSteps|, 0, "<code>next</code>", « »),
+    where |nextSteps| is the following algorithm:
 
     1.  Let |interface| be the [=interface=] for which the
         [=iterator prototype object=] exists.
@@ -13119,7 +13120,8 @@ The \[[Prototype]] [=/internal slot=] of an [=asynchronous iterator prototype ob
     An [=asynchronous iterator prototype object=] must have a <code class="idl">next</code> data
     property with attributes { \[[Writable]]: <emu-val>true</emu-val>,
     \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
-    and whose value is a [=built-in function object=] that behaves as follows:
+    and whose value is the [=built-in function object=] [$CreateBuiltinFunction$](|nextSteps|, 0, "<code>next</code>", « »),
+    where |nextSteps| is the following algorithm:
 
     1.  Let |interface| be the [=interface=] for which the
         [=asynchronous iterator prototype object=] exists.
@@ -13208,8 +13210,8 @@ The \[[Prototype]] [=/internal slot=] of an [=asynchronous iterator prototype ob
     [=asynchronous iterator prototype object=] must have a <code class="idl">return</code> data
     property with attributes { \[[Writable]]: <emu-val>true</emu-val>,
     \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }
-    and whose value is a [=built-in function object=], taking one argument |value|, that behaves as
-    follows:
+    and whose value is the [=built-in function object=] [$CreateBuiltinFunction$](|returnSteps|, 1, "<code>return</code>", « »),
+    where |returnSteps| is the following algorithm taking one argument |value|:
 
     1.  Let |interface| be the [=interface=] for which the
         [=asynchronous iterator prototype object=] exists.


### PR DESCRIPTION
> This makes it explicit what the `name` and `length` of these methods is.
> Many other functions created by WebIDL already use CreateBuiltinFunction.

Right now it was a bit implicit, because we were defining _steps_ taking 0/1 parameters, but not actual JS functions.

This is already tested by https://github.com/web-platform-tests/wpt/blob/8e113d970b5ef2b6c0b9a81f38dd6dbadaa31795/streams/readable-streams/async-iterator.any.js#L38-L39.

In ECMA-262 these `.return()`/`.next()` methods have length of 0 or 1 depending on whether they use their argument or not, so it's probably ok for WebIDL to have `.next()` have length of 0 and `.return(value)` have length of 1.

Note that both Chrome and Firefox currently fail this test (https://wpt.fyi/results/streams/readable-streams/async-iterator.any.html?label=master&label=experimental&aligned&q=stream), as they set the length of `.return()` to 0. Looking at precedent in ECMA-262, 1 is the right length here since the algorithm actually use the parameter.

cc @javifernandez


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1610.html" title="Last updated on Jun 17, 2026, 2:18 PM UTC (c9664b5)">Preview</a> | <a href="https://whatpr.org/webidl/1610/cca1103...c9664b5.html" title="Last updated on Jun 17, 2026, 2:18 PM UTC (c9664b5)">Diff</a>