### PR TITLE
Editorial: use CreateBuiltinFunction for more built-in function objects

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12759,7 +12759,8 @@ then there must exist a property with the following characteristics:
     and <emu-val>true</emu-val> otherwise.
 *   <div algorithm="to invoke the toString method of interfaces">
 
-        The value of the property is a [=built-in function object=], which behaves as follows:
+        The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|toStringSteps|, 0, "<code>toString</code>", « »),
+        where |toStringSteps| is the following algorithm:
 
         1.  Let |thisValue| be the <emu-val>this</emu-val> value.
         1.  Let |O| be [=?=] <a abstract-op>ToObject</a>(|thisValue|).
@@ -12784,10 +12785,6 @@ then there must exist a property with the following characteristics:
             </dl>
         1.  Return the result of [=converted to a JavaScript value|converting=] |V| to a String value.
     </div>
-*   The value of the [=function object=]'s <code class="idl">length</code>
-    property is the Number value <emu-val>0</emu-val>.
-*   The value of the [=function object=]'s <code class="idl">name</code>
-    property is the String value "<code>toString</code>".
 
 
 <h4 id="js-iterable" oldids="es-iterable">Iterable declarations</h4>
@@ -13301,18 +13298,14 @@ with the following characteristics:
     defined below.
 *   <div algorithm="to invoke the size method of Maps">
 
-        The [=map size getter=] is a [=built-in function object=]
-        whose behavior when invoked is as follows:
+        The [=map size getter=] is the [=built-in function object=] [$CreateBuiltinFunction$](|sizeSteps|, 0, "<code>get size</code>", « »),
+        where |sizeSteps| is the following algorithm:
 
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>size</code>" and type "<code>getter</code>".
         1.  Let |map| be the [=map entries=] of the IDL value
             that represents a reference to |O|.
         1.  Return |map|'s [=map/size=], [=converted to a JavaScript value=].
     </div>
-
-    The value of the [=function object=]'s <code class="idl">length</code> property is the Number value <emu-val>0</emu-val>.
-
-    The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>get size</code>".
 
 
 <h5 id="js-map-iterator" oldids="es-map-iterator,es-iterator, es-iterators">%Symbol.iterator%</h5>
@@ -13352,8 +13345,8 @@ There must exist an <code class="idl">entries</code> data property on
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=built-in function object=]
-    whose behavior when invoked is as follows:
+*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|entriesSteps|, 0, "<code>entries</code>", « »),
+    where |entriesSteps| is the following algorithm:
 
     <div algorithm="to invoke the entries method of Maps">
         1. Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>entries</code>" and type "<code>method</code>".
@@ -13362,10 +13355,6 @@ with the following characteristics:
         1. Return the result of [=creating a map iterator=] from |map| with kind "<code>key+value</code>".
     </div>
 
-The value of the [=function object=]'s <code class="idl">length</code> property is the Number value <emu-val>0</emu-val>.
-
-The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>entries</code>".
-
 <h5 id="js-map-keys" oldids="es-map-keys,es-map-keys-values">keys</h5>
 
 There must exist a <code class="idl">keys</code> data property on
@@ -13373,8 +13362,8 @@ There must exist a <code class="idl">keys</code> data property on
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=built-in function object=]
-    whose behavior when invoked is as follows:
+*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|keysSteps|, 0, "<code>keys</code>", « »),
+    where |keysSteps| is the following algorithm:
 
     <div algorithm="to invoke the keys method of Maps">
         1. Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>keys</code>" and type "<code>method</code>".
@@ -13382,10 +13371,6 @@ with the following characteristics:
             that represents a reference to |O|.
         1. Return the result of [=creating a map iterator=] from |map| with kind "<code>key</code>".
     </div>
-
-The value of the [=function object=]'s <code class="idl">length</code> property is the Number value <emu-val>0</emu-val>.
-
-The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>keys</code>".
 
 
 <h5 id="js-map-values" oldids="es-map-values">values</h5>
@@ -13395,8 +13380,8 @@ There must exist a <code class="idl">values</code> data property on
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=built-in function object=]
-    whose behavior when invoked is as follows:
+*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|valuesSteps|, 0, "<code>values</code>", « »),
+    where |valuesSteps| is the following algorithm:
 
     <div algorithm="to invoke the values method of Maps">
         1. Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>values</code>" and type "<code>method</code>".
@@ -13404,10 +13389,6 @@ with the following characteristics:
             that represents a reference to |O|.
         1. Return the result of [=creating a map iterator=] from |map| with kind "<code>value</code>".
     </div>
-
-The value of the [=function object=]'s <code class="idl">length</code> property is the Number value <emu-val>0</emu-val>.
-
-The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>values</code>".
 
 
 <h5 id="js-map-forEach" oldids="es-map-forEach,es-forEach">forEach</h5>
@@ -13417,25 +13398,19 @@ There must exist a <code class="idl">forEach</code> data property on
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=built-in function object=]
-    whose behavior when invoked is as follows:
+*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|forEachSteps|, 1, "<code>forEach</code>", « »),
+    where |forEachSteps| is the following algorithm taking arguments |callbackFn| and |thisArg|:
 
     <div algorithm="to invoke the forEach method of Maps">
         1. Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>forEach</code>" and type "<code>method</code>".
         1.  Let |map| be the [=map entries=] of the IDL value
             that represents a reference to |O|.
-        1.  Let |callbackFn| be the first argument passed to the function, or <emu-val>undefined</emu-val> if not supplied.
         1.  If [$IsCallable$](|callbackFn|) is <emu-val>false</emu-val>, [=JavaScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
-        1.  Let |thisArg| be the second argument passed to the function, or <emu-val>undefined</emu-val> if not supplied.
         1. [=map/For each=] |key| → |value| of |map|:
             1. Let |jsKey| and |jsValue| be |key| and |value| [=converted to a JavaScript value=].
             1. Perform [=?=] [$Call$](|callbackFn|, |thisArg|, « |jsValue|, |jsKey|, |O| »).
         1.  Return <emu-val>undefined</emu-val>.
     </div>
-
-The value of the [=function object=]'s <code class="idl">length</code> property is the Number value <emu-val>1</emu-val>.
-
-The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>forEach</code>".
 
 
 <h5 id="js-map-get" oldids="es-map-get,es-map-get-has">get</h5>
@@ -13445,24 +13420,19 @@ There must exist a <code class="idl">get</code> data property on
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=built-in function object=]
-    that behaves as follows when invoked:
+*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|getSteps|, 1, "<code>get</code>", « »),
+    where |getSteps| is the following algorithm taking one argument |keyArg|:
 
     <div algorithm="to invoke the get method of Maps">
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>get</code>" and type "<code>method</code>".
         1.  Let |map| be the [=map entries=] of the IDL value
             that represents a reference to |O|.
         1.  Let |keyType| be the key type specified in the [=maplike declaration=].
-        1.  Let |keyArg| be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
         1.  Let |key| be |keyArg| [=converted to an IDL value=] of type |keyType|.
         1.  If |key| is -0, set |key| to +0.
         1.  If |map|[|key|] [=map/exists=], then return |map|[|key|],
             [=converted to a JavaScript value=].
     </div>
-
-The value of the [=function object=]'s <code class="idl">length</code> property is the Number value <emu-val>1</emu-val>.
-
-The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>get</code>".
 
 
 <h5 id="js-map-has" oldids="es-map-has">has</h5>
@@ -13472,24 +13442,19 @@ There must exist a <code class="idl">has</code> data property on
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=built-in function object=]
-    that behaves as follows when invoked:
+*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|hasSteps|, 1, "<code>has</code>", « »),
+    where |hasSteps| is the following algorithm taking one argument |keyArg|:
 
     <div algorithm="to invoke the has method of Maps">
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>has</code>" and type "<code>method</code>".
         1.  Let |map| be the [=map entries=] of the IDL value
             that represents a reference to |O|.
         1.  Let |keyType| be the key type specified in the [=maplike declaration=].
-        1.  Let |keyArg| be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
         1.  Let |key| be |keyArg| [=converted to an IDL value=] of type |keyType|.
         1.  If |key| is -0, set |key| to +0.
         1.  If |map|[|key|] [=map/exists=], then return <emu-val>true</emu-val>;
             otherwise return <emu-val>false</emu-val>.
     </div>
-
-The value of the [=function object=]'s <code class="idl">length</code> property is the Number value <emu-val>1</emu-val>.
-
-The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>has</code>".
 
 
 <h5 id="js-map-set" oldids="es-map-set">set</h5>
@@ -13501,26 +13466,20 @@ on |A|'s [=interface prototype object=]
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=built-in function object=]
-    that behaves as follows when invoked:
+*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|setSteps|, 2, "<code>set</code>", « »),
+    where |setSteps| is the following algorithm taking arguments |keyArg| and |valueArg|:
 
     <div algorithm="to invoke the set method of Maps">
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>set</code>" and type "<code>method</code>".
         1.  Let |map| be the [=map entries=] of the IDL value
             that represents a reference to |O|.
         1.  Let |keyType| be the key type specified in the [=maplike declaration=], and |valueType| be the value type.
-        1.  Let |keyArg| be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
         1.  Let |key| be |keyArg| [=converted to an IDL value=] of type |keyType|.
         1.  If |key| is -0, set |key| to +0.
-        1.  Let |valueArg| be the second argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
         1.  Let |value| be |valueArg| [=converted to an IDL value=] of type |valueType|.
         1.  [=map/Set=] |map|[|key|] to |value|.
         1.  Return |O|.
     </div>
-
-The value of the [=function object=]'s <code class="idl">length</code> property is the Number value <emu-val>2</emu-val>.
-
-The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>set</code>".
 
 If the interface does declare a <code class=idl>set</code> method,
 it should similarly map a -0 key to +0,
@@ -13536,15 +13495,14 @@ on |A|'s [=interface prototype object=]
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=built-in function object=]
-    that behaves as follows when invoked:
+*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|deleteSteps|, 1, "<code>delete</code>", « »),
+    where |deleteSteps| is the following algorithm taking one argument |keyArg|:
 
     <div algorithm="to invoke the delete method of Maps">
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>delete</code>" and type "<code>method</code>".
         1.  Let |map| be the [=map entries=] of the IDL value
             that represents a reference to |O|.
         1.  Let |keyType| be the key type specified in the [=maplike declaration=].
-        1.  Let |keyArg| be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
         1.  Let |key| be |keyArg| [=converted to an IDL value=] of type |keyType|.
         1.  If |key| is -0, set |key| to +0.
         1.  Let |retVal| be <emu-val>true</emu-val> if |map|[|key|] exists,
@@ -13552,10 +13510,6 @@ with the following characteristics:
         1.  [=map/Remove=] |map|[|key|].
         1.  Return |retVal|.
     </div>
-
-The value of the [=function object=]'s <code class="idl">length</code> property is the Number value <emu-val>1</emu-val>.
-
-The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>delete</code>".
 
 If the interface does declare a <code class=idl>delete</code> method,
 it should similarly map a -0 key to +0,
@@ -13571,8 +13525,8 @@ on |A|'s [=interface prototype object=]
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=built-in function object=]
-    that behaves as follows when invoked:
+*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|clearSteps|, 0, "<code>clear</code>", « »),
+    where |clearSteps| is the following algorithm:
 
     <div algorithm="to invoke the clear method of Maps">
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>clear</code>" and type "<code>method</code>".
@@ -13584,10 +13538,6 @@ with the following characteristics:
             iterators, currently suspended, iterating over it.
         1.  Return <emu-val>undefined</emu-val>.
     </div>
-
-The value of the [=function object=]'s <code class="idl">length</code> property is the Number value <emu-val>0</emu-val>.
-
-The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>clear</code>".
 
 If the interface does declare a <code class=idl>clear</code> method,
 it must preserve the [=map entries=] object (rather than generating a new one)
@@ -13611,18 +13561,14 @@ with the following characteristics:
     defined below.
 *   <div algorithm="to invoke the size method of Sets">
 
-        The [=set size getter=] is a [=built-in function object=]
-        whose behavior when invoked is as follows:
+        The [=set size getter=] is the [=built-in function object=] [$CreateBuiltinFunction$](|sizeSteps|, 0, "<code>get size</code>", « »),
+        where |sizeSteps| is the following algorithm:
 
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>size</code>" and type "<code>getter</code>".
         1.  Let |set| be the [=set entries=] of the IDL value
             that represents a reference to |O|.
         1.  Return |set|'s [=set/size=], [=converted to a JavaScript value=].
     </div>
-
-    The value of the [=function object=]'s <code class="idl">length</code> property is the Number value <emu-val>0</emu-val>.
-
-    The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>get size</code>".
 
 
 <h5 id="js-set-iterator" oldids="es-set-iterator">%Symbol.iterator%</h5>
@@ -13661,8 +13607,8 @@ There must exist an <code class="idl">entries</code> data property on
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=built-in function object=]
-    whose behavior when invoked is as follows:
+*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|entriesSteps|, 0, "<code>entries</code>", « »),
+    where |entriesSteps| is the following algorithm:
 
     <div algorithm="to invoke the entries method of Sets">
         1. Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>entries</code>" and type "<code>method</code>".
@@ -13670,12 +13616,6 @@ with the following characteristics:
             that represents a reference to |O|.
         1. Return the result of [=creating a set iterator=] from |set| with kind "<code>key+value</code>".
     </div>
-
-The value of the [=function object=]'s <code class="idl">length</code> property is
-the Number value <emu-val>0</emu-val>.
-
-The value of the [=function object=]'s <code class="idl">name</code> property is
-the String value "<code>entries</code>".
 
 
 <h5 id="js-set-keys" oldids="es-set-keys">keys</h5>
@@ -13694,8 +13634,8 @@ There must exist a <code class="idl">values</code> data property on
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=built-in function object=]
-    whose behavior when invoked is as follows:
+*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|valuesSteps|, 0, "<code>values</code>", « »),
+    where |valuesSteps| is the following algorithm:
 
     <div algorithm="to invoke the values method of Sets">
         1. Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>values</code>" and type "<code>method</code>".
@@ -13703,12 +13643,6 @@ with the following characteristics:
             that represents a reference to |O|.
         1. Return the result of [=creating a set iterator=] from |set| with kind "<code>value</code>".
     </div>
-
-The value of the [=function object=]'s <code class="idl">length</code> property is
-the Number value <emu-val>0</emu-val>.
-
-The value of the [=function object=]'s <code class="idl">name</code> property is
-the String value "<code>values</code>".
 
 
 <h5 id="js-set-forEach" oldids="es-set-forEach">forEach</h5>
@@ -13718,25 +13652,19 @@ There must exist a <code class="idl">forEach</code> data property on
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=built-in function object=]
-    whose behavior when invoked is as follows:
+*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|forEachSteps|, 1, "<code>forEach</code>", « »),
+    where |forEachSteps| is the following algorithm taking arguments |callbackFn| and |thisArg|:
 
     <div algorithm="to invoke the forEach method of Sets">
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>forEach</code>" and type "<code>method</code>".
         1.  Let |set| be the [=set entries=] of the IDL value
             that represents a reference to |O|.
-        1.  Let |callbackFn| be the first argument passed to the function, or <emu-val>undefined</emu-val> if not supplied.
         1.  If [$IsCallable$](|callbackFn|) is <emu-val>false</emu-val>, [=JavaScript/throw=] a <l spec=ecmascript>{{TypeError}}</l>.
-        1.  Let |thisArg| be the second argument passed to the function, or <emu-val>undefined</emu-val> if not supplied.
         1. [=map/For each=] |value| of |set|:
             1. Let |jsValue| be |value| [=converted to a JavaScript value=].
             1. Perform [=?=] [$Call$](|callbackFn|, |thisArg|, « |jsValue|, |jsValue|, |O|»).
         1.  Return <emu-val>undefined</emu-val>.
     </div>
-
-The value of the [=function object=]'s <code class="idl">length</code> property is the Number value <emu-val>1</emu-val>.
-
-The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>forEach</code>".
 
 
 <h5 id="js-set-has" oldids="es-set-has">has</h5>
@@ -13746,24 +13674,19 @@ There must exist a <code class="idl">has</code> data property on
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=built-in function object=]
-    that behaves as follows when invoked:
+*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|hasSteps|, 1, "<code>has</code>", « »),
+    where |hasSteps| is the following algorithm taking one argument |valueArg|:
 
     <div algorithm="to invoke the has method of Sets">
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>has</code>" and type "<code>method</code>".
         1.  Let |set| be the [=set entries=] of the IDL value
             that represents a reference to |O|.
         1.  Let |valueType| be the value type specified in the [=setlike declaration=].
-        1.  Let |valueArg| be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
         1.  Let |value| be |valueArg| [=converted to an IDL value=] of type |valueType|.
         1.  If |value| is -0, set |value| to +0.
         1.  If |set| [=set/contains=] |value|, then return <emu-val>true</emu-val>,
             otherwise return <emu-val>false</emu-val>.
     </div>
-
-The value of the [=function object=]'s <code class="idl">length</code> property is a Number value <emu-val>1</emu-val>.
-
-The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>has</code>".
 
 
 <h5 id="js-set-add" oldids="es-set-add,es-add-delete">add</h5>
@@ -13775,24 +13698,19 @@ on |A|'s [=interface prototype object=]
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=built-in function object=]
-    that behaves as follows when invoked:
+*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|addSteps|, 1, "<code>add</code>", « »),
+    where |addSteps| is the following algorithm taking one argument |valueArg|:
 
     <div algorithm="to invoke the add method of Sets">
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>add</code>" and type "<code>method</code>".
         1.  Let |set| be the [=set entries=] of the IDL value
             that represents a reference to |O|.
         1.  Let |valueType| be the value type specified in the [=setlike declaration=].
-        1.  Let |valueArg| be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
         1.  Let |value| be |valueArg| [=converted to an IDL value=] of type |valueType|.
         1.  If |value| is -0, set |value| to +0.
         1.  [=set/Append=] |value| to |set|.
         1.  Return |O|.
     </div>
-
-The value of the [=function object=]'s <code class="idl">length</code> property is the Number value <emu-val>1</emu-val>.
-
-The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>add</code>".
 
 If the interface does declare an <code class=idl>add</code> method,
 it should similarly map a -0 value to +0,
@@ -13808,24 +13726,19 @@ on |A|'s [=interface prototype object=]
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=built-in function object=]
-    that behaves as follows when invoked:
+*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|deleteSteps|, 1, "<code>delete</code>", « »),
+    where |deleteSteps| is the following algorithm taking one argument |valueArg|:
 
     <div algorithm="to invoke the delete method of Sets">
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>delete</code>" and type "<code>method</code>".
         1.  Let |set| be |O|'s [=set entries=].
         1.  Let |valueType| be the value type specified in the [=setlike declaration=].
-        1.  Let |valueArg| be the first argument passed to this function, or <emu-val>undefined</emu-val> if not supplied.
         1.  Let |value| be |valueArg| [=converted to an IDL value=] of type |valueType|.
         1.  If |value| is -0, set |value| to +0.
         1.  Let |retVal| be <emu-val>true</emu-val> if |set| [=set/contains=] |value|, or else <emu-val>false</emu-val>.
         1.  [=list/Remove=] |value| from |set|.
         1.  Return |retVal|.
     </div>
-
-The value of the [=function object=]'s <code class="idl">length</code> property is the Number value <emu-val>1</emu-val>.
-
-The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>delete</code>".
 
 If the interface does declare a <code class=idl>delete</code> method,
 it should similarly map a -0 value to +0,
@@ -13841,8 +13754,8 @@ on |A|'s [=interface prototype object=]
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is a [=built-in function object=]
-    that behaves as follows when invoked:
+*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|clearSteps|, 0, "<code>clear</code>", « »),
+    where |clearSteps| is the following algorithm:
 
     <div algorithm="to invoke the clear method of Sets">
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>clear</code>" and type "<code>method</code>".
@@ -13854,10 +13767,6 @@ with the following characteristics:
             iterators, currently suspended, iterating over it.
         1.  Return <emu-val>undefined</emu-val>.
     </div>
-
-The value of the [=function object=]'s <code class="idl">length</code> property is the Number value <emu-val>0</emu-val>.
-
-The value of the [=function object=]'s <code class="idl">name</code> property is the String value "<code>clear</code>".
 
 If the interface does declare a <code class=idl>clear</code> method,
 it must preserve the [=set entries=] object (rather than generating a new one)

--- a/index.bs
+++ b/index.bs
@@ -13345,10 +13345,11 @@ There must exist an <code class="idl">entries</code> data property on
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|entriesSteps|, 0, "<code>entries</code>", « »),
-    where |entriesSteps| is the following algorithm:
+*   <div algorithm="to invoke the entries method of Maps">
 
-    <div algorithm="to invoke the entries method of Maps">
+        The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|entriesSteps|, 0, "<code>entries</code>", « »),
+        where |entriesSteps| is the following algorithm:
+
         1. Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>entries</code>" and type "<code>method</code>".
         1.  Let |map| be the [=map entries=] of the IDL value
             that represents a reference to |O|.
@@ -13362,10 +13363,11 @@ There must exist a <code class="idl">keys</code> data property on
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|keysSteps|, 0, "<code>keys</code>", « »),
-    where |keysSteps| is the following algorithm:
+*   <div algorithm="to invoke the keys method of Maps">
 
-    <div algorithm="to invoke the keys method of Maps">
+        The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|keysSteps|, 0, "<code>keys</code>", « »),
+        where |keysSteps| is the following algorithm:
+
         1. Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>keys</code>" and type "<code>method</code>".
         1.  Let |map| be the [=map entries=] of the IDL value
             that represents a reference to |O|.
@@ -13380,10 +13382,11 @@ There must exist a <code class="idl">values</code> data property on
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|valuesSteps|, 0, "<code>values</code>", « »),
-    where |valuesSteps| is the following algorithm:
+*   <div algorithm="to invoke the values method of Maps">
 
-    <div algorithm="to invoke the values method of Maps">
+        The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|valuesSteps|, 0, "<code>values</code>", « »),
+        where |valuesSteps| is the following algorithm:
+
         1. Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>values</code>" and type "<code>method</code>".
         1.  Let |map| be the [=map entries=] of the IDL value
             that represents a reference to |O|.
@@ -13398,10 +13401,11 @@ There must exist a <code class="idl">forEach</code> data property on
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|forEachSteps|, 1, "<code>forEach</code>", « »),
-    where |forEachSteps| is the following algorithm taking arguments |callbackFn| and |thisArg|:
+*   <div algorithm="to invoke the forEach method of Maps">
 
-    <div algorithm="to invoke the forEach method of Maps">
+        The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|forEachSteps|, 1, "<code>forEach</code>", « »),
+        where |forEachSteps| is the following algorithm taking arguments |callbackFn| and |thisArg|:
+
         1. Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>forEach</code>" and type "<code>method</code>".
         1.  Let |map| be the [=map entries=] of the IDL value
             that represents a reference to |O|.
@@ -13420,10 +13424,11 @@ There must exist a <code class="idl">get</code> data property on
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|getSteps|, 1, "<code>get</code>", « »),
-    where |getSteps| is the following algorithm taking one argument |keyArg|:
+*   <div algorithm="to invoke the get method of Maps">
 
-    <div algorithm="to invoke the get method of Maps">
+        The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|getSteps|, 1, "<code>get</code>", « »),
+        where |getSteps| is the following algorithm taking one argument |keyArg|:
+
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>get</code>" and type "<code>method</code>".
         1.  Let |map| be the [=map entries=] of the IDL value
             that represents a reference to |O|.
@@ -13442,10 +13447,11 @@ There must exist a <code class="idl">has</code> data property on
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|hasSteps|, 1, "<code>has</code>", « »),
-    where |hasSteps| is the following algorithm taking one argument |keyArg|:
+*   <div algorithm="to invoke the has method of Maps">
 
-    <div algorithm="to invoke the has method of Maps">
+        The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|hasSteps|, 1, "<code>has</code>", « »),
+        where |hasSteps| is the following algorithm taking one argument |keyArg|:
+
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>has</code>" and type "<code>method</code>".
         1.  Let |map| be the [=map entries=] of the IDL value
             that represents a reference to |O|.
@@ -13466,10 +13472,11 @@ on |A|'s [=interface prototype object=]
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|setSteps|, 2, "<code>set</code>", « »),
-    where |setSteps| is the following algorithm taking arguments |keyArg| and |valueArg|:
+*   <div algorithm="to invoke the set method of Maps">
 
-    <div algorithm="to invoke the set method of Maps">
+        The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|setSteps|, 2, "<code>set</code>", « »),
+        where |setSteps| is the following algorithm taking arguments |keyArg| and |valueArg|:
+
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>set</code>" and type "<code>method</code>".
         1.  Let |map| be the [=map entries=] of the IDL value
             that represents a reference to |O|.
@@ -13495,10 +13502,11 @@ on |A|'s [=interface prototype object=]
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|deleteSteps|, 1, "<code>delete</code>", « »),
-    where |deleteSteps| is the following algorithm taking one argument |keyArg|:
+*   <div algorithm="to invoke the delete method of Maps">
 
-    <div algorithm="to invoke the delete method of Maps">
+        The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|deleteSteps|, 1, "<code>delete</code>", « »),
+        where |deleteSteps| is the following algorithm taking one argument |keyArg|:
+
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>delete</code>" and type "<code>method</code>".
         1.  Let |map| be the [=map entries=] of the IDL value
             that represents a reference to |O|.
@@ -13525,10 +13533,11 @@ on |A|'s [=interface prototype object=]
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|clearSteps|, 0, "<code>clear</code>", « »),
-    where |clearSteps| is the following algorithm:
+*   <div algorithm="to invoke the clear method of Maps">
 
-    <div algorithm="to invoke the clear method of Maps">
+        The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|clearSteps|, 0, "<code>clear</code>", « »),
+        where |clearSteps| is the following algorithm:
+
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>clear</code>" and type "<code>method</code>".
         1.  Let |map| be the [=map entries=] of the IDL value
             that represents a reference to |O|.
@@ -13607,10 +13616,11 @@ There must exist an <code class="idl">entries</code> data property on
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|entriesSteps|, 0, "<code>entries</code>", « »),
-    where |entriesSteps| is the following algorithm:
+*   <div algorithm="to invoke the entries method of Sets">
 
-    <div algorithm="to invoke the entries method of Sets">
+        The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|entriesSteps|, 0, "<code>entries</code>", « »),
+        where |entriesSteps| is the following algorithm:
+
         1. Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>entries</code>" and type "<code>method</code>".
         1.  Let |set| be the [=set entries=] of the IDL value
             that represents a reference to |O|.
@@ -13634,10 +13644,11 @@ There must exist a <code class="idl">values</code> data property on
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|valuesSteps|, 0, "<code>values</code>", « »),
-    where |valuesSteps| is the following algorithm:
+*   <div algorithm="to invoke the values method of Sets">
 
-    <div algorithm="to invoke the values method of Sets">
+        The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|valuesSteps|, 0, "<code>values</code>", « »),
+        where |valuesSteps| is the following algorithm:
+
         1. Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>values</code>" and type "<code>method</code>".
         1.  Let |set| be the [=set entries=] of the IDL value
             that represents a reference to |O|.
@@ -13652,10 +13663,11 @@ There must exist a <code class="idl">forEach</code> data property on
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|forEachSteps|, 1, "<code>forEach</code>", « »),
-    where |forEachSteps| is the following algorithm taking arguments |callbackFn| and |thisArg|:
+*   <div algorithm="to invoke the forEach method of Sets">
 
-    <div algorithm="to invoke the forEach method of Sets">
+        The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|forEachSteps|, 1, "<code>forEach</code>", « »),
+        where |forEachSteps| is the following algorithm taking arguments |callbackFn| and |thisArg|:
+
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>forEach</code>" and type "<code>method</code>".
         1.  Let |set| be the [=set entries=] of the IDL value
             that represents a reference to |O|.
@@ -13674,10 +13686,11 @@ There must exist a <code class="idl">has</code> data property on
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|hasSteps|, 1, "<code>has</code>", « »),
-    where |hasSteps| is the following algorithm taking one argument |valueArg|:
+*   <div algorithm="to invoke the has method of Sets">
 
-    <div algorithm="to invoke the has method of Sets">
+        The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|hasSteps|, 1, "<code>has</code>", « »),
+        where |hasSteps| is the following algorithm taking one argument |valueArg|:
+
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>has</code>" and type "<code>method</code>".
         1.  Let |set| be the [=set entries=] of the IDL value
             that represents a reference to |O|.
@@ -13698,10 +13711,11 @@ on |A|'s [=interface prototype object=]
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|addSteps|, 1, "<code>add</code>", « »),
-    where |addSteps| is the following algorithm taking one argument |valueArg|:
+*   <div algorithm="to invoke the add method of Sets">
 
-    <div algorithm="to invoke the add method of Sets">
+        The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|addSteps|, 1, "<code>add</code>", « »),
+        where |addSteps| is the following algorithm taking one argument |valueArg|:
+
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>add</code>" and type "<code>method</code>".
         1.  Let |set| be the [=set entries=] of the IDL value
             that represents a reference to |O|.
@@ -13726,10 +13740,11 @@ on |A|'s [=interface prototype object=]
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|deleteSteps|, 1, "<code>delete</code>", « »),
-    where |deleteSteps| is the following algorithm taking one argument |valueArg|:
+*   <div algorithm="to invoke the delete method of Sets">
 
-    <div algorithm="to invoke the delete method of Sets">
+        The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|deleteSteps|, 1, "<code>delete</code>", « »),
+        where |deleteSteps| is the following algorithm taking one argument |valueArg|:
+
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>delete</code>" and type "<code>method</code>".
         1.  Let |set| be |O|'s [=set entries=].
         1.  Let |valueType| be the value type specified in the [=setlike declaration=].
@@ -13754,10 +13769,11 @@ on |A|'s [=interface prototype object=]
 with the following characteristics:
 
 *   The property has attributes { \[[Writable]]: <emu-val>true</emu-val>, \[[Enumerable]]: <emu-val>true</emu-val>, \[[Configurable]]: <emu-val>true</emu-val> }.
-*   The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|clearSteps|, 0, "<code>clear</code>", « »),
-    where |clearSteps| is the following algorithm:
+*   <div algorithm="to invoke the clear method of Sets">
 
-    <div algorithm="to invoke the clear method of Sets">
+        The value of the property is the [=built-in function object=] [$CreateBuiltinFunction$](|clearSteps|, 0, "<code>clear</code>", « »),
+        where |clearSteps| is the following algorithm:
+
         1.  Let |O| be the <emu-val>this</emu-val> value, [=implementation-checked=] against <var ignore>A</var> with identifier "<code>clear</code>" and type "<code>method</code>".
         1.  Let |set| be the [=set entries=] of the IDL value
             that represents a reference to |O|.


### PR DESCRIPTION
This is a bit clearer and more explicit than having the separate paragraphs afterwards. It also makes the arguments clear upfront.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/webidl/1612.html" title="Last updated on Jun 26, 2026, 8:19 AM UTC (6b13269)">Preview</a> | <a href="https://whatpr.org/webidl/1612/29fb50e...6b13269.html" title="Last updated on Jun 26, 2026, 8:19 AM UTC (6b13269)">Diff</a>